### PR TITLE
Allow embedded documents to have array attributes searched by single strings

### DIFF
--- a/lib/mongoid/matchers/default.rb
+++ b/lib/mongoid/matchers/default.rb
@@ -8,7 +8,8 @@ module Mongoid #:nodoc:
       end
       # Return true if the attribute and value are equal.
       def matches?(value)
-        value === @attribute
+        @attribute.is_a?(Array) && value.is_a?(String) ?
+          @attribute.include?(value) : value === @attribute
       end
 
       protected

--- a/spec/unit/mongoid/matchers/default_spec.rb
+++ b/spec/unit/mongoid/matchers/default_spec.rb
@@ -2,9 +2,10 @@ require "spec_helper"
 
 describe Mongoid::Matchers::Default do
 
-  let(:matcher) { Mongoid::Matchers::Default.new("Testing") }
 
   describe "#matches?" do
+
+    let(:matcher) { Mongoid::Matchers::Default.new("Testing") }
 
     context "when the values are equal" do
 
@@ -18,6 +19,28 @@ describe Mongoid::Matchers::Default do
 
       it "returns false" do
         matcher.matches?("Other").should be_false
+      end
+
+    end
+
+  end
+
+  describe "#matches? when comparing a String to an Array attribute" do
+
+    let(:matcher) { Mongoid::Matchers::Default.new(["Test1", "Test2", "Test3"]) }
+
+    context "when the attribute contains the value" do
+
+      it "returns true" do
+        matcher.matches?("Test1").should be_true
+      end
+
+    end
+
+    context "when the attribute does not contain the value" do
+
+      it "returns false" do
+        matcher.matches?("Test4").should be_false
       end
 
     end


### PR DESCRIPTION
[Github issue #244](http://github.com/mongoid/mongoid/issues/issue/244) allowed single values to be set in a where clause when the field type is Array.  However, embedded documents do not allow searching Array attributes by single values.  I've made this change to allow matching Arrays to behave the same in top-level and embedded documents.

My knowledge of the mongoid codebase is limited, so this may or may not be a good way to implement this. Thanks for creating mongoid!
