### PR TITLE
validates_presence_of for localized fields

### DIFF
--- a/lib/mongoid/validations.rb
+++ b/lib/mongoid/validations.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 require "mongoid/validations/associated"
 require "mongoid/validations/uniqueness"
+require "mongoid/validations/presence"
 
 module Mongoid #:nodoc:
 
@@ -117,6 +118,10 @@ module Mongoid #:nodoc:
       # @param [ Array ] *args The arguments to pass to the validator.
       def validates_uniqueness_of(*args)
         validates_with(UniquenessValidator, _merge_attributes(args))
+      end
+      
+      def validates_presence_of(*args)
+        validates_with(PresenceValidator, _merge_attributes(args))
       end
 
       protected

--- a/lib/mongoid/validations/presence.rb
+++ b/lib/mongoid/validations/presence.rb
@@ -1,0 +1,29 @@
+# encoding: utf-8
+module Mongoid #:nodoc:
+  module Validations #:nodoc:
+    
+    # Validates that the specified attributes are not blank (as defined by
+    # Object#blank?).
+    #
+    # @example Define the presence validator.
+    #
+    #   class Person
+    #     include Mongoid::Document
+    #     field :title
+    #
+    #     validates_presence_of :title
+    #   end
+    
+    class PresenceValidator < ActiveModel::EachValidator
+      def validate_each(document, attribute, value)
+        if document.fields[attribute.to_s] && document.fields[attribute.to_s].localized? && value.kind_of?(Hash)
+          value.keys.each do |language|
+            document.errors.add(attribute, :blank, options) if value[language.to_s].blank?
+          end
+        else
+          document.errors.add(attribute, :blank, options) if value.blank?
+        end
+      end
+    end
+  end
+end

--- a/spec/app/models/product.rb
+++ b/spec/app/models/product.rb
@@ -3,5 +3,6 @@ class Product
   field :description, :localize => true
   field :name, :localize => true, :default => "no translation"
   field :price, :type => Integer
+  field :brand_name
   alias_attribute :cost, :price
 end

--- a/spec/unit/mongoid/validations/presence_spec.rb
+++ b/spec/unit/mongoid/validations/presence_spec.rb
@@ -1,0 +1,97 @@
+require "spec_helper"
+
+describe Mongoid::Validations::PresenceValidator do
+  let(:product) do
+    Product.new
+  end
+  
+  describe "#validate_each" do
+    let(:validator) do
+      described_class.new(:attributes => product.attributes)
+    end
+    
+    context "when the field is not localized" do
+      context "when the value is valid" do
+        before do
+          validator.validate_each(product, :brand_name, "Apple")
+        end
+        
+        it "adds no errors" do
+          product.errors[:brand_name].should be_empty
+        end
+      end
+      
+      context "when the value is nil" do
+        before do
+          validator.validate_each(product, :brand_name, nil)
+        end
+        
+        it "adds errors" do
+          product.errors[:brand_name].should eq(["can't be blank"])
+        end
+      end
+      
+      context "when the value is empty" do
+        before do
+          validator.validate_each(product, :brand_name, "")
+        end
+        
+        it "adds errors" do
+          product.errors[:brand_name].should eq(["can't be blank"])
+        end
+      end
+    end
+    
+    context "when the field is localized" do
+      context "when the value is valid" do
+        before do
+          validator.validate_each(product, :name, { "en" => "iPod Nano 8GB - Black" })
+        end
+        
+        it "adds no errors" do
+          product.errors[:name].should be_empty
+        end
+      end
+      
+      context "when the value is nil" do
+        before do
+          validator.validate_each(product, :name, nil)
+        end
+        
+        it "adds errors" do
+          product.errors[:name].should eq(["can't be blank"])
+        end
+      end
+      
+      context "when the localized value is nil" do
+        before do
+          validator.validate_each(product, :name, { "en" => nil })
+        end
+        
+        it "adds errors" do
+          product.errors[:name].should eq(["can't be blank"])
+        end
+      end
+      
+      context "when the value is empty" do
+        before do
+          validator.validate_each(product, :name, { "en" => "" })
+        end
+        
+        it "adds errors" do
+          product.errors[:name].should eq(["can't be blank"])
+        end
+      end
+      
+      context "when the value is empty for a language" do
+        before do
+          validator.validate_each(product, :name, { "en" => "iPod Nano 8GB - Black", "de" => "" })
+        end
+        
+        it "adds errors" do
+          product.errors[:name].should eq(["can't be blank"])
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/mongoid/validations_spec.rb
+++ b/spec/unit/mongoid/validations_spec.rb
@@ -79,4 +79,20 @@ describe Mongoid::Validations do
       klass.validates(:title, :uniqueness => true)
     end
   end
+  
+  describe ".validates_presence_of" do
+    before do
+      klass.expects(:validates_with).with(
+        Mongoid::Validations::PresenceValidator, { :attributes => [ :title ] }
+      )
+    end
+    
+    it "adds the presence validator" do
+      klass.validates_presence_of(:title)
+    end
+    
+    it "is picked up by validates method" do
+      klass.validates(:title, :presence => true)
+    end
+  end
 end


### PR DESCRIPTION
Implementation of `validates_presence_of` to work with localized fields.

``` ruby
class Post
  include Mongoid::Document

  field :title, localize: true

  validates_presence_of :title
end
```
