### PR TITLE
Pull request: modification to constant resolution in database.rake for yet-another-model-directory-layout

### DIFF
--- a/lib/mongoid/railties/database.rake
+++ b/lib/mongoid/railties/database.rake
@@ -80,7 +80,6 @@ namespace :db do
     def find_constant_from_path_array model_path
       begin
         klass = model_path.map(&:camelize).join('::').constantize
-        puts klass.name
       rescue LoadError => e
         # Try to constantize the model when organized in a subdir of models, but not namespaced under a module
         klass = model_path.last.camelize.constantize


### PR DESCRIPTION
Added the convention of models-in-subdirectories-but-not-namespaced-by-module resolution to database rake tasks

Background: since there is no real solid convention about what happens with organizing models under subdirectories of "app/model", there is another convention to handle in rake tasks. I have chosen to do what I've seen several others do: not to namespace models in modules, since Rails and, particularly, plugins/gems have been somewhat flighty with this, but to create a subdirectory (e.g. "app/models/foo") and add all these subdirectories to the rails autoload path. Works great, but I was getting load errors from Mongoid's rake task db:mongoid:create_indexes, since it assumes that the constants in subdirectories will always be namespaced by module. 

Submitted for your approval: this patch will fall back to looking for non-namespaced global constants if a module-namespaced constant cannot be found.
