### PR TITLE
Quick fix to an issue with embeds_many and accepts_nested_attributes_for.

### DIFF
--- a/lib/mongoid/associations/embeds_many.rb
+++ b/lib/mongoid/associations/embeds_many.rb
@@ -192,8 +192,10 @@ module Mongoid #:nodoc:
               document.write_attributes(attrs)
             end
           else
-            document = build(attrs)
-            id_index[document.id.to_s] = index.to_i
+            unless options && options[:allow_destroy] && Boolean.set(attrs['_destroy'])
+              document = build(attrs)
+              id_index[document.id.to_s] = index.to_i
+            end
           end
         end
         if reordering


### PR DESCRIPTION
As the commit says:

Fixing issue where new nested objects would get built even if allow_destroy is true and the new nested object was marked for _destroy.

Detailed here: http://groups.google.com/group/mongoid/browse_thread/thread/ea4696392b1868af

This issue also appears in references_many, but that association has many other issues regarding accepts_nested_attributes_for that fixing it there wouldn't be helpful yet.
