### PR TITLE
Set record_timestamps to false to temporarily disable timestamping functionality

### DIFF
--- a/lib/mongoid/timestamps.rb
+++ b/lib/mongoid/timestamps.rb
@@ -15,12 +15,14 @@ module Mongoid #:nodoc:
     # Update the created_at field on the Document to the current time. This is
     # only called on create.
     def set_created_at
+      return if self.class.record_timestamps == false
       self.created_at = Time.now.utc if !created_at
     end
 
     # Update the updated_at field on the Document to the current time.
     # This is only called on create and on save.
     def set_updated_at
+      return if self.class.record_timestamps == false
       self.updated_at = Time.now.utc
     end
   end

--- a/spec/unit/mongoid/timestamps_spec.rb
+++ b/spec/unit/mongoid/timestamps_spec.rb
@@ -24,6 +24,27 @@ describe Mongoid::Timestamps do
     it "includes a record_timestamps class_accessor to ease AR compatibility" do
       Person.should.respond_to? :record_timestamps
     end
+    
+    context 'record_timestamps is set to false' do
+      before :all do
+        Person.record_timestamps = false
+      end
+      
+      it 'does not update updated_at' do
+        person = Person.new
+        person.run_callbacks(:save)
+        updated_at_before = person.updated_at
+        sleep(1)
+        person.run_callbacks(:save)
+        person.updated_at.should == updated_at_before
+      end
+      
+      it 'does not add created_at' do
+        person = Person.new
+        person.run_callbacks(:create)
+        person.created_at.should == nil
+      end
+    end
 
   end
 


### PR DESCRIPTION
Hello,

I needed this for my project. 

Sometimes you want to skip updating of timestamps. I found this useful, because I was told that object shouldn't have timestamps updated when they are updated from admin interface.

I realize that better solution would be to add something like public timestamp and keep updated_at and created_at **always** updated.

But since you already had this class variable called _record_timestamps_ I kinda felt like this is desired functionality for this variable.

Vojto
vojto@rinik.net
