### PR TITLE
Allow optional pre-formatting of keys before composing primary key

### DIFF
--- a/lib/mongoid/identity.rb
+++ b/lib/mongoid/identity.rb
@@ -69,9 +69,11 @@ module Mongoid #:nodoc:
     #
     # @return [ Array<Object> ] The array of keys.
     def compose
+      kf = document.key_formatter
       document.primary_key.collect do |key|
-        document.attributes[key.to_s]
-      end.reject { |val| val.nil? }
+        val = document.attributes[key.to_s]
+        val && kf ? kf.call(val) : val
+      end.compact
     end
 
     # Determines if the document stores the type information. This is if it is

--- a/lib/mongoid/keys.rb
+++ b/lib/mongoid/keys.rb
@@ -9,7 +9,7 @@ module Mongoid #:nodoc:
     attr_reader :identifier
 
     included do
-      cattr_accessor :primary_key, :using_object_ids
+      cattr_accessor :primary_key, :using_object_ids, :key_formatter
       self.using_object_ids = true
     end
 
@@ -122,6 +122,7 @@ module Mongoid #:nodoc:
       # @since 1.0.0
       def key(*fields)
         self.primary_key = fields
+        self.key_formatter = block_given? ? Proc.new : nil
         identity(:type => String)
         set_callback(:save, :around, :set_composite_key)
       end

--- a/spec/unit/mongoid/keys_spec.rb
+++ b/spec/unit/mongoid/keys_spec.rb
@@ -49,6 +49,22 @@ describe Mongoid::Keys do
         field.type.should == String
       end
     end
+    
+    context "when key is provided a formatter block" do
+
+      before do
+        Address.key(:street, :city) {|field| field.gsub('e', 'o') }
+        address.run_callbacks(:save)
+      end
+
+      let(:address) do
+        Address.new(:street => "Testing Street Name", :city => "Berlin")
+      end
+
+      it "combines all formatted fields" do
+        address.id.should == "tosting-stroot-namo-borlin"
+      end
+    end
 
     context "when key is composite" do
 


### PR DESCRIPTION
Contrived example scenario:

``` ruby
class Product
  include Mongoid::Document

  field :vendor
  field :name

  key(:vendor, :name) {|field| field.parameterize }

end

p = Product.create! vendor: '$$ vendor', name: '!Product!'
```

This prevents having to create a separate field and before_save callback to format the key.  It gives you a clean, sluggable primary key such as `'vendor-product'` as opposed to what would normally be `-dol--dol--productz--excl-product-excl-`.  There are many different use cases for this, especially when dealing with data as terrible as I do at my job.
