### PR TITLE
Heroku lazy assets compilation fix

### DIFF
--- a/lib/mongoid/railtie.rb
+++ b/lib/mongoid/railtie.rb
@@ -78,7 +78,7 @@ module Rails #:nodoc:
       initializer "setup database" do
         config_file = Rails.root.join("config", "mongoid.yml")
         # @todo: Durran: Remove extra check when #1291 complete.
-        if config_file.file? &&
+        if config_file.file? && (ARGV[0] || '').slice(0,17) != 'assets:precompile' &&
           YAML.load(ERB.new(File.read(config_file)).result)[Rails.env].values.flatten.any?
           ::Mongoid.load!(config_file)
         end


### PR DESCRIPTION
A little fix for the heroku cedar lazy assets compilation bug that is discussed over here https://github.com/mongoid/mongoid/issues/1166

Basically it checks if it's one of the `assets:precompile` task is run then skips the database connection in this case
