### PR TITLE
Retrying to connect when the replica set is reconfigured

### DIFF
--- a/spec/unit/mongoid/collections/retry_spec.rb
+++ b/spec/unit/mongoid/collections/retry_spec.rb
@@ -113,4 +113,105 @@ describe Mongoid::Collections::Retry do
       end
     end
   end
+
+  describe "when an operation failure occurs" do
+
+    context "because the primary server has changed" do
+
+      before do
+        subject.expects(:do_action).raises(Mongo::OperationFailure.new("10054: not master")).times(max_retries + 1)
+      end
+
+      describe "and Mongoid.max_retries_on_connection_failure is 0" do
+
+        let :max_retries do
+          0
+        end
+
+        it "raises Mongo::OperationFailure" do
+          expect { subject.perform }.to raise_error(Mongo::OperationFailure)
+        end
+      end
+
+      describe "and Mongoid.max_retries_on_connection_failure is greater than 0" do
+
+        let :max_retries do
+          5
+        end
+
+        before do
+          Mongoid.max_retries_on_connection_failure = max_retries
+        end
+
+        after do
+          Mongoid.max_retries_on_connection_failure = 0
+        end
+
+        it "raises Mongo::OperationFailure" do
+          expect { subject.perform }.to raise_error(Mongo::OperationFailure)
+        end
+      end
+    end
+
+
+    context "because the primary server has changed and it comes back after a few retries" do
+      let :result do
+        'something'
+      end
+
+      before do
+        subject.stubs(:do_action).raises(Mongo::OperationFailure.new("10054: not master")).then.returns(result)
+      end
+
+      describe "and Mongoid.max_retries_on_connection_failure is 0" do
+
+        let :max_retries do
+          0
+        end
+
+        it "raises Mongo::OperationFailure" do
+          expect { subject.perform }.to raise_error(Mongo::OperationFailure)
+        end
+      end
+
+      describe "and Mongoid.max_retries_on_connection_failure is greater than 0" do
+
+        let :max_retries do
+          5
+        end
+
+        before do
+          Mongoid.max_retries_on_connection_failure = max_retries
+        end
+
+        after do
+          Mongoid.max_retries_on_connection_failure = 0
+        end
+
+        it "should not raise Mongo::ConnectionFailure" do
+          expect { subject.perform }.to_not raise_error(Mongo::OperationFailure)
+        end
+
+        it "should return the result of the command" do
+          subject.perform.should == result
+        end
+
+        it "sends warning message to logger on retry attempts" do
+          logger.expects(:warn).with { |value| value =~ /1/ }
+          subject.perform
+        end
+      end
+    end
+
+    context "because some other error occurs" do
+      before do
+        subject.stubs(:do_action).raises(Mongo::OperationFailure.new("some other error"))
+      end
+
+      it "raises Mongo::OperationFailure" do
+        expect { subject.perform }.to raise_error(Mongo::OperationFailure)
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
This makes replica set reconfigurations transparent to the applications, by attempting to reconnect when the primary server changes (e.g. when the priority of a node in a replica set is changed).
