### PR TITLE
Added accepts_nested_attributes_for support for referenced_in associations.

### DIFF
--- a/lib/mongoid/associations.rb
+++ b/lib/mongoid/associations.rb
@@ -178,8 +178,11 @@ module Mongoid # :nodoc:
       #
       def referenced_in(name, options = {}, &block)
         opts = optionize(name, options, constraint(name, options, :in), &block)
-        Associations::ReferencedIn.validate_options(opts)
-        associate(Associations::ReferencedIn, opts)
+        type = Associations::ReferencedIn
+        type.validate_options(opts)
+        associate(type, opts)
+        add_builder(type, opts)
+        add_creator(type, opts)
         field(opts.foreign_key, :inverse_class_name => opts.class_name, :identity => true)
         index(opts.foreign_key, :background => true) if !embedded? && opts.index
         set_callback(:save, :before) { |document| document.update_foreign_keys }

--- a/lib/mongoid/attributes.rb
+++ b/lib/mongoid/attributes.rb
@@ -219,10 +219,11 @@ module Mongoid #:nodoc:
             association = send(name)
             if association
               # observe(association, true)
-              association.nested_build(attrs, options)
+              association = association.nested_build(attrs, options)
             else
-              send("build_#{name}", attrs, options)
+              association = send("build_#{name}", attrs, options)
             end
+            association.save if association.present? && options[:save_parent]
           end
         end
       end

--- a/spec/integration/mongoid/attributes_spec.rb
+++ b/spec/integration/mongoid/attributes_spec.rb
@@ -122,5 +122,28 @@ describe Mongoid::Attributes do
         person.game.should be_nil
       end
     end
+    
+    context "when the nested document is a referenced_in" do
+      let(:description) { Description.create }
+
+      it "adds a document" do
+        description.update_attributes(:user_attributes => {"name" => "Bob"})
+        description.user.name.should == "Bob"
+      end
+
+      it "updates a document" do
+        user = description.create_user(:name => "Suzy")
+        description.update_attributes(:user_attributes => {"name" => "Tony"})
+        description.user.name.should == "Tony"
+        user.reload.name.should == "Tony"
+      end
+
+      it "deletes a document" do
+        user = description.create_user(:name => "Suzy")
+        description.update_attributes(:user_attributes => {"_destroy" => "1"})
+        description.user.should be_nil
+        lambda { User.find(user.id) }.should raise_error(Mongoid::Errors::DocumentNotFound)
+      end
+    end
   end
 end

--- a/spec/models/description.rb
+++ b/spec/models/description.rb
@@ -5,4 +5,6 @@ class Description
 
   referenced_in :user
   referenced_in :updater, :class_name => 'User'
+  
+  accepts_nested_attributes_for :user, :allow_destroy => true, :save_parent => true
 end


### PR DESCRIPTION
Currently, you cannot use nested attribute forms with referenced_in associations because accepts_nested_attributes_for doesn't support referenced_in associations. This fix adds support for it, and includes a new option on accepts_nested_attributes_for called :save_parent, which allows you to update the parent model (referenced_in association) just as if it were a child model.
