### PR TITLE
Correct error when using attributes= to assign a blank value to an empty embeds_many

### DIFF
--- a/lib/mongoid/relations/embedded/many.rb
+++ b/lib/mongoid/relations/embedded/many.rb
@@ -232,7 +232,7 @@ module Mongoid # :nodoc:
         def substitute(replacement)
           tap do |proxy|
             if replacement.blank?
-              if assigning?
+              if assigning? && !proxy.empty?
                 base.atomic_unsets.push(proxy.first.atomic_path)
               end
               proxy.clear

--- a/spec/unit/mongoid/attributes_spec.rb
+++ b/spec/unit/mongoid/attributes_spec.rb
@@ -893,6 +893,21 @@ describe Mongoid::Attributes do
             @owner.pet.vet_visits.size.should == 1
           end
         end
+
+        context "when the parent has an empty embeds_many" do
+
+          let(:person) do
+            Person.new
+          end
+
+          let(:attributes) do
+            { :services => [] }
+          end
+
+          it "does not raise an error" do
+            person.send(method, attributes)
+          end
+        end
       end
 
       context "on a child document" do


### PR DESCRIPTION
Small patch to fix a nil value error when using attributes= to set an empty embeds_many to a blank value.
