### PR TITLE
edge rails (3.1): undefined local variable or method `mongoid_instantiate_observers'

### DIFF
--- a/lib/mongoid/railtie.rb
+++ b/lib/mongoid/railtie.rb
@@ -131,7 +131,7 @@ module Rails #:nodoc:
         config.after_initialize do
           ::Mongoid.instantiate_observers
 
-          ActionDispatch::Callbacks.to_prepare(:mongoid_instantiate_observers) do
+          ActionDispatch::Callbacks.to_prepare do
             ::Mongoid.instantiate_observers
           end
         end


### PR DESCRIPTION
Just tested mongoid edge on rails edge (3.1).  Getting the following on app startup:

undefined local variable or method `mongoid_instantiate_observers' for #ActionDispatch::Reloader:0x00000003704a88

/home/foo/.bundler/ruby/1.9.1/rails-1413c9b1d514/activesupport/lib/active_support/callbacks.rb:421:in `_run_prepare_callbacks'
/home/foo/.bundler/ruby/1.9.1/rails-1413c9b1d514/activesupport/lib/active_support/callbacks.rb:80:in`run_callbacks'
/home/foo/.bundler/ruby/1.9.1/rails-1413c9b1d514/actionpack/lib/action_dispatch/middleware/reloader.rb:67:in `call'
/home/foo/.bundler/ruby/1.9.1/rack-1a5a44ab518c/lib/rack/sendfile.rb:102:in`call'
/home/foo/.bundler/ruby/1.9.1/rails-1413c9b1d514/actionpack/lib/action_dispatch/middleware/remote_ip.rb:48:in `call'
/home/foo/.bundler/ruby/1.9.1/rails-1413c9b1d514/actionpack/lib/action_dispatch/middleware/show_exceptions.rb:47:in`call'
/home/foo/.bundler/ruby/1.9.1/rails-1413c9b1d514/railties/lib/rails/rack/logger.rb:13:in `call'
/home/foo/.bundler/ruby/1.9.1/rack-1a5a44ab518c/lib/rack/runtime.rb:17:in`call'
/home/foo/.bundler/ruby/1.9.1/rails-1413c9b1d514/activesupport/lib/active_support/cache/strategy/local_cache.rb:72:in `call'
/home/foo/.bundler/ruby/1.9.1/rack-1a5a44ab518c/lib/rack/lock.rb:34:in`call'
/home/foo/.bundler/ruby/1.9.1/rails-1413c9b1d514/actionpack/lib/action_dispatch/middleware/static.rb:60:in `call'
/home/foo/.bundler/ruby/1.9.1/rails-1413c9b1d514/railties/lib/rails/engine.rb:425:in`call'
/home/foo/.bundler/ruby/1.9.1/rails-1413c9b1d514/railties/lib/rails/rack/log_tailer.rb:14:in `call'
thin (1.2.8) lib/thin/connection.rb:84:in`block in pre_process'
thin (1.2.8) lib/thin/connection.rb:82:in `catch'
thin (1.2.8) lib/thin/connection.rb:82:in`pre_process'
thin (1.2.8) lib/thin/connection.rb:57:in `process'
thin (1.2.8) lib/thin/connection.rb:42:in`receive_data'
eventmachine (0.12.10) lib/eventmachine.rb:256:in `run_machine'
eventmachine (0.12.10) lib/eventmachine.rb:256:in`run'
thin (1.2.8) lib/thin/backends/base.rb:61:in `start'
thin (1.2.8) lib/thin/server.rb:159:in`start'
/home/foo/.bundler/ruby/1.9.1/rack-1a5a44ab518c/lib/rack/handler/thin.rb:13:in `run'
/home/foo/.bundler/ruby/1.9.1/rack-1a5a44ab518c/lib/rack/server.rb:231:in`start'
/home/foo/.bundler/ruby/1.9.1/rails-1413c9b1d514/railties/lib/rails/commands/server.rb:69:in `start'
/home/foo/.bundler/ruby/1.9.1/rails-1413c9b1d514/railties/lib/rails/commands.rb:51:in`block in <top (required)>'
/home/foo/.bundler/ruby/1.9.1/rails-1413c9b1d514/railties/lib/rails/commands.rb:46:in `tap'
/home/foo/.bundler/ruby/1.9.1/rails-1413c9b1d514/railties/lib/rails/commands.rb:46:in`<top (required)>'
script/rails:6:in `require'
script/rails:6:in`<main>'
