### PR TITLE
Typecast $or and $and conditions.

### DIFF
--- a/lib/mongoid/criterion/selector.rb
+++ b/lib/mongoid/criterion/selector.rb
@@ -85,11 +85,29 @@ module Mongoid #:nodoc:
       # @since 1.0.0
       def try_to_typecast(key, value)
         access = key.to_s
-        if !fields.has_key?(access) && !aliased_fields.has_key?(access)
-          return value
+        if field = fields[key.to_s] || fields[aliased_fields[key.to_s]]
+          typecast_value_for(field, value)
+        elsif proper_and_or_value?(key, value)
+          handle_and_or_value(value)
+        else
+          value
         end
-        field = fields[access] || fields[aliased_fields[access]]
-        typecast_value_for(field, value)
+      end
+
+      def proper_and_or_value?(key, value)
+        ["$and", "$or"].include?(key) &&
+          value.is_a?(Array) &&
+          value.all?{ |e| e.is_a?(Hash) }
+      end
+
+      def handle_and_or_value(values)
+        [].tap do |result|
+          values.map do |value|
+            value.each do |key, value|
+              result.push key => try_to_typecast(key, value)
+            end
+          end
+        end
       end
 
       # Get the typecast value for the defined field.


### PR DESCRIPTION
When it comes to typecasting, $or and $and conditions weren't handled. Now they were.
Also described in #1577
