### PR TITLE
The query result of embedded document should be consistent.

### DIFF
--- a/lib/mongoid/matchers.rb
+++ b/lib/mongoid/matchers.rb
@@ -18,8 +18,12 @@ module Mongoid #:nodoc:
     # @return [ true, false ] True if matches, false if not.
     def matches?(selector)
       selector.each_pair do |key, value|
-        unless Strategies.matcher(self, key, value).matches?(value)
-          return false
+        if value.is_a?(Hash)
+          value.each do |item|
+            return false unless Strategies.matcher(self, key, Hash[*item]).matches?(Hash[*item])
+          end
+        else
+          return false unless Strategies.matcher(self, key, value).matches?(value)
         end
       end
       return true

--- a/spec/unit/mongoid/matchers_spec.rb
+++ b/spec/unit/mongoid/matchers_spec.rb
@@ -4,6 +4,42 @@ describe Mongoid::Matchers do
 
   describe "#matches?" do
 
+    context "when document is embeded" do
+
+      let(:document) do
+        Address.new(:street => "Clarkenwell Road")
+      end
+
+      before do
+        document.locations << Location.new(:name => 'No.1')
+      end
+
+      context "when the attributes do not match" do
+
+        let(:selector) do
+          { :name => { "$in" => ["No.2"], "$ne" => nil } }
+        end
+
+        it "returns false" do
+          document.locations.first.matches?(selector).should be_false
+        end
+
+        context "when just change the selector order" do
+
+          let(:selector) do
+            { :name => { "$ne" => nil, "$in" => ["No.2"] } }
+          end
+
+          it "returns false " do
+            document.locations.first.matches?(selector).should be_false
+          end
+
+        end
+
+      end
+
+    end
+
     context "when performing simple matching" do
 
       let(:document) do


### PR DESCRIPTION
```
require 'mongoid'

class Address
  include Mongoid::Document
  embeds_many :locations
end

class Location
  include Mongoid::Document
  field :name
  embedded_in :address
end

Mongoid.configure.master = Mongo::Connection.new.db('mongoid-bug-2011-03-14')

@address = Address.new(:street => "Clarkenwell Road")
@address.locations << Location.new(:name => 'No.1')
@address.save

#just change the condition order, but the result is difference.
p @address.locations.where(:name.in => ['No.2'], :name.ne => nil     ).size    #get 0
p @address.locations.where(:name.ne => nil,      :name.in => ['No.2']).size    #get 1
```

You can download the code at https://gist.github.com/869147
Run it with mongoid 2.0.0.rc.7

The result is strange.
Any idea?
