### PR TITLE
Added Mongoid::Criteria#find

### DIFF
--- a/lib/mongoid/finders.rb
+++ b/lib/mongoid/finders.rb
@@ -64,7 +64,7 @@ module Mongoid #:nodoc:
     # <tt>Person.find(Mongo::ObjectID.new.to_s)</tt>
     def find(*args)
       raise Errors::InvalidOptions.new(:calling_document_find_with_nil_is_invalid, {}) if args[0].nil?
-      type = args.delete_at(0) if args[0].is_a?(Symbol)
+      type = args.shift if args.first.is_a?(Symbol)
       criteria = Criteria.translate(self, *args)
       case type
       when :first then return criteria.one

--- a/spec/unit/mongoid/criteria_spec.rb
+++ b/spec/unit/mongoid/criteria_spec.rb
@@ -395,6 +395,34 @@ describe Mongoid::Criteria do
 
   end
 
+  describe "#find" do
+    
+    before do
+      @context = stub.quacks_like(Mongoid::Contexts::Mongo.allocate)
+      @criteria.instance_variable_set(:@context, @context)
+      @conditions = BSON::ObjectId.new
+      @result = stub.quacks_like(Mongoid::Criteria.allocate)
+    end
+    
+    it 'calls translate_criteria on the class' do
+      Mongoid::Criteria.expects(:translate_criteria).with(@criteria, @conditions)
+      @criteria.find @conditions
+    end
+    
+    it 'optionally takes a :first position parameter' do
+      Mongoid::Criteria.expects(:translate_criteria).at_least_once.with(@criteria, @conditions).returns(@result)
+      @result.expects(:one)
+      @criteria.find :first, @conditions
+    end
+    
+    it 'optionally takes a :last position parameter' do
+      Mongoid::Criteria.expects(:translate_criteria).at_least_once.with(@criteria, @conditions).returns(@result)
+      @result.expects(:last)
+      @criteria.find :last, @conditions
+    end
+    
+  end
+
   describe "#first" do
 
     before do


### PR DESCRIPTION
Hey guys,

I added a find method to Mongoid::Criteria so you can user criteria closer to how you use documents - namely, it wont return a Criteria object now and it will correctly do things such as raising an exception if not found. As part of this, I also slightly moved around Mongoid::Criteria.translate. This was something talked about in #273 but I couldn't find anything having been done since.
