### PR TITLE
Added replica set support

### DIFF
--- a/lib/mongoid/config.rb
+++ b/lib/mongoid/config.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 require "uri"
 require "mongoid/config/database"
+require "mongoid/config/replset_database"
 
 module Mongoid #:nodoc
 
@@ -315,7 +316,11 @@ module Mongoid #:nodoc
     #
     # @since 2.0.0.rc.1
     def configure_databases(options)
-      @master, @slaves = Database.new(options).configure
+      if options.has_key?('hosts')
+        @master, @slaves = ReplsetDatabase.new(options).configure
+      else
+        @master, @slaves = Database.new(options).configure
+      end
     end
 
     # Get the secondary databases from settings.

--- a/lib/mongoid/config/replset_database.rb
+++ b/lib/mongoid/config/replset_database.rb
@@ -1,0 +1,49 @@
+# encoding: utf-8
+module Mongoid #:nodoc:
+  module Config #:nodoc:
+    class ReplsetDatabase < Hash
+
+      # Configure the database connections. This will return an array
+      # containing one Mongo::DB and nil (to keep compatibility with Mongoid::Config::Database)
+      # If you want the reads to go to a secondary node use the :read_secondary(true): option
+      #
+      # @example Configure the connection.
+      #   db.configure
+      #
+      # @return [ Array<Mongo::DB, nil ] The Mongo databases.
+      #
+      # @since #TODO
+      def configure
+        #yes, construction is weird but the driver wants "A list of host-port pairs ending with a hash containing any options"
+        #mongo likes symbols
+        options = self.inject({}) { |memo, (k, v)| memo[k.to_sym] = v; memo}
+        connection = Mongo::ReplSetConnection.new(*(self['hosts'] << options))
+        [ connection.db(self['database']), nil ]
+      end
+
+      # Create the new db configuration class.
+      #
+      # @example Initialize the class.
+      #   Config::ReplsetDatabase.new(
+      #     "hosts" => [[host1,port1],[host2,port2]]
+      #   )
+      #
+      # replSet does not supports auth
+      #
+      # @param [ Hash ] options The configuration options.
+      #
+      # @option options [ Array ] :hosts The database host.
+      # @option options [ String ] :database The database name.
+      # @option options [ Boolean ] :read_secondary Tells the driver to read from secondaries.
+      # ...
+      #
+      # @see Mongo::ReplSetConnection for all options
+      #
+      # @since #TODO
+      def initialize(options = {})
+        merge!(options)
+      end
+      
+    end
+  end
+end

--- a/spec/config/mongoid.replset.yml
+++ b/spec/config/mongoid.replset.yml
@@ -1,0 +1,15 @@
+defaults: &defaults
+  hosts: [[localhost, 27017], [localhost, 27017]]
+  read_secondary: true
+  allow_dynamic_fields: false
+  parameterize_keys: false
+  persist_in_safe_mode: false
+  raise_not_found_error: false
+  reconnect_time: 5
+  persist_types: false
+  option_no_exist: false
+  skip_version_check: false
+
+test:
+  <<: *defaults
+  database: mongoid_config_test

--- a/spec/integration/mongoid/config/replset_database_spec.rb
+++ b/spec/integration/mongoid/config/replset_database_spec.rb
@@ -1,0 +1,21 @@
+require "spec_helper"
+
+describe Mongoid::Config::ReplsetDatabase do
+
+  let(:replset_config) do
+    File.join(File.dirname(__FILE__), "..", "..", "..", "config", "mongoid.replset.yml")
+  end
+
+  describe "#configure" do
+
+    it "should create a valid Mongo::ReplSetConnection" do
+      options = YAML.load(ERB.new(File.new(replset_config).read).result)
+      res = described_class.new(options['test']).configure
+      res[0].connection.should be_a(Mongo::ReplSetConnection)
+      res[0].connection.slave_ok?.should be_true
+      res[1].should be_nil
+    end
+
+  end
+
+end

--- a/spec/integration/mongoid/config_spec.rb
+++ b/spec/integration/mongoid/config_spec.rb
@@ -19,9 +19,13 @@ describe Mongoid::Config do
     File.join(File.dirname(__FILE__), "..", "..", "config", "mongoid_with_multiple_mongos.yml")
   end
 
+  let(:replset_config) do
+    File.join(File.dirname(__FILE__), "..", "..", "config", "mongoid.replset.yml")
+  end
+
   after(:all) do
     Mongoid.configure do |config|
-      name = "mongoid_test"
+      name          = "mongoid_test"
       config.master = Mongo::Connection.new.db(name)
       config.slaves = []
       config.logger = nil
@@ -43,7 +47,7 @@ describe Mongoid::Config do
 
       it "adds the language" do
         I18n.translate("activemodel.errors.messages.taken").should ==
-          "ist bereits vergeben"
+                "ist bereits vergeben"
       end
     end
   end
@@ -150,6 +154,19 @@ describe Mongoid::Config do
         end
       end
     end
+
+    context "when configured with replset", :config => :replset_config do
+
+      let(:settings) do
+        YAML.load(ERB.new(File.new(replset_config).read).result)
+      end
+
+      it "should create a regular Mongo::ReplSetConnection" do
+        described_class.master.connection.should be_a Mongo::ReplSetConnection
+      end
+
+    end
+
   end
 
   describe ".logger" do
@@ -309,7 +326,7 @@ describe Mongoid::Config do
 
       before do
         described_class.slaves = [
-          Mongo::Connection.new("localhost", 27018, :slave_ok => true).db("mongoid_test")
+                Mongo::Connection.new("localhost", 27018, :slave_ok => true).db("mongoid_test")
         ]
       end
 
@@ -336,7 +353,7 @@ describe Mongoid::Config do
 
       before do
         described_class.slaves = [
-          Mongo::Connection.new("localhost", 27018, :slave_ok => true).db("mongoid_test")
+                Mongo::Connection.new("localhost", 27018, :slave_ok => true).db("mongoid_test")
         ]
       end
 
@@ -349,9 +366,10 @@ describe Mongoid::Config do
 
       it "raises an error" do
         expect {
-          described_class.slaves = [ :testing ]
+          described_class.slaves = [:testing]
         }.to raise_error(Mongoid::Errors::InvalidDatabase)
       end
     end
   end
+
 end


### PR DESCRIPTION
Hi,

I have added support to connect to a replica set using Mongo::ReplSetConnection.

When the key 'hosts' is present instead of 'host' @master.connection is a Mongo::ReplSetConnection, @slave is nil.
Adding the read_secondary: true option in the yml will make the reads go to a random server in the set (but the driver is handling this).

2 new tests, all tests pass.

I realize I have reformatted the config_spec.rb file (sorry, bad habbit) but the damage is minimal.

Thanks

--Gilles
