### PR TITLE
Added support for a primary key factory

### DIFF
--- a/lib/mongoid/identity.rb
+++ b/lib/mongoid/identity.rb
@@ -24,7 +24,9 @@ module Mongoid #:nodoc:
     protected
     # Return the proper id for the document.
     def generate_id
-      id = BSON::ObjectId.new
+      pk_factory = Mongoid.master.pk_factory || BSON::ObjectId
+      attrs = pk_factory.create_pk(@document.attributes)
+      id = attrs['_id'] || attrs[:_id]
       @document.using_object_ids? ? id : id.to_s
     end
 

--- a/spec/unit/mongoid/identity_pk_factory_spec.rb
+++ b/spec/unit/mongoid/identity_pk_factory_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+describe Mongoid::Identity do
+  context "when a PK factory exists" do
+    before do
+      module TestPkFactory
+        def self.create_pk(row)
+          row[:_id] ||= "pk_factory"
+          return row
+        end
+      end
+
+      Person.identity :type => String
+      Mongoid.master.pk_factory = TestPkFactory
+      @person = Person.allocate
+    end
+
+    after do
+      Person.identity {} # reset
+      Mongoid.master.instance_variable_set(:@pk_factory, nil)
+    end
+
+    context "and the id is blank" do
+      before do
+        @person.instance_variable_set(:@attributes, {})
+        Mongoid::Identity.new(@person).create
+      end
+
+      it "should create a new id" do
+        @person.id.should == "pk_factory"
+      end
+    end
+
+    context "and the id exists" do
+      before do
+        @person.instance_variable_set(:@attributes, {:_id => "old_id"})
+        Mongoid::Identity.new(@person).create
+      end
+
+      it "should return the existing id" do
+        @person.id.should == "old_id"
+      end
+    end
+  end
+end


### PR DESCRIPTION
The Identity class has comments eluding to eventual support for primary key factories. The comments hint that the author may have envisioned a more advanced implementation that allows per class or per collection factories. The solution I've implemented is far simpler as it only allows one factory per database. This semi piggybacks off of and mimics the design of the underlying Mongo driver.

This feature is very important to my team as we move our applications to Rails 3 and I'd be glad to make any updates or changes to help get this integrated into your repository. I'd even attempt to build a more complex design if someone would be kind enough to provide an explanation of the direction they'd like to see.

Thanks
Andrew
