### PR TITLE
Add failing spec to illustrate #1551.

### DIFF
--- a/spec/unit/mongoid/timestamps_spec.rb
+++ b/spec/unit/mongoid/timestamps_spec.rb
@@ -54,6 +54,21 @@ describe Mongoid::Timestamps do
     end
   end
 
+  context "when a embedded document is updated" do
+
+    let!(:person) { Person.create(:videos => [Video.new]) }
+    let(:video) { person.videos.first }
+
+    before do
+      video.title = "Snatch"
+      video.save
+    end
+
+    it "sets updated_at on the parent" do
+      person.expects(:updated_at=).once
+    end
+  end
+
   context "when the document has changed with updated_at specified" do
 
     let(:person) do


### PR DESCRIPTION
When an embedded document is updated the parents update_at should be set. These specs are failing.
