### PR TITLE
Temporary fix to Mongo 1.4.1 dependency issues

### DIFF
--- a/mongoid.gemspec
+++ b/mongoid.gemspec
@@ -19,10 +19,10 @@ Gem::Specification.new do |s|
 
   s.add_dependency("activemodel", ["~> 3.1"])
   s.add_dependency("tzinfo", ["~> 0.3.22"])
-  s.add_dependency("mongo", ["~> 1.4"])
+  s.add_dependency("mongo", ["~> 1.3"])
 
   s.add_development_dependency("rdoc", ["~> 3.5.0"])
-  s.add_development_dependency("bson_ext", ["~> 1.4"])
+  s.add_development_dependency("bson_ext", ["~> 1.3"])
   s.add_development_dependency("mocha", ["~> 0.9.12"])
   s.add_development_dependency("rspec", ["~> 2.6"])
   s.add_development_dependency("watchr", ["~> 0.6"])


### PR DESCRIPTION
This is a temporary fix because Mongo and bson 1.4.0 and 1.4.1 were yanked from Github due to critical bugs

See http://rubygems.org/gems/mongo/versions  and this thread http://groups.google.com/group/mongodb-user/browse_thread/thread/7ddaabe02d43fbab?pli=1
