### PR TITLE
Fix typo in object#_vacant? method documentation

### DIFF
--- a/lib/mongoid/extensions/object/checks.rb
+++ b/lib/mongoid/extensions/object/checks.rb
@@ -12,10 +12,10 @@ module Mongoid #:nodoc:
         # field called "empty" on the document.
         #
         # @example Is the array vacant?
-        #   [].vacant?
+        #   []._vacant?
         #
         # @example Is the object vacant?
-        #   nil.vacant?
+        #   nil._vacant?
         #
         # @return [ true, false ] True if empty or nil, false if not.
         #


### PR DESCRIPTION
Just a small typo I noticed ;)
`vacant?` => `_vacant?`
