### PR TITLE
Serialization with embedded relations is inconsistent

### DIFF
--- a/spec/mongoid/serialization_spec.rb
+++ b/spec/mongoid/serialization_spec.rb
@@ -129,6 +129,84 @@ describe Mongoid::Serialization do
       end
     end
 
+    context "when a model has relations" do
+      let(:attributes) do
+        { "title" => "President", "security_code" => "1234" }
+      end
+
+      before do
+        person.write_attributes(attributes, false)
+      end
+
+      context "when the model is saved before the relation is added" do
+
+        before do
+          person.save
+        end
+
+        context "when a model has an embeds many" do
+
+          let!(:address_one) do
+            person.addresses.build(:street => "Kudamm")
+          end
+
+          before do
+            person.save
+          end
+
+          it "includes the relation" do
+            person.serializable_hash.keys.should include('addresses')
+          end
+        end
+
+        context "when a model has an embeds one" do
+          let!(:name) do
+            person.build_name(:first_name => "Leo", :last_name => "Marvin")
+          end
+
+          before do
+            person.save
+          end
+
+          it "includes the relation" do
+            person.serializable_hash.keys.should include('name')
+          end
+        end
+      end
+
+      context "when the model is saved after the relation is added" do
+
+        context "when a model has an embeds many" do
+
+          let!(:address_one) do
+            person.addresses.build(:street => "Kudamm")
+          end
+
+          before do
+            person.save
+          end
+
+          it "includes the relation" do
+            person.serializable_hash.keys.should include('addresses')
+          end
+        end
+
+        context "when a model has an embeds one" do
+          let!(:name) do
+            person.build_name(:first_name => "Leo", :last_name => "Marvin")
+          end
+
+          before do
+            person.save
+          end
+
+          it "includes the relation" do
+            person.serializable_hash.keys.should include('name')
+          end
+        end
+      end
+    end
+
     context "when including methods" do
 
       it "includes the method result" do


### PR DESCRIPTION
If I add an embedded relation _before_ saving a document, the relation is serialized (without the :includes option):

```
person = Person.new
person.write_attributes(:title => "President")
person.addresses.build(:street => "Kudamm")
person.save
person.serializable_hash
  => {'title' => 'President', 'addresses' => [{'street' => 'Kudamm'], ...}
```

But if the relation is added _after_ saving a document, the relation is not serialized:

```
person = Person.new
person.write_attributes(:title => "President")
person.save
person.addresses.build(:street => "Kudamm")
person.save
person.serializable_hash
  => {'title' => 'President', ...}
```

If I pass `:includes => ['addresses']` to the `serialize_hash` method, it works in both situations.  What is the intended behavior when `:includes` is not specified?

The attached specs demonstrate the problem.  2 of the 4 added specs fail.

(I'm using mongoid 2.4.3)
