### PR TITLE
Fix IdentityMap to work with inherited classes.

### DIFF
--- a/lib/mongoid/identity_map.rb
+++ b/lib/mongoid/identity_map.rb
@@ -93,7 +93,12 @@ module Mongoid #:nodoc:
     #
     # @since 2.1.0
     def documents_for(klass)
-      self[klass] ||= {}
+      if index = klass.try(:collection_name)
+        index += "." + klass.name if klass.embedded?
+        self[index] ||= {}
+      else
+        {}
+      end
     end
 
     class << self

--- a/spec/functional/mongoid/criterion/inclusion_spec.rb
+++ b/spec/functional/mongoid/criterion/inclusion_spec.rb
@@ -379,11 +379,11 @@ describe Mongoid::Criterion::Inclusion do
       end
 
       it "inserts the first document into the identity map" do
-        Mongoid::IdentityMap[Post][post_one.id].should eq(post_one)
+        Mongoid::IdentityMap[Post.collection_name][post_one.id].should eq(post_one)
       end
 
       it "inserts the second document into the identity map" do
-        Mongoid::IdentityMap[Post][post_two.id].should eq(post_two)
+        Mongoid::IdentityMap[Post.collection_name][post_two.id].should eq(post_two)
       end
     end
 
@@ -410,11 +410,11 @@ describe Mongoid::Criterion::Inclusion do
       end
 
       it "inserts the first document into the identity map" do
-        Mongoid::IdentityMap[Game][game_one.id].should eq(game_one)
+        Mongoid::IdentityMap[Game.collection_name][game_one.id].should eq(game_one)
       end
 
       it "inserts the second document into the identity map" do
-        Mongoid::IdentityMap[Game][game_two.id].should eq(game_two)
+        Mongoid::IdentityMap[Game.collection_name][game_two.id].should eq(game_two)
       end
     end
 
@@ -445,11 +445,11 @@ describe Mongoid::Criterion::Inclusion do
       end
 
       it "inserts the first document into the identity map" do
-        Mongoid::IdentityMap[Person][person.id].should eq(person)
+        Mongoid::IdentityMap[Person.collection_name][person.id].should eq(person)
       end
 
       it "inserts the second document into the identity map" do
-        Mongoid::IdentityMap[Person][person_two.id].should eq(person_two)
+        Mongoid::IdentityMap[Person.collection_name][person_two.id].should eq(person_two)
       end
     end
 
@@ -484,19 +484,19 @@ describe Mongoid::Criterion::Inclusion do
       end
 
       it "inserts the first has many document into the identity map" do
-        Mongoid::IdentityMap[Post][post_one.id].should eq(post_one)
+        Mongoid::IdentityMap[Post.collection_name][post_one.id].should eq(post_one)
       end
 
       it "inserts the second has many document into the identity map" do
-        Mongoid::IdentityMap[Post][post_two.id].should eq(post_two)
+        Mongoid::IdentityMap[Post.collection_name][post_two.id].should eq(post_two)
       end
 
       it "inserts the first has one document into the identity map" do
-        Mongoid::IdentityMap[Game][game_one.id].should eq(game_one)
+        Mongoid::IdentityMap[Game.collection_name][game_one.id].should eq(game_one)
       end
 
       it "inserts the second has one document into the identity map" do
-        Mongoid::IdentityMap[Game][game_two.id].should eq(game_two)
+        Mongoid::IdentityMap[Game.collection_name][game_two.id].should eq(game_two)
       end
     end
   end

--- a/spec/unit/mongoid/criterion/inclusion_spec.rb
+++ b/spec/unit/mongoid/criterion/inclusion_spec.rb
@@ -291,7 +291,7 @@ describe Mongoid::Criterion::Inclusion do
 
         it "puts the related documents in the identity map" do
           criteria.entries
-          map[Post][{"person_id" => person.id}].should eq([ post ])
+          map[Post.collection_name][{"person_id" => person.id}].should eq([ post ])
         end
       end
 
@@ -335,7 +335,7 @@ describe Mongoid::Criterion::Inclusion do
 
         it "puts the related documents in the identity map" do
           criteria.entries
-          map[Post][{"person_id" => person.id}].should eq([ post ])
+          map[Post.collection_name][{"person_id" => person.id}].should eq([ post ])
         end
       end
     end
@@ -399,7 +399,7 @@ describe Mongoid::Criterion::Inclusion do
 
         it "puts the related documents in the identity map" do
           criteria.entries
-          map[Game][{"person_id" => person.id}].should eq(game)
+          map[Game.collection_name][{"person_id" => person.id}].should eq(game)
         end
       end
 
@@ -443,7 +443,7 @@ describe Mongoid::Criterion::Inclusion do
 
         it "puts the related documents in the identity map" do
           criteria.entries
-          map[Game][{"person_id" => person.id}].should eq(game)
+          map[Game.collection_name][{"person_id" => person.id}].should eq(game)
         end
       end
     end
@@ -507,7 +507,7 @@ describe Mongoid::Criterion::Inclusion do
 
         it "puts the related documents in the identity map" do
           criteria.entries
-          map[Person][person.id].should eq(person)
+          map[Person.collection_name][person.id].should eq(person)
         end
       end
 
@@ -551,7 +551,7 @@ describe Mongoid::Criterion::Inclusion do
 
         it "puts the related documents in the identity map" do
           criteria.entries
-          map[Person][person.id].should eq(person)
+          map[Person.collection_name][person.id].should eq(person)
         end
       end
     end


### PR DESCRIPTION
The IdentityMap currently stores documents by class.  However, this does not work with inherited classes, as they are stored by the subclass and may be requested by the superclass name (particularly with eager loading).  So I changed the IdentityMap to store by the collection name, which seems more appropriate.  

Since it appears that embedded documents may also be stored in the IdentityMap, I append the class name to the collection name.  Actually, it appears that the collection name is just assigned for embedded documents based on the class name, so maybe this is not appropriate.  I'm not sure what's best for this case... is there even a use case for storing embedded documents in the IdentityMap?

I updated the tests and added a few to cover these new cases.

Let me know if you have any questions.  This addresses the bug https://github.com/mongoid/mongoid/issues/1371

Thanks!
