### PR TITLE
the embedded? method does not seem to check properly if the relation is cyclic or not

### DIFF
--- a/lib/mongoid/relations.rb
+++ b/lib/mongoid/relations.rb
@@ -58,7 +58,7 @@ module Mongoid # :nodoc:
     #
     # @since 2.0.0.rc.1
     def embedded?
-      @embedded ||= (cyclic ? _parent.present? : self.class.embedded?)
+      @embedded ||= (metadata && metadata.cyclic ? _parent.present? : self.class.embedded?)
     end
 
     # Determine if the document is part of an embeds_many relation.


### PR DESCRIPTION
Even though my relation were set to :cyclic => true, the embedded? method was still returning false, until I figured cyclic was nil because it should have been metadata.cyclic.
