### PR TITLE
Added an 'after_build' callback allowing for relations to be referenced during initialization

### DIFF
--- a/lib/mongoid/callbacks.rb
+++ b/lib/mongoid/callbacks.rb
@@ -5,7 +5,7 @@ module Mongoid #:nodoc:
 
     CALLBACKS = [
       :before_validation, :after_validation,
-      :after_initialize,
+      :after_initialize, :after_build,
       :before_create, :around_create, :after_create,
       :before_destroy, :around_destroy, :after_destroy,
       :before_save, :around_save, :after_save,
@@ -17,6 +17,7 @@ module Mongoid #:nodoc:
       include ActiveModel::Validations::Callbacks
 
       define_model_callbacks :initialize, :only => :after
+      define_model_callbacks :build, :only => :after
       define_model_callbacks :create, :destroy, :save, :update
     end
   end

--- a/lib/mongoid/relations/many.rb
+++ b/lib/mongoid/relations/many.rb
@@ -48,6 +48,7 @@ module Mongoid #:nodoc:
           doc.identify
           append(doc, default_options(:binding => true))
           block.call(doc) if block
+          doc.run_callbacks(:build) { doc }
         end
       end
       alias :new :build

--- a/spec/models/player.rb
+++ b/spec/models/player.rb
@@ -15,9 +15,23 @@ class Player
   named_scope :deaths_under, lambda { |count| criteria.where(:deaths.lt => count) }
   scope :deaths_over, lambda { |count| criteria.where(:deaths.gt => count) }
 
+  references_many :weapons
+
   class << self
     def alive
       criteria.where(:status => "Alive")
     end
+  end
+end
+
+class Weapon
+  include Mongoid::Document
+  
+  field :name
+  
+  referenced_in :player, :inverse_of => :weapons
+  
+  after_build do
+    self.name = "Holy Hand Grenade (#{player.frags})"
   end
 end

--- a/spec/unit/mongoid/callbacks_spec.rb
+++ b/spec/unit/mongoid/callbacks_spec.rb
@@ -62,6 +62,10 @@ describe Mongoid::Callbacks do
     it "includes the after_initialize callback" do
       @class.should respond_to(:after_initialize)
     end
+    
+    it "includes the after_build callback" do
+      @class.should respond_to(:after_build)
+    end
   end
 
   describe ".after_initialize" do
@@ -72,6 +76,17 @@ describe Mongoid::Callbacks do
 
     it "runs after document instantiation" do
       game.name.should == "Testing"
+    end
+  end
+  
+  describe ".after_build" do
+
+    let(:weapon) do
+      Player.new(:frags => 5).weapons.build
+    end
+
+    it "runs after document build" do
+      weapon.name.should == "Holy Hand Grenade (5)"
     end
   end
 


### PR DESCRIPTION
after_initialize runs before associations are set, which I believe to be appropriate behavior (a full work around would likely be messy), so rather than changing it, I've added an after_build callback which only runs when you call `object.relation.build`. This is useful for those who need to reference relationships as part of their initialization process.

Another person has also requested this, see: https://github.com/mongoid/mongoid/issues/815
