### PR TITLE
Fix error with create_indexes task in rails 3.2

### DIFF
--- a/lib/mongoid/railties/database.rake
+++ b/lib/mongoid/railties/database.rake
@@ -78,7 +78,7 @@ namespace :db do
     desc 'Create the indexes defined on your mongoid models'
     task :create_indexes => :environment do
       engines_models_paths = Rails.application.railties.engines.map do |engine|
-        engine.paths["app/models"].paths
+        engine.paths["app/models"].expanded
       end
       root_models_paths = Rails.application.paths["app/models"]
       models_paths = engines_models_paths.push(root_models_paths).flatten


### PR DESCRIPTION
Rails::Paths::Path.paths is deprecated in rails 3.1 & removed in 3.2. Use the 'expanded' method instead.

Fix for Issue #1521
