### PR TITLE
Adding authentication support for Replica Sets

### DIFF
--- a/lib/mongoid/config/replset_database.rb
+++ b/lib/mongoid/config/replset_database.rb
@@ -71,6 +71,8 @@ module Mongoid #:nodoc:
       #
       # @since 2.0.0.rc.5
       def initialize(options = {})
+        self[:logger] = Mongoid::Logger.new
+
         merge!(options)
       end
     end

--- a/spec/unit/mongoid/config/replset_database_spec.rb
+++ b/spec/unit/mongoid/config/replset_database_spec.rb
@@ -12,6 +12,10 @@ describe Mongoid::Config::ReplsetDatabase do
       [["localhost", 27010], ["localhost", 27010]]
     end
 
+    let(:options) do
+      { 'database' => 'mongoid_test', 'hosts' => hosts }
+    end
+
     let(:replica_set) do
       described_class.new(options).configure
     end
@@ -24,11 +28,11 @@ describe Mongoid::Config::ReplsetDatabase do
       Mongo::ReplSetConnection.stubs(:new).returns(repl_set_connection)
     end
 
-    context "when authentication keys are not given" do
+    it "should set a logger" do
+      subject[:logger].should be_an_instance_of(Mongoid::Logger)
+    end
 
-      let(:options) do
-        { 'database' => 'mongoid_test', 'hosts' => hosts }
-      end
+    context "when authentication keys are not given" do
 
       it { should_not be_authenticating }
 


### PR DESCRIPTION
MongoDB 1.8 added support for Replica Sets authentication, but Mongoid does not authenticates connections yet. I've added this support, and also added logging which wasn't being used when working with Replica Sets.

If username/password are not specified in mongoid.yml then it won't authenticate, keeping old behavior. If you set username/password it uses that.

Also works when reconnecting after a replica crashes.
