### PR TITLE
Apply default attributes when upcasting

### DIFF
--- a/lib/mongoid/document.rb
+++ b/lib/mongoid/document.rb
@@ -223,11 +223,13 @@ module Mongoid #:nodoc:
         raise ArgumentError, 'A class which includes Mongoid::Document is expected'
       end
       became = klass.new
-      became.instance_variable_set('@attributes', @attributes)
+      became.instance_variable_set('@attributes', frozen? ? raw_attributes.dup : raw_attributes)
       became.instance_variable_set('@errors', @errors)
       became.instance_variable_set('@new_record', new_record?)
       became.instance_variable_set('@destroyed', destroyed?)
       became.send(:apply_default_attributes)
+      became._type = klass.to_s
+            
       became
     end
 

--- a/spec/functional/mongoid/document_spec.rb
+++ b/spec/functional/mongoid/document_spec.rb
@@ -114,6 +114,11 @@ describe Mongoid::Document do
           became.should_not be_valid
           became.errors.should include(:ssn)
         end
+        
+        it "sets the class type" do
+          became = @obj.becomes(@to_become)          
+          became._type.should == @to_become.to_s
+        end
 
         it "raises an error when inappropriate class is provided" do
           lambda {@obj.becomes(String)}.should raise_error(ArgumentError)


### PR DESCRIPTION
When you upcast a document using Document#become it should apply any default attributes that don't exist in the original class.

An example would be if you have "Person" and "Manager" classes. The Manager inherits from Person and has an additional field with a default value. When you upcast from a Person it should set the default attribute and also update the _type attribute.
