### PR TITLE
Validation exceptions expose the offending document.

### DIFF
--- a/lib/mongoid/errors/validations.rb
+++ b/lib/mongoid/errors/validations.rb
@@ -9,7 +9,11 @@ module Mongoid #:nodoc
     #
     # <tt>Validations.new(person.errors)</tt>
     class Validations < MongoidError
+      attr_reader :document
+
       def initialize(document)
+        @document = document
+
         super(
           translate(
             "validations",


### PR DESCRIPTION
This is useful when you want to have structured access to the errors somewhere higher up the chain. Simple Sinatra example:

```
error Mongoid::Errors::Validations do
  halt 412, json(env["sinatra.error"].document.errors)
end

post "/users" do
  user = User.new do |u|
    u.email    = params[:email]
    u.password = params[:password]
  end

  halt 201, json(user.save!)
end
```
