### PR TITLE
Add Observer support. Fixes #280

### DIFF
--- a/lib/mongoid.rb
+++ b/lib/mongoid.rb
@@ -73,6 +73,7 @@ require "mongoid/multi_parameter_attributes"
 require "mongoid/multi_database"
 require "mongoid/named_scope"
 require "mongoid/nested_attributes"
+require "mongoid/observer"
 require "mongoid/paths"
 require "mongoid/persistence"
 require "mongoid/safety"
@@ -129,7 +130,8 @@ module Mongoid #:nodoc
   #
   # @example Delegate the configuration methods.
   #   Mongoid.database = Mongo::Connection.new.db("test")
-  Mongoid::Config.public_instance_methods(false).each do |name|
+  (Mongoid::Config.public_instance_methods(false) +
+    ActiveModel::Observing::ClassMethods.public_instance_methods(false)).each do |name|
     (class << self; self; end).class_eval <<-EOT
       def #{name}(*args)
         configure.send("#{name}", *args)

--- a/lib/mongoid/callbacks.rb
+++ b/lib/mongoid/callbacks.rb
@@ -2,6 +2,16 @@
 module Mongoid #:nodoc:
   module Callbacks
     extend ActiveSupport::Concern
+
+    CALLBACKS = [
+      :before_validation, :after_validation,
+      :after_initialize,
+      :before_create, :around_create, :after_create,
+      :before_destroy, :around_destroy, :after_destroy,
+      :before_save, :around_save, :after_save,
+      :before_update, :around_update, :after_update,
+    ]
+
     included do
       extend ActiveModel::Callbacks
       include ActiveModel::Validations::Callbacks

--- a/lib/mongoid/components.rb
+++ b/lib/mongoid/components.rb
@@ -13,6 +13,7 @@ module Mongoid #:nodoc
     include ActiveModel::Conversion
     include ActiveModel::MassAssignmentSecurity
     include ActiveModel::Naming
+    include ActiveModel::Observing
     include ActiveModel::Serializers::JSON
     include ActiveModel::Serializers::Xml
     include Mongoid::Atomicity

--- a/lib/mongoid/config.rb
+++ b/lib/mongoid/config.rb
@@ -11,6 +11,7 @@ module Mongoid #:nodoc
   # @todo Durran: This module needs an overhaul, remove singleton, etc.
   module Config
     extend self
+    include ActiveModel::Observing
 
     attr_accessor :master, :slaves, :settings
     @settings = {}

--- a/lib/mongoid/observer.rb
+++ b/lib/mongoid/observer.rb
@@ -1,0 +1,36 @@
+# encoding: utf-8
+module Mongoid #:nodoc:
+  class Observer < ActiveModel::Observer
+    def initialize
+      super
+      observed_descendants.each { |klass| add_observer!(klass) }
+    end
+
+    protected
+
+    def observed_descendants
+      observed_classes.sum([]) { |klass| klass.descendants }
+    end
+
+    def add_observer!(klass)
+      super
+      define_callbacks klass
+    end
+
+    def define_callbacks(klass)
+      observer = self
+      observer_name = observer.class.name.underscore.gsub('/', '__')
+
+      Mongoid::Callbacks::CALLBACKS.each do |callback|
+        next unless respond_to?(callback)
+        callback_meth = :"_notify_#{observer_name}_for_#{callback}"
+        unless klass.respond_to?(callback_meth)
+          klass.send(:define_method, callback_meth) do |&block|
+            observer.send(callback, self, &block)
+          end
+          klass.send(callback, callback_meth)
+        end
+      end
+    end
+  end
+end

--- a/lib/mongoid/railtie.rb
+++ b/lib/mongoid/railtie.rb
@@ -124,6 +124,18 @@ module Rails #:nodoc:
           end
         end
       end
+
+      # Instantitate any registered observers after Rails initialization and
+      # instantiate them after being reloaded in the development environment
+      initializer "instantiate observers" do
+        config.after_initialize do
+          ::Mongoid.instantiate_observers
+
+          ActionDispatch::Callbacks.to_prepare(:activerecord_instantiate_observers) do
+            ::Mongoid.instantiate_observers
+          end
+        end
+      end
     end
   end
 end

--- a/lib/rails/generators/mongoid/observer/observer_generator.rb
+++ b/lib/rails/generators/mongoid/observer/observer_generator.rb
@@ -1,0 +1,17 @@
+# encoding: utf-8
+require "rails/generators/mongoid_generator"
+
+module Mongoid #:nodoc:
+  module Generators #:nodoc:
+    class ObserverGenerator < Base #:nodoc:
+
+      check_class_collision :suffix => "Observer"
+
+      def create_observer_file
+        template 'observer.rb', File.join('app/models', class_path, "#{file_name}_observer.rb")
+      end
+
+      hook_for :test_framework
+    end
+  end
+end

--- a/lib/rails/generators/mongoid/observer/templates/observer.rb
+++ b/lib/rails/generators/mongoid/observer/templates/observer.rb
@@ -1,0 +1,4 @@
+<% module_namespacing do -%>
+class <%= class_name %>Observer < Mongoid::Observer
+end
+<% end -%>

