### PR TITLE
dup mutable class_attributes

### DIFF
--- a/lib/mongoid/nested_attributes.rb
+++ b/lib/mongoid/nested_attributes.rb
@@ -39,7 +39,7 @@ module Mongoid #:nodoc:
         options = args.extract_options!
         options[:reject_if] = REJECT_ALL_BLANK_PROC if options[:reject_if] == :all_blank
         args.each do |name|
-          nested_attributes << "#{name}_attributes="
+          self.nested_attributes += [ "#{name}_attributes=" ]
           define_method("#{name}_attributes=") do |attrs|
             relation = relations[name.to_s]
             relation.nested_builder(attrs, options).build(self)

--- a/lib/mongoid/relations/cascading.rb
+++ b/lib/mongoid/relations/cascading.rb
@@ -47,7 +47,7 @@ module Mongoid # :nodoc:
         #
         # @since 2.0.0.rc.1
         def cascade(metadata)
-          tap { cascades << metadata.name.to_s if metadata.dependent? }
+          tap { self.cascades += [ metadata.name.to_s ] if metadata.dependent? }
         end
       end
     end

--- a/lib/mongoid/relations/macros.rb
+++ b/lib/mongoid/relations/macros.rb
@@ -297,7 +297,7 @@ module Mongoid # :nodoc:
         # @param [ Symbol ] name The name of the relation.
         # @param [ Metadata ] metadata The metadata for the relation.
         def relate(name, metadata)
-          relations[name.to_s] = metadata
+          self.relations = relations.merge(name.to_s => metadata)
           getter(name, metadata).setter(name, metadata)
         end
       end

--- a/spec/functional/mongoid/inheritance_spec.rb
+++ b/spec/functional/mongoid/inheritance_spec.rb
@@ -226,5 +226,10 @@ describe Mongoid::Document do
       @container.vehicles.create({},Truck)
       @container.vehicles.map(&:class).should == [Car,Truck]
     end
+
+    it "should not bleed relations from one subclass to another" do
+      Truck.relations.keys.should =~ %w/ shipping_container bed /
+      Car.relations.keys.should =~ %w/ shipping_container /
+    end
   end
 end

--- a/spec/models/inheritance.rb
+++ b/spec/models/inheritance.rb
@@ -82,6 +82,9 @@ class Vehicle
   include Mongoid::Document
   referenced_in :shipping_container
 end
+class Bed; end
 class Car < Vehicle; end
-class Truck < Vehicle; end
+class Truck < Vehicle
+  embeds_one :bed
+end
 


### PR DESCRIPTION
fixes #592. the documentation for `class_attribute` advises using `+=` or similar for mutable objects that are class attributes. I went through and added this for any mutable `class_attribute` and added a test for at least `references_many` and the `relations` class_attribute.
