### PR TITLE
update_attribute now returns true if the values are the same value

### DIFF
--- a/lib/mongoid/persistence.rb
+++ b/lib/mongoid/persistence.rb
@@ -102,7 +102,7 @@ module Mongoid #:nodoc:
     #
     # @since 2.0.0.rc.6
     def update_attribute(name, value)
-      write_attribute(name, value) and save(:validate => false)
+      write_attribute(name, value); save(:validate => false)
     end
 
     # Update the document attributes in the datbase.

--- a/spec/functional/mongoid/persistence_spec.rb
+++ b/spec/functional/mongoid/persistence_spec.rb
@@ -450,6 +450,18 @@ describe Mongoid::Persistence do
         end
       end
 
+      context "when updating to the same value" do
+        before do
+          post.update_attribute(:title, "Testing")
+        end
+
+        it "can update to the save value" do
+          post.update_attribute(:title, "Testing").should be_true
+        end
+        
+      end
+
+
       context "when the document is invalid" do
 
         before do


### PR DESCRIPTION
to address the issue of:
f = Foo.create :name => "Bob"
f.update_attribute(:name, "Bob")
# => nil

according to the docs, this should return true; so now it does.
