### PR TITLE
Call as_json when serialize_relations recursion

### DIFF
--- a/lib/mongoid/serialization.rb
+++ b/lib/mongoid/serialization.rb
@@ -56,7 +56,7 @@ module Mongoid # :nodoc:
         relation = send(metadata.name, false, :eager => true)
         if relation
           attributes[metadata.name.to_s] =
-            relation.serializable_hash(relation_options(inclusions, options, name))
+            relation.as_json(relation_options(inclusions, options, name))
         end
       end
     end

--- a/spec/functional/mongoid/serialization_spec.rb
+++ b/spec/functional/mongoid/serialization_spec.rb
@@ -409,6 +409,18 @@ describe Mongoid::Serialization do
       it "uses the mongoid configuration" do
         person.to_json.should include("person")
       end
+      
+      context "when including root in json with relations" do
+
+        let!(:json) do
+          person.posts.build(:title => "First")
+          person.as_json(:include => :posts)
+        end
+
+        it "include root in json of children" do
+          json["person"]["posts"].first.keys.should include("post")
+        end
+      end
     end
 
     context "when not including root in json" do


### PR DESCRIPTION
Call as_json when serialize_relations recursion. Because the include_root_in_json option valid in as_json.

I add a new rspec context but not run it. I couldn't run rspec for mongoid. :(

https://github.com/rails/rails/blob/v3.0.7/activemodel/lib/active_model/serializers/json.rb#L86
