### PR TITLE
Use a provided _type when building a new object on a many association

### DIFF
--- a/lib/mongoid/relations/many.rb
+++ b/lib/mongoid/relations/many.rb
@@ -43,6 +43,13 @@ module Mongoid #:nodoc:
       #
       # @return [ Document ] The new document.
       def build(attributes = {}, type = nil, &block)
+        if not type and attributes and klass = attributes.delete('_type')
+          type = begin
+            klass.constantize
+          rescue NameError => e
+            nil
+          end
+        end
         instantiated(type).tap do |doc|
           doc.write_attributes(attributes)
           doc.identify

--- a/spec/functional/mongoid/relations/embedded/many_spec.rb
+++ b/spec/functional/mongoid/relations/embedded/many_spec.rb
@@ -720,6 +720,21 @@ describe Mongoid::Relations::Embedded::Many do
           end
         end
       end
+
+      context "when providing _type" do
+        class Clip < Video
+        end
+
+        let(:person) do
+          Person.new
+        end
+
+        it "instantiates a proper class" do
+          clip = person.videos.build({'_type' => 'Clip'})
+          clip.should be_a_kind_of(Clip)
+        end
+
+      end
     end
   end
 


### PR DESCRIPTION
Allow specifying the class with the _type attribute for 'many' association.
This is often needed when creating different subclasses from a form.

Unfortunately I couldn't find a way to select only the latest commit, so it includes my earlier pull request for changing the signature of respond_to?
