### PR TITLE
Fix Paranoid criteria method.

### DIFF
--- a/lib/mongoid/paranoia.rb
+++ b/lib/mongoid/paranoia.rb
@@ -84,7 +84,7 @@ module Mongoid #:nodoc:
       # Returns:
       #
       # A +Criteria+ for deleted_at not existing.
-      def criteria(embedded = false)
+      def criteria(embedded = false, scoped = true)
         super.where(:deleted_at.exists => false)
       end
 


### PR DESCRIPTION
NamedScope is a build-in module. Paranoid is a mix-in module. They have the same method: criteria.

https://github.com/mongoid/mongoid/blob/master/lib/mongoid/named_scope.rb#L26
