### PR TITLE
Fix for bad insert order for embeds_many relations when 11 or more child documents are created at once

### DIFF
--- a/lib/mongoid/relations/builders/nested_attributes/many.rb
+++ b/lib/mongoid/relations/builders/nested_attributes/many.rb
@@ -45,7 +45,7 @@ module Mongoid # :nodoc:
           # A new builder.
           def initialize(metadata, attributes, options = {})
             @attributes = attributes.with_indifferent_access.sort do |a, b|
-              a[0] <=> b[0]
+              a[0].to_i <=> b[0].to_i
             end
             @metadata = metadata
             @options = options


### PR DESCRIPTION
Here's a spec for the problem, I would have included it but I couldn't figure out where it should go:

```
context "when there are 10 or more child records" do

  let(:person) do
    Person.new(:addresses => addresses)
  end

  let(:addresses) do
    ('0'..'10').inject({}) do |addresses,i|
      addresses.merge(i => {:number => i})
    end
  end

  it "should preserve the order of the children" do
    person.addresses.map(&:number).should == (0..10).to_a
  end
end
```

The setup might look a bit strange so I'll explain:
The `let(:addresses)` is creating a hash that looks like data coming in from a form where all child documents are submitted at once. So `NestedBuilder#initialize` ultimately gets a hash for the `attributes` params that looks something like this: `{'0' => ..., '1' => ..., ..., '10' => ...}`.  Consequently, when `NestedBuilder#initialize` attempts to sort the attributes by key, the order will get hosed on comparisons like `'2' <=> '10'`.
