### PR TITLE
Add support for using Model#set to set a field to false

### DIFF
--- a/lib/mongoid/persistence/atomic/sets.rb
+++ b/lib/mongoid/persistence/atomic/sets.rb
@@ -17,7 +17,7 @@ module Mongoid #:nodoc:
         # @ssete 2.0.0
         def persist
           prepare do
-            value ? document[field] = value : @value = document[field]
+            (not value.nil?) ? document[field] = value : @value = document[field]
             document[field].tap do
               collection.update(document.atomic_selector, operation("$set"), options)
               document.remove_change(field)

--- a/spec/functional/mongoid/persistence/atomic/sets_spec.rb
+++ b/spec/functional/mongoid/persistence/atomic/sets_spec.rb
@@ -9,7 +9,7 @@ describe Mongoid::Persistence::Atomic::Sets do
   describe "#set" do
 
     let(:person) do
-      Person.create(:ssn => "777-66-1010", :age => 100)
+      Person.create(:ssn => "777-66-1010", :age => 100, :pets => true)
     end
 
     let(:reloaded) do
@@ -56,6 +56,30 @@ describe Mongoid::Persistence::Atomic::Sets do
       it "resets the dirty attributes" do
         person.changes["age"].should be_nil
       end
+    end
+
+    context "when setting a field to false" do
+
+      let!(:set) do
+        person.set(:pets, false)
+      end
+
+      it "sets the provided value" do
+        person.pets.should == false
+      end
+
+      it "returns the new value" do
+        set.should == false
+      end
+
+      it "persists the changes" do
+        reloaded.pets.should == false
+      end
+
+      it "resets the dirty attributes" do
+        person.changes["pets"].should be_nil
+      end
+
     end
 
     context "when setting a nil field" do


### PR DESCRIPTION
Sets#persist checked if the given value was a falsey value, this prevented you from using #set to change a field from a truthy value to false.

I don't know why the check for nil exists at all, it might also be possible to remove the tertiary condition completely (which would probably be even better, then it would also be possible to set a field to nil). The tests still seem to pass if you do that, but there might be some other reason, which is why this patch checks for value.nil?
