### PR TITLE
Support for `becomes`

### DIFF
--- a/lib/mongoid/document.rb
+++ b/lib/mongoid/document.rb
@@ -204,6 +204,29 @@ module Mongoid #:nodoc:
       end
     end
 
+    # Returns an instance of the specified class with the attributes
+    # and errors of the current document.
+    #
+    # @example Return a subclass document as a superclass instance.
+    #   manager.becomes(Person)
+    #
+    # @raise [ ArgumentError ] If the class doesn't include Mongoid::Document
+    #
+    # @param [ Class ] klass The class to become.
+    #
+    # @return [ Document ] An instance of the specified class.
+    def becomes(klass)
+      unless klass.include?(Mongoid::Document)
+        raise ArgumentError, 'A class which includes Mongoid::Document is expected'
+      end
+      became = klass.new
+      became.instance_variable_set('@attributes', @attributes)
+      became.instance_variable_set('@errors', @errors)
+      became.instance_variable_set('@new_record', new_record?)
+      became.instance_variable_set('@destroyed', destroyed?)
+      became
+    end
+
     module ClassMethods #:nodoc:
 
       # Performs class equality checking.


### PR DESCRIPTION
I ported the ActiveRecord's #becomes method. It's very handy for OO design, as form builders, etc, get confused when they get an instance of class that inherited from a base class.
