### PR TITLE
Change serialize_relations to call #as_json on the relation

### DIFF
--- a/lib/mongoid/serialization.rb
+++ b/lib/mongoid/serialization.rb
@@ -77,7 +77,7 @@ module Mongoid # :nodoc:
         relation = send(metadata.name, false, :eager => true)
         if relation
           attributes[metadata.name.to_s] =
-            relation.serializable_hash(relation_options(inclusions, options, name))
+            relation.as_json(relation_options(inclusions, options, name))
         end
       end
     end


### PR DESCRIPTION
Changed serialize_relations to call #as_json on the relation, so we respect the individual json representation of the relation model.

Otherwise, this won't be satisfied for children with custom as_json:
mother.as_json(:include => ['children'])['children'].first !== child.as_json

This bug has existed in Rails too, see this ticket https://github.com/rails/rails/issues/576
