### PR TITLE
Change signature for Mongoid::Relations::Many#respond_to?

### DIFF
--- a/lib/mongoid/relations/many.rb
+++ b/lib/mongoid/relations/many.rb
@@ -146,8 +146,8 @@ module Mongoid #:nodoc:
       # @return [ true, false ] If the proxy responds to the method.
       #
       # @since 2.0.0
-      def respond_to?(name)
-        [].respond_to?(name) || methods.include?(name)
+      def respond_to?(name, include_private = false)
+        [].respond_to?(name, include_private) || super
       end
 
       # Gets the document as a serializable hash, used by ActiveModel's JSON and

--- a/spec/unit/mongoid/relations/embedded/many_spec.rb
+++ b/spec/unit/mongoid/relations/embedded/many_spec.rb
@@ -719,4 +719,14 @@ describe Mongoid::Relations::Embedded::Many do
       end
     end
   end
+
+  describe "respond_to?" do
+    let(:relation) do
+      described_class.new(base, target, metadata)
+    end
+
+    it "supports 'include_private = boolean'" do
+      expect { relation.respond_to?(:Rational, true) }.not_to raise_error
+    end
+  end
 end


### PR DESCRIPTION
Change it from `def respond_to?(name)` to
`def respond_to?(name, include_private = false)`

This is required if a Delegator is to be used on the collection.
