### PR TITLE
Metadata #inverse_foreign_key returns a demodulized class foreign_key if inverse_of is not set;

### DIFF
--- a/lib/mongoid/relations/metadata.rb
+++ b/lib/mongoid/relations/metadata.rb
@@ -375,7 +375,7 @@ module Mongoid # :nodoc:
       # @since 2.0.0.rc.1
       def inverse_foreign_key
         @inverse_foreign_key ||=
-          ( inverse_of ? inverse_of.to_s.singularize : inverse_class_name.underscore ) <<
+          ( inverse_of ? inverse_of.to_s.singularize : inverse_class_name.demodulize.underscore ) <<
           relation.foreign_key_suffix
       end
 

--- a/spec/unit/mongoid/relations/metadata_spec.rb
+++ b/spec/unit/mongoid/relations/metadata_spec.rb
@@ -343,6 +343,26 @@ describe Mongoid::Relations::Metadata do
               metadata.foreign_key.should == "follower_ids"
             end
           end
+
+          context "when the class is namespaced" do
+            let(:metadata) do
+              described_class.new(
+                :name => :bananas,
+                :relation => Mongoid::Relations::Referenced::ManyToMany,
+                :inverse_class_name => "Fruits::Apple",
+                :class_name => "Fruits::Banana"
+              )
+            end
+
+            it "returns the foreign_key without the module name" do
+              metadata.foreign_key.should == "banana_ids"
+            end
+
+            it "returns the inverse_foreign_key without the module name" do
+              metadata.inverse_foreign_key.should == "apple_ids"
+            end
+
+          end
         end
       end
 


### PR DESCRIPTION
Metadata #inverse_foreign_key returns a demodulized class foreign_key for when
inverse_of is not set;

Fix Bug where ManytoMany relation using namespace classes will not bind
corrrectly; why because bind_one uses metadata.inverse_foreign_key which
will generated inverse_foreign_keys like "fruit/apple_ids"
