### PR TITLE
Delegate Document.logger and Document#logger to Mongoid.logger

### DIFF
--- a/lib/mongoid/document.rb
+++ b/lib/mongoid/document.rb
@@ -213,6 +213,13 @@ module Mongoid #:nodoc:
 
     private
 
+    # Returns the logger
+    #
+    # @return [ Logger ] The configured logger or a default Logger instance.
+    def logger
+      Mongoid.logger
+    end
+
     # Implement this for calls to flatten on array.
     #
     # @example Get the document as an array.
@@ -273,6 +280,16 @@ module Mongoid #:nodoc:
       # Set the i18n scope to overwrite ActiveModel.
       def i18n_scope
         :mongoid
+      end
+
+      # Returns the logger
+      #
+      # @example Get the logger.
+      #   Person.logger
+      #
+      # @return [ Logger ] The configured logger or a default Logger instance.
+      def logger
+        Mongoid.logger
       end
     end
   end

--- a/spec/unit/mongoid/document_spec.rb
+++ b/spec/unit/mongoid/document_spec.rb
@@ -665,4 +665,16 @@ describe Mongoid::Document do
       end
     end
   end
+
+  describe "logger" do
+    it "has a class logger method" do
+      Person.should respond_to(:logger)
+      Person.logger.should == Mongoid.logger
+    end
+
+    it "has a private logger method" do
+      person = Person.new
+      person.send(:logger).should == Mongoid.logger
+    end
+  end
 end


### PR DESCRIPTION
Make Logger accessible from within documents in both class and instance methods (as it's in ActiveRecord).
