### PR TITLE
Added Rails::Mongoid.preload_models to handle conditional loading of models

### DIFF
--- a/lib/mongoid/railtie.rb
+++ b/lib/mongoid/railtie.rb
@@ -93,7 +93,7 @@ module Rails #:nodoc:
       # environments.
       initializer "preload all application models" do |app|
         config.to_prepare do
-          ::Rails::Mongoid.load_models(app) unless $rails_rake_task
+          ::Rails::Mongoid.preload_models(app) unless $rails_rake_task
         end
       end
 

--- a/lib/rails/mongoid.rb
+++ b/lib/rails/mongoid.rb
@@ -36,12 +36,19 @@ module Rails #:nodoc:
     #
     # @param [ Application ] app The rails application.
     def load_models(app)
-      return unless ::Mongoid.preload_models
       app.config.paths["app/models"].each do |path|
         Dir.glob("#{path}/**/*.rb").sort.each do |file|
           load_model(file.gsub("#{path}/" , "").gsub(".rb", ""))
         end
       end
+    end
+
+    # Conditionally calls `Rails::Mongoid.load_models(app)` if the
+    # `::Mongoid.preload_models` is `true`.
+    #
+    # @param [ Application ] app The rails application.
+    def preload_models(app)
+      load_models(app) if ::Mongoid.preload_models
     end
 
     private

--- a/spec/unit/rails/mongoid_spec.rb
+++ b/spec/unit/rails/mongoid_spec.rb
@@ -63,7 +63,7 @@ describe "Rails::Mongoid" do
     end
   end
 
-  describe ".load_models" do
+  describe ".preload_models" do
 
     let(:app) do
       stub(:config => config)
@@ -77,7 +77,7 @@ describe "Rails::Mongoid" do
       { "app/models" => [ "/rails/root/app/models" ] }
     end
 
-    context "when load models config is false" do
+    context "when preload models config is false" do
 
       let(:files) do
         [
@@ -93,11 +93,11 @@ describe "Rails::Mongoid" do
 
       it "does not load any models" do
         Rails::Mongoid.expects(:load_model).never
-        Rails::Mongoid.load_models(app)
+        Rails::Mongoid.preload_models(app)
       end
     end
 
-    context "when load models config is true" do
+    context "when preload models config is true" do
 
       before(:all) do
         Mongoid.preload_models = true
@@ -119,7 +119,7 @@ describe "Rails::Mongoid" do
         it "requires the models by basename" do
           Rails::Mongoid.expects(:load_model).with("address")
           Rails::Mongoid.expects(:load_model).with("user")
-          Rails::Mongoid.load_models(app)
+          Rails::Mongoid.preload_models(app)
         end
       end
 
@@ -135,8 +135,44 @@ describe "Rails::Mongoid" do
 
         it "requires the models by subdirectory and basename" do
           Rails::Mongoid.expects(:load_model).with("mongoid/behaviour")
-          Rails::Mongoid.load_models(app)
+          Rails::Mongoid.preload_models(app)
         end
+      end
+    end
+  end
+
+  describe ".load_models" do
+
+    let(:app) do
+      stub(:config => config)
+    end
+
+    let(:config) do
+      stub(:paths => paths)
+    end
+
+    let(:paths) do
+      { "app/models" => [ "/rails/root/app/models" ] }
+    end
+
+    context "even when preload models config is false" do
+
+      let(:files) do
+        [
+          "/rails/root/app/models/user.rb",
+          "/rails/root/app/models/address.rb"
+        ]
+      end
+
+      before(:all) do
+        Mongoid.preload_models = false
+        Dir.stubs(:glob).with("/rails/root/app/models/**/*.rb").returns(files)
+      end
+
+      it "loads all models" do
+        Rails::Mongoid.expects(:load_model).with("address")
+        Rails::Mongoid.expects(:load_model).with("user")
+        Rails::Mongoid.load_models(app)
       end
     end
   end


### PR DESCRIPTION
Added Rails::Mongoid.preload_models to handle conditional loading of models

This moves the the conditional check for the preload_models config away from
load_models.  Let Rails::Mongoid.load_models load the models as the name implies
regardless of the config option.

I ran into a scenario where I needed to load all the models before running a thor task, but there was no easy way to do so, because `load_models(app)` checked to see if the preload_models config was set or not, and preload_models defaults to false now.  This new method handles the conditional check of whether or not to preload models, but the `load_models` method now loads all models regardless of the config.
