### PR TITLE
Enable dynamic configuration of the additional databases through config.databases=

### DIFF
--- a/lib/mongoid/config.rb
+++ b/lib/mongoid/config.rb
@@ -79,9 +79,22 @@ module Mongoid #:nodoc
       @databases || {}
     end
 
-    # @todo Durran: There were no tests around the databases setter, not sure
-    # what the exact expectation was. Set with a hash?
+    # Set extra databases using a hash.
+    #
+    # @example Set the extra databases.
+    #   config.databases =  { "secondary" => {
+    #                            "database" => "secondary_config_test",
+    #                            "host" => "localhost",
+    #                            "port" => 27017
+    #                           }
+    #                       }
+    #
+    # @return [ Hash ] A hash of secondary databases.
     def databases=(databases)
+      return unless databases
+      @settings["databases"] = databases
+      configure_extras(@settings["databases"])
+      @databases || {}
     end
 
     # Return field names that could cause destructive things to happen if

--- a/spec/functional/mongoid/config_spec.rb
+++ b/spec/functional/mongoid/config_spec.rb
@@ -472,4 +472,20 @@ describe Mongoid::Config do
       end
     end
   end
+
+  describe ".databases=" do
+    before do
+      described_class.databases =  { "secondary" => {
+                                            "database" => "secondary_config_test",
+                                            "host" => "localhost",
+                                            "port" => 27017
+                                       }
+                                    }
+    end
+
+    it "sets the databases" do
+      described_class.databases['secondary'].should be_a(Mongo::DB)
+      described_class.databases['secondary'].name.should == "secondary_config_test"
+    end
+  end
 end


### PR DESCRIPTION
It wasn't possible to use config.databases= set the additional databases to use. This commit includes the spec and code to do that.
