### PR TITLE
Don't modify the foreign_key string when foreign_key_setter is called 

### DIFF
--- a/lib/mongoid/relations/metadata.rb
+++ b/lib/mongoid/relations/metadata.rb
@@ -114,7 +114,7 @@ module Mongoid # :nodoc:
       #
       # The foreign_key plus =.
       def foreign_key_setter
-        foreign_key << "="
+        "#{foreign_key}="
       end
 
       # Tells whether a foreign key index exists on the relation.


### PR DESCRIPTION
... or the foreign_key might look like parent_id==== anytime soon. ;-)
