### PR TITLE
Very small "bug" fix

### DIFF
--- a/lib/mongoid/extensions.rb
+++ b/lib/mongoid/extensions.rb
@@ -45,7 +45,10 @@ class Binary #:nodoc
   extend Mongoid::Extensions::Binary::Conversions
 end
 
-class Boolean #:nodoc
+unless defined?(Boolean)
+  class Boolean; end
+end
+Boolean.module_eval do #:nodoc
   include Mongoid::Extensions::Boolean::Conversions
 end
 


### PR DESCRIPTION
Hi guys,

I've made a small change in extensions.rb, which basically just re-uses an eventually already existing Boolean class/module. I did this because I had this conflict with the Ripple gem (which drives Riak db) which also defines/reuse Boolean. Also, I guess that Boolean must be created in a fairly good number of projects, so this could help. All specs still pass with this "fix".

So, you can merge if you're happy with it :)

Florent.
