### PR TITLE
example spec for bug with criteria cloning

### DIFF
--- a/lib/mongoid/criteria.rb
+++ b/lib/mongoid/criteria.rb
@@ -369,7 +369,6 @@ module Mongoid #:nodoc:
     def initialize_copy(other)
       @selector = other.selector.dup
       @options = other.options.dup
-      @options[:sort] = @options[:sort].dup if @options.key?(:sort)
       @includes = other.inclusions.dup
       @context = nil
     end

--- a/lib/mongoid/criterion/optional.rb
+++ b/lib/mongoid/criterion/optional.rb
@@ -15,7 +15,7 @@ module Mongoid #:nodoc:
       # @return [ Criteria ] The cloned criteria.
       def ascending(*fields)
         clone.tap do |crit|
-          crit.options[:sort] = [] unless options[:sort] || fields.first.nil?
+          setup_sort_options(crit.options) unless fields.first.nil?
           fields.flatten.each { |field| merge_options(crit.options[:sort], [ localize(field), :asc ]) }
         end
       end
@@ -56,7 +56,7 @@ module Mongoid #:nodoc:
       # @return [ Criteria ] The cloned criteria.
       def descending(*fields)
         clone.tap do |crit|
-          crit.options[:sort] = [] unless options[:sort] || fields.first.nil?
+          setup_sort_options(crit.options) unless fields.first.nil?
           fields.flatten.each { |field| merge_options(crit.options[:sort], [ localize(field), :desc ]) }
         end
       end
@@ -136,7 +136,7 @@ module Mongoid #:nodoc:
       def order_by(*args)
         clone.tap do |crit|
           arguments = args.size == 1 ? args.first : args
-          crit.options[:sort] = [] unless options[:sort] || args.first.nil?
+          setup_sort_options(crit.options) unless args.first.nil?
           if arguments.is_a?(Array)
             #[:name, :asc]
             if arguments.size == 2 && (arguments.first.is_a?(Symbol) || arguments.first.is_a?(String))
@@ -227,6 +227,19 @@ module Mongoid #:nodoc:
         else
           options << new_option.flatten
         end
+      end
+
+      # Initialize the sort options
+      # Set options[:sort] to an empty array if it does not exist, or dup it if
+      # it already has been defined
+      #
+      # @example criteria.setup_sort_options(crit.options)
+      #
+      # @param [ Array<Array> ] Existing options
+      #
+      # @since 2.3.4
+      def setup_sort_options(options)
+        options[:sort] = options[:sort] ? options[:sort].dup : []
       end
 
       # Check if field is localized and return localized version if it is.

--- a/spec/unit/mongoid/criteria_spec.rb
+++ b/spec/unit/mongoid/criteria_spec.rb
@@ -418,11 +418,6 @@ describe Mongoid::Criteria do
       copy.options.should == criteria.options
     end
 
-    it 'copies the sort' do
-      copy.options[:sort].should == criteria.options[:sort]
-      copy.options[:sort].should_not be criteria.options[:sort]
-    end
-
     it "copies the embedded flag" do
       copy.embedded.should == criteria.embedded
     end

--- a/spec/unit/mongoid/criterion/optional_spec.rb
+++ b/spec/unit/mongoid/criterion/optional_spec.rb
@@ -156,14 +156,23 @@ describe Mongoid::Criterion::Optional do
   end
 
   context "when chaining sort criteria" do
+    let(:original) do
+      base.desc(:title)
+    end
 
     let(:criteria) do
-      base.asc(:title).desc(:dob, :name).order_by(:score.asc)
+      original.asc(:title).desc(:dob, :name).order_by(:score.asc)
     end
 
     it "does not overwrite any previous criteria" do
       criteria.options[:sort].should ==
         [[ :title, :asc ], [ :dob, :desc ], [ :name, :desc ], [ :score, :asc ]]
+    end
+
+    it 'does not alter the original criteria' do
+      expect {
+        criteria
+      }.not_to change { original.options[:sort] }
     end
   end
 


### PR DESCRIPTION
I just ran into this bug in a project. Basically, if you change the sort
option on a criteria, it updates the sort on the original criteria and
the cloned copy, rather than just updating the sort on the cloned copy

that is, if you do:
    names = Person.all.asc(:name)
    names_reverse = names.desc(:name)

then both `names` and `names_reverse` will subsequently be sorted
descending

I wasn't quite sure where the right place to put this test was, so I'm
just starting it here, and will move it around as I get guidance
