### PR TITLE
Simple fix for broken --versioning option on model generator

### DIFF
--- a/lib/rails/generators/mongoid/model/templates/model.rb
+++ b/lib/rails/generators/mongoid/model/templates/model.rb
@@ -5,7 +5,9 @@ class <%= class_name %><%= " < #{options[:parent].classify}" if options[:parent]
 <% if options[:timestamps] -%>
   include Mongoid::Timestamps
 <% end -%>
-<%= 'include Mongoid::Versioning' if options[:versioning] -%>
+<% if options[:versioning] -%>
+  include Mongoid::Versioning
+<% end -%>
 <% attributes.reject{|attr| attr.reference?}.each do |attribute| -%>
   field :<%= attribute.name %>, :type => <%= attribute.type_class %>
 <% end -%>


### PR DESCRIPTION
The overly clever one-liner in the generator template currently results in invalid Ruby:

```
$ rails g model Note --timestamps --versioning
...
$ cat app/models/note.rb
class Note
  include Mongoid::Document
  include Mongoid::Timestamps
include Mongoid::Versioningend
```
