### PR TITLE
Changing Document#to_key for work with stub_model in rspec-rails.

### DIFF
--- a/lib/mongoid/document.rb
+++ b/lib/mongoid/document.rb
@@ -145,7 +145,11 @@ module Mongoid #:nodoc:
     #
     # @since 2.4.0
     def to_key
-      new_record? ? nil : [ id ]
+      if destroyed?
+        [ id ]
+      else
+        persisted? ? [ id ] : nil
+      end
     end
 
     # Return an array with this +Document+ only in it.


### PR DESCRIPTION
The problem was discussed in #1510.
