### PR TITLE
Fix Mongoid.observer.disable :all.

### DIFF
--- a/lib/mongoid/observer.rb
+++ b/lib/mongoid/observer.rb
@@ -170,5 +170,12 @@ module Mongoid #:nodoc:
         end
       end
     end
+
+    def disabled_for?(object)
+      klass = object.class
+      return false unless klass.respond_to?(:observers)
+      klass.observers.disabled_for?(self) || Mongoid.observers.disabled_for?(self)
+    end
+
   end
 end

--- a/spec/mongoid/observer_spec.rb
+++ b/spec/mongoid/observer_spec.rb
@@ -46,6 +46,23 @@ describe Mongoid::Observer do
     end
   end
 
+  context "when all observers are disabled" do
+
+    let!(:observer) do
+      ActorObserver.instance
+    end
+
+    let(:actor) do
+      Actor.create!(:name => "Johnny Depp")
+    end
+
+    it "does not fire the observer" do
+      Mongoid.observers.disable(:all) do
+        actor and observer.last_after_create_record.should_not eq(actor)
+      end
+    end
+  end
+
   context "when the document is new" do
 
     let!(:actor) do


### PR DESCRIPTION
Fixes #1639.
Note: It seems to work for activerecord too, but they didn't
overwritten disabled_for?. Dunno how they did the trick.
