### PR TITLE
Access attributes using a method, allows attributes overriding.

### DIFF
--- a/lib/mongoid/attributes.rb
+++ b/lib/mongoid/attributes.rb
@@ -156,7 +156,7 @@ module Mongoid #:nodoc:
     # @param [ Array ] *args The arguments to the method.
     def method_missing(name, *args)
       attr = name.to_s
-      return super unless @attributes.has_key?(attr.reader)
+      return super unless attributes.has_key?(attr.reader)
       if attr.writer?
         write_attribute(attr.reader, (args.size > 1) ? args : args.first)
       else


### PR DESCRIPTION
The AR api describes the attributes method as a means to override serialization attributes, etc.
The proposed fix makes it trivial to inject new attributes to a model, while not doing any dirty hacks to the method_missing. All specs pass.
