### PR TITLE
Cannot query on hash in an embedded relationship

### DIFF
--- a/lib/mongoid/matchers/strategies.rb
+++ b/lib/mongoid/matchers/strategies.rb
@@ -49,15 +49,26 @@ module Mongoid #:nodoc:
       # @since 2.0.0.rc.7
       def matcher(document, key, value)
         if value.is_a?(Hash)
-          MATCHERS[value.keys.first].new(document.attributes[key.to_s])
+          MATCHERS[value.keys.first].new(extract_attribute(document, key))
         else
           if key == "$or"
             Matchers::Or.new(value, document)
           else
-            Default.new(document.attributes[key.to_s])
+            Default.new(extract_attribute(document, key))
           end
         end
       end
+      
+      private
+      
+      def extract_attribute(document, key)
+        if (key_string = key.to_s) =~ /.+\..+/
+          key_string.split('.').inject(document.attributes){|attribs, key| attribs.try(:[],key) }
+        else
+          document.attributes[key_string]
+        end
+      end
+      
     end
   end
 end

--- a/spec/models/location.rb
+++ b/spec/models/location.rb
@@ -1,5 +1,6 @@
 class Location
   include Mongoid::Document
   field :name
+  field :info, :type => Hash
   embedded_in :address
 end

--- a/spec/unit/mongoid/matchers_spec.rb
+++ b/spec/unit/mongoid/matchers_spec.rb
@@ -11,7 +11,7 @@ describe Mongoid::Matchers do
       end
 
       before do
-        document.locations << Location.new(:name => 'No.1')
+        document.locations << Location.new(:name => 'No.1', :info => { 'door' => 'Red'} )
       end
 
       context "when the attributes do not match" do
@@ -36,6 +36,37 @@ describe Mongoid::Matchers do
 
         end
 
+      end
+      
+      context "when matching embedded hash values" do
+
+        context "when the contents match" do
+          let(:selector){ { 'info.door' => 'Red' } }
+        
+          
+          it "returns true " do
+            document.locations.first.matches?(selector).should be_true
+          end
+          
+        end
+ 
+        context "when the contents do not match" do
+          let(:selector){ { 'info.door' => 'Blue' } }
+          
+          it "returns false" do
+            document.locations.first.matches?(selector).should be_false
+          end
+          
+        end
+        
+        context "when the contents do not exist" do
+          let(:selector){ { 'info.something_else' => 'Red' } }
+          
+          it "returns false" do
+            document.locations.first.matches?(selector).should be_false
+          end
+          
+        end
       end
 
     end


### PR DESCRIPTION
Based upon issue #517

https://github.com/mongoid/mongoid/issues/517

Here is a gist showing the issue

https://gist.github.com/764632

I considered moving this into the default matcher, (as Durran suggested) however it would have required chaining the matcher interface. (As it doesn't know the key and therefore cannot determine how to get the attribute)

My fix simply extracts the attribute from the document more intelligently by handling the dot notation. 

Cheers

Scott
