### PR TITLE
Using update_attributes! with safely doesn't work with a failed validation

### DIFF
--- a/lib/mongoid/safety.rb
+++ b/lib/mongoid/safety.rb
@@ -199,7 +199,7 @@ module Mongoid #:nodoc:
       def update_attributes!(attributes = {})
         target.write_attributes(attributes)
         update(:safe => safety_options).tap do |result|
-          target.class.fail_validate!(self) unless result
+          target.class.fail_validate!(target) unless result
         end
       end
     end


### PR DESCRIPTION
Using safely and update_attributes! together when trying to update an invalid document causes and ArgumentError. Some sample code that demonstrates the problem:

https://gist.github.com/769611

The error is due to the proxy object created when using safely trying to proxy the safe attributes through when the failed validation handler tries to access the errors on the object. Passing the original document to the failed validation handler solves the argument error problem.
