### PR TITLE
add support for embeds_many when querying Enumerable

### DIFF
--- a/lib/mongoid/matchers/strategies.rb
+++ b/lib/mongoid/matchers/strategies.rb
@@ -85,7 +85,7 @@ module Mongoid #:nodoc:
             begin
               _attribs.try(:[], _key)
             rescue TypeError
-              throw $! unless _attribs.kind_of? Array
+              throw $! unless _attribs.respond_to? :map
               _attribs.map {|doc| doc.try(:[], _key)}
             end
           end

--- a/spec/app/models/location.rb
+++ b/spec/app/models/location.rb
@@ -2,5 +2,6 @@ class Location
   include Mongoid::Document
   field :name
   field :info, :type => Hash
+  field :occupants, :type => Array
   embedded_in :address
 end

--- a/spec/mongoid/matchers_spec.rb
+++ b/spec/mongoid/matchers_spec.rb
@@ -11,7 +11,11 @@ describe Mongoid::Matchers do
       end
 
       before do
-        document.locations << Location.new(:name => 'No.1', :info => { 'door' => 'Red'} )
+        document.locations << Location.new(
+          :name => 'No.1',
+          :info => { 'door' => 'Red'},
+          :occupants => [{'name' => 'Tim'}]
+        )
       end
 
       context "when the attributes do not match" do
@@ -71,6 +75,43 @@ describe Mongoid::Matchers do
           end
         end
       end
+
+      context "when matching values of multiple embedded hashes" do
+
+        context "when the contents match" do
+
+          let(:selector) do
+            { "occupants.name" => "Tim" }
+          end
+
+          it "returns true" do
+            document.locations.first.matches?(selector).should be_true
+          end
+        end
+
+        context "when the contents do not match" do
+
+          let(:selector) do
+            { "occupants.name" => "Lyle" }
+          end
+
+          it "returns false" do
+            document.locations.first.matches?(selector).should be_false
+          end
+        end
+
+        context "when the contents do not exist" do
+
+          let(:selector) do
+            { "occupants.something_else" => "Tim" }
+          end
+
+          it "returns false" do
+            document.locations.first.matches?(selector).should be_false
+          end
+        end
+      end
+
     end
 
     context "when performing simple matching" do


### PR DESCRIPTION
Mongoid::Matchers::Strategies.extract_attributes was not taking into account the possibility of an array result, as in the case of an embeds_many.

This fix is fairly dumb.
