### PR TITLE
Support for creating proxy extensions from a module

### DIFF
--- a/lib/mongoid/relations/macros.rb
+++ b/lib/mongoid/relations/macros.rb
@@ -242,13 +242,12 @@ module Mongoid # :nodoc:
         # @return [ Metadata ] The metadata for the relation.
         def characterize(name, relation, options, &block)
           Metadata.new(
-            options.merge(
+          {
               :relation => relation,
               :extend => create_extension_module(name, &block),
               :inverse_class_name => self.name,
               :name => name
-            )
-          )
+          }.merge(options))
         end
 
         # Generate a named extension module suitable for marshaling

--- a/spec/unit/mongoid/relations/macros_spec.rb
+++ b/spec/unit/mongoid/relations/macros_spec.rb
@@ -539,4 +539,37 @@ describe Mongoid::Relations::Macros do
         be_a_kind_of(Mongoid::Relations::Metadata)
     end
   end
+
+  describe "Proxy extensions" do
+
+    class Person
+      include Mongoid::Document
+    end
+
+    class Name
+      include Mongoid::Document
+
+      module Extension
+        def short_name
+          "spec"
+        end
+      end
+    end
+
+    let(:inst) {Person.new(:name => Name.new)}
+
+    it "supports creating extension from a block" do
+      Person.embeds_one(:name) do
+        def full_name
+          "spec"
+        end
+      end
+      inst.name.full_name.should == "spec"
+    end
+
+    it "supports creating extension from a module" do
+      Person.embeds_one(:name, :extend => Name::Extension)
+      inst.name.short_name.should == "spec"
+    end
+  end
 end


### PR DESCRIPTION
Make it possible to extract the extensions methods to a module:

class Person
  include Mongoid::Document

  embeds_one :name, :extend => Name::Extension
end
