### PR TITLE
Better range support

### DIFF
--- a/lib/mongoid/fields/serializable/range.rb
+++ b/lib/mongoid/fields/serializable/range.rb
@@ -34,7 +34,7 @@ module Mongoid #:nodoc:
         #
         # @since 2.1.0
         def serialize(object)
-          object.nil? ? nil : { "min" => object.min, "max" => object.max }
+          object.nil? ? nil : { "min" => object.first, "max" => object.last }
         end
       end
     end

--- a/spec/unit/mongoid/fields/serializable/range_spec.rb
+++ b/spec/unit/mongoid/fields/serializable/range_spec.rb
@@ -15,8 +15,16 @@ describe Mongoid::Fields::Serializable::Range do
 
   describe "#deserialize" do
 
-    it "returns the range" do
+    it "returns a range" do
       field.deserialize({"min" => 1, "max" => 3}).should == (1..3)
+    end
+    
+    it "returns an inverse range" do
+      field.deserialize({"min" => 5, "max" => 1}).should == (5..1)
+    end
+    
+    it "returns a letter range" do
+      field.deserialize({"min" => 'a', "max" => 'z'}).should == ('a'..'z')
     end
   end
 
@@ -24,8 +32,16 @@ describe Mongoid::Fields::Serializable::Range do
 
     context "when the value is not nil" do
 
-      it "returns the object to_hash" do
+      it "returns the object hash" do
         field.serialize(1..3).should == {"min" => 1, "max" => 3}
+      end
+
+      it "returns the object hash when passed an inverse range" do
+        field.serialize(5..1).should == {"min" => 5, "max" => 1}
+      end
+
+      it "returns the object hash when passed a letter range" do
+        field.serialize('a'..'z').should == {"min" => 'a', "max" => 'z'}
       end
     end
 


### PR DESCRIPTION
This patch supports inverse ranges (`5..1`) and letter ranges (`'a'..'z'`).

Ranges are now asked for their `first` and `last` instead of their `min` and `max`, but the serialization to `min` and `max` has been left as-is.
