### PR TITLE
Fix for undefined method `distinct' for references_many association in 2.0.0.rc.5 and rc.6

### DIFF
--- a/lib/mongoid/relations/referenced/many.rb
+++ b/lib/mongoid/relations/referenced/many.rb
@@ -312,7 +312,7 @@ module Mongoid #:nodoc:
           load!(:binding => true) and return super if [].respond_to?(name)
           klass = metadata.klass
           klass.send(:with_scope, criteria) do
-            klass.send(name, *args)
+            criteria.send(name, *args)
           end
         end
 

--- a/spec/integration/mongoid/relations/referenced/many_spec.rb
+++ b/spec/integration/mongoid/relations/referenced/many_spec.rb
@@ -1699,6 +1699,13 @@ describe Mongoid::Relations::Referenced::Many do
         posts.should == [ post_one ]
       end
     end
+
+    #TODO: spec for other delegated methods like : group, aggregate...?
+    context "delegated methods" do
+      it "#distinct" do
+        person.posts.distinct(:title).should =~ [ "First",  "Second"]
+      end
+    end
   end
 
   describe "#nullify_all" do


### PR DESCRIPTION
see issue : https://github.com/mongoid/mongoid/issues/issue/568
