### PR TITLE
Document#update_attributes accepts additional options hash.

### DIFF
--- a/lib/mongoid/persistence.rb
+++ b/lib/mongoid/persistence.rb
@@ -131,8 +131,8 @@ module Mongoid #:nodoc:
     # @raise [ Errors::Validations ] If validation failed.
     #
     # @return [ true, false ] True if validation passed.
-    def update_attributes!(attributes = {})
-      update_attributes(attributes).tap do |result|
+    def update_attributes!(attributes = {}, options = {})
+      update_attributes(attributes, options).tap do |result|
         unless result
           self.class.fail_validate!(self) if errors.any?
           self.class.fail_callback!(self, :update_attributes!)

--- a/spec/mongoid/persistence_spec.rb
+++ b/spec/mongoid/persistence_spec.rb
@@ -1051,6 +1051,24 @@ describe Mongoid::Persistence do
 
   describe "#update_attributes!" do
 
+    context "when providing options" do
+
+      let(:person) { Person.create }
+      let(:params) { [{:pets => false}, {:as => :default}]}
+
+      it "accepts the additional parameter" do
+        expect {
+          person.update_attributes!(*params)
+        }.to_not raise_error(ArgumentError)
+      end
+
+      it "calls assign_attributes" do
+        person.expects(:assign_attributes).with(*params)
+        person.update_attributes!(*params)
+      end
+
+    end
+
     context "when a callback returns false" do
 
       let(:oscar) do


### PR DESCRIPTION
In Rails >3.1.0 updates_attributes accepts an additional options hash so we do, too. Its used for mass assignment security.

Fixes #1376.
