### PR TITLE
fix for child embedded documents' #changes and #previous_changes not being updated on insert

### DIFF
--- a/lib/mongoid/persistence/insert.rb
+++ b/lib/mongoid/persistence/insert.rb
@@ -27,7 +27,10 @@ module Mongoid #:nodoc:
             doc.run_callbacks(:create) do
               if insert
                 doc.new_record = false
-                doc._children.each { |child| child.new_record = false }
+                doc._children.each do |child| 
+                  child.move_changes
+                  child.new_record = false
+                end
               end
             end
           end

--- a/spec/functional/mongoid/relations/embedded/dirty_spec.rb
+++ b/spec/functional/mongoid/relations/embedded/dirty_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+
+describe "when initialize a model with an embedded model" do
+  let(:person){Person.new :pet => Pet.new}
+
+  it "should have changes in the embedded model" do
+    person.pet.changes.should_not be_empty
+  end
+
+  it "should not have previous_changes in the embedded model" do
+    person.pet.previous_changes.should be_nil
+  end
+end
+
+describe "when creating a model with an embedded model" do
+  let (:person){Person.create :pet => Pet.new}
+
+  it "should not have changes in the embedded model" do
+    person.pet.changes.should be_empty
+  end
+
+  it "should have previous_changes in the embedded model" do
+    person.pet.previous_changes.should_not be_empty
+  end
+end
+
+describe "when embedding a model on an already saved model" do
+  let (:person) { Person.create }
+  before do
+    person.pet = Pet.new
+  end
+
+  it "should have not changes on the embedded model" do
+    person.pet.changes.should be_empty
+  end
+
+  it "should have previous changes on the embedded model" do
+    person.pet.previous_changes.should_not be_empty
+  end
+
+  describe "and saving the model" do
+    before do
+      person.save!
+    end
+
+    it "should not have changes on the embedded model" do
+      person.pet.changes.should be_empty
+    end
+
+    it "should not have previous changes on the embedded model" do
+      person.pet.previous_changes.should be_empty
+    end
+  end
+end
+


### PR DESCRIPTION
I've added a handful of specs around the setting and updating of #changes and #previous_changes for child embedded documents, including a fix to ensure child embedded models are getting #changes and #previous_changes updated during inserts.

previously, this was happening:

```
p = Person.create :pet => Pet.new
p.pet.changes #=> {"_id" => [nil, BSON::ObjectId('...')]}
p.pet.previous_changes #=> nil 
```

which is incorrect. the previous_changes should have been set because the Pet was being persisted. i've corrected this so now it works like this:

```
p = Person.create :pet => Pet.new
p.pet.changes #=> {}
p.pet.previous_changes #=> {"_id" => [nil, BSON::ObjectId('...')]}
```
