### PR TITLE
embeds_one + nested_attributes_for + ObjectId input as string doesn't update embedded object

### DIFF
--- a/lib/mongoid/relations/constraint.rb
+++ b/lib/mongoid/relations/constraint.rb
@@ -35,7 +35,7 @@ module Mongoid # :nodoc:
       # @since 2.0.0.rc.7
       def convert(object)
         return object if metadata.polymorphic?
-        if metadata.stores_foreign_key? && metadata.klass.using_object_ids?
+        if metadata.klass.using_object_ids?
           return BSON::ObjectId.cast!(metadata.klass, object)
         end
         object

--- a/spec/functional/mongoid/nested_attributes_spec.rb
+++ b/spec/functional/mongoid/nested_attributes_spec.rb
@@ -490,6 +490,23 @@ describe Mongoid::NestedAttributes do
                   end
                 end
               end
+
+              context "when ids are ObjectId strings" do
+
+                let(:quiz) do
+                  person.quiz = Quiz.new(:topic => "Math")
+                end
+
+                before do
+                  person.quiz_attributes = {
+                    "id" => quiz.id.to_s, :topic => "English"
+                  }
+                end
+
+                it "updates the existing document" do
+                  person.quiz.topic.should == "English"
+                end
+              end
             end
           end
         end

--- a/spec/models/person.rb
+++ b/spec/models/person.rb
@@ -58,6 +58,7 @@ class Person
       first_name == "Richard" && last_name == "Dawkins"
     end
   end
+  embeds_one :quiz
 
   accepts_nested_attributes_for :addresses
   accepts_nested_attributes_for :name, :update_only => true
@@ -66,6 +67,7 @@ class Person
   accepts_nested_attributes_for :favorites, :allow_destroy => true, :limit => 5
   accepts_nested_attributes_for :posts
   accepts_nested_attributes_for :preferences
+  accepts_nested_attributes_for :quiz
 
   references_one :game, :dependent => :destroy, :validate => false do
     def extension

--- a/spec/models/quiz.rb
+++ b/spec/models/quiz.rb
@@ -1,4 +1,5 @@
 class Quiz
   include Mongoid::Document
+  field :topic
   embeds_many :pages
 end


### PR DESCRIPTION
the object id ends up not converting from string to a real object id. relaxing the conditions on whether or not to convert it in relations/constraint fixes it. remaining tests all pass.
