### PR TITLE
Provides a repeatable rspec test to check all locales can be loaded (test for issue 502)

### DIFF
--- a/spec/unit/mongoid/locales_spec.rb
+++ b/spec/unit/mongoid/locales_spec.rb
@@ -1,0 +1,11 @@
+require "spec_helper"
+
+describe "locales" do
+
+  Dir.glob("lib/config/locales/*.yml").sort.each do |file|
+    it "no parsing errors for locale #{file}" do
+      expect { YAML.load_file(file) }.to_not raise_error
+    end
+  end
+
+end


### PR DESCRIPTION
The commit adds spec/unit/mongoid/locales_spec.rb that tries to load all available locales. The test fails for me at the moment for Korean locale (kr.yml) as specified in issue 502:

https://github.com/mongoid/mongoid/issues#issue/502

Please consider putting the spec in a place where it is not run all the time but just to check the release is ready to be posted. For me it adds a sec to run all tests. Thanks!
