### PR TITLE
#1656 Don't hit database for uniqueness validation if BOTH scope and attribute hasn't changed.

### DIFF
--- a/lib/mongoid/validations/uniqueness.rb
+++ b/lib/mongoid/validations/uniqueness.rb
@@ -41,7 +41,7 @@ module Mongoid #:nodoc:
       #
       # @since 1.0.0
       def validate_each(document, attribute, value)
-        return unless document.send("attribute_changed?", attribute.to_s)
+        return unless document.send("attribute_changed?", attribute.to_s) || scope_value_changed?(document)
         if document.embedded?
           return if skip_validation?(document)
           relation = document._parent.send(document.metadata.name)
@@ -143,6 +143,22 @@ module Mongoid #:nodoc:
       # @since 2.3.0
       def skip_validation?(document)
         !document._parent || document.embedded_one?
+      end
+
+      # Scope reference has changed? 
+      #
+      # @example Has scope reference changed?
+      #   validator.scope_value_changed?(doc)
+      #
+      # @param [ Document ] document The embedded document.
+      #
+      # @return [ true, false ] If the scope reference has changed.
+      #
+      # @since 
+      def scope_value_changed?(document)
+        Array.wrap(options[:scope]).reduce(false) do |result, item|
+          (result || document.send("attribute_changed?", item.to_s))
+        end
       end
     end
   end

--- a/spec/app/models/folder.rb
+++ b/spec/app/models/folder.rb
@@ -1,0 +1,7 @@
+class Folder
+  include Mongoid::Document
+
+  field :name, :type => String
+  has_many :folder_items
+
+end

--- a/spec/app/models/folder_item.rb
+++ b/spec/app/models/folder_item.rb
@@ -1,0 +1,9 @@
+class FolderItem
+
+  include Mongoid::Document
+
+  belongs_to :folder
+  field :name, :type => String
+
+  validates :name, :uniqueness => {:scope => :folder_id} 
+end

--- a/spec/mongoid/validations/uniqueness_spec.rb
+++ b/spec/mongoid/validations/uniqueness_spec.rb
@@ -153,6 +153,25 @@ describe Mongoid::Validations::UniquenessValidator do
             end
           end
 
+          context "when uniqueness is violated due to scope change" do
+
+            let(:personal_folder) { Folder.create!(:name => "Personal") }
+            let(:public_folder)   { Folder.create!(:name => "Public") }
+            
+            before do
+              personal_folder.folder_items << FolderItem.new(:name => "non-unique") 
+              public_folder.folder_items   << FolderItem.new(:name => "non-unique") 
+            end
+
+            let(:item) { public_folder.folder_items.last }
+
+            it "should set an error for associated object not being unique" do
+              item.update_attributes(:folder_id => personal_folder.id)
+              item.errors.messages[:name].first.should eq("is already taken")
+            end
+
+          end
+
           context "when the attribute is not unique with no scope" do
 
             before do


### PR DESCRIPTION
Currently uniqueness constraint is violated, if attribute on a mongoid document hasn't changed but scope has. To ensure that it doesn't happen, we need to make sure that scope reference hasn't changed either. Making a fix to check that. Submitting a pull request to fix newly opened bug #1656.
