### PR TITLE
Return 0 if Integer field can't be serialized

### DIFF
--- a/lib/mongoid/fields/internal/integer.rb
+++ b/lib/mongoid/fields/internal/integer.rb
@@ -35,7 +35,7 @@ module Mongoid #:nodoc:
         # @since 2.1.0
         def serialize(object)
           return nil if object.blank?
-          numeric(object) rescue object
+          numeric(object) rescue 0
         end
 
         private

--- a/spec/mongoid/fields/internal/integer_spec.rb
+++ b/spec/mongoid/fields/internal/integer_spec.rb
@@ -88,8 +88,8 @@ describe Mongoid::Fields::Internal::Integer do
 
       context "when the string is non numerical" do
 
-        it "returns the string" do
-          field.serialize("foo").should eq("foo")
+        it "returns 0" do
+          field.serialize("foo").should eq(0)
         end
       end
 


### PR DESCRIPTION
ActiveRecord defaults to 0 when you try to assign non-numeric string to an integer field.
Mongoid saves the original string. 

I am not sure whether what was the reasoning behind that decision and maybe it makes sense, but maybe it would be nice to make it consistent with ActiveRecord. 

Moreover, when you have integer field you probably assume that this is integer and you do not check whether it actually is. Therefore, you can get exceptions in some strange places in your app when in some place you do `field_that_is_supposed_to_be_integer_but_is_not + 45`.

What you guys think? Makes sense, does not make sense ?
