### PR TITLE
Rename pt-br to pt-BR

### DIFF
--- a/lib/config/locales/pt-BR.yml
+++ b/lib/config/locales/pt-BR.yml
@@ -1,4 +1,4 @@
-pt-br:
+pt-BR:
   mongoid:
     errors:
       messages:


### PR DESCRIPTION
This is the standard locale name. As the rails-i18n ones: https://github.com/svenfuchs/rails-i18n/tree/master/rails/locale
