### PR TITLE
fix rails edge error when starting server in production mode

### DIFF
--- a/lib/rails/mongoid.rb
+++ b/lib/rails/mongoid.rb
@@ -9,7 +9,7 @@ module Rails #:nodoc:
       def load_models(app)
         app.config.paths['app/models'].each do |path|
           Dir.glob("#{path}/**/*.rb").sort.each do |file|
-            require_dependency(file)
+            require_dependency(File.basename(file, ".rb"))
           end
         end
       end


### PR DESCRIPTION
When config.cache_classes = true mongoid fall with 

> /home/kes/.rvm/gems/ruby-1.9.2-p136@easybt/bundler/gems/rails-ec960c3730ed/activesupport/lib/active_support/dependencies.rb:304:in `rescue in depend_on': No such file to load -- app/models/ability (LoadError)
