### PR TITLE
Allowing the :autosave option for referenced_in associations

### DIFF
--- a/lib/mongoid/relations/macros.rb
+++ b/lib/mongoid/relations/macros.rb
@@ -131,6 +131,7 @@ module Mongoid # :nodoc:
           characterize(name, Referenced::In, options, &block).tap do |meta|
             relate(name, meta)
             reference(meta)
+            autosave(meta)
             validates_relation(meta)
           end
         end

--- a/spec/functional/mongoid/relations/auto_save_spec.rb
+++ b/spec/functional/mongoid/relations/auto_save_spec.rb
@@ -97,8 +97,53 @@ describe Mongoid::Relations::AutoSave do
           it "does not save the relation" do
             account.should_not be_persisted
           end
+          
         end
       end
+    
+      context "when the relation is a referenced in" do
+        
+        before do
+          [ Ghost, Movie ].each(&:delete_all)
+        end
+        
+        let(:ghost) do
+          Ghost.new(:name => "Slimer")
+        end
+        
+        let(:movie) do
+          Movie.new(:title => "Ghostbusters")
+        end
+        
+        context "when saving a new parent document" do
+          
+          before do
+            ghost.movie = movie
+            ghost.save
+          end
+          
+          it "saves the relation" do
+            movie.should be_persisted
+          end
+          
+        end
+        
+        context "when saving an existing parent document" do
+          
+          before do
+            ghost.save
+            ghost.movie = movie
+            ghost.save
+          end
+
+          it "does not save the relation" do
+            movie.should_not be_persisted
+          end
+          
+        end
+        
+      end
+    
     end
   end
 end

--- a/spec/models/ghost.rb
+++ b/spec/models/ghost.rb
@@ -1,0 +1,7 @@
+class Ghost
+  include Mongoid::Document
+  
+  field :name, :type => String
+  
+  referenced_in :movie, :autosave => true
+end


### PR DESCRIPTION
since rc1 there is the ability to accept nested attributes for referenced_in associations. So it could be useful to create and save the referenced object with the parent object.

(I created a new model Ghost for the specs. I used Agent first but in https://github.com/mongoid/mongoid/blob/master/spec/functional/mongoid/persistence/insert_spec.rb#L11 all callbacks are being removed from Agent).

I also created a message in the google group about that: https://groups.google.com/group/mongoid/browse_thread/thread/ab70e456f372842c
