### PR TITLE
setting cache at the class level was being ignored 

### DIFF
--- a/lib/mongoid/contexts/mongo.rb
+++ b/lib/mongoid/contexts/mongo.rb
@@ -169,7 +169,7 @@ module Mongoid #:nodoc:
         if klass.hereditary? && !criteria.selector.keys.include?(:_type)
           @criteria = criteria.in(:_type => criteria.klass._types)
         end
-        @criteria.cache if klass.cached?
+        @criteria = @criteria.cache if klass.cached?
       end
 
       # Iterate over each +Document+ in the results. This can take an optional

--- a/spec/unit/mongoid/contexts/mongo_spec.rb
+++ b/spec/unit/mongoid/contexts/mongo_spec.rb
@@ -336,6 +336,17 @@ describe Mongoid::Contexts::Mongo do
         context.selector[:_type].should be_nil
       end
     end
+    
+    it 'set the cache if the class has cache defined' do
+      klass.stubs(:cached? => true)
+      context.options[:cache].should be_true
+    end
+
+    it 'not set the cache if the class has cache defined' do
+      klass.stubs(:cached? => false)
+      context.options[:cache].should_not be_true
+    end
+    
   end
 
   describe "#iterate" do


### PR DESCRIPTION
not for all queries but for many.  This was caused by the @criteria object, which is immutable, not being reset.  fixed with tests.
