### PR TITLE
Adding back alias to criteria.id

### DIFF
--- a/lib/mongoid/criterion/optional.rb
+++ b/lib/mongoid/criterion/optional.rb
@@ -98,8 +98,8 @@ module Mongoid #:nodoc:
       #
       # Example:
       #
-      # <tt>criteria.id("4ab2bc4b8ad548971900005c")</tt>
-      # <tt>criteria.id(["4ab2bc4b8ad548971900005c", "4c454e7ebf4b98032d000001"])</tt>
+      # <tt>criteria.for_ids("4ab2bc4b8ad548971900005c")</tt>
+      # <tt>criteria.for_ids(["4ab2bc4b8ad548971900005c", "4c454e7ebf4b98032d000001"])</tt>
       #
       # Returns: <tt>self</tt>
       def for_ids(*ids)
@@ -115,6 +115,8 @@ module Mongoid #:nodoc:
           end
         end
       end
+
+      alias :id :for_ids
 
       # Adds a criterion to the +Criteria+ that specifies the maximum number of
       # results to return. This is mostly used in conjunction with <tt>skip()</tt>

--- a/spec/unit/mongoid/criterion/optional_spec.rb
+++ b/spec/unit/mongoid/criterion/optional_spec.rb
@@ -305,6 +305,12 @@ describe Mongoid::Criterion::Optional do
           base.for_ids(ids).selector.should == { :_id => ids.first }
         end
       end
+
+      context "backwards compatibility with previous criteria.id" do
+        it "should respond to id" do
+          base.should respond_to(:id)
+        end
+      end
     end
 
     context "when using object ids" do


### PR DESCRIPTION
Hi guys. I recently switched a project to mongoid master (from rc.7) and noticed the `criteria.id` was changed to `criteria.for_ids`. I like the new name much butter, but it might help to have an alias in the short term for other people who might have depended on the old name. 

Thanks!
