### PR TITLE
Document#update_attributes accepts additional options hash.

### DIFF
--- a/lib/mongoid/persistence.rb
+++ b/lib/mongoid/persistence.rb
@@ -116,8 +116,8 @@ module Mongoid #:nodoc:
     # @param [ Hash ] attributes The attributes to update.
     #
     # @return [ true, false ] True if validation passed, false if not.
-    def update_attributes(attributes = {})
-      write_attributes(attributes); save
+    def update_attributes(attributes = {}, options = {})
+      assign_attributes(attributes, options); save
     end
 
     # Update the document attributes in the database and raise an error if
@@ -131,8 +131,8 @@ module Mongoid #:nodoc:
     # @raise [ Errors::Validations ] If validation failed.
     #
     # @return [ true, false ] True if validation passed.
-    def update_attributes!(attributes = {})
-      update_attributes(attributes).tap do |result|
+    def update_attributes!(attributes = {}, options = {})
+      update_attributes(attributes, options).tap do |result|
         unless result
           self.class.fail_validate!(self) if errors.any?
           self.class.fail_callback!(self, :update_attributes!)

--- a/spec/mongoid/persistence_spec.rb
+++ b/spec/mongoid/persistence_spec.rb
@@ -829,6 +829,24 @@ describe Mongoid::Persistence do
 
   describe "#update_attributes" do
 
+    context "when providing options" do
+
+      let(:person) { Person.create }
+      let(:params) { [{:pets => false}, {:as => :default}]}
+
+      it "accepts the additional parameter" do
+        expect {
+          person.update_attributes(*params)
+        }.to_not raise_error(ArgumentError)
+      end
+
+      it "calls assign_attributes" do
+        person.expects(:assign_attributes).with(*params)
+        person.update_attributes(*params)
+      end
+
+    end
+
     context "when saving with a hash field with invalid keys" do
 
       let(:person) do
@@ -1032,6 +1050,24 @@ describe Mongoid::Persistence do
   end
 
   describe "#update_attributes!" do
+
+    context "when providing options" do
+
+      let(:person) { Person.create }
+      let(:params) { [{:pets => false}, {:as => :default}]}
+
+      it "accepts the additional parameter" do
+        expect {
+          person.update_attributes!(*params)
+        }.to_not raise_error(ArgumentError)
+      end
+
+      it "calls assign_attributes" do
+        person.expects(:assign_attributes).with(*params)
+        person.update_attributes!(*params)
+      end
+
+    end
 
     context "when a callback returns false" do
 


### PR DESCRIPTION
In Rails >3.1.0 updates_attributes accepts an additional options hash
so we do, too. Its used for mass assignment security.

Fixes #1376 and replaces #1687.
