### PR TITLE
Fixed naming conflicts with custom types

### DIFF
--- a/lib/mongoid/fields/mappings.rb
+++ b/lib/mongoid/fields/mappings.rb
@@ -26,7 +26,12 @@ module Mongoid #:nodoc
           return "#{MODULE}::ForeignKeys::#{klass.to_s.demodulize}".constantize
         end
         begin
-          "#{MODULE}::#{klass.to_s.demodulize}".constantize
+          modules = "#{ MODULE }::|BSON::|ActiveSupport::"
+          if match = klass.to_s.match(Regexp.new("^(#{ modules })?(\\w+)$"))
+            "#{MODULE}::#{ match[2] }".constantize
+          else
+            klass.to_s.constantize
+          end
         rescue NameError
           klass
         end

--- a/spec/app/models/custom_types.rb
+++ b/spec/app/models/custom_types.rb
@@ -1,0 +1,17 @@
+module Custom
+  class Type
+    include Mongoid::Fields::Serializable
+  end
+
+  class String
+    include Mongoid::Fields::Serializable
+  end
+end
+
+module Mongoid
+  module MyExtension
+    class Object
+      include Mongoid::Fields::Serializable
+    end
+  end
+end

--- a/spec/unit/mongoid/fields/mappings_spec.rb
+++ b/spec/unit/mongoid/fields/mappings_spec.rb
@@ -215,13 +215,58 @@ describe Mongoid::Fields::Mappings do
 
     context "when given a custom type" do
 
-      let(:klass) do
-        Person
+      context "without a module" do
+
+        let(:klass) do
+          Person
+        end
+
+        it "returns the class of the custom type" do
+          definable.should eq(Person)
+        end
+
       end
 
-      it "returns the class of the custom type" do
-        definable.should eq(Person)
+      context "with a module" do
+
+        context "and a class not matching a defined serializable" do
+
+          let(:klass) do
+            Custom::Type
+          end
+
+          it "returns the module and class of the custom type" do
+            definable.should eq(Custom::Type)
+          end
+
+        end
+
+        context "and a class matching a defined serializable" do
+
+          let(:klass) do
+            Custom::String
+          end
+
+          it "returns the module and class of the custom type" do
+            definable.should eq(Custom::String)
+          end
+
+        end
+
+        context "inside the Mongoid namespace" do
+
+          let(:klass) do
+            Mongoid::MyExtension::Object
+          end
+
+          it "returns the module and class of the custom type" do
+            definable.should eq(Mongoid::MyExtension::Object)
+          end
+
+        end
+
       end
+
     end
 
     context "when given nil" do


### PR DESCRIPTION
This pull request fixes an issue that prevents defining your own custom (serializable) types by simply using your own module namespace.  Mongoid gets confused by type names like `Mongoid::MyMongoidExtension::Time` and uses `Mongoid::Fields::Serializable::Time` instead.

The same issue would also happen for custom types like `AnyModule::Date` or `Some::OtherModule::Range`. See specs for more details.
