### PR TITLE
support count and distinct and other chained queries on references_and_referenced_in_many relations w/o an inverse

### DIFF
--- a/lib/mongoid/relations/referenced/many_to_many.rb
+++ b/lib/mongoid/relations/referenced/many_to_many.rb
@@ -204,7 +204,11 @@ module Mongoid # :nodoc:
         #
         # @return [ Criteria ] A new criteria.
         def criteria
-          metadata.klass.any_in(metadata.inverse_foreign_key => [ base.id ])
+          if metadata.inverse
+            metadata.klass.any_in(metadata.inverse_foreign_key => [ base.id ])
+          else
+            metadata.klass.where(:_id => { "$in" => base.send(metadata.foreign_key) })
+          end
         end
 
         # Dereferences the supplied document from the base of the relation.

--- a/spec/functional/mongoid/relations/referenced/many_to_many_spec.rb
+++ b/spec/functional/mongoid/relations/referenced/many_to_many_spec.rb
@@ -547,6 +547,31 @@ describe Mongoid::Relations::Referenced::ManyToMany do
         end
       end
     end
+
+    context "when the inverse relation is not defined" do
+
+      context "when documents have been persisted" do
+
+        let!(:house) do
+          person.houses.create(:name => "Wayne Manor")
+        end
+
+        it "returns the number of persisted documents" do
+          person.houses.count.should == 1
+        end
+      end
+
+      context "when documents have not been persisted" do
+
+        let!(:house) do
+          person.houses.build(:name => "Ryugyong Hotel")
+        end
+
+        it "returns 0" do
+          person.preferences.count.should == 0
+        end
+      end
+    end
   end
 
   [ :create, :create! ].each do |method|
@@ -1168,6 +1193,17 @@ describe Mongoid::Relations::Referenced::ManyToMany do
         it "returns the distinct values for the fields" do
           person.preferences.distinct(:name).should =~
             [ "First",  "Second"]
+        end
+
+        context "when the inverse relation is not defined" do
+
+          let!(:house) do
+            person.houses.create(:name => "Wayne Manor")
+          end
+
+          it "returns the distinct values for the fields" do
+            person.houses.distinct(:name).should == [ house.name ]
+          end
         end
       end
     end


### PR DESCRIPTION
I didn't feel so hot adding the if clause in `referenced/many_to_many` criteria, but it works well and all the tests like it.
