### PR TITLE
Fix mongoid atomic_path errors

### DIFF
--- a/lib/mongoid/relations/embedded/many.rb
+++ b/lib/mongoid/relations/embedded/many.rb
@@ -231,7 +231,7 @@ module Mongoid # :nodoc:
         # @since 2.0.0.rc.1
         def substitute(replacement)
           tap do |proxy|
-            if replacement.blank?
+            if replacement.blank? && !proxy.blank?
               if assigning?
                 base.atomic_unsets.push(proxy.first.atomic_path)
               end


### PR DESCRIPTION
There is a bug when you try to replace an empty associated collection with another empty collection. This fixes it.

Cheers
