### PR TITLE
Made fix for #1656 more efficient.

### DIFF
--- a/lib/mongoid/validations/uniqueness.rb
+++ b/lib/mongoid/validations/uniqueness.rb
@@ -156,8 +156,8 @@ module Mongoid #:nodoc:
       #
       # @since 
       def scope_value_changed?(document)
-        Array.wrap(options[:scope]).reduce(false) do |result, item|
-          (result || document.send("attribute_changed?", item.to_s))
+        Array.wrap(options[:scope]).any? do |item|
+          document.send("attribute_changed?", item.to_s)
         end
       end
     end


### PR DESCRIPTION
Changed "reduce" call to "any?" on scope enumerable. "any?" is more readable and more efficient. As discussed here https://github.com/mongoid/mongoid/commit/791a6d111de053333461dd775725803c74a8e7e5
