### PR TITLE
Mongoid documents ignoring all class inheritable methods (subclasses + sunspot fix)

### DIFF
--- a/lib/mongoid/fields.rb
+++ b/lib/mongoid/fields.rb
@@ -87,6 +87,7 @@ module Mongoid #:nodoc
       #
       # @since 2.0.0.rc.6
       def inherited(subclass)
+        super
         subclass.fields = fields.dup
       end
 

--- a/spec/functional/mongoid/named_scope_spec.rb
+++ b/spec/functional/mongoid/named_scope_spec.rb
@@ -60,11 +60,24 @@ describe Mongoid::NamedScope do
       end
     end
 
+    context "when an inheritable class hash is defined" do
+      
+      it "should be accessible" do
+        Person.somebody_elses_important_class_options.should == { :keep_me_around => true }
+      end
+      
+    end
+
     context "when calling scopes on parent classes" do
 
       it "inherits the scope" do
         Doctor.minor.should == []
       end
+      
+      it "inherits the inheritable class methods" do
+        Doctor.somebody_elses_important_class_options.should == { :keep_me_around => true }
+      end
+      
     end
   end
 end

--- a/spec/models/person.rb
+++ b/spec/models/person.rb
@@ -5,6 +5,8 @@ class Person
   include Mongoid::Versioning
 
   attr_accessor :mode
+	class_inheritable_hash :somebody_elses_important_class_options
+	self.somebody_elses_important_class_options = { :keep_me_around => true }
 
   field :title
   field :terms, :type => Boolean


### PR DESCRIPTION
Needed to hook into the standard inherited method to maintain compatibility with various inheritable methods (class_inheritable_hash being the one I chose to test against).  Also allows mongoid documents with subclasses to be properly indexed by Sunspot.