--- a/spec/models/observed.rb
+++ b/spec/models/observed.rb
@@ -1,0 +1,41 @@
+class Actor
+  include Mongoid::Document
+  field :name
+end
+
+class Actress < Actor
+end
+
+class ActorObserver < Mongoid::Observer
+  attr_reader :last_after_create_record
+
+  def after_create(record)
+    @last_after_create_record = record
+  end
+end
+
+class CallbackRecorder < Mongoid::Observer
+  observe :actor
+
+  attr_reader :last_callback, :call_count, :last_record
+
+  def initialize
+    reset
+    super
+  end
+
+  def reset
+    @last_callback = nil
+    @call_count = Hash.new(0)
+    @last_record = {}
+  end
+
+  Mongoid::Callbacks::CALLBACKS.each do |callback|
+    define_method(callback) do |record, &block|
+      @last_callback = callback
+      @call_count[callback] += 1
+      @last_record[callback] = record
+      block ? block.call : true
+    end
+  end
+end

--- a/spec/unit/mongoid/callbacks_spec.rb
+++ b/spec/unit/mongoid/callbacks_spec.rb
@@ -6,6 +6,13 @@ describe Mongoid::Callbacks do
     include Mongoid::Callbacks
   end
 
+  it "CALLBACKS includes all callbacks" do
+    Mongoid::Callbacks::CALLBACKS.should =~ TestClass.methods.map(&:to_s).grep(/^(before|after|around)_/).map(&:to_sym).reject do |method|
+      # deprecated callbacks
+      [:after_validation_on_create, :after_validation_on_update, :before_validation_on_create, :before_validation_on_update].include? method
+    end
+  end
+
   describe ".included" do
 
     before do

--- a/spec/unit/mongoid/observer_spec.rb
+++ b/spec/unit/mongoid/observer_spec.rb
@@ -1,0 +1,72 @@
+require "spec_helper"
+
+describe Mongoid::Observer do
+  after { CallbackRecorder.instance.reset }
+
+  it { ActorObserver.instance.should be_a_kind_of(ActiveModel::Observer) }
+
+  it "observes descendent classes" do
+    actor_observer = ActorObserver.instance
+    actor = Actor.create!(:name => "Johnny Depp")
+    actor_observer.last_after_create_record.try(:name).should == actor.name
+
+    actress = Actress.create!(:name => "Tina Fey")
+    actor_observer.last_after_create_record.try(:name).should == actress.name
+  end
+
+  it "observes after_initialize" do
+    observer = CallbackRecorder.instance
+    actor = Actor.new
+
+    observer.last_callback.should == :after_initialize
+    observer.call_count[:after_initialize].should == 1
+    observer.last_record[:after_initialize].should eq(actor)
+  end
+
+  [:before_create, :after_create, :around_create, :before_save, :after_save, :around_save].each do |callback|
+    it "observes #{callback} when creating" do
+      observer = CallbackRecorder.instance
+      actor = Actor.create!
+      actor.should be_persisted
+
+      observer.call_count[callback].should == 1
+      observer.last_record[callback].should eq(actor)
+    end
+  end
+
+  [:before_update, :after_update, :around_update, :before_save, :after_save, :around_save].each do |callback|
+    it "observes #{callback} when updating" do
+      observer = CallbackRecorder.instance
+      actor = Actor.create!
+      observer.reset
+      actor.update_attributes! :name => "Johnny Depp"
+      actor.should be_persisted
+
+      observer.call_count[callback].should == 1
+      observer.last_record[callback].should eq(actor)
+    end
+  end
+
+  [:before_destroy, :after_destroy, :around_destroy].each do |callback|
+    it "observes #{callback}" do
+      observer = CallbackRecorder.instance
+      actor = Actor.create!.tap(&:destroy)
+      actor.should be_destroyed
+
+      observer.call_count[callback].should == 1
+      observer.last_record[callback].should eq(actor)
+    end
+  end
+
+  [:before_validation, :after_validation].each do |callback|
+    it "observes #{callback}" do
+      observer = CallbackRecorder.instance
+      actor = Actor.new
+      validity = actor.valid?
+      validity.should be_true
+
+      observer.call_count[callback].should == 1
+      observer.last_record[callback].should eq(actor)
+    end
+  end
+end


### PR DESCRIPTION
Mongoid::Observer is an almost exact copy of ActiveRecord::Observer
- Hook into the fast callback system, like ActiveRecord
- Mongoid:Observer fixes a bug with around hooks that exists in ActiveRecord::Observer
- Complete with generator
- Complete with specs

Add ActiveModel::Observing methods to Mongoid::Config and Mongoid::Document
- ActiveModel assumes the ORM uses a Base class, like ActiveRecord, it should be split:
  - Observable (dealing with @observer_instances), for Mongoid::Document
  - some sort of Observer manager (dealing with @observers), for Mongoid::Config
- Add delegators to ::Mongoid
- Railtie handle lifecycle, taken from ActiveRecord
