### PR TITLE
accept_nested_attributes_for :reject_if => :all_blank changes 2.0.0.rc.1+

### DIFF
--- a/lib/mongoid/nested_attributes.rb
+++ b/lib/mongoid/nested_attributes.rb
@@ -4,6 +4,7 @@ module Mongoid #:nodoc:
     extend ActiveSupport::Concern
 
     module ClassMethods
+      REJECT_ALL_BLANK_PROC = proc { |attributes| attributes.all? { |_, value| value.blank? } }
 
       # Used when needing to update related models from a parent relation. Can
       # be used on embedded or referenced relations.
@@ -29,6 +30,7 @@ module Mongoid #:nodoc:
       # @option *args [ true, false ] :update_only Only update existing docs.
       def accepts_nested_attributes_for(*args)
         options = args.extract_options!
+        options[:reject_if] = REJECT_ALL_BLANK_PROC if options[:reject_if] == :all_blank
         args.each do |name|
           define_method("#{name}_attributes=") do |attrs|
             relation = relations[name.to_s]

--- a/spec/integration/mongoid/nested_attributes_spec.rb
+++ b/spec/integration/mongoid/nested_attributes_spec.rb
@@ -52,6 +52,42 @@ describe Mongoid::NestedAttributes do
           end
         end
 
+        context "when :reject_if => :all_blank is specified" do
+
+          before :all do
+            Person.send(:undef_method, :name_attributes=)
+            Person.accepts_nested_attributes_for \
+              :name, :reject_if => :all_blank
+          end
+
+          after :all do
+            Person.send(:undef_method, :name_attributes=)
+            Person.accepts_nested_attributes_for :name
+          end
+
+          context "when all attributes are empty" do
+
+            before do
+              person.name_attributes = { :last_name => "" }
+            end
+
+            it "does not add the document" do
+              person.name.should be_nil
+            end
+          end
+
+          context "when an attribute is non-empty" do
+
+            before do
+              person.name_attributes = { :first_name => "Lang" }
+            end
+
+            it "adds the document" do
+              person.name.first_name.should == "Lang"
+            end
+          end
+        end
+
         context "when no id has been passed" do
 
           context "with no destroy attribute" do
@@ -923,6 +959,48 @@ describe Mongoid::NestedAttributes do
             end
           end
 
+          context "when :reject_if => :all_blank is supplied" do
+
+            before :all do
+              Person.send(:undef_method, :addresses_attributes=)
+              Person.accepts_nested_attributes_for \
+                :addresses, :reject_if => :all_blank
+            end
+
+            after :all do
+              Person.send(:undef_method, :addresses_attributes=)
+              Person.accepts_nested_attributes_for :addresses
+            end
+
+            context "when all attributes are empty" do
+
+              before do
+                person.addresses_attributes =
+                  { "3" => { "city" => "" } }
+              end
+
+              it "does not add the new document" do
+                person.addresses.should be_empty
+              end
+            end
+
+            context "when an attribute is not-empty" do
+
+              before do
+                person.addresses_attributes =
+                  { "3" => { "street" => "Maybachufer" } }
+              end
+
+              it "adds the new document" do
+                person.addresses.size.should == 1
+              end
+
+              it "sets the correct attributes" do
+                person.addresses.first.street.should == "Maybachufer"
+              end
+            end
+          end
+
           context "when destroy attributes are passed" do
 
             context "when allow_destroy is true" do
@@ -1145,6 +1223,42 @@ describe Mongoid::NestedAttributes do
           end
 
           context "when the attributes do not match" do
+
+            before do
+              person.game_attributes = { :name => "Tron" }
+            end
+
+            it "adds the document" do
+              person.game.name.should == "Tron"
+            end
+          end
+        end
+
+        context "when reject_if => :all_blank is specified" do
+
+          before :all do
+            Person.send(:undef_method, :game_attributes=)
+            Person.accepts_nested_attributes_for \
+              :game, :reject_if => :all_blank
+          end
+
+          after :all do
+            Person.send(:undef_method, :game_attributes=)
+            Person.accepts_nested_attributes_for :game
+          end
+
+          context "when all attributes are empty" do
+
+            before do
+              person.game_attributes = { :score => nil }
+            end
+
+            it "does not add the document" do
+              person.game.should be_nil
+            end
+          end
+
+          context "when an attribute is non-empty" do
 
             before do
               person.game_attributes = { :name => "Tron" }
@@ -2052,6 +2166,48 @@ describe Mongoid::NestedAttributes do
             end
           end
 
+          context "when :reject_if => :all_blank is supplied" do
+
+            before :all do
+              Person.send(:undef_method, :posts_attributes=)
+              Person.accepts_nested_attributes_for \
+                :posts, :reject_if => :all_blank
+            end
+
+            after :all do
+              Person.send(:undef_method, :posts_attributes=)
+              Person.accepts_nested_attributes_for :posts
+            end
+
+            context "when all attributes are blank" do
+
+              before do
+                person.posts_attributes =
+                  { "3" => { "content" => "" } }
+              end
+
+              it "does not add the new document" do
+                person.posts.should be_empty
+              end
+            end
+
+            context "when an attribute is non-empty" do
+
+              before do
+                person.posts_attributes =
+                  { "3" => { "title" => "Blogging" } }
+              end
+
+              it "adds the new document" do
+                person.posts.size.should == 1
+              end
+
+              it "sets the correct attributes" do
+                person.posts.first.title.should == "Blogging"
+              end
+            end
+          end
+
           context "when destroy attributes are passed" do
 
             context "when allow_destroy is true" do
@@ -2616,6 +2772,48 @@ describe Mongoid::NestedAttributes do
             end
 
             context "when the attributes do not match" do
+
+              before do
+                person.preferences_attributes =
+                  { "3" => { "name" => "Blogging" } }
+              end
+
+              it "adds the new document" do
+                person.preferences.size.should == 1
+              end
+
+              it "sets the correct attributes" do
+                person.preferences.first.name.should == "Blogging"
+              end
+            end
+          end
+
+          context "when :reject_if => :all_blank is supplied" do
+
+            before :all do
+              Person.send(:undef_method, :preferences_attributes=)
+              Person.accepts_nested_attributes_for \
+                :preferences, :reject_if => :all_blank
+            end
+
+            after :all do
+              Person.send(:undef_method, :preferences_attributes=)
+              Person.accepts_nested_attributes_for :preferences
+            end
+
+            context "when all attributes are empty" do
+
+              before do
+                person.preferences_attributes =
+                  { "3" => { "content" => "" } }
+              end
+
+              it "does not add the new document" do
+                person.preferences.should be_empty
+              end
+            end
+
+            context "when an attribute is non-empty" do
 
               before do
                 person.preferences_attributes =


### PR DESCRIPTION
Hello,

This pull request adds the :reject_if => :all_blank option for accept_nested_attributes_for, as well as the corresponding tests.

The changes have been made and tested on version 2.0.0.rc.1.
