### PR TITLE
removing hierarchy while versoning 

### DIFF
--- a/lib/mongoid/versioning.rb
+++ b/lib/mongoid/versioning.rb
@@ -36,6 +36,7 @@ module Mongoid #:nodoc:
     def revise
       previous = previous_revision
       if previous && versioned_attributes_changed?
+	previous.attributes.delete("versions") # remove unnesessary versioning hierarchy 
         versions.build(previous.versioned_attributes).attributes.delete("_id")
         if version_max.present? && versions.length > version_max
           versions.delete(versions.first)


### PR DESCRIPTION
As whole object is versioned before saving a new copy , it creates a long hierarchy of versions inside versions when object is edited many times.What if we delete the versions object before archiving it?
Does this break anything?
