### PR TITLE
rake task to update existing documents with new field defaults

### DIFF
--- a/lib/mongoid/railties/database.rake
+++ b/lib/mongoid/railties/database.rake
@@ -116,6 +116,8 @@ namespace :db do
             :safe => true)
           updated = result[0][0]["updatedExisting"]
           count += result.first.first['n'] if updated
+        rescue Exception => e
+          puts "Error trying to update #{collection.name} to use a default #{field_name_query} of #{default_value}: #{e.message}"
         end while (embeds_many && updated)
         puts "Updated #{count} #{collection.name} to use a default #{field_name_query} of: #{default_value}" if updated
       end


### PR DESCRIPTION
RE: http://groups.google.com/group/mongoid/browse_thread/thread/26b72733dc58e97a/35b4f7122398da80#35b4f7122398da80

The rake task works on both root and nested documents.  Accessible via db:set_defaults

I'm not quite sure how to specify only the last 3 commits.  The 3 older ones were already pulled in September.  The Files Changed looks right though.
