### PR TITLE
Fix for custom message not being used with uniqueness validator.

### DIFF
--- a/lib/mongoid/validations/uniqueness.rb
+++ b/lib/mongoid/validations/uniqueness.rb
@@ -47,14 +47,14 @@ module Mongoid #:nodoc:
           criteria = relation.where(criterion(document, attribute, value))
           criteria = scope(criteria, document, attribute)
           if document.primary_key == Array.wrap(attribute)
-            document.errors.add(attribute, :taken) if criteria.count > 1
+            document.errors.add(attribute, :taken, options.except(:case_sensitive, :scope).merge(:value => value)) if criteria.count > 1
           else
-            document.errors.add(attribute, :taken) if criteria.exists?
+            document.errors.add(attribute, :taken, options.except(:case_sensitive, :scope).merge(:value => value)) if criteria.exists?
           end
         else
           criteria = klass.where(criterion(document, attribute, value))
           criteria = scope(criteria, document, attribute)
-          document.errors.add(attribute, :taken) if criteria.exists?
+          document.errors.add(attribute, :taken, options.except(:case_sensitive, :scope).merge(:value => value)) if criteria.exists?
         end
       end
 

--- a/spec/unit/mongoid/validations/uniqueness_spec.rb
+++ b/spec/unit/mongoid/validations/uniqueness_spec.rb
@@ -90,6 +90,24 @@ describe Mongoid::Validations::UniquenessValidator do
           dictionary.errors[:name].should eq([ "is already taken" ])
         end
       end
+
+      context "when providing a message" do
+
+        let(:options) do
+          { :attributes => dictionary.attributes, :message => "my test message" }
+        end
+
+        before do
+          Dictionary.expects(:where).with(:name => "Oxford").returns(criteria)
+          criteria.expects(:where).with(:year => dictionary.year).returns(criteria)
+          criteria.expects(:exists?).returns(true)
+          validator.validate_each(dictionary, :name, "Oxford")
+        end
+
+        it "checks existance with a message" do
+          dictionary.errors[:name].should eq([ "my test message" ])
+        end
+      end
     end
 
     context "when the document is embedded" do


### PR DESCRIPTION
The uniqueness validator fails to pass options when adding errors to the document. I merely mimicked what the ActiveRecord uniqueness validator passes when adding errors so that the message and value options get passed. I also added a unit test to verify the behavior.
