### PR TITLE
Mongo dependency bump

### DIFF
--- a/mongoid.gemspec
+++ b/mongoid.gemspec
@@ -20,10 +20,10 @@ Gem::Specification.new do |s|
   s.add_dependency("activemodel", ["~> 3.0"])
   s.add_dependency("tzinfo", ["~> 0.3.22"])
   s.add_dependency("will_paginate", ["~>3.0.pre"])
-  s.add_dependency("mongo", ["= 1.0.8"])
-  s.add_dependency("bson", ["= 1.0.7"])
+  s.add_dependency("mongo", ["= 1.0.9"])
+  s.add_dependency("bson", ["= 1.0.9"])
 
-  s.add_development_dependency("bson_ext", ["= 1.0.7"])
+  s.add_development_dependency("bson_ext", ["= 1.0.9"])
   s.add_development_dependency("mocha", ["= 0.9.8"])
   s.add_development_dependency("rspec", ["= 2.0.0.beta.22"])
   s.add_development_dependency("watchr", ["= 0.6"])


### PR DESCRIPTION
Bumped to 0.9 for gems: mongo, bson, and bson_ext

As an aside, would it be better to remove direct dependencies on bson and bson_ext?  The mongo gem already depends on bson, and copious warnings are already spewed if bson_ext isn't installed.

Also, it's my understanding that the mongo, bson, and bson_ext gems should always be the same version.  What was the reason for having different versions depended on in the mongoid.gemspec?  (Problems in the past?)
