### PR TITLE
Many to many foreign key issue with nested models.

### DIFF
--- a/lib/mongoid/relations/metadata.rb
+++ b/lib/mongoid/relations/metadata.rb
@@ -208,7 +208,7 @@ module Mongoid # :nodoc:
       # @since 2.0.0.rc.1
       def inverse_foreign_key
         @inverse_foreign_key ||=
-          ( inverse_of ? inverse_of.to_s.singularize : inverse_class_name.underscore ) <<
+          ( inverse_of ? inverse_of.to_s.singularize : inverse_class_name.split("::").last.underscore ) <<
           relation.foreign_key_suffix
       end
 

--- a/spec/functional/mongoid/relations/referenced/many_to_many_spec.rb
+++ b/spec/functional/mongoid/relations/referenced/many_to_many_spec.rb
@@ -7,7 +7,7 @@ describe Mongoid::Relations::Referenced::ManyToMany do
   end
 
   before do
-    [ Person, Preference, Event, Tag ].map(&:delete_all)
+    [ Person, Preference, Event, Tag, Medical::Patient, Medical::Doctor ].map(&:delete_all)
   end
 
   [ :<<, :push, :concat ].each do |method|
@@ -270,6 +270,7 @@ describe Mongoid::Relations::Referenced::ManyToMany do
           end
         end
       end
+
     end
   end
 
@@ -1524,6 +1525,18 @@ describe Mongoid::Relations::Referenced::ManyToMany do
             person.houses.distinct(:name).should == [ house.name ]
           end
         end
+      end
+    end
+
+    context "when the models are namespaced" do
+
+      let(:patient) do
+        Medical::Patient.create
+      end
+
+      it "queries using the same foreign key as the association" do
+        doctor = patient.doctors.create(:name => "dave")
+        patient.doctors.where(:name => "dave").to_a.should == [doctor]
       end
     end
   end

--- a/spec/models/namespacing.rb
+++ b/spec/models/namespacing.rb
@@ -3,9 +3,15 @@ module Medical
     include Mongoid::Document
     field :name
     embeds_many :prescriptions, :class_name => "Medical::Prescription"
+    references_and_referenced_in_many :doctors, :class_name => "Medical::Doctor"
   end
   class Prescription
     include Mongoid::Document
     field :name
+  end
+  class Doctor
+    include Mongoid::Document
+    field :name
+    references_and_referenced_in_many :patients, :class_name => "Medical::Patient"
   end
 end

--- a/spec/unit/mongoid/relations/metadata_spec.rb
+++ b/spec/unit/mongoid/relations/metadata_spec.rb
@@ -695,6 +695,23 @@ describe Mongoid::Relations::Metadata do
         metadata.inverse_foreign_key.should == "person_ids"
       end
     end
+
+    context "when the model is namespaced" do
+
+      let(:metadata) do
+        described_class.new(
+          :name => :preferences,
+          :index => true,
+          :dependent => :nullify,
+          :relation => Mongoid::Relations::Referenced::ManyToMany,
+          :inverse_class_name => "Medical::Patient"
+        )
+      end
+
+      it "returns the inverse key without namespacing, to match the key in the other document" do
+        metadata.inverse_foreign_key.should == "patient_ids"
+      end
+    end
   end
 
   context "#inverse_klass" do


### PR DESCRIPTION
When declaring `references_and_referenced_in_many` relationships, the IDs for related objects are stored in a document using a key based on the association name, rather than the class name. For example:

  module Blah
    class Thing
      include Mongoid::Document
      references_and_referenced_in_many :widgets, :class_name => "Blah::Widget"
    end
    class Widget
      include Mongoid::Document
      references_and_referenced_in_many :things, :class_name => "Blah::Thing"
    end
  end

  thing = Blah::Thing.create
  widget = thing.widgets.create

The object `thing` will now have a property called `widget_ids`, which it uses to load its associated `Blah::Widget` instances.

The problem is when you try to use criteria to query this associations. Filtering by name, for example:

  thing.widgets.where(:name => "alpha")

will try to query using 'blah/widget_ids' as the foreign key, whereas the ids are actually stored in `widget_ids`.

This fix is very hacky, but I'm not yet familiar enough with the internals of Mongoid to do anything more elegant. At the very least, nothing else seems to be affected.

However, there may be cleaner, better fixes.
