### PR TITLE
add autofields extension to get up and running with mongoid even easier

### DIFF
--- a/lib/mongoid.rb
+++ b/lib/mongoid.rb
@@ -83,6 +83,7 @@ require "mongoid/versioning"
 require "mongoid/components"
 require "mongoid/paranoia"
 require "mongoid/document"
+require "mongoid/autofields"
 
 # add railtie
 if defined?(Rails)

--- a/lib/mongoid/autofields.rb
+++ b/lib/mongoid/autofields.rb
@@ -1,0 +1,13 @@
+module Mongoid
+  # sloppily define undefined fields to make getting up and running with mongoid even easier.
+  module Autofields
+    def method_missing(m, *a)
+      return super unless m =~ /=/
+        return super unless a.size == 1
+      meth = m.to_s.gsub('=', '')
+      type = a.first.class
+      self.class.field meth.to_sym, type: type
+      self.send m.to_sym, *a
+    end
+  end
+end


### PR DESCRIPTION
example:

```
class Basic                                                                                                   
  include Mongoid::Document                                                                                   
  include Mongoid::Autofields                                                                                 
end                                                                                                           

b = Basic.new :name => 'very basic model', :description => 'fields are automatically detected but are limited'
b.save                                                                                                        
p Basic.last                                                                                                                                                                                                
```
