### PR TITLE
create indexes rake task is not recognizing a lot of mongoid models because it has problems guessing their model names from filenames

### DIFF
--- a/lib/mongoid/railties/database.rake
+++ b/lib/mongoid/railties/database.rake
@@ -65,7 +65,7 @@ namespace :db do
       Dir.glob("app/models/**/*.rb").sort.each do |file|
         model_path = file[0..-4].split('/')[2..-1]
         begin
-          klass = model_path.map(&:classify).join('::').constantize
+          klass = model_path.map(&:camelize).join('::').constantize
           if klass.ancestors.include?(Mongoid::Document) && !klass.embedded
             documents << klass
           end


### PR DESCRIPTION
Hi There,

i just found out why the create_indexes rake task did not create indexes for most of our models:
It tries to do a #classify on the filenames/namespaces. Model filenames are already singular though and #classify does a singularize first.

IMHO this should be easy to understand and reproduce :-)

Best,

Tobias
