### PR TITLE
add aliases :size, :length to :count. 

### DIFF
--- a/lib/mongoid/contexts/mongo.rb
+++ b/lib/mongoid/contexts/mongo.rb
@@ -69,6 +69,8 @@ module Mongoid #:nodoc:
       def count(extras = false)
         @count ||= klass.collection.find(selector, process_options).count(extras)
       end
+      alias :size :count
+      alias :length :count
 
       # Delete all the documents in the database matching the selector.
       #

--- a/lib/mongoid/criteria.rb
+++ b/lib/mongoid/criteria.rb
@@ -46,6 +46,8 @@ module Mongoid #:nodoc:
       :avg,
       :blank?,
       :count,
+      :size,
+      :length,
       :delete,
       :delete_all,
       :destroy,

--- a/spec/unit/mongoid/criteria_spec.rb
+++ b/spec/unit/mongoid/criteria_spec.rb
@@ -237,6 +237,28 @@ describe Mongoid::Criteria do
       end
     end
 
+    describe "#size" do
+
+      before do
+        context.expects(:size).returns(10)
+      end
+
+      it "delegates to the context" do
+        criteria.size.should == 10
+      end
+    end
+
+    describe "#length" do
+
+      before do
+        context.expects(:length).returns(10)
+      end
+
+      it "delegates to the context" do
+        criteria.length.should == 10
+      end
+    end
+
     describe "#exists?" do
 
       context "when there are documents in the db" do


### PR DESCRIPTION
add aliases :size, :length to :count.  Otherwise, if a call is made to collection#size, it will rerun the query from scratch.

this showed up as a regression somewhere between 2.0.0.beta20 and 2.0.2, and had a _huge_ impact for us.  We had a couple of loops (using while) where we had to possibly move forward in the array based upon factors..and we did this by checking the length.  In 2.0.2, that caused a ton of queries to be rerun and slowed down that process by almost 5x.

let me know if you would like any additional tests!
