### PR TITLE
fix bug in versioning.rb

### DIFF
--- a/lib/mongoid/versioning.rb
+++ b/lib/mongoid/versioning.rb
@@ -14,6 +14,8 @@ module Mongoid #:nodoc:
 
     module ClassMethods #:nodoc:
       attr_accessor :version_max
+      
+      # the number of max_version should >= 0
       def max_versions(number)
         self.version_max = number.to_i
       end
@@ -26,10 +28,14 @@ module Mongoid #:nodoc:
     def revise
       last_version = self.class.first(:conditions => { :_id => id, :version => version })
       if last_version
+        old_versions = @attributes["versions"]
         self.versions << last_version.clone
-        self.versions.shift if self.class.version_max.present? && self.versions.length > self.class.version_max
+        new_versions = @attributes["versions"]
+        if self.class.version_max.present? && ( self.class.version_max >= 0 ) && ( self.versions.length > self.class.version_max )
+          new_versions.shift
+        end
         self.version = (version || 1 ) + 1
-        @modifications["versions"] = [ nil, @attributes["versions"] ] if @modifications
+        @modifications["versions"] = [ old_versions, new_versions ] if @modifications
       end
     end
   end

--- a/spec/unit/mongoid/versioning_spec.rb
+++ b/spec/unit/mongoid/versioning_spec.rb
@@ -4,6 +4,14 @@ describe Mongoid::Versioning do
 
   describe "#version" do
 
+    def first_update_post
+      @post.title = "New"
+      @version = Post.new(:title => "Test")
+      Post.expects(:first).at_least(1).with(:conditions => { :_id => @post.id, :version => 1 }).returns(@version)
+      @post.save
+      @post.reload
+    end
+
     before do
       @post = Post.new
     end
@@ -15,10 +23,7 @@ describe Mongoid::Versioning do
     context "when document is saved" do
 
       before do
-        @post.title = "New"
-        @version = Post.new(:title => "Test")
-        Post.expects(:first).at_least(1).with(:conditions => { :_id => @post.id, :version => 1 }).returns(@version)
-        @post.revise
+        first_update_post
       end
 
       it "increments the version" do
@@ -33,35 +38,52 @@ describe Mongoid::Versioning do
         version.title.should == "Test"
         version.version.should == 1
       end
+      
+    end
+    
+    context "when a max_versions limit has been set to 0" do
 
-      context "when a max_versions limit has been set" do
+      before do
+        Post.max_versions 0
+        first_update_post
+      end
 
-        before do
-          Post.max_versions 1
-        end
+      it "update version number without actually saving old versions" do
+        @post.title.should == "New"
+        @post.version.should == 2
+        @post.versions.size.should == 0
+      end
 
-        it "adds a snapshot of the document to the versions if it hasn't been exceeded" do
-          @post.title.should == "New"
-          @post.version.should == 2
-          @post.versions.size.should == 1
-          version = @post.versions.first
-          version.title.should == "Test"
-          version.version.should == 1
-        end
+    end
+    
+    context "when a max_versions limit has been set to > 0" do
 
-        it "discards the oldest version if it's been exceeded" do
-          @previous_version = @post.clone
-          @post.title = "Another change"
-          Post.expects(:first).at_least(1).with(:conditions => { :_id => @post.id, :version => 2 }).returns(@previous_version)
-          @post.revise
-          @post.title.should == "Another change"
-          @post.version.should == 3
-          @post.versions.size.should == 1
-          latest_version = @post.versions.first
-          latest_version.title.should == "New"
-          latest_version.version.should == 2
-        end
+      before do
+        Post.max_versions 1
+        first_update_post
+      end
 
+      it "update version number and save old versions" do
+        @post.title.should == "New"
+        @post.version.should == 2
+        @post.versions.size.should == 1
+        version = @post.versions.first
+        version.title.should == "Test"
+        version.version.should == 1
+      end
+
+      it "discards the oldest version if it's been exceeded" do
+        @previous_version = @post.clone
+        @post.title = "Another change"
+        Post.expects(:first).at_least(1).with(:conditions => { :_id => @post.id, :version => 2 }).returns(@previous_version)
+        @post.save
+        @post.reload
+        @post.title.should == "Another change"
+        @post.version.should == 3
+        @post.versions.size.should == 1
+        latest_version = @post.versions.first
+        latest_version.title.should == "New"
+        latest_version.version.should == 2
       end
 
     end


### PR DESCRIPTION
When I use
    include Mongoid::Versioning
    max_versions 1
in my project, I found the model keep saving old copies dicarding the existence of max_versions.

I think the problem occurs because
    self.versions.shift
won't actually change the underlying object.

I wrote a patch that fix the problem and add an option to specify `max_versions 0` which only update version numbers without actually saving old copies.
