### PR TITLE
Frozen documents

### DIFF
--- a/lib/mongoid/document.rb
+++ b/lib/mongoid/document.rb
@@ -258,5 +258,27 @@ module Mongoid #:nodoc:
         :mongoid
       end
     end
+
+    # Freezes the internal attributes of the document.
+    #
+    # @example Freeze the document
+    #   document.freeze
+    #
+    # @return [ Document ] The document.
+    def freeze
+      raw_attributes.freeze
+      self
+    end
+
+    # Checks if the document is frozen
+    #
+    # @example Check if frozen
+    #   document.frozen?
+    #
+    # @return [ true, false ] True if frozen, else false.
+    def frozen?
+      raw_attributes.frozen?
+    end
+    
   end
 end

--- a/spec/unit/mongoid/document_spec.rb
+++ b/spec/unit/mongoid/document_spec.rb
@@ -609,4 +609,50 @@ describe Mongoid::Document do
       end
     end
   end
+
+  describe "#frozen?" do
+    let(:person) do
+      Person.new
+    end
+
+    context "when attributes are not frozen" do
+      it "return false" do
+        person.should_not be_frozen
+        lambda { person.title = "something" }.should_not raise_error
+      end
+    end
+
+    context "when attributes are frozen" do
+      before do
+        person.raw_attributes.freeze
+      end
+      it "return true" do
+        person.should be_frozen
+      end
+    end
+  end
+
+  describe "#freeze" do
+    let(:person) do
+      Person.new
+    end
+
+    context "when not frozen" do
+      it "freezes attributes" do
+        person.freeze.should == person
+        lambda { person.title = "something" }.should raise_error
+      end
+    end
+
+    context "when frozen" do
+      before do
+        person.raw_attributes.freeze
+      end
+      it "keeps things frozen" do
+        person.freeze
+        lambda { person.title = "something" }.should raise_error
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
Added #freeze #frozen? to Document that works the same way as ActiveRecord. I felt this would fit better in the Persistence module, but #freeze wasn't being picked up correctly in that module. So, I moved it to Document.
