### PR TITLE
Proper typecasting of Criteria merged from multiple wheres

### DIFF
--- a/lib/mongoid/criterion/inclusion.rb
+++ b/lib/mongoid/criterion/inclusion.rb
@@ -147,7 +147,7 @@ module Mongoid #:nodoc:
 
           selector.each_pair do |key, value|
             if crit.selector.has_key?(key) && crit.selector[key].respond_to?(:merge!)
-              crit.selector[key].merge!(value)
+              crit.selector[key] = crit.selector[key].merge!(value)
             else
               crit.selector[key] = value
             end

--- a/spec/functional/mongoid/criterion/inclusion_spec.rb
+++ b/spec/functional/mongoid/criterion/inclusion_spec.rb
@@ -276,6 +276,20 @@ describe Mongoid::Criterion::Inclusion do
           from_db.should == [ person ]
         end
       end
+
+      context "with different criteria on the same key" do
+
+        it "merges criteria" do
+          Person.where(:age.gt => 30).where(:age.lt => 40).should == [person]
+        end
+
+        it "typecasts criteria" do
+          before_dob = (dob - 1.month).to_s
+          after_dob = (dob + 1.month).to_s
+          Person.where(:dob.gt => before_dob).and(:dob.lt => after_dob).should == [person]
+        end
+
+      end
     end
 
     context "with untyped criteria" do


### PR DESCRIPTION
Partial fix for https://github.com/mongoid/mongoid/issues/#issue/278

Along with specs texting fixed functionality.

It fixes the issue with not typecasting merged criteria, specified in multiple wheres.

e.g. Person.where(:dob.gt => "1960-01-10").and(:dob.lt => "2000-12-31")

Date from second condition would not be typecasted resulting in Date/String comparison 
returning empty collection everytime.
