### PR TITLE
Observer support typo/conflict

### DIFF
--- a/lib/mongoid/railtie.rb
+++ b/lib/mongoid/railtie.rb
@@ -131,7 +131,7 @@ module Rails #:nodoc:
         config.after_initialize do
           ::Mongoid.instantiate_observers
 
-          ActionDispatch::Callbacks.to_prepare(:activerecord_instantiate_observers) do
+          ActionDispatch::Callbacks.to_prepare(:mongoid_instantiate_observers) do
             ::Mongoid.instantiate_observers
           end
         end


### PR DESCRIPTION
Oops, I forgot to change the Railtie ActionDispatch callback name which could conflict with ActiveRecord's observer support and cause weird issues in hybrid applications.
