### PR TITLE
Chaining $in criteria intersects arguments

### DIFF
--- a/lib/mongoid/criteria.rb
+++ b/lib/mongoid/criteria.rb
@@ -315,7 +315,9 @@ module Mongoid #:nodoc:
     # Example:
     #
     # <tt>criteria.update_selector({ :field => "value" }, "$in")</tt>
-    def update_selector(attributes, operator)
+    #
+    # @param [ Symbol ] combine The operator to use when combining sets.
+    def update_selector(attributes, operator, combine = :+)
       clone.tap do |crit|
         converted = BSON::ObjectId.convert(klass, attributes || {})
         converted.each do |key, value|
@@ -323,8 +325,7 @@ module Mongoid #:nodoc:
             crit.selector[key] = { operator => value }
           else
             if crit.selector[key].has_key?(operator)
-              op = operator == "$in" ? :& : :+
-              new_value = crit.selector[key].values.first.send(op, value)
+              new_value = crit.selector[key].values.first.send(combine, value)
               crit.selector[key] = { operator => new_value }
             else
               crit.selector[key][operator] = value

--- a/lib/mongoid/criterion/inclusion.rb
+++ b/lib/mongoid/criterion/inclusion.rb
@@ -20,6 +20,22 @@ module Mongoid #:nodoc:
       end
       alias :all_in :all
 
+      # Adds a criterion to the +Criteria+ that specifies values where any can
+      # be matched in order to return results. This is similar to an SQL "IN"
+      # clause. The MongoDB conditional operator that will be used is "$in".
+      # Any previously matching "$in" arrays will be unioned with new
+      # arguments.
+      #
+      # @example Adding the criterion.
+      #   criteria.in(:field => ["value1"]).also_in(:field => ["value2"])
+      #
+      # @param [ Hash ] attributes Name/value pairs any can match.
+      #
+      # @return [ Criteria ] A new criteria with the added selector.
+      def also_in(attributes = {})
+        update_selector(attributes, "$in")
+      end
+
       # Adds a criterion to the +Criteria+ that specifies values that must
       # be matched in order to return results. This is similar to a SQL "WHERE"
       # clause. This is the actual selector that will be provided to MongoDB,
@@ -105,7 +121,7 @@ module Mongoid #:nodoc:
       #
       # @return [ Criteria ] A new criteria with the added selector.
       def in(attributes = {})
-        update_selector(attributes, "$in")
+        update_selector(attributes, "$in", :&)
       end
       alias :any_in :in
 

--- a/spec/functional/mongoid/criterion/inclusion_spec.rb
+++ b/spec/functional/mongoid/criterion/inclusion_spec.rb
@@ -387,10 +387,6 @@ describe Mongoid::Criterion::Inclusion do
       it "returns the intersection of in and nin clauses" do
         Person.any_in(:title => ["Sir", "Mrs"]).not_in(:title => ["Mrs"]).should == [person]
       end
-
-      it "returns the intersection of in and in clauses" do
-        Person.any_in(:title => ["Sir", "Mrs"]).any_in(:title => ["Sir", "Ms"]).should == [person]
-      end
     end
 
     context "with complex criterion" do

--- a/spec/unit/mongoid/criterion/inclusion_spec.rb
+++ b/spec/unit/mongoid/criterion/inclusion_spec.rb
@@ -169,6 +169,42 @@ describe Mongoid::Criterion::Inclusion do
     end
   end
 
+  describe "#also_in" do
+
+    let(:criteria) do
+      base.also_in(:title => ["title1", "title2"], :text => ["test"])
+    end
+
+    it "adds the $in clause to the selector" do
+      criteria.selector.should ==
+        {
+          :title => { "$in" => ["title1", "title2"] }, :text => { "$in" => ["test"] }
+        }
+    end
+
+    it "returns a copy" do
+      criteria.also_in(:title => ["title1"]).should_not eql(criteria)
+    end
+
+    context "when existing in criteria exists" do
+
+      let(:criteria) do
+        base.
+          in(:title => ["title1", "title2"]).
+          also_in(:title => ["title3"], :text => ["test"])
+      end
+
+      it "appends to the existing criteria" do
+        criteria.selector.should ==
+          {
+            :title => {
+              "$in" => ["title1", "title2", "title3"] }, :text => { "$in" => ["test"]
+            }
+          }
+      end
+    end
+  end
+
   describe "#near" do
 
     let(:criteria) do


### PR DESCRIPTION
I looked around in the current issues on github and dredged up this old thread:

http://groups.google.com/group/mongoid/browse_thread/thread/381e69a9be19f3d0/b82e7f79a79255e4?lnk=gst&q=%24in+intersection#b82e7f79a79255e4

nothing seemed conclusive. so I wanted to bring it up:

```
Person.where(:name.in => [ "Bob", "Mary" ]).where(:name.in => [ "Bob", "Joe" ])
```

to me should really be the AND of the two arrays, which means intersection. currently, mongoid does a union (and there's a test for it). I'm pretty sure this should be an intersection to be consistent with all other chained `.where()` calls, right?
