### PR TITLE
regexp should be escaped when specifying ':case_sensitive => false'

### DIFF
--- a/lib/mongoid/validations/uniqueness.rb
+++ b/lib/mongoid/validations/uniqueness.rb
@@ -54,7 +54,7 @@ module Mongoid #:nodoc:
       # ensure :case_sensitive is true by default
       def unique_search_value(value)
         if options[:case_sensitive] == false
-          value ? /^#{value}$/i : nil
+          value ? Regexp.new("^#{Regexp.escape(value.to_s)}$", Regexp::IGNORECASE) : nil
         else
           value
         end

--- a/spec/integration/mongoid/validations/uniqueness_spec.rb
+++ b/spec/integration/mongoid/validations/uniqueness_spec.rb
@@ -62,6 +62,11 @@ describe Mongoid::Validations::UniquenessValidator do
             account.email = "chiTchins@TEST.CoM"
             account.should_not be_valid
           end
+          
+          it "passes validation when using special chars in string that will be escaped in regexp" do
+            account.email = "chiT.hins@T.ST.CoM"
+            account.should be_valid
+          end
         end
       end
 
@@ -82,8 +87,15 @@ describe Mongoid::Validations::UniquenessValidator do
         
         context "with case insensitive validation" do
           it "fails validation when another document has the same unique field with a different case" do
+            account.username = 'boblu'
             account.email = "chiTchins@TEST.CoM"
             account.should_not be_valid
+          end
+          
+          it "passes validation when using special chars in string that will be escaped in regexp" do
+            account.username = 'boblu'
+            account.email = "chiT.hins@T.ST.CoM"
+            account.should be_valid
           end
         end
       end


### PR DESCRIPTION
regexp should be escaped when specifying `:case_sensitive => false` in validates_uniqueness_of.

This will consider '...' and 'abc' as differrent strings, or they will match if directly put into regexp.
