### PR TITLE
After initialize fix

### DIFF
--- a/lib/mongoid/document.rb
+++ b/lib/mongoid/document.rb
@@ -236,6 +236,7 @@ module Mongoid #:nodoc:
             doc.instance_variable_set(:@attributes, attributes)
             doc.send(:apply_default_attributes)
             doc.setup_modifications
+            doc.run_callbacks(:initialize) { doc }
           end
         else
           new(attrs)

--- a/spec/unit/mongoid/document_spec.rb
+++ b/spec/unit/mongoid/document_spec.rb
@@ -291,6 +291,27 @@ describe Mongoid::Document do
           person.game.name.should == "Ms. Pacman"
         end
       end
+
+      context "when instantiating model" do
+
+        let(:person) do
+          Person.instantiate("_id" => BSON::ObjectId.new, "title" => "Sir")
+        end
+
+        before do
+          Person.set_callback :initialize, :after do |doc|
+            doc.title = "Madam"
+          end
+        end
+
+        after do
+          Person.reset_callbacks(:initialize)
+        end
+
+        it "runs the callbacks" do
+          person.title.should == "Madam"
+        end
+      end
     end
 
     context "when defaults are defined" do


### PR DESCRIPTION
Added support for after_initialize callbacks on models when they are loaded from the database, in addition to the pre-existing functionality where after_initialize only got fired via normal class instantiation (.new, .build, .create and so on).
