### PR TITLE
key agnostic expansion

### DIFF
--- a/lib/mongoid/extensions/hash/criteria_helpers.rb
+++ b/lib/mongoid/extensions/hash/criteria_helpers.rb
@@ -17,8 +17,7 @@ module Mongoid #:nodoc:
         def expand_complex_criteria
           {}.tap do |hsh|
             each_pair do |k,v|
-              case k
-              when Mongoid::Criterion::Complex
+              if k.respond_to?(:key) && k.respond_to?(:to_mongo_query)
                 hsh[k.key] ||= {}
                 hsh[k.key].merge!(k.to_mongo_query(v))
               else


### PR DESCRIPTION
Small bug in my last pull. This allows for key agnostic expansion. Right now it has to be a Mongoid::Criterion::Complex Class
