### PR TITLE
Added *_before_type_cast attributes

### DIFF
--- a/lib/mongoid/attributes.rb
+++ b/lib/mongoid/attributes.rb
@@ -98,6 +98,7 @@ module Mongoid #:nodoc:
     def write_attribute(name, value)
       _assigning do
         access = name.to_s
+        instance_variable_set :"@#{access}_before_type_cast", value
         localized = fields[access].try(:localized?)
         typed_value_for(access, value).tap do |value|
           unless attributes[access] == value || attribute_changed?(access)
@@ -201,7 +202,11 @@ module Mongoid #:nodoc:
     #
     # @since 1.0.0
     def typed_value_for(key, value)
-      fields.has_key?(key) ? fields[key].serialize(value) : value
+      begin
+        fields.has_key?(key) ? fields[key].serialize(value) : value
+      rescue
+        nil
+      end
     end
 
     module ClassMethods #:nodoc:

--- a/lib/mongoid/document.rb
+++ b/lib/mongoid/document.rb
@@ -241,6 +241,7 @@ module Mongoid #:nodoc:
         attributes = attrs || {}
         allocate.tap do |doc|
           doc.instance_variable_set(:@attributes, attributes)
+          attributes.each { |name, value| doc.instance_variable_set "@#{name}_before_type_cast", value }
           doc.send(:apply_defaults)
           IdentityMap.set(doc)
           doc.run_callbacks(:initialize) { doc }

--- a/lib/mongoid/fields.rb
+++ b/lib/mongoid/fields.rb
@@ -313,6 +313,9 @@ module Mongoid #:nodoc
             attr = read_attribute(name)
             (options[:type] == Boolean) ? attr == true : attr.present?
           end
+          define_method("#{meth}_before_type_cast") do
+            instance_variable_get :"@#{meth}_before_type_cast"
+          end
         end
       end
 

--- a/spec/unit/mongoid/attributes_spec.rb
+++ b/spec/unit/mongoid/attributes_spec.rb
@@ -970,6 +970,17 @@ describe Mongoid::Attributes do
         person.terms.should be_true
       end
     end
+
+    context "when setting the attribute" do
+
+      let(:person) do
+        Person.new(:age => 30)
+      end
+
+      it "sets the before_type_cast attribute for the field to the same value" do
+        person.age_before_type_cast.should == 30
+      end
+    end
   end
 
   describe "#typed_value_for" do

--- a/spec/unit/mongoid/document_spec.rb
+++ b/spec/unit/mongoid/document_spec.rb
@@ -395,6 +395,10 @@ describe Mongoid::Document do
         person.title.should == "Sir"
       end
 
+      it "sets the *_before_type_cast attributes" do
+        person.title_before_type_cast.should == "Sir"
+      end
+
       it "sets persisted to true" do
         person.should be_persisted
       end

--- a/spec/unit/mongoid/fields_spec.rb
+++ b/spec/unit/mongoid/fields_spec.rb
@@ -188,6 +188,10 @@ describe Mongoid::Fields do
         Person.new.testing?.should be_false
       end
 
+      it "adds a before_type_cast method for the fields defined" do
+        person.should respond_to :testing_before_type_cast
+      end
+
       it "adds field methods in a module to allow overriding and preserve inheritance" do
         Person.class_eval do
           attr_reader :testing_override_called


### PR DESCRIPTION
I was using a competing ODM before switching to Mongoid this week, and that one created *_before_type_cast attributes.

I was missing these sorely for Rails validation, so I added them.  I hope I did it cleanly; it was just a few lines of code.
