### PR TITLE
Fix Relations::Builder to not call Object.to_a, avoiding deprecated messages

### DIFF
--- a/lib/mongoid/relations/builder.rb
+++ b/lib/mongoid/relations/builder.rb
@@ -33,8 +33,7 @@ module Mongoid # :nodoc:
       #
       # @since 2.0.0.rc.1
       def query?
-        return true unless object.respond_to?(:to_a)
-        obj = object.to_a.first
+        obj = Array(object).first
         !obj.respond_to?(:attributes) && !obj.nil?
       end
     end


### PR DESCRIPTION
On Ruby < 1.9, sometimes you'd get many deprecation warnings because of the use of the Object.to_a method, specially if you are using mocks on your tests.

This fixes the warnings by calling Array() instead.
