### PR TITLE
Create accessor and dirty methods for name and alias.

### DIFF
--- a/lib/mongoid/dirty.rb
+++ b/lib/mongoid/dirty.rb
@@ -207,33 +207,34 @@ module Mongoid #:nodoc:
       # Generate all the dirty methods needed for the attribute.
       #
       # @example Generate the dirty methods.
-      #   Model.create_dirty_methods("name")
+      #   Model.create_dirty_methods("name", "name")
       #
-      # @param [ String ] name The name of the attribute.
+      # @param [ String ] name The name of the field.
+      # @param [ String ] name The name of the accessor.
       #
       # @return [ Module ] The fields module.
       #
       # @since 2.4.0
-      def create_dirty_methods(name)
+      def create_dirty_methods(name, meth)
         generated_methods.module_eval do
           class_eval <<-EOM
-            def #{name}_change
+            def #{meth}_change
               attribute_change(#{name.inspect})
             end
 
-            def #{name}_changed?
+            def #{meth}_changed?
               attribute_changed?(#{name.inspect})
             end
 
-            def #{name}_was
+            def #{meth}_was
               attribute_was(#{name.inspect})
             end
 
-            def #{name}_will_change!
+            def #{meth}_will_change!
               attribute_will_change!(#{name.inspect})
             end
 
-            def reset_#{name}!
+            def reset_#{meth}!
               reset_attribute!(#{name.inspect})
             end
           EOM

--- a/lib/mongoid/fields.rb
+++ b/lib/mongoid/fields.rb
@@ -285,14 +285,15 @@ module Mongoid #:nodoc
       def add_field(name, options = {})
         aliased = options[:as]
         aliased_fields[aliased.to_s] = name if aliased
-        meth = aliased || name
         type = options[:localize] ? Fields::Internal::Localized : options[:type]
         Mappings.for(type, options[:identity]).instantiate(name, options).tap do |field|
           fields[name] = field
           add_defaults(field)
-          create_accessors(name, meth, options)
+          create_accessors(name, name, options)
+          create_accessors(name, aliased, options) if aliased
           process_options(field)
-          create_dirty_methods(name)
+          create_dirty_methods(name, name)
+          create_dirty_methods(name, aliased) if aliased
         end
       end
 

--- a/spec/unit/mongoid/fields_spec.rb
+++ b/spec/unit/mongoid/fields_spec.rb
@@ -244,6 +244,61 @@ describe Mongoid::Fields do
         person.alias?
       end
 
+      it "uses the name to write the attribute" do
+        person.expects(:write_attribute).with("aliased", true)
+        person.aliased = true
+      end
+
+      it "uses the name to read the attribute" do
+        person.expects(:read_attribute).with("aliased")
+        person.aliased
+      end
+
+      it "uses the name for the query method" do
+        person.expects(:read_attribute).with("aliased")
+        person.aliased?
+      end
+
+      it "creates dirty methods for the name" do
+        person.should respond_to(:aliased_changed?)
+      end
+
+      it "creates dirty methods for the alias" do
+        person.should respond_to(:alias_changed?)
+      end
+
+      context "when changing the name" do
+
+        before do
+          person.aliased = true
+        end
+
+        it "sets name_changed?" do
+          person.aliased_changed?.should be
+        end
+
+        it "sets alias_changed?" do
+          person.alias_changed?.should be
+        end
+
+      end
+
+      context "when changing the alias" do
+
+        before do
+          person.alias = true
+        end
+
+        it "sets name_changed?" do
+          person.aliased_changed?.should be
+        end
+
+        it "sets alias_changed?" do
+          person.alias_changed?.should be
+        end
+
+      end
+
       context "when defining a criteria" do
 
         let(:criteria) do


### PR DESCRIPTION
Like @jonhyman pointed out in #1571 its a little bit confusing which accessor and dirty methods were created for aliased fields.

This commit creates accessors and dirty methods for both, the name and the alias, so its up to you which one you use.
