### PR TITLE
Legacy find one fix

### DIFF
--- a/lib/mongoid/criterion/optional.rb
+++ b/lib/mongoid/criterion/optional.rb
@@ -70,7 +70,11 @@ module Mongoid #:nodoc:
       #
       # Returns: <tt>self</tt>
       def id(*args)
-        (args.flatten.size > 1) ? self.in(:_id => args.flatten) : (@selector[:_id] = args.first)
+        if args.flatten.size > 1 or args.first.is_a?(Array)
+          self.in(:_id => args.flatten)
+        else
+          @selector[:_id] = args.first
+        end
         self
       end
 

--- a/spec/integration/mongoid/finders_spec.rb
+++ b/spec/integration/mongoid/finders_spec.rb
@@ -99,6 +99,11 @@ describe Mongoid::Finders do
 
         context "when the documents are found" do
 
+          it "returns an array of the documents even if the array of one id is given" do
+            @people = Person.find([@documents.map(&:id).first])
+            @people.should == [@documents.first]
+          end
+
           it "returns an array of the documents" do
             @people = Person.find(@documents.map(&:id))
             @people.should == @documents


### PR DESCRIPTION
Fix the searching for an array of one id:

Model.find(['1']) produces .find({'_id' => '[1]'})
