### PR TITLE
Separated mixins to create_at and updated_at. Second try.

### DIFF
--- a/lib/mongoid/timestamps.rb
+++ b/lib/mongoid/timestamps.rb
@@ -10,10 +10,5 @@ module Mongoid #:nodoc:
     extend ActiveSupport::Concern
     include Created
     include Updated
-
-    included do
-      class_attribute :record_timestamps
-      self.record_timestamps = true
-    end
   end
 end

--- a/lib/mongoid/timestamps/created.rb
+++ b/lib/mongoid/timestamps/created.rb
@@ -11,6 +11,11 @@ module Mongoid #:nodoc:
         field :created_at, :type => Time
 
         set_callback :create, :before, :set_created_at
+
+        unless methods.include? 'record_timestamps'
+          class_attribute :record_timestamps
+          self.record_timestamps = true
+        end
       end
 
       # Update the created_at field on the Document to the current time. This is

--- a/lib/mongoid/timestamps/updated.rb
+++ b/lib/mongoid/timestamps/updated.rb
@@ -11,6 +11,11 @@ module Mongoid #:nodoc:
         field :updated_at, :type => Time
 
         set_callback :save, :before, :set_updated_at, :if => Proc.new {|d| d.new_record? || d.changed? }
+
+        unless methods.include? 'record_timestamps'
+          class_attribute :record_timestamps
+          self.record_timestamps = true
+        end
       end
 
       # Update the updated_at field on the Document to the current time.

--- a/spec/models/agent.rb
+++ b/spec/models/agent.rb
@@ -1,5 +1,6 @@
 class Agent
   include Mongoid::Document
+  include Mongoid::Timestamps::Updated
   field :title
   field :number
   embeds_many :names, :as => :namable

--- a/spec/models/game.rb
+++ b/spec/models/game.rb
@@ -1,6 +1,5 @@
 class Game
   include Mongoid::Document
-  include Mongoid::Timestamps::Updated
   field :high_score, :type => Integer, :default => 500
   field :score, :type => Integer, :default => 0
   field :name

--- a/spec/unit/mongoid/timestamps/created_spec.rb
+++ b/spec/unit/mongoid/timestamps/created_spec.rb
@@ -28,6 +28,11 @@ describe Mongoid::Timestamps::Created do
     it "forces the created_at timestamps to UTC" do
       quiz.created_at.should be_within(10).of(Time.now.utc)
     end
+
+    it "includes a record_timestamps class_accessor to ease AR compatibility" do
+      Quiz.should.respond_to? :record_timestamps
+      Quiz.record_timestamps.should be_true
+    end
   end
 
   context "when the document is created" do

--- a/spec/unit/mongoid/timestamps/updated_spec.rb
+++ b/spec/unit/mongoid/timestamps/updated_spec.rb
@@ -4,17 +4,17 @@ describe Mongoid::Timestamps::Updated do
 
   describe ".included" do
 
-    let(:game) do
-      Game.new
+    let(:agent) do
+      Agent.new
     end
 
     let(:fields) do
-      Game.fields
+      Agent.fields
     end
 
     before do
-      game.run_callbacks(:create)
-      game.run_callbacks(:save)
+      agent.run_callbacks(:create)
+      agent.run_callbacks(:save)
     end
 
     it "does not add created_at to the document" do
@@ -26,39 +26,39 @@ describe Mongoid::Timestamps::Updated do
     end
 
     it "forces the updated_at timestamps to UTC" do
-      game.updated_at.should be_within(10).of(Time.now.utc)
+      agent.updated_at.should be_within(10).of(Time.now.utc)
     end
 
     it "includes a record_timestamps class_accessor to ease AR compatibility" do
-      Game.should.respond_to? :record_timestamps
+      Agent.should.respond_to? :record_timestamps
     end
   end
 
   context "when the document has not changed" do
 
-    let(:game) do
-      Game.new(:created_at => Time.now.utc)
+    let(:agent) do
+      Agent.new
     end
 
     before do
-      game.new_record = false
+      agent.new_record = false
     end
 
     it "does not run the update callbacks" do
-      game.expects(:updated_at=).never
-      game.save
+      agent.expects(:updated_at=).never
+      agent.save
     end
   end
 
   context "when the document is created" do
 
-    let(:game) do
-      Game.create
+    let(:agent) do
+      Agent.create
     end
 
     it "runs the update callbacks" do
-      game.updated_at.should_not be_nil
-      game.updated_at.should be_within(10).of(Time.now.utc)
+      agent.updated_at.should_not be_nil
+      agent.updated_at.should be_within(10).of(Time.now.utc)
     end
   end
 end


### PR DESCRIPTION
It’s repull from https://github.com/mongoid/mongoid/pull/665. I fix specs for `Timestamps::Updated` and `Timestamps::Created` and now them add `Model.record_timestamps`.
