### PR TITLE
fix rails edge deprecation message

### DIFF
--- a/lib/mongoid/extras.rb
+++ b/lib/mongoid/extras.rb
@@ -3,7 +3,7 @@ module Mongoid #:nodoc:
   module Extras #:nodoc:
     extend ActiveSupport::Concern
     included do
-      class_inheritable_accessor :cached, :enslaved
+      class_attribute :cached, :enslaved
       self.cached = false
       self.enslaved = false
       delegate :cached?, :enslaved?, :to => "self.class"

--- a/lib/mongoid/fields.rb
+++ b/lib/mongoid/fields.rb
@@ -5,7 +5,7 @@ module Mongoid #:nodoc
     included do
       # Set up the class attributes that must be available to all subclasses.
       # These include defaults, fields
-      class_inheritable_accessor :fields
+      class_attribute :fields
 
       self.fields = {}
       delegate :defaults, :fields, :to => "self.class"

--- a/lib/mongoid/relations/cascading.rb
+++ b/lib/mongoid/relations/cascading.rb
@@ -13,7 +13,7 @@ module Mongoid # :nodoc:
       extend ActiveSupport::Concern
 
       included do
-        class_inheritable_accessor :cascades
+        class_attribute :cascades
         self.cascades = []
         delegate :cascades, :to => "self.class"
       end

--- a/lib/mongoid/relations/macros.rb
+++ b/lib/mongoid/relations/macros.rb
@@ -9,7 +9,7 @@ module Mongoid # :nodoc:
 
       included do
         cattr_accessor :embedded
-        class_inheritable_accessor :relations
+        class_attribute :relations
         self.embedded = false
         self.relations = {}
 

--- a/lib/mongoid/relations/polymorphic.rb
+++ b/lib/mongoid/relations/polymorphic.rb
@@ -8,7 +8,7 @@ module Mongoid # :nodoc:
       extend ActiveSupport::Concern
 
       included do
-        class_inheritable_accessor :polymorphic
+        class_attribute :polymorphic
         delegate :polymorphic?, :to => "self.class"
       end
 

--- a/lib/mongoid/timestamps.rb
+++ b/lib/mongoid/timestamps.rb
@@ -13,7 +13,7 @@ module Mongoid #:nodoc:
       set_callback :create, :before, :set_created_at
       set_callback :save, :before, :set_updated_at
 
-      class_inheritable_accessor :record_timestamps, :instance_writer => false
+      class_attribute :record_timestamps, :instance_writer => false
       self.record_timestamps = true
     end
 


### PR DESCRIPTION
class_inheritance_accessor is deprecated in rails edge. Replaced it with class_attribute method.
