### PR TITLE
Allow configuration of embedded models to fire callbacks on parent save (#237)

### DIFF
--- a/lib/mongoid/callbacks.rb
+++ b/lib/mongoid/callbacks.rb
@@ -19,5 +19,54 @@ module Mongoid #:nodoc:
       define_model_callbacks :initialize, :only => :after
       define_model_callbacks :create, :destroy, :save, :update
     end
+
+    def run_callbacks(kind, *args, &block)
+      _run_callbacks_with_cascade(_cascade_targets(kind), kind, *args) do
+        super(kind, *args, &block)
+      end
+    end
+
+    protected
+
+    def _cascade_targets(kind)
+      cascadable_children = []
+      self.relations.each_pair do |name, metadata|
+        next unless metadata.embedded? && metadata.cascade_callbacks
+
+        target = self.send(name)
+
+        if metadata.macro == :embeds_many
+          cascadable_children += target
+        elsif metadata.macro == :embeds_one && target.present?
+          cascadable_children << target
+        end
+      end
+      cascadable_children.select { |child| _should_cascade(kind, child) }
+    end
+
+    def _should_cascade(kind, child)
+      [:create, :destroy].include?(kind) || child.changed? || child.new_record?
+    end
+
+    def _normalize_callback_kind(original_kind, child)
+      if original_kind == :update && child.new_record?
+        :create
+      else
+        original_kind
+      end
+    end
+
+    def _run_callbacks_with_cascade(children, kind, *args, &block)
+      if child = children.pop
+        _run_callbacks_with_cascade(children, kind, *args) do
+          kind = _normalize_callback_kind(kind, child)
+          child.run_callbacks(kind, *args) do
+            block.call
+          end
+        end
+      else
+        block.call
+      end
+    end
   end
 end

--- a/spec/models/callbacks.rb
+++ b/spec/models/callbacks.rb
@@ -2,7 +2,9 @@ class Artist
   include Mongoid::Document
   field :name
   embeds_many :songs
-  embeds_many :labels
+  embeds_many :labels, :cascade_callbacks => true
+  embeds_one  :instrument, :cascade_callbacks => true
+  embeds_one  :address
 
   before_create :before_create_stub
   after_create :create_songs
@@ -17,10 +19,48 @@ class Artist
   end
 end
 
+class Address
+  include Mongoid::Document
+  field :street
+  embedded_in :artist
+
+  after_save :after_save_stub
+
+  private
+  def after_save_stub
+  end
+end
+
+class Instrument
+  include Mongoid::Document
+  field :name
+  field :key
+  embedded_in :artist
+
+  after_save :after_save_stub
+  before_create :upcase_name
+  before_update :tune_to_g_sharp
+
+  private
+  def after_save_stub; end
+  def upcase_name
+    self.name = self.name.upcase
+  end
+  def tune_to_g_sharp
+    self.key = "G#"
+  end
+end
+
 class Song
   include Mongoid::Document
   field :title
   embedded_in :artist
+
+  after_save :after_save_stub
+
+  private
+  def after_save_stub
+  end
 end
 
 class Label
@@ -29,9 +69,14 @@ class Label
   embedded_in :artist
   before_validation :cleanup
 
+  after_save :after_save_stub
+
   private
   def cleanup
     self.name = self.name.downcase.capitalize
+  end
+
+  def after_save_stub
   end
 end
 


### PR DESCRIPTION
I took a stab at mongoid/mongoid#237.  Specs attached.

This patch respects the `:cascade_callbacks` setting on `embeds_many` and `embeds_one` relationships.  It defaults to false.

I would appreciate a second pair of eyes; this change carries a lot of potential impact.

(We are using Mongoid for a major project again! I'm thrilled.)
