### PR TITLE
Disable JRuby for CI 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ rvm:
   - 1.9.2
   - 1.8.7
   - ree
-  - jruby
   - rbx
   - rbx-2.0.0pre
 before_script:


### PR DESCRIPTION
We are having JRuby-specific issues on Travis, I suggest that we disable builds against JRuby until we resolve them with JRuby core team. One more addition: we now provide Ruby 1.9.3-preview 1 (rvm: 1.9.3), maybe give it a try?
