### PR TITLE
references_many should return [] during initialization of the parent

### DIFF
--- a/lib/mongoid/relations/referenced/many.rb
+++ b/lib/mongoid/relations/referenced/many.rb
@@ -343,7 +343,7 @@ module Mongoid #:nodoc:
           #
           # @since 2.0.0.rc.1
           def builder(meta, object)
-            Builders::Referenced::Many.new(meta, object)
+            Builders::Referenced::Many.new(meta, object || [])
           end
 
           # Returns true if the relation is an embedded one. In this case

--- a/spec/functional/mongoid/relations/builders/referenced/many_spec.rb
+++ b/spec/functional/mongoid/relations/builders/referenced/many_spec.rb
@@ -15,6 +15,16 @@ describe Mongoid::Relations::Builders::Referenced::Many do
         it "returns an empty array" do
           person.posts.should be_empty
         end
+
+        context "during initialization" do
+
+          it "returns an empty array" do
+            Person.new do |p|
+              p.posts.should be_empty
+              p.posts.metadata.should_not be_nil
+            end
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
during document initialization, `references_many` relations currently return `nil` with no metadata present to introspect. this means if I have a custom attribute like:

```
class Server
  include Mongoid::Document
  references_many :users

  def user=(u)
    users << u
  end
end

class User
  include Mongoid::Document
end

Server.new(:user => User.create) # raises NoMethodError: undefined method `<<' for nil:NilClass
```

this pull request definitely fixes the problem with minimal changes, but I'm not sure if it's is the best way to fix it, not knowing the builder stuff very well. another solution would be to call `identify` in document initialization before processing arguments, but that has drawbacks of its own. with this pull request, the parent's `_id` is still nil during initialization and no find is called, but `references_many` is assumed to still be `[]`.
