### PR TITLE
Add one missing replacement of localhost vs envvar

### DIFF
--- a/spec/functional/mongoid/config/replset_database_spec.rb
+++ b/spec/functional/mongoid/config/replset_database_spec.rb
@@ -32,7 +32,8 @@ describe Mongoid::Config::ReplsetDatabase do
 
       it "does not modify the options in place" do
         options["test"]["hosts"].should eq(
-          [["localhost", 27017], ["localhost", 27017]]
+          [[ENV["MONGOID_SPEC_HOST"], ENV["MONGOID_SPEC_PORT"].to_i],
+           [ENV["MONGOID_SPEC_HOST"], ENV["MONGOID_SPEC_PORT"].to_i]]
         )
       end
     end


### PR DESCRIPTION
This is applied on master, but it doesn't seem to be applied on 2.4.0-stable (and is now failing, not sure why it didn't before, in packaging, but still..).

No need to make a new release for this though, I guess.
