### PR TITLE
some specs to examine replacement on has_one relations 

### DIFF
--- a/spec/app/models/cat.rb
+++ b/spec/app/models/cat.rb
@@ -1,0 +1,8 @@
+class Cat
+  include Mongoid::Document
+
+  field :name
+
+  belongs_to :person
+
+end

--- a/spec/app/models/person.rb
+++ b/spec/app/models/person.rb
@@ -102,6 +102,7 @@ class Person
 
   has_many :drugs, :autosave => true, :validate => false
   has_one :account, :autosave => true, :validate => false
+  has_one :cat, :dependent => :nullify
 
   has_and_belongs_to_many \
     :administrated_events,

--- a/spec/functional/mongoid/relations/referenced/one_spec.rb
+++ b/spec/functional/mongoid/relations/referenced/one_spec.rb
@@ -170,6 +170,306 @@ describe Mongoid::Relations::Referenced::One do
         end
       end
 
+      context "when replacing an existing persisted (dependent: :destroy) relation" do
+
+        let!(:person) do
+          Person.create(:ssn => "122-11-1111")
+        end
+
+        let!(:game) do
+          person.create_game(:name => "Starcraft")
+        end
+
+        context "with a new one created via the parent" do
+
+          let!(:new_game) do
+            person.create_game(:name => "Starcraft 2")
+          end
+
+          it "sets the new relation on the parent" do
+            person.game.should eq(new_game)
+          end
+
+          it "removes the old foreign key reference" do
+            game.person_id.should be_nil
+          end
+
+          it "removes the reference to the parent" do
+            game.person.should be_nil
+          end
+
+          it "destroys the old child" do
+            game.should be_destroyed
+          end
+
+          it "leaves the old child unpersisted" do
+            game.persisted?.should be_false
+          end
+
+          it "leaves the new child persisted" do
+            new_game.persisted?.should be_true
+          end
+
+        end
+
+        context "with a new one built via the parent" do
+
+          let!(:new_game) do
+            person.build_game(:name => "Starcraft 2")
+          end
+
+          it "sets the new relation on the parent" do
+            person.game.should eq(new_game)
+          end
+
+          it "removes the old foreign key reference" do
+            game.person_id.should be_nil
+          end
+
+          it "removes the reference to the parent" do
+            game.person.should be_nil
+          end
+
+          it "does not destroy the old child" do
+            game.should_not be_destroyed
+          end
+
+          it "leaves the old child persisted" do
+            game.persisted?.should be_true
+          end
+
+          it "leaves the new child unpersisted" do
+            new_game.persisted?.should be_false
+          end
+
+        end
+      end
+
+      context "when replacing an existing unpersisted (dependent: :destroy) relation" do
+
+        let!(:person) do
+          Person.create(:ssn => "122-11-1111")
+        end
+
+        let!(:game) do
+          person.build_game(:name => "Starcraft")
+        end
+
+        context "with a new one created via the parent" do
+
+          let!(:new_game) do
+            person.create_game(:name => "Starcraft 2")
+          end
+
+          it "sets the new relation on the parent" do
+            person.game.should eq(new_game)
+          end
+
+          it "removes the old foreign key reference" do
+            game.person_id.should be_nil
+          end
+
+          it "removes the reference to the parent" do
+            game.person.should be_nil
+          end
+
+          it "destroys the old child" do
+            game.should be_destroyed
+          end
+
+          it "leaves the old child unpersisted" do
+            game.persisted?.should be_false
+          end
+
+          it "leaves the new child persisted" do
+            new_game.persisted?.should be_true
+          end
+
+        end
+
+        context "with a new one built via the parent" do
+
+          let!(:new_game) do
+            person.build_game(:name => "Starcraft 2")
+          end
+
+          it "sets the new relation on the parent" do
+            person.game.should eq(new_game)
+          end
+
+          it "removes the old foreign key reference" do
+            game.person_id.should be_nil
+          end
+
+          it "removes the reference to the parent" do
+            game.person.should be_nil
+          end
+
+          it "does not destroy the old child" do
+            game.should_not be_destroyed
+          end
+
+          it "leaves the old child unpersisted" do
+            game.persisted?.should be_false
+          end
+
+          it "leaves the new child unpersisted" do
+            new_game.persisted?.should be_false
+          end
+
+        end
+      end
+
+      context "when replacing an existing persisted (dependent: :nullify) relation" do
+
+        let!(:person) do
+          Person.create(:ssn => "122-11-1111")
+        end
+
+        let!(:cat) do
+          person.create_cat(:name => "Cuddles")
+        end
+
+        context "with a new one created via the parent" do
+
+          let!(:new_cat) do
+            person.create_cat(:name => "Brutus")
+          end
+
+          it "sets the new relation on the parent" do
+            person.cat.should eq(new_cat)
+          end
+
+          it "removes the old foreign key reference" do
+            cat.person_id.should be_nil
+          end
+
+          it "removes the reference to the parent" do
+            cat.person.should be_nil
+          end
+
+          it "does not destroy the old child" do
+            cat.should_not be_destroyed
+          end
+
+          it "leaves the old child persisted" do
+            cat.persisted?.should be_true
+          end
+
+          it "leaves the new child persisted" do
+            new_cat.persisted?.should be_true
+          end
+
+        end
+
+        context "with a new one built via the parent" do
+
+          let!(:new_cat) do
+            person.build_cat(:name => "Brutus")
+          end
+
+          it "sets the new relation on the parent" do
+            person.cat.should eq(new_cat)
+          end
+
+          it "removes the old foreign key reference" do
+            cat.person_id.should be_nil
+          end
+
+          it "removes the reference to the parent" do
+            cat.person.should be_nil
+          end
+
+          it "does not destroy the old child" do
+            cat.should_not be_destroyed
+          end
+
+          it "leaves the old child persisted" do
+            cat.persisted?.should be_true
+          end
+
+          it "leaves the new child unpersisted" do
+            new_cat.persisted?.should be_false
+          end
+          
+        end
+      end
+      
+      context "when replacing an existing unpersisted (dependent: :nullify) relation" do
+
+        let!(:person) do
+          Person.create(:ssn => "122-11-1111")
+        end
+
+        let!(:cat) do
+          person.build_cat(:name => "Cuddles")
+        end
+
+        context "with a new one created via the parent" do
+
+          let!(:new_cat) do
+            person.create_cat(:name => "Brutus")
+          end
+
+          it "sets the new relation on the parent" do
+            person.cat.should eq(new_cat)
+          end
+
+          it "removes the old foreign key reference" do
+            cat.person_id.should be_nil
+          end
+
+          it "removes the reference to the parent" do
+            cat.person.should be_nil
+          end
+
+          it "does not destroy the old child" do
+            cat.should_not be_destroyed
+          end
+
+          it "leaves the old child unpersisted" do
+            cat.persisted?.should be_false
+          end
+
+          it "leaves the new child persisted" do
+            new_cat.persisted?.should be_true
+          end
+
+        end
+
+        context "with a new one built via the parent" do
+
+          let!(:new_cat) do
+            person.build_cat(:name => "Brutus")
+          end
+
+          it "sets the new relation on the parent" do
+            person.cat.should eq(new_cat)
+          end
+
+          it "removes the old foreign key reference" do
+            cat.person_id.should be_nil
+          end
+
+          it "removes the reference to the parent" do
+            cat.person.should be_nil
+          end
+
+          it "does not destroy the old child" do
+            cat.should_not be_destroyed
+          end
+
+          it "leaves the old child unpersisted" do
+            cat.persisted?.should be_false
+          end
+
+          it "leaves the new child unpersisted" do
+            new_cat.persisted?.should be_false
+          end
+          
+        end
+      end
+
       context "when replacing an existing relation with a new one" do
 
         let!(:person) do


