### PR TITLE
Allow a to-many nested attributes to an array to work. [with tests]

### DIFF
--- a/spec/functional/mongoid/nested_attributes_spec.rb
+++ b/spec/functional/mongoid/nested_attributes_spec.rb
@@ -826,6 +826,25 @@ describe Mongoid::NestedAttributes do
               person.addresses.size.should == 2
             end
           end
+
+          context "when an array of attributes are passed" do
+
+            let(:attributes) do
+              [
+                { "street" => "Maybachufer" },
+                { "street" => "Alexander Platz" }
+              ]
+            end
+
+            before do
+              person.addresses_attributes = attributes
+            end
+
+            it "sets the documents on the relation" do
+              person.addresses.size.should == 2
+            end
+
+          end
         end
 
         context "when ids are passed" do
@@ -852,6 +871,52 @@ describe Mongoid::NestedAttributes do
 
               it "updates the second existing document" do
                 person.addresses.second.street.should == "Alexander Platz"
+              end
+
+              it "does not add new documents" do
+                person.addresses.size.should == 2
+              end
+            end
+
+            context "when the ids match in an array of attributes" do
+
+              before do
+                person.addresses_attributes =
+                  [
+                    { "id" => address_one.id, "street" => "Maybachufer" },
+                    { "id" => address_two.id, "street" => "Alexander Platz" }
+                  ]
+              end
+
+              it "updates the first existing document" do
+                person.addresses.collect { |a| a['street'] }.include?('Maybachufer')
+              end
+
+              it "updates the second existing document" do
+                person.addresses.collect { |a| a['street'] }.include?('Alexander Platz')
+              end
+
+              it "does not add new documents" do
+                person.addresses.size.should == 2
+              end
+            end
+
+            context "when the ids match in an array of attributes and start with '_'" do
+
+              before do
+                person.addresses_attributes =
+                  [
+                    { "_id" => address_one.id, "street" => "Maybachufer" },
+                    { "_id" => address_two.id, "street" => "Alexander Platz" }
+                  ]
+              end
+
+              it "updates the first existing document" do
+                person.addresses.collect { |a| a['street'] }.include?('Maybachufer')
+              end
+
+              it "updates the second existing document" do
+                person.addresses.collect { |a| a['street'] }.include?('Alexander Platz')
               end
 
               it "does not add new documents" do


### PR DESCRIPTION
accepts_nested_attributes_for allows should all for atributes in an array. From the documentation: http://api.rubyonrails.org/classes/ActiveRecord/NestedAttributes/ClassMethods.html

:posts_attributes => [
    { :title => 'Kari, the awesome Ruby documentation browser!' },
    { :title => 'The egalitarian assumption of the modern citizen' },
    { :title => '', :_destroy => '1' } # this will be ignored
  ]

would add the posts and this:
:posts_attributes => [
    { :id => 1, :title => '[UPDATED] An, as of yet, undisclosed awesome Ruby documentation browser!' },
    { :id => 2, :title => '[UPDATED] other post' }
  ]

would update the posts with the given id.

I've updated the Many::NestedBuilder to accept an array.
