### PR TITLE
Make "Many" collection Delegator friendly

### DIFF
--- a/lib/mongoid/relations/many.rb
+++ b/lib/mongoid/relations/many.rb
@@ -43,6 +43,13 @@ module Mongoid #:nodoc:
       #
       # @return [ Document ] The new document.
       def build(attributes = {}, type = nil, &block)
+        if not type and attributes and klass = attributes.delete('_type')
+          type = begin
+            klass.constantize
+          rescue NameError => e
+            nil
+          end
+        end
         instantiated(type).tap do |doc|
           doc.write_attributes(attributes)
           doc.identify

--- a/spec/functional/mongoid/relations/embedded/many_spec.rb
+++ b/spec/functional/mongoid/relations/embedded/many_spec.rb
@@ -720,6 +720,21 @@ describe Mongoid::Relations::Embedded::Many do
           end
         end
       end
+
+      context "when providing _type" do
+        class Clip < Video
+        end
+
+        let(:person) do
+          Person.new
+        end
+
+        it "instantiates a proper class" do
+          clip = person.videos.build({'_type' => 'Clip'})
+          clip.should be_a_kind_of(Clip)
+        end
+
+      end
     end
   end
 


### PR DESCRIPTION
Change it from `def respond_to?(name)` to
`def respond_to?(name, include_private = false)`

This is required if a Delegator is to be used on the collection.
