### PR TITLE
Fix deprecated generators call

### DIFF
--- a/lib/mongoid/railtie.rb
+++ b/lib/mongoid/railtie.rb
@@ -10,7 +10,7 @@ module Rails #:nodoc:
   module Mongoid #:nodoc:
     class Railtie < Rails::Railtie #:nodoc:
 
-      config.generators.orm :mongoid, :migration => false
+      config.app_generators.orm :mongoid, :migration => false
 
       rake_tasks do
         load "mongoid/railties/database.rake"


### PR DESCRIPTION
Hey, 

This pull request just fixes a small issue with mongoid: in the Railtie you're using generators when the new method in Rails 3.1 is app_generators.
