### PR TITLE
Additional filtering for database connection options

### DIFF
--- a/lib/mongoid/config/database.rb
+++ b/lib/mongoid/config/database.rb
@@ -7,7 +7,7 @@ module Mongoid #:nodoc:
     class Database < Hash
 
       # keys to remove from self to not pass through to Mongo::Connection
-      PRIVATE_OPTIONS = %w(uri database username password logger)
+      PRIVATE_OPTIONS = %w(uri host port database username password logger)
 
       # Configure the database connections. This will return an array
       # containing the master and an array of slaves.


### PR DESCRIPTION
After upgrading to mongo-1.6.1, I'm getting messages dumped to my terminal when my Rails app starts up (running "rails console" for example).

```
$ rails console
host is not a valid option for Mongo::Connection
port is not a valid option for Mongo::Connection
Loading development environment (Rails 3.2.2)
irb(main):001:0>
```

This seems to be coming from new code in mongodb/mongo-ruby-driver@8e64c74d that validates the options being passed in. I believe that this is because the host and port options need to be filtered out by Mongoid when it establishes the database connection, because these options should have already been used when generating the connection URI.
