### PR TITLE
Protect scopes from parent class.

### DIFF
--- a/lib/mongoid/named_scope.rb
+++ b/lib/mongoid/named_scope.rb
@@ -124,6 +124,21 @@ module Mongoid #:nodoc:
         end
       end
 
+      # When inheriting, we want to copy the scopes from the parent class and
+      # set the on the child to start, mimicking the behaviour of the old
+      # class_inheritable_accessor that was deprecated in Rails edge.
+      #
+      # @example Inherit from this class.
+      #   Person.inherited(Doctor)
+      #
+      # @param [ Class ] subclass The inheriting class.
+      #
+      # @since 2.0.0.rc.6
+      def inherited(subclass)
+        super
+        subclass.scopes = scopes.dup
+      end
+
       protected
 
       # Warns or raises exception if overriding another scope or method.

--- a/spec/mongoid/named_scope_spec.rb
+++ b/spec/mongoid/named_scope_spec.rb
@@ -90,6 +90,33 @@ describe Mongoid::NamedScope do
       end
     end
 
+    context "when there is a scope on parent class" do
+      before do
+        Person.class_eval do
+          scope(:important, where( title: 'VIP'))
+        end
+      end
+
+      context "when overwriting scope in child class" do
+
+        before do
+          Doctor.class_eval do
+            scope(:important, where( title: 'Dr.' ))
+          end
+        end
+
+        it "changes the child's scope" do
+          Doctor.important.selector.should eq({ title: 'Dr.' })
+        end
+
+        it "leaves the scope on parent class unchanged" do
+          Person.important.selector.should eq({ title: 'VIP' })
+        end
+
+      end
+
+    end
+
     context "when calling scopes on parent classes" do
 
       it "inherits the scope" do


### PR DESCRIPTION
Do not change scopes from parent class when changing scopes on inherited classes. Fixes #1636.
