### PR TITLE
Introduce finder `#find_by`

### DIFF
--- a/lib/config/locales/en.yml
+++ b/lib/config/locales/en.yml
@@ -10,6 +10,8 @@ en:
           "Calling Document#find with nil is invalid."
         document_not_found:
           "Document not found for class %{klass} with id(s) %{identifiers}."
+        document_with_attributes_not_found:
+          "Document not found for class %{klass} with attributes %{attributes}"
         eager_load:
           "Eager loading :%{name} is not supported due to it being a polymorphic
           or belongs_to relation."

--- a/lib/mongoid/errors/document_not_found.rb
+++ b/lib/mongoid/errors/document_not_found.rb
@@ -2,25 +2,43 @@
 module Mongoid #:nodoc
   module Errors #:nodoc
 
-    # Raised when querying the database for a document by a specific id which
-    # does not exist. If multiple ids were passed then it will display all of
-    # those.
+    # Raised when querying the database for a document by a specific id or by
+    # set of attributes which does not exist. If multiple ids were passed then
+    # it will display all of those.
     #
     # @example Create the error.
     #   DocumentNotFound.new(Person, ["1", "2"])
+    #
+    # @example Create the error with attributes instead of ids
+    #   DocumentNotFound.new(Person, :ssn => "1234", :name => "Helen")
     class DocumentNotFound < MongoidError
 
       attr_reader :klass, :identifiers
 
-      def initialize(klass, ids)
+      def initialize(klass, attrs)
         @klass = klass
-        @identifiers = ids.is_a?(Array) ? ids.join(", ") : ids
+        message = case attrs
+          when Array then message_for_ids(attrs.join(","))
+          when Hash  then message_for_attributes(attrs.to_s)
+          else            message_for_ids(attrs)
+        end
 
-        super(
-          translate(
-            "document_not_found",
-            { :klass => klass.name, :identifiers => identifiers }
-          )
+        super(message)
+      end
+
+      private
+      def message_for_ids(ids)
+        @identifiers = ids
+        translate(
+          "document_not_found",
+          { :klass => klass.name, :identifiers => identifiers }
+        )
+      end
+
+      def message_for_attributes(attrs)
+        translate(
+          "document_with_attributes_not_found",
+          { :klass => klass.name, :attributes => attrs }
         )
       end
     end

--- a/lib/mongoid/finders.rb
+++ b/lib/mongoid/finders.rb
@@ -103,6 +103,20 @@ module Mongoid #:nodoc:
       find_or(:new, attrs, &block)
     end
 
+    # Find the first +Document+ given the conditions, or raises Mongoid::Errors::DocumentNotFound
+    #
+    # @example Find the document by attribute other than id
+    #   Person.find_by(:username => "superuser")
+    #
+    # @param [ Hash ] attrs The attributes to check.
+    #
+    # @raise [ Errors::DocumentNotFound ] If no document found.
+    #
+    # @return [ Document ] A matching document.
+    def find_by(attrs = {})
+      where(attrs).first || raise(Errors::DocumentNotFound.new(self, attrs))
+    end
+
     # Find the first +Document+ given the conditions.
     #
     # @example Find the first document.

--- a/spec/mongoid/errors_spec.rb
+++ b/spec/mongoid/errors_spec.rb
@@ -27,6 +27,20 @@ describe Mongoid::Errors do
           error.message.should include("Document not found")
         end
       end
+
+      context "attributes search" do
+         let(:error) do
+           Mongoid::Errors::DocumentNotFound.new(Person, ssn: "123")
+         end
+
+         it "contains document not found" do
+           error.message.should include("Document not found")
+         end
+
+         it "contains with attributes" do
+           error.message.should include("with attributes")
+         end
+      end
     end
   end
 

--- a/spec/mongoid/finders_spec.rb
+++ b/spec/mongoid/finders_spec.rb
@@ -407,6 +407,27 @@ describe Mongoid::Finders do
     end
   end
 
+  describe ".find_by" do
+    context "when the document is found" do
+      let!(:person) do
+        Person.create(:ssn => "333-22-1111")
+      end
+
+      it "returns the document" do
+        Person.find_by(:ssn => "333-22-1111").should eq(person)
+      end
+    end
+
+    context "when the document is not found" do
+      it "raises an error" do
+        expect {
+          Person.find_by(:ssn => "333-22-1111")
+        }.to raise_error(Mongoid::Errors::DocumentNotFound)
+      end
+    end
+
+  end
+
   describe ".only" do
 
     let(:criteria) do


### PR DESCRIPTION
Sometimes it is nice to find an object by some attribute other than id and have DocumentNotFound raised if no such document exists. For example if I want to have vanity urls for users in my application for now I would have to do smth like that

```
class UsersController < ApplicationController
  # ... some other code

  def by_username
    @user = User.where(:username => params[:username]).first || \   
                 raise SomeNotFoundError
    # Actually DocumentNotFound does not allow attributes, only ids.
  end
end
```

Thanks to `find_by` mongoid raises that error for you. And DocumentNotFound error got the ability to handle attributes instead of only handling ids.

I am wondering what you guys think.
