### PR TITLE
Retrying issued commands when a Mongo::ConnectionFailure occurs

### DIFF
--- a/lib/mongoid/collection.rb
+++ b/lib/mongoid/collection.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+require "mongoid/collections/retry"
 require "mongoid/collections/operations"
 require "mongoid/collections/cyclic_iterator"
 require "mongoid/collections/master"

--- a/lib/mongoid/collections/master.rb
+++ b/lib/mongoid/collections/master.rb
@@ -2,6 +2,7 @@
 module Mongoid #:nodoc:
   module Collections #:nodoc:
     class Master
+      include Mongoid::Collections::Retry
 
       attr_reader :collection
 
@@ -12,7 +13,11 @@ module Mongoid #:nodoc:
       #
       # <tt>collection.save({ :name => "Al" })</tt>
       Operations::ALL.each do |name|
-        define_method(name) { |*args| collection.send(name, *args) }
+        define_method(name) do |*args|
+          retry_on_connection_failure do
+            collection.send(name, *args)
+          end
+        end
       end
 
       # Create the new database writer. Will create a collection from the

--- a/lib/mongoid/collections/retry.rb
+++ b/lib/mongoid/collections/retry.rb
@@ -1,0 +1,29 @@
+# encoding: utf-8
+module Mongoid #:nodoc:
+  module Collections #:nodoc:
+    module Retry
+      # Retries command on connection failures.
+      #
+      # This is useful when using replica sets. When a primary server wents
+      # down and a command is issued, the driver will raise a
+      # Mongo::ConnectionFailure. We wait a little bit, because nodes are
+      # electing themselves, and then retry the given command.
+      #
+      # By setting Mongoid.max_retries_on_connection_failure to a value of 0,
+      # no attempt will be made, immediately raising connection failure.
+      # Otherwise it will attempt to make the specified number of retries
+      # and then raising the exception to clients.
+      def retry_on_connection_failure
+        retries = 0
+        begin
+          yield
+        rescue Mongo::ConnectionFailure => ex
+          retries += 1
+          raise ex if retries > Mongoid.max_retries_on_connection_failure
+          Kernel.sleep(0.5)
+          retry
+        end
+      end
+    end
+  end
+end

--- a/lib/mongoid/collections/slaves.rb
+++ b/lib/mongoid/collections/slaves.rb
@@ -2,6 +2,7 @@
 module Mongoid #:nodoc:
   module Collections #:nodoc:
     class Slaves
+      include Mongoid::Collections::Retry
 
       attr_reader :iterator
 
@@ -12,7 +13,11 @@ module Mongoid #:nodoc:
       #
       # <tt>collection.save({ :name => "Al" })</tt>
       Operations::READ.each do |name|
-        define_method(name) { |*args| collection.send(name, *args) }
+        define_method(name) do |*args|
+          retry_on_connection_failure do
+            collection.send(name, *args)
+          end
+        end
       end
 
       # Is the collection of slaves empty or not?

--- a/lib/mongoid/config.rb
+++ b/lib/mongoid/config.rb
@@ -46,6 +46,7 @@ module Mongoid #:nodoc
     option :reconnect_time, :default => 3
     option :skip_version_check, :default => false
     option :time_zone, :default => nil
+    option :max_retries_on_connection_failure, :default => 0
 
     # Adds a new I18n locale file to the load path.
     #

--- a/lib/mongoid/cursor.rb
+++ b/lib/mongoid/cursor.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 module Mongoid #:nodoc
   class Cursor
+    include Mongoid::Collections::Retry
     include Enumerable
     # Operations on the Mongo::Cursor object that will not get overriden by the
     # Mongoid::Cursor are defined here.
@@ -31,7 +32,11 @@ module Mongoid #:nodoc
     #
     # <tt>cursor.close</tt>
     OPERATIONS.each do |name|
-      define_method(name) { |*args| @cursor.send(name, *args) }
+      define_method(name) do |*args|
+        retry_on_connection_failure do
+          @cursor.send(name, *args)
+        end
+      end
     end
 
     # Iterate over each document in the cursor and yield to it.

