### PR TITLE
Unset @context on Criteria#clone

### DIFF
--- a/lib/mongoid/criteria.rb
+++ b/lib/mongoid/criteria.rb
@@ -297,6 +297,7 @@ module Mongoid #:nodoc:
     def initialize_copy(other)
       @selector = other.selector.dup
       @options = other.options.dup
+      @context = nil
     end
 
     # Update the selector setting the operator on the value for each key in the

--- a/spec/unit/mongoid/criteria_spec.rb
+++ b/spec/unit/mongoid/criteria_spec.rb
@@ -1000,4 +1000,11 @@ describe Mongoid::Criteria do
       end
     end
   end
+
+  context "when chaining criteria after an initial execute" do
+    it 'should not carry scope to cloned criteria' do
+      criteria.first
+      criteria.limit(1).context.options[:limit].should == 1
+    end
+  end
 end


### PR DESCRIPTION
Howdy,

I noticed a problem where I get results back from a Criteria, and then continue chaining on to it -- the chained criteria when executed were acting as if the chains had never happened. I tracked this down to the fact that the memoized `@context` ivar is being copied over by Ruby's `Object#clone` method, and that memoized Context still refers to the original Criteria.

Simple fix just to clear out `@context` in `initialize_copy`. Patch includes a spec that failed before fixing; hope that was the right place to put the spec.

Cheers,
Mat
