### PR TITLE
Fix type casting when retrieving attributes

### DIFF
--- a/lib/mongoid/attributes.rb
+++ b/lib/mongoid/attributes.rb
@@ -39,7 +39,7 @@ module Mongoid #:nodoc:
     def read_attribute(name)
       access = name.to_s
       value = @attributes[access]
-      accessed(access, value)
+      accessed(access, ruby_typed_value_for(access, value))
     end
     alias :[] :read_attribute
 
@@ -90,7 +90,7 @@ module Mongoid #:nodoc:
     # @since 1.0.0
     def write_attribute(name, value)
       access = name.to_s
-      modify(access, @attributes[access], typed_value_for(access, value))
+      modify(access, @attributes[access], mongo_typed_value_for(access, value))
     end
     alias :[]= :write_attribute
 
@@ -144,7 +144,7 @@ module Mongoid #:nodoc:
       (@attributes ||= {}).tap do |h|
         defaults.each_pair do |key, val|
           unless h.has_key?(key)
-            h[key] = val.respond_to?(:call) ? typed_value_for(key, val.call) : val
+            h[key] = val.respond_to?(:call) ? mongo_typed_value_for(key, val.call) : val
           end
         end
       end
@@ -164,19 +164,31 @@ module Mongoid #:nodoc:
       end
     end
 
-    # Return the typecasted value for a field.
+    private
+
+    # Return the Mongo-typecasted value for a field.
     #
     # @example Get the value typecasted.
-    #   person.typed_value_for(:title, :sir)
+    #   person.typed_value_for(:title, :sir) # => "sir"
     #
     # @param [ String, Symbol ] key The field name.
     # @param [ Object ] value The uncast value.
     #
-    # @return [ Object ] The cast value.
+    # @return [ Object ] The Mongo-compatible cast value.
     #
     # @since 1.0.0
-    def typed_value_for(key, value)
+    def mongo_typed_value_for(key, value)
       fields.has_key?(key) ? fields[key].set(value) : value
+    end
+
+    # Return the typecasted value of a field, which can be
+    # any Ruby object that has a converter.
+    #
+    # @example
+    #   person.ruby_typed_value_for :title, "sir" # => :sir
+    #
+    def ruby_typed_value_for(key, value)
+      fields[key] ? fields[key].get(value) : value
     end
   end
 end

--- a/spec/models/person.rb
+++ b/spec/models/person.rb
@@ -26,6 +26,7 @@ class Person
   field :security_code
   field :reading, :type => Object
   field :bson_id, :type => BSON::ObjectId
+  field :account_balance, :type => BigDecimal
 
   index :age
   index :addresses

--- a/spec/unit/mongoid/attributes_spec.rb
+++ b/spec/unit/mongoid/attributes_spec.rb
@@ -637,6 +637,15 @@ describe Mongoid::Attributes do
           person.age.should == 100
         end
       end
+
+      context 'when the field has a type converter' do
+
+        it 'should typecast values' do
+          person.account_balance = "4000000"
+          person.account_balance.should be_a(BigDecimal)
+        end
+      end
+
     end
   end
 
@@ -743,7 +752,7 @@ describe Mongoid::Attributes do
     end
   end
 
-  describe "#typed_value_for" do
+  describe "#mongo_typed_value_for" do
 
     let(:person) { Person.new }
 
@@ -753,7 +762,7 @@ describe Mongoid::Attributes do
 
       it "retuns the typed value" do
         person.fields["age"].expects(:set).with("51")
-        person.send(:typed_value_for, "age", "51")
+        person.send(:mongo_typed_value_for, "age", "51")
       end
 
     end
@@ -763,7 +772,7 @@ describe Mongoid::Attributes do
       before { person.stubs(:fields).returns({}) }
 
       it "returns the value" do
-        person.send(:typed_value_for, "age", "51").should == "51"
+        person.send(:mongo_typed_value_for, "age", "51").should == "51"
       end
 
     end
@@ -776,7 +785,7 @@ describe Mongoid::Attributes do
 
     it "typecasts proc values" do
       person.stubs(:defaults).returns("age" => lambda { "51" })
-      person.expects(:typed_value_for).with("age", "51")
+      person.expects(:mongo_typed_value_for).with("age", "51")
       person.instance_variable_set(:@attributes, {})
       person.send(:apply_default_attributes)
     end


### PR DESCRIPTION
A type-casting bug was introduced by 5286a42ae841fdb91d61e62e1bc61d0f9c553780

When retrieving objects from a field, say:

```
class Bacon
  field :smokiness, :type => SmokinessLevel
end
```

Mongoid is not converting the type back from a Float, Array, or whatever the MongoDB type is, back into a SmokinessLevel. The same problem is affecting standard ruby objects, like Date, DateTime, Time, and BigDecimal.

This commit fixes it, although I do have a few questions around our naming. Feedback is appreciated!

Duplicate reports: #796, #801, #808
