### PR TITLE
Optimizations to help my little old Rails 3.1 with the asset pipline load faster.

### DIFF
--- a/lib/mongoid/dirty.rb
+++ b/lib/mongoid/dirty.rb
@@ -228,23 +228,21 @@ module Mongoid #:nodoc:
       #
       # @param [ String ] name The name of the attributes.
       def add_dirty_methods(name)
-        unless instance_methods.include?("#{name}_change") ||
-          instance_methods.include?(:"#{name}_change")
+        instance_methods_array = instance_methods
+        ruby18 = /^1\.8/ === RUBY_VERSION
+        unless instance_methods_array.include?(ruby18 ? "#{name}_change" : :"#{name}_change")
           define_method("#{name}_change") { attribute_change(name) }
         end
 
-        unless instance_methods.include?("#{name}_changed?") ||
-          instance_methods.include?(:"#{name}_changed?")
+        unless instance_methods_array.include?(ruby18 ? "#{name}_changed?" : :"#{name}_changed?")
           define_method("#{name}_changed?") { attribute_changed?(name) }
         end
 
-        unless instance_methods.include?("#{name}_was") ||
-          instance_methods.include?(:"#{name}_was")
+        unless instance_methods_array.include?(ruby18 ? "#{name}_was" : :"#{name}_was")
           define_method("#{name}_was") { attribute_was(name) }
         end
 
-        unless instance_methods.include?("reset_#{name}!") ||
-          instance_methods.include?(:"reset_#{name}!")
+        unless instance_methods_array.include?(ruby18 ? "reset_#{name}!" : :"reset_#{name}!")
           define_method("reset_#{name}!") { reset_attribute!(name) }
         end
       end


### PR DESCRIPTION
Optimized the array lookups and provided ruby version context to why it was looking for two different things in the array.

Another question, is it even required we have these instance_methods scans? Other places in the code it doesn't do this: Mongoid::Fields.create_accessors 
