### PR TITLE
Allow reordering of foreign keys even with pulls/pushes

### DIFF
--- a/lib/mongoid/fields/internal/foreign_keys/array.rb
+++ b/lib/mongoid/fields/internal/foreign_keys/array.rb
@@ -23,17 +23,22 @@ module Mongoid #:nodoc:
           # @param [ Array ] old The old elements getting removed.
           #
           # @since 2.4.0
-          def add_atomic_changes(document, name, key, mods, new, old)
-            pushes = (new || []) - (old || [])
-            pulls = (old || []) - (new || [])
-            if old.nil?
-              mods[key] = pushes
-            elsif !pushes.empty? && !pulls.empty?
-              mods[key] = document.attributes[name]
-            elsif !pushes.empty?
-              document.atomic_array_add_to_sets[key] = pushes
-            elsif !pulls.empty?
-              document.atomic_array_pulls[key] = pulls
+          def add_atomic_changes(document, name, key, mods, new_elements, old_elements)
+            old = (old_elements || [])
+            new = (new_elements || [])
+            if new.length > old.length
+              if new.first(old.length) == old
+                document.atomic_array_add_to_sets[key] = new.drop(old.length)
+              else
+                mods[key] = document.attributes[name]
+              end
+            elsif new.length < old.length
+              pulls = old - new
+              if new == old - pulls
+                document.atomic_array_pulls[key] = pulls
+              else
+                mods[key] = document.attributes[name]
+              end
             elsif new != old
               mods[key] = document.attributes[name]
             end

--- a/spec/mongoid/relations/referenced/many_to_many_spec.rb
+++ b/spec/mongoid/relations/referenced/many_to_many_spec.rb
@@ -2597,5 +2597,47 @@ describe Mongoid::Relations::Referenced::ManyToMany do
         reloaded.preference_ids.should eq([ preference_two.id, preference_one.id ])
       end
     end
+
+    context "and the order is changed and an element is added" do
+
+      let(:preference_three) do
+        Preference.create(:name => "three")
+      end
+
+      before do
+        person.preference_ids = [ preference_two.id, preference_one.id, preference_three.id ]
+        person.save
+      end
+
+      let(:reloaded) do
+        Person.find(person.id)
+      end
+
+      it "also persists the change in id order" do
+        reloaded.preference_ids.should eq([ preference_two.id, preference_one.id, preference_three.id ])
+      end
+    end
+
+    context "and the order is changed and an element is removed" do
+
+      let(:preference_three) do
+        Preference.create(:name => "three")
+      end
+
+      before do
+        person.preference_ids = [ preference_one.id, preference_two.id, preference_three.id ]
+        person.save
+        person.preference_ids = [ preference_three.id, preference_two.id ]
+        person.save
+      end
+
+      let(:reloaded) do
+        Person.find(person.id)
+      end
+
+      it "also persists the change in id order" do
+        reloaded.preference_ids.should eq([ preference_three.id, preference_two.id ])
+      end
+    end
   end
 end


### PR DESCRIPTION
When there were pushes (or pulls) as well as elements being reordered,
save would only push (or pull) elements. The changed order of the other
elements were lost.

With this change, checking is done to ensure that we only push when the
new elements are at the end, and pull when the remaining element's order
has not changed.

Noticed that this behavior was not quite right when looking at the fix for
mongoid/mongoid#1705.
