### PR TITLE
When updating a document, $unset nil fields.

### DIFF
--- a/lib/mongoid/atomicity.rb
+++ b/lib/mongoid/atomicity.rb
@@ -55,6 +55,18 @@ module Mongoid #:nodoc:
           end
         end
         updates
+      end.tap do |updates|
+        sets, unsets = {}, {}
+
+        updates["$set"].each do |key, value|
+          if value.nil?
+            unsets[key] = 1
+          else
+            sets[key] = value
+          end
+        end
+
+        updates["$set"], updates["$unset"] = sets, unsets
       end.delete_if do |key, value|
         value.empty?
       end

--- a/spec/models/location.rb
+++ b/spec/models/location.rb
@@ -1,5 +1,6 @@
 class Location
   include Mongoid::Document
   field :name
+  field :style
   embedded_in :address
 end


### PR DESCRIPTION
When updating a document where some fields have been nullified, this uses the $unset operator to remove nil fields entirely. This ensures that fields with no content don't take up space unnecessarily in the db.

Also, there were some failures in the spec suite that were present both before and after my changes - I put them in a gist in case you were unaware of them:

https://gist.github.com/803439

Thoughts and changes are of course welcome :)

Thanks!
