### PR TITLE
Minor tweaks to Mongoid::Paranoia

### DIFF
--- a/lib/mongoid/paranoia.rb
+++ b/lib/mongoid/paranoia.rb
@@ -49,7 +49,7 @@ module Mongoid #:nodoc:
     # true
     def remove(options = {})
       now = Time.now
-      collection.update({ :_id => id }, { '$set' => { :deleted_at => Time.now } })
+      collection.update({ :_id => id }, { '$set' => { :deleted_at => now } })
       @attributes["deleted_at"] = now
       true
     end


### PR DESCRIPTION
1. There were a few extraneous `self` calls.
2. The timestamp used for the `deleted_at` attribute was not the same as the one stored in the database.
