### PR TITLE
references_many should query off foreign_key, then inverse_of, then class name (missing inverse_of now)

### DIFF
--- a/lib/mongoid/associations/options.rb
+++ b/lib/mongoid/associations/options.rb
@@ -28,7 +28,9 @@ module Mongoid #:nodoc:
       # Return the foreign key if it exists, otherwise inflect it from the
       # associated class name.
       def foreign_key
-        key = self[:foreign_key] || klass.name.to_s.foreign_key
+        key = self[:foreign_key] ||
+                (inverse_of ? inverse_of.foreign_key : nil) ||
+                klass.name.to_s.foreign_key
         key.to_s
       end
 


### PR DESCRIPTION
This fixes the following issue, where:

```
class AccountFolder
  references_many :files, :class_name => 'AccountFile', :inverse_of => :folder
end

class AccountFile
  referenced_in :folder, :class_name => 'AccountFolder', :inverse_of => :files
end

some_folder.files
# => queries on :account_folder_id => 123
```

One would expect it to be queried on what the files `:inverse_of` is set to:
    some_folder.files
    # => queries on :folder_id => 123

Without this patch, the above configuration will store AccountFile with a `:folder_id`, but will query on `:account_folder_id`. This simple patch fixes that.