### PR DESCRIPTION
Hi @durran.  Thanks for your fix for #1442!  I was trying to fix it myself, but got stuck.  

The reason I got stuck was because I noticed that the code was probably going to result in this behavior:

``` ruby
a = A.create!
b1 = a.build_b
b2 = a.create_b
```

The code above, I believe, results in b1 being saved when it's a dependent: :nullify relation with the current version of Mongoid.

So, in any case, this isn't really a real pull request.  Feel free to discard some/all of it.  What is included in this commit are some specs that test all of the has_one replacement cases -- I'm pretty sure it tackles all of them in the correct way, but you probably want to review them to make sure.

From what it looks like, the only spec in the submitted commit that fails is the following one (which is what is described in the code block above):

```
Failures:

  1) Mongoid::Relations::Referenced::One#= when the relation is polymorphic when replacing an existing unpersisted (dependent: :nullify) relation with a new one created via the parent leaves the old child unpersisted
     Failure/Error: cat.persisted?.should be_false
       expected true to be false
     # ./spec/functional/mongoid/relations/referenced/one_spec.rb:431:in `block (6 levels) in <top (required)>'

Finished in 23.98 seconds
137 examples, 1 failure
```

Should I create a new issue for this?

And thanks again for the fix you provided.  It does work!  And thanks again for some great code!
