### PR TITLE
Return documents from push on many to many relation

### DIFF
--- a/spec/mongoid/relations/referenced/many_to_many_spec.rb
+++ b/spec/mongoid/relations/referenced/many_to_many_spec.rb
@@ -20,6 +20,44 @@ describe Mongoid::Relations::Referenced::ManyToMany do
 
     describe "##{method}" do
 
+      context "when the parent is a new record" do
+
+        let(:person) do
+          Person.new
+        end
+
+        let!(:preference) do
+          Preference.new
+        end
+
+        let(:result) do
+          person.preferences.send(method, preference)
+        end
+
+        it "returns an array of loaded documents" do
+          result.should eq([ preference ])
+        end
+      end
+
+      context "when the parent is not a new record" do
+
+        let(:person) do
+          Person.create
+        end
+
+        let!(:preference) do
+          Preference.new
+        end
+
+        let(:result) do
+          person.preferences.send(method, preference)
+        end
+
+        it "returns an array of loaded documents" do
+          result.should eq([ preference ])
+        end
+      end
+
       context "when the relations are not polymorphic" do
 
         context "when the inverse relation is not defined" do


### PR DESCRIPTION
The documentation for the push method on the many_to_many relation states that the method should return an array of loaded documents. It doesn't seem to though.

When pushing a related object onto a parent that has not been persisted, push returns an empty array:

``` ruby
preference = Preference.new
person     = Person.new
person.preferences.push(preference)
# => []
```

When the parent has been persisted, only an array containing the object id of the child is returned:

``` ruby
preference = Preference.create
person     = Person.new
person.preferences.push(preference)
# => [BSON::ObjectId('4f58e279cd22553fb2000009')]
```

This is being returned by the call to batched within the push method. It seems like the relation itself should be returned instead.
