### PR TITLE
Cast #limit() and #skip() arguments as Integer

### DIFF
--- a/lib/mongoid/criterion/optional.rb
+++ b/lib/mongoid/criterion/optional.rb
@@ -109,7 +109,7 @@ module Mongoid #:nodoc:
       #
       # @return [ Criteria ] The cloned criteria.
       def limit(value = 20)
-        clone.tap { |crit| crit.options[:limit] = value }
+        clone.tap { |crit| crit.options[:limit] = value.to_i }
       end
 
       # Returns the offset option. If a per_page option is in the list then it
@@ -163,7 +163,7 @@ module Mongoid #:nodoc:
       #
       # @return [ Criteria ] The cloned criteria.
       def skip(value = 0)
-        clone.tap { |crit| crit.options[:skip] = value }
+        clone.tap { |crit| crit.options[:skip] = value.to_i }
       end
 
       # Adds a criterion to the +Criteria+ that specifies a type or an Array of

--- a/spec/mongoid/criterion/optional_spec.rb
+++ b/spec/mongoid/criterion/optional_spec.rb
@@ -533,6 +533,17 @@ describe Mongoid::Criterion::Optional do
     it "returns a copy" do
       base.limit.should_not eql(base)
     end
+
+    context "when value is a String" do
+
+      let(:criteria) do
+        base.limit('100')
+      end
+
+      it "cast the limit value to an Integer" do
+        criteria.options.should eq({ :limit => 100 })
+      end
+    end
   end
 
   describe "#offset" do
@@ -731,6 +742,17 @@ describe Mongoid::Criterion::Optional do
 
       it "defaults to zero" do
         criteria.options.should eq({ :skip => 0 })
+      end
+    end
+
+    context "when value is a String" do
+
+      let(:criteria) do
+        base.skip('100')
+      end
+
+      it "cast the skip value to an Integer" do
+        criteria.options.should eq({ :skip => 100 })
       end
     end
 


### PR DESCRIPTION
To avoid raising ArgumentError deep inside Mongo's driver:
`MyModel.limit("2").to_a`

Before this patch:

```
mongo-1.5.2/lib/mongo/cursor.rb:272:in `>'
mongo-1.5.2/lib/mongo/cursor.rb:272:in `batch_size'
mongo-1.5.2/lib/mongo/cursor.rb:80:in `initialize'
mongo-1.5.2/lib/mongo/collection.rb:236:in `new'
mongo-1.5.2/lib/mongo/collection.rb:236:in `find'
mongoid-2.4.4/lib/mongoid/collections/master.rb:25:in `block in find'
mongoid-2.4.4/lib/mongoid/collections/retry.rb:29:in `retry_on_connection_failure'
mongoid-2.4.4/lib/mongoid/collections/master.rb:24:in `find'
mongoid-2.4.4/lib/mongoid/collection.rb:42:in `find'
mongoid-2.4.4/lib/mongoid/contexts/mongo.rb:175:in `block in execute'
mongoid-2.4.4/lib/mongoid/contexts/mongo.rb:478:in `selecting'
mongoid-2.4.4/lib/mongoid/contexts/mongo.rb:169:in `execute'
mongoid-2.4.4/lib/mongoid/contexts/mongo.rb:261:in `iterate'
mongoid-2.4.4/lib/mongoid/criteria.rb:145:in `block in each'
mongoid-2.4.4/lib/mongoid/criteria.rb:145:in `tap'
mongoid-2.4.4/lib/mongoid/criteria.rb:145:in `each'
```

With this patch: Work just like `MyModel.limit(2).to_a`
