### PR TITLE
create_indexes rake task silently swallows exceptions, hiding invalid index specification reporting

### DIFF
--- a/lib/rails/mongoid.rb
+++ b/lib/rails/mongoid.rb
@@ -15,14 +15,21 @@ module Rails #:nodoc:
     #
     # @since 2.1.0
     def create_indexes(pattern)
+      logger = Logger.new($stdout)
       Dir.glob(pattern).each do |file|
         begin
           model = determine_model(file)
           if model
             model.create_indexes
-            Logger.new($stdout).info("Generated indexes for #{model}")
+            logger.info("Generated indexes for #{model}")
+          else
+            logger.info("Not a Mongoid parent model: #{file}")
           end
         rescue => e
+          logger.error %Q{Failed to create indexes for #{model}:
+            #{e.class}:#{e.message}
+            #{e.backtrace.join("\n")}
+          }
         end
       end
     end


### PR DESCRIPTION
When you incorrectly specify an index in a model, Mongoid raises an exception with a nice explanation message:

```
Mongo::MongoArgumentError:Invalid index specification [:game_id, -1]; should be either a string, symbol, or an array of arrays.
```

Except it doesn't.

These exceptions are rescued without any mention in the command output. The net result is missing indexes on specific collection, which then can take quite a bit of time and production slownesses before getting figured out.

This occurs since the last modification of `lib/rails/mongoid.rb` (in eca6f32: Fixing all the failures for 1.8.7).

The attached pull request logs index creation failures to STDOUT instead of swallowing them silently.
