### PR TITLE
Print out warning if user redefines a class method with scope

### DIFF
--- a/lib/mongoid/named_scope.rb
+++ b/lib/mongoid/named_scope.rb
@@ -51,6 +51,7 @@ module Mongoid #:nodoc:
       # @since 1.0.0
       def scope(name, conditions = {}, &block)
         name = name.to_sym
+        valid_scope_name?(name)
         scopes[name] = Scope.new(conditions, &block)
         (class << self; self; end).class_eval <<-EOT
           def #{name}(*args)
@@ -120,6 +121,15 @@ module Mongoid #:nodoc:
           yield criteria
         ensure
           scope_stack.pop
+        end
+      end
+
+    protected
+
+      def valid_scope_name?(name)
+        if !scopes[name] && respond_to?(name, true)
+          Mongoid.logger.warn "Creating scope :#{name}. " \
+                                    "Overwriting existing method #{self.name}.#{name}."
         end
       end
     end

--- a/spec/models/override.rb
+++ b/spec/models/override.rb
@@ -1,0 +1,16 @@
+class Override
+  include Mongoid::Document
+
+  def self.public_method
+  end
+
+  protected
+
+  def self.protected_method
+  end
+
+  private
+
+  def self.private_method
+  end
+end

--- a/spec/unit/mongoid/named_scope_spec.rb
+++ b/spec/unit/mongoid/named_scope_spec.rb
@@ -57,6 +57,30 @@ describe Mongoid::NamedScope do
         Player.scopes.should include(:deaths_over)
       end
     end
+
+    context "when overrides a class method" do
+
+      let(:logger) { stub.quacks_like(Logger.allocate) }
+
+      before do
+        Mongoid.stubs(:logger => logger)
+      end
+
+      it "sends warning message to logger on public method" do
+        logger.expects(:warn)
+        Override.scope :public_method
+      end
+
+      it "sends warning message to logger on protected method" do
+        logger.expects(:warn)
+        Override.scope :protected_method
+      end
+
+      it "sends warning message to logger on private method" do
+        logger.expects(:warn)
+        Override.scope :private_method
+      end
+    end
   end
 
   context "when chaining scopes" do


### PR DESCRIPTION
Hi,

I've created a patch to print out a warning to `Mongoid.logger` if user has created a scope with the duplicate class method name. For example:

```
class Person
  def self.foo; end
end

Person.scope :foo, where(:name => true)
```

will prints out warning.

I wish that Mongoid will include this functionality, as I personally was creating a scope name `public` without knowing that it's the reserved method. I don't want people to spend a day or so debugging their code when they can't run Cucumber/RSpec spec and doesn't know what went wrong ;)

Thank you,

Prem
