### PR TITLE
Make #update_attributes work for new records as well

### DIFF
--- a/lib/mongoid/persistence.rb
+++ b/lib/mongoid/persistence.rb
@@ -89,7 +89,7 @@ module Mongoid #:nodoc:
     #
     # +true+ if validation passed, +false+ if not.
     def update_attributes(attributes = {})
-      write_attributes(attributes); update
+      write_attributes(attributes); save
     end
 
     # Update the +Document+ attributes in the datbase.
@@ -102,8 +102,7 @@ module Mongoid #:nodoc:
     #
     # +true+ if validation passed, raises an error if not
     def update_attributes!(attributes = {})
-      write_attributes(attributes)
-      result = update
+      result = update_attributes(attributes)
       self.class.fail_validate!(self) unless result
       result
     end

--- a/spec/integration/mongoid/persistence_spec.rb
+++ b/spec/integration/mongoid/persistence_spec.rb
@@ -296,12 +296,10 @@ describe Mongoid::Persistence do
   end
 
   describe "#update_attributes" do
-
-    before do
-      @person.save
-    end
-
     context "when validation passes" do
+      before do
+        @person.save
+      end
 
       it "returns true" do
         @person.update_attributes(:ssn => "555-55-1234").should be_true
@@ -313,6 +311,13 @@ describe Mongoid::Persistence do
         @from_db.ssn.should == "555-55-1235"
         @from_db.pets.should == false
         @from_db.title.should be_nil
+      end
+    end
+
+    context "on a new record" do
+      it "saves the new record" do
+        @person.update_attributes(:ssn => "555-55-1235", :pets => false, :title => nil)
+        Person.find(@person.id).should_not be_nil
       end
     end
   end


### PR DESCRIPTION
This is a fix for #486. The problem was that `#update_attributes` before my patch looked like this:

```
def update_attributes(attributes = {})
  write_attributes(attributes); update
end
```

which does not work for new records, since `#update` internally only performs an update if `@document._updates` is not empty (and it always is on a new record). As `#save` already has logic for calling `#insert` when a record is new, and `#update` if it is not, we just use that instead of `#update` directly.

The commit also makes `#update_attributes!` use `#update_attributes` instead of duplicating its code to get the result, thus making both methods work as expected on new records and DRY.
