### PR TITLE
Bug: enumerable.to_json should pass options through

### DIFF
--- a/lib/mongoid/relations/targets/enumerable.rb
+++ b/lib/mongoid/relations/targets/enumerable.rb
@@ -325,11 +325,13 @@ module Mongoid #:nodoc:
         # @example Get the enumerable as json.
         #   enumerable.to_json
         #
+        # @param [ Hash ] options Optional parameters.
+        #
         # @return [ String ] The entries all loaded as a string.
         #
         # @since 2.2.0
-        def to_json
-          entries.to_json
+        def to_json(options = {})
+          entries.to_json(options)
         end
 
         # Return all the unique documents in the enumerable.

--- a/spec/functional/mongoid/relations/targets/enumerable_spec.rb
+++ b/spec/functional/mongoid/relations/targets/enumerable_spec.rb
@@ -1197,6 +1197,29 @@ describe Mongoid::Relations::Targets::Enumerable do
     end
   end
 
+  describe "#to_json(parameters)" do
+
+    let(:person) do
+      Person.create(:ssn => "422-21-9687")
+    end
+
+    let!(:post) do
+      Post.create(:title => "test", :person_id => person.id)
+    end
+
+    let(:criteria) do
+      Post.where(:person_id => person.id)
+    end
+
+    let!(:json) do
+      person.posts.to_json({:except => 'title'})
+    end
+
+    it "serializes the enumerable" do
+      json.should_not include(post.title)
+    end
+  end
+
   describe "#uniq" do
 
     let(:person) do


### PR DESCRIPTION
We use options everywhere, including with individual objects and collections. See http://api.rubyonrails.org/classes/ActiveModel/Serializers/JSON.html. This lets you do person.posts.to_json(options).
