### PR TITLE
Resolved ticket #996

### DIFF
--- a/lib/mongoid/contexts/enumerable.rb
+++ b/lib/mongoid/contexts/enumerable.rb
@@ -252,7 +252,7 @@ module Mongoid #:nodoc:
       #
       # @return [ Collection ] The root collection.
       def set_collection
-        root = documents.first._root
+        root = documents.first.try(:_root)
         @collection = root.collection if root && !root.embedded?
       end
 

--- a/spec/functional/mongoid/relations/embedded/many_spec.rb
+++ b/spec/functional/mongoid/relations/embedded/many_spec.rb
@@ -1107,6 +1107,68 @@ describe Mongoid::Relations::Embedded::Many do
           end
         end
       end
+      
+      context "when the documents empty" do
+        
+        context "when scoped" do
+          let!(:deleted) do
+            person.addresses.without_postcode.send(method)
+          end
+          
+          it "deletes all the documents" do
+            person.addresses.count.should == 0
+          end
+        
+          it "deletes all the documents from the db" do
+            person.reload.addresses.count.should == 0
+          end
+
+          it "returns the number deleted" do
+            deleted.should == 0
+          end
+        end
+        
+        context "when conditions are provided" do
+          
+          let!(:deleted) do
+            person.addresses.send(
+              method,
+              :conditions => { :street => "Bond" }
+            )
+          end
+        
+          it "deletes all the documents" do
+            person.addresses.count.should == 0
+          end
+        
+          it "deletes all the documents from the db" do
+            person.reload.addresses.count.should == 0
+          end
+
+          it "returns the number deleted" do
+            deleted.should == 0
+          end
+        end
+        
+        context "when conditions are not provided" do
+          
+          let!(:deleted) do
+            person.addresses.send(method)
+          end
+        
+          it "deletes all the documents" do
+            person.addresses.count.should == 0
+          end
+        
+          it "deletes all the documents from the db" do
+            person.reload.addresses.count.should == 0
+          end
+
+          it "returns the number deleted" do
+            deleted.should == 0
+          end
+        end
+      end
     end
   end
 

--- a/spec/models/address.rb
+++ b/spec/models/address.rb
@@ -28,6 +28,7 @@ class Address
 
   referenced_in :account
 
+  scope :without_postcode, where(:postcode => nil)
   named_scope :rodeo, where(:street => "Rodeo Dr") do
     def mansion?
       all? { |address| address.street == "Rodeo Dr" }


### PR DESCRIPTION
https://github.com/mongoid/mongoid/issues/996

when I have this structure:

``` ruby
class Page
  include Mongoid::Document
  field :title, :type => String
  embeds_many :blocks
end

class Block
  include Mongoid::Document
  field :title, :type => String
  field :changed, :type => Boolean, :default => false
  embedded_in :page
  scope :unchanged, where(:changed => false)
end
```

And then I call method `delete_all` for empty collection, I catch error:

```
NoMethodError: undefined method `_root' for nil:NilClass
    from /Users/undr/.rvm/gems/ruby-1.9.2-p180/gems/activesupport-3.0.7/lib/active_support/whiny_nil.rb:48:in `method_missing'
    from /Users/undr/.rvm/gems/ruby-1.9.2-p180/gems/mongoid-2.0.2/lib/mongoid/contexts/enumerable.rb:256:in `set_collection'
    ...
```

For example:

``` ruby
p = Page.create(:title => 'Title')
p.blocks.unchanged # => [] - it is empty collection
p.blocks.unchanged.delete_all # I catch error  undefined method `_root' for nil:NilClass
```

Problem in `set_collection` method:

``` ruby
# /lib/mongoid/contexts/enumerable.rb:255
def set_collection
  root = documents.first._root  # `documents` is equal [], means `documents.first` is nil
  @collection = root.collection if root && !root.embedded?
end
```
