### PR TITLE
Validations error

### DIFF
--- a/lib/mongoid/errors/validations.rb
+++ b/lib/mongoid/errors/validations.rb
@@ -9,7 +9,9 @@ module Mongoid #:nodoc
     #
     # <tt>Validations.new(person.errors)</tt>
     class Validations < MongoidError
+      attr_reader :document
       def initialize(document)
+        @document = document
         super(
           translate(
             "validations",

--- a/spec/unit/mongoid/errors_spec.rb
+++ b/spec/unit/mongoid/errors_spec.rb
@@ -84,19 +84,26 @@ describe Mongoid::Errors do
 
   describe Mongoid::Errors::Validations do
 
+    before do
+      @errors = stub(:full_messages => [ "Error 1", "Error 2" ], :empty? => false)
+      @document = stub(:errors => @errors)
+      @error = Mongoid::Errors::Validations.new(@document)
+    end
+    
     describe "#message" do
 
       context "default" do
 
-        before do
-          @errors = stub(:full_messages => [ "Error 1", "Error 2" ], :empty? => false)
-          @document = stub(:errors => @errors)
-          @error = Mongoid::Errors::Validations.new(@document)
-        end
-
         it "contains the errors' full messages" do
           @error.message.should == "Validation failed - Error 1, Error 2."
         end
+      end
+    end
+    
+    describe "#document" do
+      
+      it "contains the a reference to the document" do
+        @error.document.should == @document
       end
     end
   end


### PR DESCRIPTION
Hey Guys,

In commit [b6ede780](http://github.com/mongoid/mongoid/commit/b6ede78ff9981e4fb10979d4bc320c62e9aa3018) a reference to the document where the validation error occurred was removed from the Validation MongoidError class. This commit adds it back so that the document can be inspected for more information.

Please let me know if you have any questions or feedback.

Thanks,

Josh
