### PR TITLE
Added locale for en-GB

### DIFF
--- a/lib/config/locales/en-GB.yml
+++ b/lib/config/locales/en-GB.yml
@@ -1,0 +1,48 @@
+en-GB:
+  mongoid:
+    errors:
+      messages:
+        taken:
+          is already taken
+        document_not_found:
+          Document not found for class %{klass} with id(s) %{identifiers}.
+        invalid_database:
+          "Database should be a Mongo::DB, not %{name}."
+        invalid_options:
+          "Invalid option :%{invalid} provided to relation :%{name}. Valid options
+          are: %{valid}."
+        invalid_type:
+          Field was defined as a(n) %{klass}, but received a %{other} with
+          the value %{value}.
+        unsupported_version:
+          MongoDB %{version} not supported, please upgrade
+          to %{mongo_version}.
+        validations:
+          Validation failed - %{errors}.
+        invalid_collection:
+          Access to the collection for %{klass} is not allowed since it
+          is an embedded document, please access a collection from
+          the root document.
+        invalid_field:
+          Defining a field named %{name} is not allowed. Do not define
+          fields that conflict with Mongoid internal attributes or method
+          names. Use Document#instance_methods to see what names this includes.
+        too_many_nested_attribute_records:
+          Accepting nested attributes for %{association} is limited
+          to %{limit} records.
+        embedded_in_must_have_inverse_of:
+          Options for embedded_in association must include inverse_of.
+        dependent_only_references_one_or_many:
+          The dependent => destroy|delete option that was supplied
+          is only valid on references_one or references_many associations.
+        association_cant_have_inverse_of:
+          Defining an inverse_of on this association is not allowed. Only
+          use this option on embedded_in or references_many as array.
+        calling_document_find_with_nil_is_invalid:
+          Calling Document#find with nil is invalid
+        unsaved_document:
+          "You cannot call create or create! through a relational association
+          relation (%{document}) who's parent (%{base}) is not already saved."
+        mixed_relations:
+          Referencing a(n) %{embedded} document from the %{root} document via a
+          relational association is not allowed since the %{embedded} is embedded.


### PR DESCRIPTION
Changing the default locale for Rails using `config.i18n.default_locale = 'en-GB'` causes Mongoid to produce translation errors such as:

```
Mongoid::Errors::DocumentNotFound: translation missing: en-GB.mongoid.errors.messages.document_not_found
```

I have created a locale for en-GB to prevent this from happening.
