### PR TITLE
Sending warning message to logger when retrying operations after a Mongo::ConnectionFailure

### DIFF
--- a/lib/mongoid/collections/retry.rb
+++ b/lib/mongoid/collections/retry.rb
@@ -31,8 +31,15 @@ module Mongoid #:nodoc:
           retries += 1
           raise ex if retries > Mongoid.max_retries_on_connection_failure
           Kernel.sleep(0.5)
+          log_retry retries
           retry
         end
+      end
+
+      private
+
+      def log_retry(retry_number)
+        Mongoid.logger.warn "A Mongo::ConnectionFailure was raised. Retry attempt ##{retry_number}."
       end
     end
   end

--- a/spec/unit/mongoid/collections/retry_spec.rb
+++ b/spec/unit/mongoid/collections/retry_spec.rb
@@ -18,8 +18,13 @@ describe Mongoid::Collections::Retry do
 
   subject { SomeCollection.new }
 
+  let(:logger) { stub.quacks_like(Logger.allocate) }
+
   before do
     Kernel.stubs(:sleep)
+
+    logger.expects(:warn).at_least(0)
+    Mongoid.stubs(:logger => logger)
   end
 
   describe "when a connection failure occurs" do
@@ -100,6 +105,11 @@ describe Mongoid::Collections::Retry do
 
       it "should return the result of the command" do
         subject.perform.should == result
+      end
+
+      it "sends warning message to logger on retry attempts" do
+        logger.expects(:warn).with { |value| value =~ /1/ }
+        subject.perform
       end
     end
   end


### PR DESCRIPTION
It is very important to system administrators to know when this happens frequently, so logging occurences is useful.
