### PR TITLE
Survive requests for foreign_key of Embedded::One relations

### DIFF
--- a/lib/mongoid/relations/metadata.rb
+++ b/lib/mongoid/relations/metadata.rb
@@ -892,7 +892,7 @@ module Mongoid # :nodoc:
       # @since 2.0.0.rc.1
       def determine_foreign_key
         return self[:foreign_key].to_s if self[:foreign_key]
-        suffix = relation.foreign_key_suffix
+        suffix = relation.foreign_key_suffix if relation.respond_to? :foreign_key_suffix
         if relation.stores_foreign_key?
           if relation.macro == :has_and_belongs_to_many
             "#{name.to_s.singularize}#{suffix}"

--- a/spec/mongoid/relations/metadata_spec.rb
+++ b/spec/mongoid/relations/metadata_spec.rb
@@ -777,6 +777,20 @@ describe Mongoid::Relations::Metadata do
             end
           end
         end
+
+        context "when embeds one" do
+          let(:metadata) do
+            described_class.new(
+              name: :post,
+              relation: Mongoid::Relations::Embedded::One,
+              inverse_class_name: "Person"
+            )
+          end
+
+          it "returns the inverse foreign key" do
+            metadata.foreign_key.should eq("person_id")
+          end
+        end
       end
     end
 


### PR DESCRIPTION
I'm trying to render a formtastic form that is enquiring about the relations in my mongoid document. I have some embedded documents, and when formtastic asks about the foreign key I get an exception because the determine_foreign_key method in Metadata assumes that all relations respond to :foreign_key_suffix, which is not the case for Embedded::One. I've patched it to only call the method :foreign_key_suffix if it responds to it. I'm not sure if there are any other considerations here?
