### PR TITLE
Embedded doc doesn't know if parent is being destroyed in before_destroy callback

### DIFF
--- a/lib/mongoid/persistence.rb
+++ b/lib/mongoid/persistence.rb
@@ -28,6 +28,7 @@ module Mongoid #:nodoc:
     #
     # @return [ true, false ] True if successful, false if not.
     def destroy(options = {})
+      self.flagged_for_destroy = true
       run_callbacks(:destroy) { remove(options) }
     end
 


### PR DESCRIPTION
See full details in Issue #1455

All specs pass with this change
