### PR TITLE
Excluding versions attribute from versioned attributes

### DIFF
--- a/lib/mongoid/versioning.rb
+++ b/lib/mongoid/versioning.rb
@@ -153,7 +153,7 @@ module Mongoid #:nodoc:
     # @since 2.1.0
     def only_versioned_attributes(hash)
       {}.tap do |versioned|
-        hash.each_pair do |name, value|
+        hash.except("versions").each_pair do |name, value|
           field = fields[name]
           versioned[name] = value if !field || field.versioned?
         end

--- a/spec/functional/mongoid/versioning_spec.rb
+++ b/spec/functional/mongoid/versioning_spec.rb
@@ -102,5 +102,15 @@ describe Mongoid::Versioning do
         page.versions.map(&:title).should == expected
       end
     end
+
+    it "should not version versions attributes" do
+      3.times do |n|
+        page.title = "#{n + 2}"
+        page.save
+      end
+
+      page.versions[1].versions.should == []
+      page.versions[2].versions.should == []
+    end
   end
 end


### PR DESCRIPTION
When a new version was created, Mongoid versioned the "versions" attribute too. I put `except("versions")` in the method `only_versioned_attributes`
