### PR TITLE
Korrean translation-file does cause errors, when used with i18n

### DIFF
--- a/lib/config/locales/kr.yml
+++ b/lib/config/locales/kr.yml
@@ -8,43 +8,43 @@ kr:
     errors:
       messages:
         document_not_found:
-		클라스 %{klass}와 id를 %{identifiers} 위한 문서를 찾을수 없습니다.
+          클라스 %{klass}와 id를 %{identifiers} 위한 문서를 찾을수 없습니다.
           #Document not found for class %{klass} with id(s) %{identifiers}.
 
         invalid_database:
-		데이타베이스가 Mongo::DB이어야 합니다, %{name}이면 안됩니다.
+          데이타베이스가 Mongo::DB이어야 합니다, %{name}이면 안됩니다.
           #Database should be a Mongo::DB, not %{name}.
 
         invalid_type:
-		데이터 필드가 %{klass} 처럼 정의를 내립니다. 하지만 그것은  %{other}를 %{value} 으로 산출되어  받습니다
+          데이터 필드가 %{klass} 처럼 정의를 내립니다. 하지만 그것은  %{other}를 %{value} 으로 산출되어  받습니다
           #Field was defined as a(n) %{klass}, but received a %{other} with
           #the value %{value}.
 
         unsupported_version:
-		MongoDB %{version} 를 사용할수 없습니다. %{mongo_version} 으로 업그레이드 시켜주세요.
+          MongoDB %{version} 를 사용할수 없습니다. %{mongo_version} 으로 업그레이드 시켜주세요.
           #MongoDB %{version} not supported, please upgrade
           #to %{mongo_version}.
 
         validations:
-		 확인할수 없습니다 - %{errors}.
+          확인할수 없습니다 - %{errors}.
           #Validation failed - %{errors}.
 
         invalid_collection:
-		 %{klass} 를 위한 콜렉션에 접근하는것은 임베디드 문서이게 때문에 허락되지 않습니다. 루트 문서에서 콜렉션을 접근해 주세요
+          %{klass} 를 위한 콜렉션에 접근하는것은 임베디드 문서이게 때문에 허락되지 않습니다. 루트 문서에서 콜렉션을 접근해 주세요
           #Access to the collection for %{klass} is not allowed since it
           #is an embedded document, please access a collection from
           #the root document.
 
         invalid_field:
-		필드의 정의를 %{name}으로 이름짓는것은 허락되지 않습니다. 
-		Mongoid 내부의 속성과 메서드이름이 충돌이 되므로 필드의 정의를 내리지 마세요. 
-		어떤이름이 포함되는지 보려면 Document#instance_methods를 사용하세요.
+          필드의 정의를 %{name}으로 이름짓는것은 허락되지 않습니다.
+          Mongoid 내부의 속성과 메서드이름이 충돌이 되므로 필드의 정의를 내리지 마세요.
+          어떤이름이 포함되는지 보려면 Document#instance_methods를 사용하세요.
           #Defining a field named %{name} is not allowed. Do not define
           #fields that conflict with Mongoid internal attributes or method
           #names. Use Document#instance_methods to see what names this includes.
-        
-	too_many_nested_attribute_records:
-		 %{association} 을 위한 내부의 속성을 수용하는것은 %{limit}데이터로 제한되어있습니다.
+
+        too_many_nested_attribute_records:
+          %{association} 을 위한 내부의 속성을 수용하는것은 %{limit}데이터로 제한되어있습니다.
           #Accepting nested attributes for %{association} is limited
           #to %{limit} records.
 
@@ -53,13 +53,13 @@ kr:
           #Options for embedded_in association must include inverse_of.
 
         dependent_only_references_one_or_many:
-		공급되는 dependent => destroy|delete  옵션은 오직  references_one 또는 references_many 관련되는것에서만 확인 가능합니다.
+          공급되는 dependent => destroy|delete  옵션은 오직  references_one 또는 references_many 관련되는것에서만 확인 가능합니다.
           #The dependent => destroy|delete option that was supplied
           #is only valid on references_one or references_many associations.
 
         association_cant_have_inverse_of:
- 		 이관련된것에서 inverse_of 처럼  정의내리는것은 허락되지 않습니다. 
-		 오직 embedded_in 에있는 옵션 또는 array된 references_many 옵션을 사용하세요
+          이관련된것에서 inverse_of 처럼  정의내리는것은 허락되지 않습니다.
+          오직 embedded_in 에있는 옵션 또는 array된 references_many 옵션을 사용하세요
           #Defining an inverse_of on this association is not allowed. Only
           #use this option on embedded_in or references_many as array.
 


### PR DESCRIPTION
Hello everyone.

I tried to just create a small application with i18n. Then I got an error about ArgumentError about a "syntax error on line 13, col 25 ... invalid_database". 
This happened, when i18n was trying to parse lib/config/locales/kr.yml, and had problems with the tabs. 
This commit should fix it.
