### PR TITLE
Added MongoDB auth in mongoid 1.9.x

### DIFF
--- a/spec/config/mongoid_authentication.yml
+++ b/spec/config/mongoid_authentication.yml
@@ -1,0 +1,4 @@
+test:
+  username: kate
+  password: secret
+  database: mongoid_config_test

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,6 +26,6 @@ Dir[ File.join(MODELS, "*.rb") ].sort.each { |file| require File.basename(file) 
 Spec::Runner.configure do |config|
   config.mock_with :mocha
   config.after :suite do
-    Mongoid.master.collections.each(&:drop)
+    Mongoid.master.collections.each(&:drop) if Mongoid.master.is_a?(Mongo::DB)
   end
 end


### PR DESCRIPTION
Mongoid 1.9.x didn't support MongoDB in non-trusted mode (when authentication required).
I've copied that code from mongoid 2.x, plus I've added specs.
