### PR TITLE
Add Mongoid::Field.option for custom field options

### DIFF
--- a/lib/mongoid/field.rb
+++ b/lib/mongoid/field.rb
@@ -12,6 +12,40 @@ module Mongoid #:nodoc:
     attr_accessor :type
     attr_reader :copyable, :klass, :label, :name, :options
 
+    class << self
+
+      # Return a map of custom option names to their handlers.
+      #
+      # @example
+      #   Mongoid::Field.options
+      #   # => { :required => #<Proc:0x00000100976b38> }
+      #
+      # @return [ Hash ] the option map
+      def options
+        @options ||= {}
+      end
+
+      # Stores the provided block to be run when the option name specified is
+      # defined on a field.
+      #
+      # No assumptions are made about what sort of work the handler might
+      # perform, so it will always be called if the `option_name` key is
+      # provided in the field definition -- even if it is false or nil.
+      #
+      # @example
+      #   Mongoid::Field.option :required do |model, field, value|
+      #     model.validates_presence_of field if value
+      #   end
+      #
+      # @param [ Symbol ] option_name the option name to match against
+      # @param [ Proc ] block the handler to execute when the option is
+      #   provided.
+      def option(option_name, &block)
+        options[option_name] = block
+      end
+
+    end
+
     # When reading the field do we need to cast the value? This holds true when
     # times are stored or for big decimals which are stored as strings.
     #

--- a/lib/mongoid/fields.rb
+++ b/lib/mongoid/fields.rb
@@ -107,6 +107,30 @@ module Mongoid #:nodoc
           fields[name] = field
           create_accessors(name, meth, options)
           add_dirty_methods(name)
+          process_options(field)
+        end
+      end
+
+      # Run through all custom options stored in Mongoid::Field.options and
+      # execute the handler if the option is provided.
+      #
+      # @example
+      #   Mongoid::Field.option :custom do
+      #     puts "called"
+      #   end
+      #
+      #   field = Mongoid::Field.new(:test, :custom => true)
+      #   Person.process_options(field)
+      #   # => "called"
+      #
+      # @param [ Field ] field the field to process
+      def process_options(field)
+        options = field.options
+
+        Field.options.each do |option_name, handler|
+          if options.has_key?(option_name)
+            handler.call(self, field, options[option_name])
+          end
         end
       end
 

--- a/spec/unit/mongoid/field_spec.rb
+++ b/spec/unit/mongoid/field_spec.rb
@@ -2,6 +2,31 @@ require "spec_helper"
 
 describe Mongoid::Field do
 
+  describe ".options" do
+
+    it "returns a hash of custom options" do
+      Mongoid::Field.options.should be_a Hash
+    end
+
+    it "is memoized" do
+      Mongoid::Field.options.should equal Mongoid::Field.options
+    end
+  end
+
+  describe ".option" do
+
+    let(:options) { Mongoid::Field.options }
+
+    let(:handler) do
+      proc {}
+    end
+
+    it "stores the custom option in the options hash" do
+      options.expects(:[]=).with(:option, handler)
+      Mongoid::Field.option(:option, &handler)
+    end
+  end
+
   describe "#cast_on_read?" do
 
     [ Date, DateTime, Time, BigDecimal, Image ].each do |klass|

--- a/spec/unit/mongoid/fields_spec.rb
+++ b/spec/unit/mongoid/fields_spec.rb
@@ -193,6 +193,61 @@ describe Mongoid::Fields do
         person.alias?
       end
     end
+
+    context "custom options" do
+
+      let(:handler) do
+        proc {}
+      end
+
+      before do
+        Mongoid::Field.option :option, &handler
+      end
+
+      context "when option is provided" do
+
+        it "calls the handler with the model" do
+          handler.expects(:call).with do |model|
+            model.should eql Person
+          end
+
+          Person.field :custom, :option => true
+        end
+
+        it "calls the handler with the field" do
+          handler.expects(:call).with do |_,field,_|
+            field.should eql Person.fields["custom"]
+          end
+
+          Person.field :custom, :option => true
+        end
+
+        it "calls the handler with the option value" do
+          handler.expects(:call).with do |_,_,value|
+            value.should eql true
+          end
+
+          Person.field :custom, :option => true
+        end
+      end
+
+      context "when option is nil" do
+
+        it "calls the handler" do
+          handler.expects(:call)
+          Person.field :custom, :option => nil
+        end
+      end
+
+      context "when option is not provided" do
+
+        it "does not call the handler" do
+          handler.expects(:call).never
+
+          Person.field :custom
+        end
+      end
+    end
   end
 
   describe "#fields" do


### PR DESCRIPTION
This allows users of Mongoid to define custom field options, and execute
handlers when that option is provided.

A few use-cases spring to mind:
## Auto-validations

It should be (fairly) trivial to implement field-level validations like
DataMapper and ActiveRecord, with the most trivial example looking
something like this.

```
Mongoid::Field.option :required do |model, field, required|
  model.validates_presence_of field.name if required
end
```

Now the block will be executed whenever a field is defined that includes
the key `:required` in its options:

```
Person.field :name, required: true
Person.field :age, required: false
```

All options provided are still stored on the Field, which should also
allow for a richer level of introspection:

```
class Person
  def required_fields
    fields.select { |field| field.options[:required] }
  end
end
```
## Mass Assignment

```
Mongoid::Field.option :accessible do |model, field, accessible|
  model.attr_accessible field.name if accessible
end
```
## Re-writing option values, and other uses

```
# Turn :alias => :city into :alias => [:city]
Mongoid::Field.option :alias do |model, field|
  field.options[:aliases] = [*field.options.delete(:alias)]
end

Mongoid::Field.option :aliases do |model, field, aliases|
  aliases.each do |new_name|
    model.alias_attribute new_name, field.name
  end
end
```
