### PR TITLE
FormatValidator with support for localized fields

### DIFF
--- a/lib/mongoid/validations.rb
+++ b/lib/mongoid/validations.rb
@@ -2,6 +2,7 @@
 require "mongoid/validations/associated"
 require "mongoid/validations/uniqueness"
 require "mongoid/validations/presence"
+require "mongoid/validations/format"
 
 module Mongoid #:nodoc:
 
@@ -138,6 +139,21 @@ module Mongoid #:nodoc:
       # @since 2.4.0
       def validates_presence_of(*args)
         validates_with(PresenceValidator, _merge_attributes(args))
+      end
+      
+      # Validates whether or not a field matches a certain regular expression.
+      #
+      # @example
+      #   class Person
+      #     include Mongoid::Document
+      #     field :website
+      #
+      #     validates_format_of :website, :with => URI.regexp
+      #   end
+      #
+      # @param [ Array ] *args The arguments to pass to the validator.
+      def validates_format_of(*args)
+        validates_with(FormatValidator, _merge_attributes(args))
       end
 
       protected

--- a/lib/mongoid/validations/format.rb
+++ b/lib/mongoid/validations/format.rb
@@ -1,0 +1,29 @@
+# encoding: utf-8
+module Mongoid #:nodoc:
+  module Validations #:nodoc:
+
+    # Validates that the specified attributes do or do not match a certain 
+    # regular expression.
+    #
+    # @example Set up the format validator.
+    #
+    #   class Person
+    #     include Mongoid::Document
+    #     field :website
+    #
+    #     validates_format_of :website, :with => URI.regexp
+    #   end
+    class FormatValidator < ActiveModel::Validations::FormatValidator
+      def validate_each(document, attribute, value)
+        field = document.fields[attribute.to_s]
+        if field && field.localized? && !value.blank?
+          value.each_pair do |_locale, _value|
+            super(document, attribute, _value)
+          end
+        else
+          super
+        end
+      end
+    end
+  end
+end

--- a/spec/app/models/product.rb
+++ b/spec/app/models/product.rb
@@ -5,7 +5,9 @@ class Product
   field :price, :type => Integer
   field :brand_name
   field :stores, :type => Array
+  field :website, :localize => true
   alias_attribute :cost, :price
 
   validates :name, :presence => true
+  validates :website, :format => { :with => URI.regexp, :allow_blank => true }
 end

--- a/spec/mongoid/validations/format_spec.rb
+++ b/spec/mongoid/validations/format_spec.rb
@@ -1,0 +1,80 @@
+require "spec_helper"
+
+describe Mongoid::Validations::FormatValidator do
+
+  describe "#validate_each" do
+
+    let(:product) do
+      Product.new
+    end
+
+    context "when the field is not localized" do
+
+      let(:validator) do
+        described_class.new(:attributes => [:brand_name], :with => /\A[a-z]*\z/i)
+      end
+
+      context "when the value is valid" do
+
+        before do
+          validator.validate_each(product, :brand_name, "Apple")
+        end
+
+        it "adds no errors" do
+          product.errors[:brand_name].should be_empty
+        end
+      end
+
+      context "when the value is invalid" do
+
+        before do
+          validator.validate_each(product, :brand_name, "123")
+        end
+
+        it "adds errors" do
+          product.errors[:brand_name].should eq(["is invalid"])
+        end
+      end
+    end
+
+    context "when the field is localized" do
+
+      let(:validator) do
+        described_class.new(:attributes => [:website], :with => URI.regexp)
+      end
+
+      context "when the localized value is valid" do
+
+        before do
+          validator.validate_each(product, :website, { "en" => "http://www.apple.com" })
+        end
+
+        it "adds no errors" do
+          product.errors[:website].should be_empty
+        end
+      end
+
+      context "when one of the localized values is invalid" do
+
+        before do
+          validator.validate_each(product, :website, { "en" => "http://www.apple.com", "fr" => "not_a_website" })
+        end
+
+        it "adds errors" do
+          product.errors[:website].should eq(["is invalid"])
+        end
+      end
+
+      context "when the localized value is invalid" do
+
+        before do
+          validator.validate_each(product, :website, { "en" => "not_a_website" })
+        end
+
+        it "adds errors" do
+          product.errors[:website].should eq(["is invalid"])
+        end
+      end
+    end
+  end
+end

--- a/spec/mongoid/validations_spec.rb
+++ b/spec/mongoid/validations_spec.rb
@@ -267,7 +267,6 @@ describe Mongoid::Validations do
         klass.validators.first.should be_a(
           Mongoid::Validations::PresenceValidator
         )
-        klass.validators
       end
     end
 
@@ -280,6 +279,41 @@ describe Mongoid::Validations do
       it "adds the validator" do
         klass.validators.first.should be_a(
           Mongoid::Validations::PresenceValidator
+        )
+      end
+    end
+  end
+  
+  describe ".validates_format_of" do
+
+    let(:klass) do
+      Class.new do
+        include Mongoid::Document
+      end
+    end
+
+    context "when adding via the traditional macro" do
+
+      before do
+        klass.validates_format_of(:website, :with => URI.regexp)
+      end
+
+      it "adds the validator" do
+        klass.validators.first.should be_a(
+          Mongoid::Validations::FormatValidator
+        )
+      end
+    end
+
+    context "when adding via the new syntax" do
+
+      before do
+        klass.validates(:website, :format => { :with => URI.regexp })
+      end
+
+      it "adds the validator" do
+        klass.validators.first.should be_a(
+          Mongoid::Validations::FormatValidator
         )
       end
     end


### PR DESCRIPTION
Implementation of `FormatValidator` that supports localized fields.

``` ruby
class Person
  include Mongoid::Document

  field :website, :localize => true

  validates_format_of :website, :with => URI.regexp
end
```

RE: #1624
