### PR TITLE
Spec to test that embeds_many resets the collection when using the assignment method

### DIFF
--- a/spec/integration/mongoid/associations_spec.rb
+++ b/spec/integration/mongoid/associations_spec.rb
@@ -582,11 +582,25 @@ describe Mongoid::Associations do
       context "when overwriting" do
         before do
           @person.addresses.build(:street => "Oxford St")
-          @person.addresses = @person.addresses
+          @person.addresses = [Address.new(:street => "Cambridge St")]
         end
 
         it "still recognizes the embedded document as a new record" do
           @person.addresses.first.should be_new_record
+        end
+
+        it "should only have one address" do
+          @person.should have(1).addresses
+        end
+
+        it "should only have one address after persisting" do
+          @person.save!
+          @person.reload
+          @person.should have(1).addresses
+          @person.addresses = [Address.new(:street => "Broadway Blvd")]
+          @person.save!
+          @person.reload
+          @person.should have(1).addresses
         end
       end
 


### PR DESCRIPTION
I am seeing that when you have the following:

```
class Address
  include Mongoid::Document

  field :street

  embedded_in :person, :inverse_of => :addresses
end
class Person
  include Mongoid::Document

  field :name
  embeds_many :addresses
end

person = Person.new(:name => "Joe")
person.addresses << Address.new(:street => "123 Fake St")
person.save
person.reload
person.addresses = [Address.new(:street => "123 Chicago Ave.")]
person.addresses.size   # => 2
person.save
person.reload
person.addresses.size   # => 2
```

So the addresses association doesn't get reset when the record gets persisted. Looking in the logs at the executed Mongo command, it does a `push` onto the `addresses` field.

This is inconsistent with the state of the record before the saving. 

This push request includes a spec to test for this failure.
