### PR TITLE
RE: Auto generated _id for embedded documents

### DIFF
--- a/lib/mongoid/config.rb
+++ b/lib/mongoid/config.rb
@@ -34,6 +34,7 @@ module Mongoid #:nodoc
       define_method("#{name}?") { send(name) }
     end
 
+    option :embedded_object_id, :default => true
     option :allow_dynamic_fields, :default => true
     option :include_root_in_json, :default => false
     option :parameterize_keys, :default => true

--- a/lib/mongoid/identity.rb
+++ b/lib/mongoid/identity.rb
@@ -49,8 +49,10 @@ module Mongoid #:nodoc:
     # @example Set the id.
     #   identity.identify
     def identify
-      document.id = compose.join(" ").identify if document.primary_key
-      document.id = generate_id if document.id.blank?
+      if Mongoid.embedded_object_id
+          document.id = compose.join(" ").identify if document.primary_key
+          document.id = generate_id if document.id.blank?
+      end
     end
 
     # Set the _type field on the document if the document is hereditary or in a


### PR DESCRIPTION
Added new config option 'embedded_object_id' to allow disabling of auto generated object_id for all embedded documents. There are several use cases where there is no need to lookup an embedded object by _id. Having no way to disable this leads to bloated document size and potential issues integrating with other language ODM's such as Python MongoKit where embedded objects are not auto generated.
