### PR TITLE
Count skip and limit

### DIFF
--- a/lib/mongoid/contexts/mongo.rb
+++ b/lib/mongoid/contexts/mongo.rb
@@ -53,7 +53,10 @@ module Mongoid #:nodoc:
       end
       alias :empty? :blank?
 
-      # Get the count of matching documents in the database for the context.
+      # Get the count of matching documents in the database for the context. 
+      # 
+      # @param [Boolean] skip_and_limit True to inclued previous skip/limit 
+      #   statements in the count; false to ignore them. Defaults to `true`.
       #
       # Example:
       #
@@ -62,8 +65,8 @@ module Mongoid #:nodoc:
       # Returns:
       #
       # An +Integer+ count of documents.
-      def count
-        @count ||= klass.collection.find(selector, process_options).count
+      def count(skip_and_limit = false)
+        @count ||= klass.collection.find(selector, process_options).count(skip_and_limit)
       end
 
       # Delete all the documents in the database matching the selector.

--- a/spec/integration/mongoid/contexts/mongo_spec.rb
+++ b/spec/integration/mongoid/contexts/mongo_spec.rb
@@ -34,6 +34,53 @@ describe Mongoid::Contexts::Mongo do
     end
   end
 
+  describe "#count" do
+    
+    context "when documents exist in the collection" do
+
+      before do
+        13.times do |n|
+          Person.create(
+            :title => "Sir",
+            :age => ((n + 1) * 10),
+            :aliases => ["D", "Durran"],
+            :ssn => "#{n}"
+          )
+        end
+      end
+
+      context "without skip or limit" do
+        it "returns the number of documents" do
+          Person.count.should == 13
+        end
+      end
+
+      context "with skip and limit" do
+
+        context "by default" do
+
+          it "ignores previous offset/limit statements" do
+            Person.limit(5).offset(10).count.should == 13
+          end
+        end
+
+        context "when passed 'true'" do
+
+          it "includes previous offset/limit statements" do
+            Person.limit(5).offset(5).count(true).should == 5
+          end
+        end
+
+        context "when passed 'false'" do
+
+          it "ignores previous offset/limit statements" do
+            Person.limit(5).offset(10).count(false).should == 13
+          end
+        end
+      end
+    end
+  end
+
   describe "#max" do
 
     context "when no documents are in the collection" do


### PR DESCRIPTION
Here are the changes mentioned in this thread on the message group: http://groups.google.com/group/mongoid/browse_thread/thread/8ae4215267f5fbe0 count defaults to 'false' which keeps consistent with its current behavior, as well as ActiveRecord. I know it's undecided on the group, but I figured I would just toss it up here. You can take it or reject it if you want.
