### PR TITLE
Include _type in serialization

### DIFF
--- a/lib/mongoid/serialization.rb
+++ b/lib/mongoid/serialization.rb
@@ -31,8 +31,6 @@ module Mongoid # :nodoc:
       only   = Array.wrap(options[:only]).map(&:to_s)
       except = Array.wrap(options[:except]).map(&:to_s)
 
-      except |= ['_type']
-
       field_names = fields.keys.map { |field| field.to_s }
       attribute_names = (attributes.keys + field_names).sort
       if only.any?

--- a/spec/functional/mongoid/serialization_spec.rb
+++ b/spec/functional/mongoid/serialization_spec.rb
@@ -26,13 +26,9 @@ describe Mongoid::Serialization do
         person.serializable_hash.should include attributes
       end
 
-      it "includes all defined fields except _type" do
-        field_names = person.fields.keys.map(&:to_s) - ['_type']
+      it "includes all defined fields" do
+        field_names = person.fields.keys.map(&:to_s)
         person.serializable_hash.keys.should include(*field_names)
-      end
-
-      it "does not include _type" do
-        person.serializable_hash.keys.should_not include '_type'
       end
 
       it "does not modify the options in the argument" do


### PR DESCRIPTION
That fixes a problem with deserialization, which depends on this field.
I.e. 

``` ruby
class Person
   include Mongoid::Document
end

class Manager < Person
end

m = Manager.new
Person.new(m.serializable_hash).class.should eq(Manager)
```

I didn't figure out where to put a test like this.
