### PR TITLE
field defaults on existing records

### DIFF
--- a/spec/integration/mongoid/attributes_spec.rb
+++ b/spec/integration/mongoid/attributes_spec.rb
@@ -123,4 +123,42 @@ describe Mongoid::Attributes do
       end
     end
   end
+
+  context "with default value for existed documents" do
+
+    it "overload default for existed documents" do
+      class TeamMember
+        include Mongoid::Document
+
+        field :title
+        field :terms,   :type => Boolean
+        field :aliases, :type => Array
+        field :map,     :type => Hash
+        field :count,   :type => Integer
+      end
+
+      member = TeamMember.new
+      member.save
+      member.title.should be_nil
+      member.terms.should be_false
+      member.aliases.should be_nil
+      member.map.should be_nil
+      member.count.should be_nil
+
+      TeamMember.field :title,   :default => 'CEO'
+      TeamMember.field :terms,   :type => Boolean, :default => true
+      TeamMember.field :aliases, :type => Array,   :default => ['cool', 2]
+      TeamMember.field :map,     :type => Hash,    :default => { :cool => 3 }
+      TeamMember.field :count,   :type => Integer, :default => lambda { 1 + 1 }
+
+      member.reload
+      member.title.should == 'CEO'
+      member.terms.should be_true
+      member.aliases.should == ['cool', 2]
+      member.map.should == { :cool => 3 }
+      member.count.should == 2
+    end
+
+  end
+
 end

--- a/spec/unit/mongoid/attributes_spec.rb
+++ b/spec/unit/mongoid/attributes_spec.rb
@@ -37,9 +37,11 @@ describe Mongoid::Attributes do
         @person = Person.new
       end
 
-      it "does not use the default value" do
+      it "use the default value, but the no need to save it" do
         @person[:age] = nil
-        @person.age.should be_nil
+
+        @person[:age].should be_nil
+        @person.age.should == 100
       end
     end
 
@@ -633,8 +635,9 @@ describe Mongoid::Attributes do
         @person = Person.new(:age => nil)
       end
 
-      it "does not use the default value" do
-        @person.age.should be_nil
+      it "use the default value, but the no need to save it" do
+        @person[:age].should be_nil
+        @person.age.should == 100
       end
     end
 


### PR DESCRIPTION
use the default value for nil save us many "NoMethodError...for Nil"
suppose adding a new attribute which default is empty array, the existed documents should return a empty array even their attributes are nil

all tests passed

See #414 and #447 for more discussion about why this is needed.