--- a/spec/unit/mongoid/collections/master_spec.rb
+++ b/spec/unit/mongoid/collections/master_spec.rb
@@ -35,6 +35,11 @@ describe Mongoid::Collections::Master do
         it "delegates to the collection" do
           master.send(name)
         end
+
+        it "retries on connection failure" do
+          master.expects(:retry_on_connection_failure).then.yields
+          master.send(name)
+        end
       end
     end
   end

--- a/spec/unit/mongoid/collections/retry_spec.rb
+++ b/spec/unit/mongoid/collections/retry_spec.rb
@@ -1,0 +1,106 @@
+
+require "spec_helper"
+
+describe Mongoid::Collections::Retry do
+  class SomeCollection
+    include Mongoid::Collections::Retry
+
+    def perform
+      retry_on_connection_failure do
+        do_action
+      end
+    end
+
+    def do_action
+      "do something here"
+    end
+  end
+  
+  subject { SomeCollection.new }
+
+  before do
+    Kernel.stubs(:sleep)
+  end
+
+  describe "when a connection failure occurs" do
+
+    before do
+      subject.expects(:do_action).raises(Mongo::ConnectionFailure).times(max_retries + 1)
+    end
+
+    describe "and Mongoid.max_retries_on_connection_failure is 0" do
+
+      let :max_retries do
+        0
+      end
+
+      it "raises Mongo::ConnectionFailure" do
+        expect { subject.perform }.to raise_error(Mongo::ConnectionFailure)
+      end
+    end
+
+    describe "and Mongoid.max_retries_on_connection_failure is greater than 0" do
+
+      let :max_retries do
+        5
+      end
+
+      before do
+        Mongoid.max_retries_on_connection_failure = max_retries
+      end
+
+      after do
+        Mongoid.max_retries_on_connection_failure = 0
+      end
+
+      it "raises Mongo::ConnectionFailure" do
+        expect { subject.perform }.to raise_error(Mongo::ConnectionFailure)
+      end
+    end
+  end
+
+  describe "when a connection failure occurs and it comes back after a few retries" do
+
+    let :result do
+      'something'
+    end
+
+    before do
+      subject.stubs(:do_action).raises(Mongo::ConnectionFailure).then.returns(result)
+    end
+
+    describe "and Mongoid.max_retries_on_connection_failure is 0" do
+
+      let :max_retries do
+        0
+      end
+
+      it "raises Mongo::ConnectionFailure" do
+        expect { subject.perform }.to raise_error(Mongo::ConnectionFailure)
+      end
+    end
+
+    describe "and Mongoid.max_retries_on_connection_failure is greater than 0" do
+
+      let :max_retries do
+        5
+      end
+
+      before do
+        Mongoid.max_retries_on_connection_failure = max_retries
+      end
+
+      after do
+        Mongoid.max_retries_on_connection_failure = 0
+      end
+
+      it "should not raise Mongo::ConnectionFailure" do
+        expect { subject.perform }.to_not raise_error(Mongo::ConnectionFailure)
+      end
+
+      it "should return the result of the command" do
+        subject.perform.should == result
+      end
+    end
+  end
+end

--- a/spec/unit/mongoid/collections/slaves_spec.rb
+++ b/spec/unit/mongoid/collections/slaves_spec.rb
@@ -75,6 +75,11 @@ describe Mongoid::Collections::Master do
         it "delegates to the collection" do
           slave.send(name)
         end
+
+        it "retries on connection failure" do
+          slave.expects(:retry_on_connection_failure).then.yields
+          slave.send(name)
+        end
       end
     end
   end

--- a/spec/unit/mongoid/cursor_spec.rb
+++ b/spec/unit/mongoid/cursor_spec.rb
@@ -31,6 +31,11 @@ describe Mongoid::Cursor do
       it "delegates to the proxy" do
         cursor.send(name)
       end
+
+      it "retries on connection failure" do
+        cursor.expects(:retry_on_connection_failure).then.yields
+        cursor.send(name)
+      end
     end
   end
 


### PR DESCRIPTION
This patch makes recovery from failures of mongos in a replica set possible, by retrying to issue commands when a Mongo::ConnectionFailure occurs.
