### PR TITLE
Fixed the param doc for Criterion::Exclusion#without

### DIFF
--- a/lib/mongoid/criterion/exclusion.rb
+++ b/lib/mongoid/criterion/exclusion.rb
@@ -88,7 +88,7 @@ module Mongoid #:nodoc:
       #
       # @note #only and #without cannot be used together.
       #
-      # @param [ Array<Symbol> args A list of fields to exclude.
+      # @param [ Array<Symbol> ] args A list of fields to exclude.
       #
       # @return [ Criteria ] A newly cloned copy.
       #


### PR DESCRIPTION
Just a small patch to fix formatting of the YARD documentation.

See [here](http://rubydoc.info/gems/mongoid/2.4.2/Mongoid/Criterion/Exclusion#without-instance_method) for the current, faulty result.
