### PR TITLE
sorting option for Hash fields

### DIFF
--- a/lib/mongoid/fields/internal/hash.rb
+++ b/lib/mongoid/fields/internal/hash.rb
@@ -5,6 +5,20 @@ module Mongoid #:nodoc:
       # Defines the behaviour for hash fields.
       class Hash
         include Serializable
+        
+        def selection(object)
+          serialize(object)
+        end
+
+        def serialize(object)
+          if options[:sorted] == true && object.is_a?(::Hash)
+            sorted_hash = {}
+            object.keys.sort.each {|x| sorted_hash[x] = serialize(object[x])}
+            sorted_hash
+          else
+            object
+          end
+        end
       end
     end
   end

--- a/spec/unit/mongoid/fields/internal/hash_spec.rb
+++ b/spec/unit/mongoid/fields/internal/hash_spec.rb
@@ -52,6 +52,63 @@ describe Mongoid::Fields::Internal::Hash do
         field.eval_default(nil).should_not equal(default)
       end
     end
+    
+    context "sorted is true" do
+      
+      let(:sorted_field) do
+        { "parentA" => {"childA" => "value1", "childB" => "value2"}, "parentB" => {"childC" => "value3", "childD" => "value4"} }
+      end
+      
+      context "when the default is a proc" do
+
+        let(:field) do
+          described_class.instantiate(
+            :test,
+            :type => Hash,
+            :default => lambda { { "parentB" => {"childD" => "value4", "childC" => "value3"}, "parentA" => {"childB" => "value2", "childA" => "value1"} } },
+            :sorted => true
+          )
+        end
+
+        # Required since ruby will consider the 2 hashes to be equal, but mongodb won't
+        it "calls the proc and sorts the result" do
+          field.eval_default(nil).keys.should eq(sorted_field.keys)
+        end
+
+        it "calls the proc and sorts the children of the result" do
+          field.eval_default(nil)["parentA"].keys.should eq(sorted_field["parentA"].keys)
+        end
+      end
+      
+      context "when the default is a hash and sorted is true" do
+
+        let(:default) do
+          { "parentB" => {"childD" => "value4", "childC" => "value3"}, "parentA" => {"childB" => "value2", "childA" => "value1"} }
+        end
+
+        let(:field) do
+          described_class.instantiate(
+            :test,
+            :type => Hash,
+            :default => default,
+            :sorted => true
+          )
+        end
+
+        # Required since ruby will consider the 2 hashes to be equal, but mongodb won't
+        it "calls the proc and sorts the result" do
+          field.eval_default(nil).keys.should eq(sorted_field.keys)
+        end
+
+        it "calls the proc and sorts the children of the result" do
+          field.eval_default(nil)["parentA"].keys.should eq(sorted_field["parentA"].keys)
+        end
+        
+        it "returns a duped hash" do
+          field.eval_default(nil).should_not equal(default)
+        end
+      end
+    end
   end
 
   describe "#selection" do
@@ -60,6 +117,34 @@ describe Mongoid::Fields::Internal::Hash do
 
       it "returns the value" do
         field.selection({ "field" => "value" }).should eq({ "field" => "value" })
+      end
+    end
+    
+    context "when providing an unsorted hash, and sorted option is true" do
+      
+      let(:field) do
+        described_class.instantiate(
+          :test,
+          :type => Hash,
+          :sorted => true
+        )
+      end
+
+      let(:object) do
+        { "parentB" => {"childD" => "value4", "childC" => "value3"}, "parentA" => {"childB" => "value2", "childA" => "value1"} }
+      end
+      
+      let(:serialized_object) do
+        { "parentA" => {"childA" => "value1", "childB" => "value2"}, "parentB" => {"childC" => "value3", "childD" => "value4"} }
+      end
+      
+      # Required since ruby will consider the 2 hashes to be equal, but mongodb won't
+      it "returns the hash with its keys sorted" do
+        field.selection(object).keys.should eq(serialized_object.keys)
+      end
+      
+      it "returns the hash with its children's keys sorted" do
+        field.selection(object)["parentA"].keys.should eq(serialized_object["parentA"].keys)
       end
     end
   end
@@ -77,6 +162,34 @@ describe Mongoid::Fields::Internal::Hash do
 
       it "returns the hash" do
         field.serialize({ "field" => "value" }).should eq({ "field" => "value" })
+      end
+    end
+    
+    context "when the value is a hash, and sorted option is true" do
+      
+      let(:field) do
+        described_class.instantiate(
+          :test,
+          :type => Hash,
+          :sorted => true
+        )
+      end
+
+      let(:object) do
+        { "parentB" => {"childD" => "value4", "childC" => "value3"}, "parentA" => {"childB" => "value2", "childA" => "value1"} }
+      end
+      
+      let(:serialized_object) do
+        { "parentA" => {"childA" => "value1", "childB" => "value2"}, "parentB" => {"childC" => "value3", "childD" => "value4"} }
+      end
+      
+      # Required since ruby will consider the 2 hashes to be equal, but mongodb won't
+      it "returns the hash with its keys sorted" do
+        field.serialize(object).keys.should eq(serialized_object.keys)
+      end
+      
+      it "returns the hash with its children's keys sorted" do
+        field.serialize(object)["parentA"].keys.should eq(serialized_object["parentA"].keys)
       end
     end
   end


### PR DESCRIPTION
This pull request addresses https://github.com/mongoid/mongoid/issues/1572

This pull request adds a "sorted" option for Hash fields.  When :sorted => true, Hash fields are completely sorted on storage and search.  This way mongoid can support ruby's definition of Hash equality, i.e.

```
{"A" => 1, "B" => 2} == {"B" => 2, "A" => 1}
```

even though mongodb does not.

I'm not sure I've done all of the appropriate testing necessary, because of how large the codebase is, and how new I am to it.  In particular I'm not sure what I need to do to restrict this option to Hashes, or where the tests for that should reside.

If this would be better suited as a gem, let me know.  I'm new to open source dev.
