### PR TITLE
use the association name as foreign key

### DIFF
--- a/lib/mongoid/relations/metadata.rb
+++ b/lib/mongoid/relations/metadata.rb
@@ -420,7 +420,7 @@ module Mongoid # :nodoc:
         suffix = relation.foreign_key_suffix
         if relation.stores_foreign_key?
           if relation.macro == :references_and_referenced_in_many
-            class_name.underscore << suffix
+            name.to_s.singularize << suffix
           else
             name.to_s << suffix
           end

--- a/spec/unit/mongoid/relations/metadata_spec.rb
+++ b/spec/unit/mongoid/relations/metadata_spec.rb
@@ -234,6 +234,34 @@ describe Mongoid::Relations::Metadata do
           it "returns the foreign_key" do
             metadata.foreign_key.should == "person_ids"
           end
+
+          context "given a specific foreign key" do
+            let(:metadata) do
+            described_class.new(
+                :name => :follower,
+                :foreign_key => :follower_list,
+                :relation => Mongoid::Relations::Referenced::ManyToMany
+              )
+            end
+
+            it "returns the foreign_key" do
+              metadata.foreign_key.should == "follower_list"
+            end
+          end
+
+          context "using name as foreign key" do
+            let(:metadata) do
+            described_class.new(
+                :name => :followers,
+                :class_name => "Person",
+                :relation => Mongoid::Relations::Referenced::ManyToMany
+              )
+            end
+
+            it "returns the foreign_key" do
+              metadata.foreign_key.should == "follower_ids"
+            end
+          end
         end
       end
 


### PR DESCRIPTION
currently it is incompatible with previous versions of mongoid, for example if I define

```
references_and_referenced_in_many :followers, :class_name => "User"
```

the foreign key is "user_ids" (which is wrong)

this change fixes this issue
