### PR TITLE
setting an embeds many association a second time does not persist the relationship 

### DIFF
--- a/spec/mongoid/relations/embedded/many_spec.rb
+++ b/spec/mongoid/relations/embedded/many_spec.rb
@@ -309,6 +309,25 @@ describe Mongoid::Relations::Embedded::Many do
         it "does not save the target" do
           address.should_not be_persisted
         end
+
+        context "when setting the relation multiple times" do
+          let(:address_two) do
+            Address.new(:street => "kudamm")
+          end
+
+          before do
+            person.addresses = [ address_two ]
+            person.save
+          end
+
+          it "sets the new documents" do
+            person.addresses.should eq([ address_two ])
+          end
+
+          it "persits only the new documents" do
+            person.reload.addresses.should eq([ address_two ])
+          end
+        end
       end
     end
 


### PR DESCRIPTION
here's an example

``` ruby
person = Person.create addresses: [address_one]
person.addresses = [address_two]
person.save
person.reload.addresses.first # => address_one
```

The pull request has a failing spec, but would appreciate any help on figuring out where to make the fix.

It's somewhere around persisting an embeds many relationship.
