### PR TITLE
Integer is always an integer

### DIFF
--- a/lib/mongoid/fields/internal/integer.rb
+++ b/lib/mongoid/fields/internal/integer.rb
@@ -51,7 +51,7 @@ module Mongoid #:nodoc:
         #
         # @since 2.3.0
         def numeric(object)
-          object.to_s =~ /(^[-+]?[0-9]+$)|(\.0+)$/ ? object.to_i : Float(object)
+          object.to_s =~ /(^[-+]?[0-9]+$)|(\.0+)$/ ? object.to_i : Float(object).to_i
         end
       end
     end

--- a/spec/mongoid/fields/internal/integer_spec.rb
+++ b/spec/mongoid/fields/internal/integer_spec.rb
@@ -57,8 +57,8 @@ describe Mongoid::Fields::Internal::Integer do
 
       context "when the value is a decimal" do
 
-        it "returns the decimal" do
-          field.serialize(2.5).should eq(2.5)
+        it "casts to integer" do
+          field.serialize(2.5).should eq(2)
         end
       end
 


### PR DESCRIPTION
Even if decimal is given it gets casted to integer.

This would make the behavior a little bit more predictable - the integer is always integer.
That also makes it a little bit more consistent with behavior of ActiveRecord.
