### PR TITLE
Update Paranoia Queries so they can utilize a given Index

### DIFF
--- a/lib/mongoid/paranoia.rb
+++ b/lib/mongoid/paranoia.rb
@@ -85,7 +85,7 @@ module Mongoid #:nodoc:
       #
       # @return [ Criteria ] The paranoid compliant criteria.
       def criteria(embedded = false, scoped = true)
-        scoped ? super.where(:deleted_at.exists => false) : super
+        scoped ? super.merge({ :conditions => { :deleted_at => nil } }) : super
       end
 
       # Find deleted documents
@@ -97,7 +97,7 @@ module Mongoid #:nodoc:
       #
       # @return [ Criteria ] The deleted criteria.
       def deleted
-        where(:deleted_at.exists => true)
+        where(:deleted_at.ne => nil)
       end
     end
   end

--- a/spec/unit/mongoid/paranoia_spec.rb
+++ b/spec/unit/mongoid/paranoia_spec.rb
@@ -183,7 +183,7 @@ describe Mongoid::Paranoia do
       end
 
       it "returns a scoped criteria" do
-        criteria.selector.should eq({ :deleted_at => { "$exists" => false }})
+        criteria.selector.should eq({ :deleted_at => nil })
       end
     end
 
@@ -206,7 +206,7 @@ describe Mongoid::Paranoia do
     end
 
     it "returns a scoped criteria" do
-      scoped.selector.should eq({ :deleted_at => { "$exists" => false }})
+      scoped.selector.should eq({ :deleted_at => nil })
     end
   end
 


### PR DESCRIPTION
Currently the Paranoia module uses $exists to filter records by injecting it into a given selector. By changing the query to match on 'nil', queries can use a supplied index.

This still requires a manual process of prepending each index with [ 'deleted_at', 1 ]. Not sure if that should be the default process, of if that should always be prepended to any call to :index to be inline with the criteria being added by default.

Thanks,
 Dave
