### PR TITLE
Allow arbitrary Mongo::Connection options to pass through Mongoid::Config::Database object

### DIFF
--- a/lib/mongoid/config/database.rb
+++ b/lib/mongoid/config/database.rb
@@ -6,6 +6,9 @@ module Mongoid #:nodoc:
     # database from options.
     class Database < Hash
 
+      # keys to remove from self to not pass through to Mongo::Connection
+      PRIVATE_OPTIONS = %w(uri database username password)
+
       # Configure the database connections. This will return an array
       # containing the master and an array of slaves.
       #
@@ -142,11 +145,12 @@ module Mongoid #:nodoc:
       #
       # @since 2.0.0.rc.1
       def optional(slave = false)
-        {
+        ({
           :pool_size => pool_size,
           :logger => Mongoid::Logger.new,
           :slave_ok => slave
-        }
+        }).merge(self).reject { |k,v| PRIVATE_OPTIONS.include? k }.
+          inject({}) { |memo, (k, v)| memo[k.to_sym] = v; memo} # mongo likes symbols
       end
 
       # Get a Mongo compliant URI for the database connection.

--- a/spec/functional/mongoid/config/database_spec.rb
+++ b/spec/functional/mongoid/config/database_spec.rb
@@ -197,6 +197,23 @@ describe Mongoid::Config::Database do
           end
         end
       end
+
+      context "when arbitrary options are specified", :config => :user  do
+
+        let(:options) do
+          {
+            "host" => "localhost",
+            "port" => "27017",
+            "database" => "mongoid",
+            "connect" => false,
+            "booyaho" => "temptahoo",
+          }
+        end
+
+        it "connect=false doesn't connect Mongo::Connection" do
+          connection.should_not be_connected
+        end
+      end
     end
 
     context "when configuring a slave instances", :config => :slaves do


### PR DESCRIPTION
Modified Mongoid::Config::Database object to pass arbitrary options through so options like :connect => false works.
