### PR TITLE
Prevent Mongoid::Cursor#each from raising Mongo::ConnectionFailure

### DIFF
--- a/lib/mongoid/cursor.rb
+++ b/lib/mongoid/cursor.rb
@@ -45,8 +45,11 @@ module Mongoid #:nodoc
     # @example Iterate over the cursor.
     #   cursor.each { |doc| p doc.title }
     def each
-      cursor.each do |document|
-        yield Mongoid::Factory.from_db(klass, document)
+      loop do
+        retry_on_connection_failure do
+          return unless document = cursor.next
+          yield Mongoid::Factory.from_db(klass, document)
+        end
       end
     end
 


### PR DESCRIPTION
I saw following error on a DB with replSet.  This change should fix the situation.

```
/Users/shyouhei/.rvm/gems/ruby-1.9.2-p290/gems/mongo-1.5.2/lib/mongo/networking.rb:327:in `rescue in receive_message_on_socket': Operation failed with the following exception: connection closed (Mongo::ConnectionFailure)
    from /Users/shyouhei/.rvm/gems/ruby-1.9.2-p290/gems/mongo-1.5.2/lib/mongo/networking.rb:312:in `receive_message_on_socket'
    from /Users/shyouhei/.rvm/gems/ruby-1.9.2-p290/gems/mongo-1.5.2/lib/mongo/networking.rb:184:in `receive_header'
    from /Users/shyouhei/.rvm/gems/ruby-1.9.2-p290/gems/mongo-1.5.2/lib/mongo/networking.rb:171:in `receive'
    from /Users/shyouhei/.rvm/gems/ruby-1.9.2-p290/gems/mongo-1.5.2/lib/mongo/networking.rb:135:in `receive_message'
    from /Users/shyouhei/.rvm/gems/ruby-1.9.2-p290/gems/mongo-1.5.2/lib/mongo/cursor.rb:469:in `block in send_initial_query'
    from /Users/shyouhei/.rvm/gems/ruby-1.9.2-p290/gems/mongo-1.5.2/lib/mongo/util/logging.rb:28:in `instrument'
    from /Users/shyouhei/.rvm/gems/ruby-1.9.2-p290/gems/mongo-1.5.2/lib/mongo/cursor.rb:467:in `send_initial_query'
    from /Users/shyouhei/.rvm/gems/ruby-1.9.2-p290/gems/mongo-1.5.2/lib/mongo/cursor.rb:458:in `refresh'
    from /Users/shyouhei/.rvm/gems/ruby-1.9.2-p290/gems/mongo-1.5.2/lib/mongo/cursor.rb:128:in `next'
    from /Users/shyouhei/.rvm/gems/ruby-1.9.2-p290/gems/mongo-1.5.2/lib/mongo/cursor.rb:290:in `each'
    from /Users/shyouhei/.rvm/gems/ruby-1.9.2-p290/gems/mongoid-2.3.4/lib/mongoid/cursor.rb:48:in `each'
    from /Users/shyouhei/.rvm/gems/ruby-1.9.2-p290/gems/mongoid-2.3.4/lib/mongoid/contexts/mongo.rb:212:in `iterate'
    from /Users/shyouhei/.rvm/gems/ruby-1.9.2-p290/gems/mongoid-2.3.4/lib/mongoid/criteria.rb:143:in `block in each'
    from /Users/shyouhei/.rvm/gems/ruby-1.9.2-p290/gems/mongoid-2.3.4/lib/mongoid/criteria.rb:143:in `tap'
    from /Users/shyouhei/.rvm/gems/ruby-1.9.2-p290/gems/mongoid-2.3.4/lib/mongoid/criteria.rb:143:in `each'
    from sample.rb:76:in `to_a'
```
