### PR TITLE
rbx and rbx-2.0 both point to rbx-18mode (master in 1.8 mode) on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,5 @@ rvm:
   - 1.9.3
   - ruby-head
   - jruby
-  - rbx
-  - rbx-2.0
+  - rbx-18mode
   - ree


### PR DESCRIPTION
rbx and rbx-2.0 both point to rbx-18mode (master in 1.8 mode) on travis, no need to double test
