### PR TITLE
Adding default_order option to ReferencesMany Association

### DIFF
--- a/lib/mongoid/associations.rb
+++ b/lib/mongoid/associations.rb
@@ -193,12 +193,16 @@ module Mongoid # :nodoc:
       # Options:
       #
       # name: A +Symbol+ that is the related class name pluralized.
+      # default_order: A +Criteria+ that specifies the default sort order for
+      # this association. (e.g. :position.asc). If an explicit ordering is
+      # specified on a +Criteria+ object, the default order will NOT be used.
       #
       # Example:
       #
       #   class Person
       #     include Mongoid::Document
       #     references_many :posts
+      #     references_many :board_games, :default_order => :title.asc
       #   end
       #
       def references_many(name, options = {}, &block)

--- a/lib/mongoid/associations/options.rb
+++ b/lib/mongoid/associations/options.rb
@@ -68,6 +68,11 @@ module Mongoid #:nodoc:
       def stored_as
         self[:stored_as]
       end
+
+      # Used with references_many to define a default sorting order
+      def default_order
+        self[:default_order]
+      end
     end
   end
 end

--- a/lib/mongoid/associations/references_many.rb
+++ b/lib/mongoid/associations/references_many.rb
@@ -166,7 +166,11 @@ module Mongoid #:nodoc:
       #   An +Array+ of objects if an ActiveRecord association
       #   A +Collection+ if a DataMapper association.
       def query
-        @query ||= lambda { @klass.all(:conditions => { @foreign_key => @parent.id }) }
+        @query ||= lambda {
+          @klass.all(:conditions => { @foreign_key => @parent.id }).tap do |crit|
+            crit.set_order_by(@options.default_order) if @options.default_order
+          end
+        }
       end
 
       # Remove the objects based on conditions.

--- a/lib/mongoid/criterion/optional.rb
+++ b/lib/mongoid/criterion/optional.rb
@@ -3,6 +3,16 @@ module Mongoid #:nodoc:
   module Criterion #:nodoc:
     module Optional
 
+      def using_default_sort?
+        @use_default_sort = true if @use_default_sort.nil? # TODO: move initialization elsewhere
+        return @use_default_sort
+      end
+
+      def remove_default_sort
+        @options[:sort] = nil if using_default_sort?
+        @use_default_sort = false
+      end
+
       # Adds fields to be sorted in ascending order. Will add them in the order
       # they were passed into the method.
       #
@@ -10,6 +20,8 @@ module Mongoid #:nodoc:
       #
       # <tt>criteria.ascending(:title, :dob)</tt>
       def ascending(*fields)
+        remove_default_sort
+
         @options[:sort] = [] unless @options[:sort] || fields.first.nil?
         fields.flatten.each { |field| @options[:sort] << [ field, :asc ] }
         self
@@ -45,6 +57,8 @@ module Mongoid #:nodoc:
       #
       # <tt>criteria.descending(:title, :dob)</tt>
       def descending(*fields)
+        remove_default_sort
+
         @options[:sort] = [] unless @options[:sort] || fields.first.nil?
         fields.flatten.each { |field| @options[:sort] << [ field, :desc ] }
         self
@@ -149,6 +163,11 @@ module Mongoid #:nodoc:
       #
       # Returns: <tt>self</tt>
       def order_by(*args)
+        remove_default_sort
+        set_order_by(*args)
+      end
+
+      def set_order_by(*args)
         @options[:sort] = [] unless @options[:sort] || args.first.nil?
         arguments = args.first
         case arguments
@@ -200,6 +219,7 @@ module Mongoid #:nodoc:
         types = [types] unless types.is_a?(Array)
         self.in(:_type => types)
       end
+
     end
   end
 end

--- a/spec/models/person.rb
+++ b/spec/models/person.rb
@@ -67,7 +67,7 @@ class Person
     end
   end
 
-  references_many :posts, :dependent => :delete do
+  references_many :posts, :dependent => :delete, :default_order => :created_at.desc do
     def extension
       "Testing"
     end

--- a/spec/unit/mongoid/associations/options_spec.rb
+++ b/spec/unit/mongoid/associations/options_spec.rb
@@ -96,6 +96,33 @@ describe Mongoid::Associations::Options do
     end
   end
 
+  describe "#default_order" do
+
+    context "when no default_order defined" do
+
+      before do
+        @attributes = { :name => :posts }
+        @options = Mongoid::Associations::Options.new(@attributes)
+      end
+
+      it "returns nil" do
+        @options.default_order.should be_nil
+      end
+    end
+
+    context "when an default_order is defined" do
+      before do
+        @attributes = { :name => :posts, :default_order => :blog_post_id.asc }
+        @options = Mongoid::Associations::Options.new(@attributes)
+      end
+
+      it "returns the custom default_order criteria object" do
+        @options.default_order.key.should == :blog_post_id.asc.key
+        @options.default_order.operator.should == :blog_post_id.asc.operator
+      end
+    end
+  end
+
   describe "#index" do
 
     context "when not defined" do

--- a/spec/unit/mongoid/associations_spec.rb
+++ b/spec/unit/mongoid/associations_spec.rb
@@ -640,6 +640,20 @@ describe Mongoid::Associations do
     end
   end
 
+  describe "default_order" do
+    before do
+      @person = Person.new
+    end
+
+    it "should default the order when no ordering is specified" do
+      @person.posts.instance_eval { @options }[:sort].should == [[:created_at, :desc]]
+    end
+
+    it "should not include the default order when specifying an ordering" do
+      @person.posts.asc(:title).instance_eval { @options }[:sort].should == [[:title, :asc]]
+    end
+  end
+
   describe ".references_many" do
 
     it "creates a getter for the association" do
@@ -754,7 +768,9 @@ describe Mongoid::Associations do
       end
 
       it "does nothing" do
-        Post.expects(:find).returns([])
+        results = []
+        results.stubs(:set_order_by)
+        Post.expects(:find).returns(results)
         @person.update_associations(:posts)
         @person.posts.first.should be_nil
       end


### PR DESCRIPTION
Howdy, all:

My pair (schustafa) and I were running into a number of cases where we wanted, by default, to have the objects from a ReferencesMany Association returned in a specific order (e.g. having all of Books for a particular Publisher ordered by title ascending, or having all of the BlogPosts for a Blog always ordered by created_at descending). We also wanted to make sure that if an explicit ordering was specified, that it was honored. That is:

class Publisher
  references_many :books, :default_order => :title.asc
end

publisher.books #=> ordered by title, ascending
publisher.books.desc(:year_published) #=> ordered by year published, descending

We didn't find any hot way to do this, so we thought we'd write it and see if it was of interest to you guys. If not, we're happy to rewrite it as a real slim gem that monkey-patches mongoid. Alternatively, if there is some hotter way to get this done, let us know! We want to learn!

Okay. You're all awesome.

Cheers,
Dan (and AJ).
