### PR TITLE
Initialization with has many

### DIFF
--- a/lib/mongoid/document.rb
+++ b/lib/mongoid/document.rb
@@ -100,9 +100,9 @@ module Mongoid #:nodoc:
     #
     # attrs: The attributes +Hash+ to set up the document with.
     def initialize(attrs = nil)
+      @new_record = true
       @attributes = default_attributes
       process(attrs)
-      @new_record = true
       document = yield self if block_given?
       identify
       run_callbacks(:initialize) do

--- a/spec/integration/mongoid/associations_spec.rb
+++ b/spec/integration/mongoid/associations_spec.rb
@@ -785,6 +785,17 @@ describe Mongoid::Associations do
 
   context "references many as array" do
 
+    context "when initializing a new document" do
+      context "with a references_many association" do
+        let(:preference) { Preference.create(:name => "test") }
+        let(:person) { Person.new :preferences => [preference] }
+
+        it 'adds the document to the array' do
+          person.preferences.first.should == preference
+        end
+      end
+    end
+
     context "with a saved parent" do
       let(:person) { Person.create!(:ssn => "992-33-1010") }
 


### PR DESCRIPTION
Initializing with a has_many referenced attribute, like so:
    Person.new :preferences => [preference] 
causes mongoid to throw an error (due to an attempt to save the person record before the initialization finishes)

Fix and failing test included.
