### PR TITLE
Upgrade mongo and bson dependencies to ~> 1.2.1

### DIFF
--- a/mongoid.gemspec
+++ b/mongoid.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("activesupport", ["< 3.0.0"])
   s.add_runtime_dependency("durran-validatable", [">= 2.0.1"])
   s.add_runtime_dependency("will_paginate", ["< 2.9"])
-  s.add_runtime_dependency("mongo", ["~> 1.0.1"])
-  s.add_runtime_dependency("bson", ["~> 1.0.1"])
+  s.add_runtime_dependency("mongo", ["~> 1.2.1"])
+  s.add_runtime_dependency("bson", ["~> 1.2.1"])
 
   s.add_development_dependency(%q<rspec>, ["= 1.3.0"])
   s.add_development_dependency(%q<mocha>, ["= 0.9.8"])


### PR DESCRIPTION
The latest MongoDB Ruby driver, 1.2.1, contains many bug fixes, one of which is very important to me because it fixes a crasher. This commit updates the gemspec to allow installation of those versions.
