### PR TITLE
Preserve the structure while typecasting.

### DIFF
--- a/lib/mongoid/criterion/selector.rb
+++ b/lib/mongoid/criterion/selector.rb
@@ -102,11 +102,9 @@ module Mongoid #:nodoc:
 
       def handle_and_or_value(values)
         [].tap do |result|
-          values.map do |value|
-            value.each do |key, value|
-              result.push key => try_to_typecast(key, value)
-            end
-          end
+           result.push(*values.map do |value|
+            Hash[value.map{ |key, value| [key, try_to_typecast(key, value)] }]
+          end)
         end
       end
 

--- a/spec/unit/mongoid/criterion/selector_spec.rb
+++ b/spec/unit/mongoid/criterion/selector_spec.rb
@@ -208,11 +208,18 @@ describe Mongoid::Criterion::Selector do
     before do
       klass.stubs(:fields).returns({})
       klass.stubs(:aliased_fields).returns({})
+      selector.expects(:try_to_typecast).with("age", "45").once.returns("45")
+      selector.expects(:try_to_typecast).with("title", "Chief Visionary").once.returns("Chief Visionary")
     end
 
+    let(:values) { [{ "age" => "45", "title" => "Chief Visionary" }] }
+
     it "tries to typecast every entry" do
-      selector.expects(:try_to_typecast).with("age", "45").once
-      selector.send(:handle_and_or_value, [{"age" => "45"}])
+      selector.send(:handle_and_or_value, values)
+    end
+
+    it "preserves the structure" do
+      selector.send(:handle_and_or_value, values).should eq(values)
     end
   end
 


### PR DESCRIPTION
As mentioned by @visnup here: https://github.com/mongoid/mongoid/commit/245482644c7cebe9535a4dca633bf909626e6d28#commitcomment-872724 the structure of the hash has to be preserved while typecasting.
