### PR TITLE
Rename _remove to remove on paranoia

### DIFF
--- a/lib/mongoid/paranoia.rb
+++ b/lib/mongoid/paranoia.rb
@@ -42,19 +42,19 @@ module Mongoid #:nodoc:
     #
     # Example:
     #
-    # <tt>document._remove</tt>
+    # <tt>document.remove</tt>
     #
     # Returns:
     #
     # true
-    def _remove(options = {})
+    def remove(options = {})
       now = Time.now
       collection.update({ :_id => self.id }, { '$set' => { :deleted_at => Time.now } })
       @attributes["deleted_at"] = now
       true
     end
 
-    alias :delete :_remove
+    alias :delete :remove
 
     # Determines if this document is destroyed.
     #

--- a/spec/unit/mongoid/paranoia_spec.rb
+++ b/spec/unit/mongoid/paranoia_spec.rb
@@ -56,7 +56,7 @@ describe Mongoid::Paranoia do
     end
   end
 
-  describe "#_remove" do
+  describe "#destroy" do
 
     before do
       @post = ParanoidPost.new
@@ -69,19 +69,44 @@ describe Mongoid::Paranoia do
       collection.expects(:update).with(
         { :_id => @post.id }, { "$set" => { :deleted_at => @time } }
       ).returns(true)
-      @post._remove
+      @post.destroy
     end
 
     it "sets the deleted flag" do
       collection.expects(:update).with(
         { :_id => @post.id }, { "$set" => { :deleted_at => @time } }
       ).returns(true)
-      @post._remove
+      @post.destroy
       @post.destroyed?.should == true
     end
   end
 
-  describe "#_restore" do
+  describe "#remove" do
+
+    before do
+      @post = ParanoidPost.new
+      @post.expects(:collection).returns(collection)
+      @time = Time.now
+      Time.stubs(:now).returns(@time)
+    end
+
+    it "sets the deleted_at flag in the database" do
+      collection.expects(:update).with(
+        { :_id => @post.id }, { "$set" => { :deleted_at => @time } }
+      ).returns(true)
+      @post.remove
+    end
+
+    it "sets the deleted flag" do
+      collection.expects(:update).with(
+        { :_id => @post.id }, { "$set" => { :deleted_at => @time } }
+      ).returns(true)
+      @post.remove
+      @post.destroyed?.should == true
+    end
+  end
+
+  describe "#restore" do
 
     before do
       @post = ParanoidPost.new(:deleted_at => Time.now)


### PR DESCRIPTION
it will fix [issue 638](https://github.com/mongoid/mongoid/issues/issue/638) and maintain consistency with [persistence module](https://github.com/mongoid/mongoid/blob/2.0.0.rc.7/lib/mongoid/persistence.rb#L32)
