### PR TITLE
Fix issue #274: do not modify options in validator in-place.

### DIFF
--- a/lib/mongoid/validations/associated.rb
+++ b/lib/mongoid/validations/associated.rb
@@ -25,7 +25,7 @@ module Mongoid #:nodoc:
       def validate_each(document, attribute, value)
         values = value.is_a?(Array) ? value : [ value ]
         return if values.collect { |doc| doc.nil? || doc.valid? }.all?
-        document.errors.add(attribute, :invalid, options.merge!(:value => value))
+        document.errors.add(attribute, :invalid, options.merge(:value => value))
       end
     end
   end


### PR DESCRIPTION
I believe this particular merge! was introduced by an attempt to follow the patterns seen in the shipping ActiveModel validators, which tend to use exclude(...).merge!(...) to pass options into the callback method. However, in this case we do not exclude, so the original options is never duped and is modified in place (which is the incorrect behavior).

This went unnoticed until josevalim froze the options hash in ActiveModel upstream to detect this (common) mistake.

This fixes the issue and prevents spurious exceptions when association validations fail using Mongoid with Rails 3.

I submitted this as an old-style pull request earlier, but there are rumors that old-style pull requests are having issues right now (plus I wanted an excuse to try the new, shiny kind out)!
