### PR TITLE
Include type config

### DIFF
--- a/lib/mongoid/config.rb
+++ b/lib/mongoid/config.rb
@@ -23,6 +23,7 @@ module Mongoid #:nodoc
     option :autocreate_indexes, :default => false
     option :identity_map_enabled, :default => false
     option :include_root_in_json, :default => false
+    option :include_type_for_serialization, :default => false
     option :max_retries_on_connection_failure, :default => 0
     option :parameterize_keys, :default => true
     option :scope_overwrite_exception, :default => false

--- a/lib/mongoid/serialization.rb
+++ b/lib/mongoid/serialization.rb
@@ -31,7 +31,7 @@ module Mongoid # :nodoc:
       only   = Array.wrap(options[:only]).map(&:to_s)
       except = Array.wrap(options[:except]).map(&:to_s)
 
-      except |= ['_type']
+      except |= ['_type'] unless Mongoid.include_type_for_serialization
 
       field_names = fields.keys.map { |field| field.to_s }
       attribute_names = (attributes.keys + field_names).sort

--- a/spec/functional/mongoid/serialization_spec.rb
+++ b/spec/functional/mongoid/serialization_spec.rb
@@ -41,6 +41,16 @@ describe Mongoid::Serialization do
         options[:except].should be_nil
       end
 
+      context "when include_type_for_serialization is true" do
+        before do
+          Mongoid.include_type_for_serialization = true
+        end
+
+        it "includes _type field" do
+          person.serializable_hash.keys.should include '_type'
+        end
+      end
+
       context "when specifying which fields to only include" do
 
         it "only includes the specified fields" do


### PR DESCRIPTION
Mongoid.include_type_for_serialization controls whether the _type
field is included when the model is serialized.

I guess that this is what you referred to in #1625
