### PR TITLE
Namespace support for generating models

### DIFF
--- a/lib/rails/generators/mongoid/model/templates/model.rb
+++ b/lib/rails/generators/mongoid/model/templates/model.rb
@@ -1,3 +1,4 @@
+<% module_namespacing do -%>
 class <%= class_name %><%= " < #{options[:parent].classify}" if options[:parent] %>
 <% unless options[:parent] -%>
   include Mongoid::Document
@@ -15,3 +16,4 @@ class <%= class_name %><%= " < #{options[:parent].classify}" if options[:parent]
   embedded_in :<%= attribute.name%>, :inverse_of => :<%= class_name.tableize %>
 <% end -%>
 end
+<% end -%>


### PR DESCRIPTION
Just mimicked how rails-core generates models. This patch embeds the model inside a module if necessary. It's especially useful when writing rails engines.
