### PR TITLE
Little refactoring of BSON::ObjectId.convert

### DIFF
--- a/lib/mongoid/extensions/object_id.rb
+++ b/lib/mongoid/extensions/object_id.rb
@@ -19,6 +19,7 @@ module Mongoid #:nodoc:
       #
       # @param [ Class ] klass The class to convert the ids for.
       # @param [ Object, Array, Hash ] object The object to convert.
+      # @param [ Boolean ] reject_blank delete blank element from object received like args
       #
       # @raise BSON::InvalidObjectId If using object ids and passed bad
       #   strings.
@@ -28,28 +29,89 @@ module Mongoid #:nodoc:
       # @since 2.0.0.rc.7
       def convert(klass, object, reject_blank = true)
         return object if object.is_a?(BSON::ObjectId) || !klass.using_object_ids?
+
         case object
         when ::String
-          return nil if object.blank?
-          if object.unconvertable_to_bson?
-            object
-          else
-            BSON::ObjectId.legal?(object) ? BSON::ObjectId.from_string(object) : object
-          end
+          convert_from_string(klass, object)
         when ::Array
-          object.delete_if { |arg| arg.blank? } if reject_blank
-          object.replace(object.map { |arg| convert(klass, arg, reject_blank) })
+          convert_from_array(klass, object, reject_blank)
         when ::Hash
-          object.tap do |hash|
-            hash.each_pair do |key, value|
-              next unless klass.object_id_field?(key)
-              hash[key] = convert(klass, value, reject_blank)
-            end
-          end
+          convert_from_hash(klass, object, reject_blank)
         else
           object
         end
       end
+
+      # Convert the supplied string ids based on the class
+      # settings.
+      #
+      # @example Convert a string to an object id
+      #   BSON::ObjectId.convert(Person, "4c52c439931a90ab29000003")
+      #
+      # @param [ Class ] klass The class to convert the ids for.
+      # @param [ String ] object The string to convert.
+      #
+      # @raise BSON::InvalidObjectId If using object ids and passed bad
+      #   strings.
+      #
+      # @return [ BSON::ObjectId ] The converted object ids.
+      #
+      # @since 3.0.0
+      def convert_from_string(klass, object)
+        return nil if object.blank?
+        if object.unconvertable_to_bson? || !BSON::ObjectId.legal?(object)
+          object
+        else
+          BSON::ObjectId.from_string(object)
+        end
+      end
+
+      # Convert the supplied arguments to array ids based on the class
+      # settings.
+      #
+      # @example Convert an array of strings to object ids.
+      #   BSON::ObjectId.convert(Person, [ "4c52c439931a90ab29000003" ])
+      #
+      # @param [ Class ] klass The class to convert the ids for.
+      # @param [ Array ] object The array to convert.
+      # @param [ Boolean ] reject_blank delete blank element from array received like args
+      #
+      # @raise BSON::InvalidObjectId If using object ids and passed bad
+      #   strings.
+      #
+      # @return [ Array ] The converted object ids.
+      #
+      # @since 3.0.0
+      def convert_from_array(klass, object, reject_blank=true)
+        object.delete_if { |arg| arg.blank? } if reject_blank
+        object.replace(object.map { |arg| convert(klass, arg, reject_blank) })
+      end
+
+      # Convert the supplied arguments to hash ids based on the class
+      # settings.
+      #
+      # @example Convert a hash of id strings to object ids.
+      #   BSON::ObjectId.convert(Person, { :_id => "4c52c439931a90ab29000003" })
+      #
+      # @param [ Class ] klass The class to convert the ids for.
+      # @param [ Hash ] object The hash to convert.
+      # @param [ Boolean ] reject_blank delete blank element from hash received like args
+      #
+      # @raise BSON::InvalidObjectId If using object ids and passed bad
+      #   strings.
+      #
+      # @return [ Hash ] The converted object ids.
+      #
+      # @since 3.0.0
+      def convert_from_hash(klass, object, reject_blank=true)
+        object.tap do |hash|
+          hash.each_pair do |key, value|
+            next unless klass.object_id_field?(key)
+            hash[key] = convert(klass, value, reject_blank)
+          end
+        end
+      end
+
     end
   end
 end

--- a/spec/mongoid/extensions/object_id_spec.rb
+++ b/spec/mongoid/extensions/object_id_spec.rb
@@ -40,28 +40,6 @@ describe Mongoid::Extensions::ObjectId do
         end
       end
 
-      context "when provided an array of nils" do
-
-        let(:converted) do
-          BSON::ObjectId.convert(Person, [ nil, nil ])
-        end
-
-        it "returns an empty array" do
-          converted.should be_empty
-        end
-      end
-
-      context "when provided an array of empty strings" do
-
-        let(:converted) do
-          BSON::ObjectId.convert(Person, [ "", "" ])
-        end
-
-        it "returns an empty array" do
-          converted.should be_empty
-        end
-      end
-
       context "when provided a single string" do
 
         context "when the string is a valid object id" do
@@ -96,37 +74,62 @@ describe Mongoid::Extensions::ObjectId do
         end
       end
 
-      context "when providing an array of strings" do
+      context "when provided an array" do
 
-        context "when the strings are valid object ids" do
-
-          let(:other_id) do
-            BSON::ObjectId.new
-          end
+        context "when array key of nils" do
 
           let(:converted) do
-            BSON::ObjectId.convert(Person, [ object_id.to_s, other_id.to_s ])
+            BSON::ObjectId.convert(Person, [ nil, nil ])
           end
 
-          it "converts to an array of object ids" do
-            converted.should eq([ object_id, other_id ])
+          it "returns an empty array" do
+            converted.should be_empty
           end
         end
 
-        context "when the strings are not valid object ids" do
-
-          let(:other_key) do
-            "hawaii-five-o"
-          end
+        context "when the array key is empty strings" do
 
           let(:converted) do
-            BSON::ObjectId.convert(Person, [ composite_key, other_key ])
+            BSON::ObjectId.convert(Person, [ "", "" ])
           end
 
-          it "returns the key" do
-            BSON::ObjectId.convert(Person, composite_key).should eq(
-              composite_key
-            )
+          it "returns an empty array" do
+            converted.should be_empty
+          end
+        end
+
+        context "when the array key is full of strings" do
+
+          context "when the strings are valid object ids" do
+
+            let(:other_id) do
+              BSON::ObjectId.new
+            end
+
+            let(:converted) do
+              BSON::ObjectId.convert(Person, [ object_id.to_s, other_id.to_s ])
+            end
+
+            it "converts to an array of object ids" do
+              converted.should eq([ object_id, other_id ])
+            end
+          end
+
+          context "when the strings are not valid object ids" do
+
+            let(:other_key) do
+              "hawaii-five-o"
+            end
+
+            let(:converted) do
+              BSON::ObjectId.convert(Person, [ composite_key, other_key ])
+            end
+
+            it "returns the key" do
+              BSON::ObjectId.convert(Person, composite_key).should eq(
+                composite_key
+              )
+            end
           end
         end
       end
@@ -345,5 +348,276 @@ describe Mongoid::Extensions::ObjectId do
         end
       end
     end
+  end
+
+  describe '.convert_from_string' do
+    context "when provided a single string" do
+
+      context "when the string is a valid object id" do
+
+        let(:converted) do
+          BSON::ObjectId.convert_from_string(Person, object_id.to_s)
+        end
+
+        it "converts to an object id" do
+          converted.should eq(object_id)
+        end
+      end
+
+      context "when the string is not a valid object id" do
+
+        it "returns the key" do
+          BSON::ObjectId.convert_from_string(Person, composite_key).should eq(
+            composite_key
+          )
+        end
+      end
+
+      context "when the string is empty" do
+
+        let(:converted) do
+          BSON::ObjectId.convert_from_string(Person, "")
+        end
+
+        it "converts to nil" do
+          converted.should be_nil
+        end
+      end
+    end
+  end
+
+  describe '.convert_from_array' do
+    context "when provided an array of object ids" do
+
+      let(:other_id) do
+        BSON::ObjectId.new
+      end
+
+      let(:converted) do
+        BSON::ObjectId.convert_from_array(Person, [ object_id, other_id ])
+      end
+
+      it "returns the array of object ids" do
+        converted.should eq([ object_id, other_id ])
+      end
+    end
+
+    context "when provided an array of nils" do
+
+      let(:converted) do
+        BSON::ObjectId.convert_from_array(Person, [ nil, nil ])
+      end
+
+      it "returns an empty array" do
+        converted.should be_empty
+      end
+    end
+
+    context "when provided an array of empty strings" do
+
+      let(:converted) do
+        BSON::ObjectId.convert(Person, [ "", "" ])
+      end
+
+      it "returns an empty array" do
+        converted.should be_empty
+      end
+    end
+
+    context "when providing an array of strings" do
+
+      context "when the strings are valid object ids" do
+
+        let(:other_id) do
+          BSON::ObjectId.new
+        end
+
+        let(:converted) do
+          BSON::ObjectId.convert_from_array(Person, [ object_id.to_s, other_id.to_s ])
+        end
+
+        it "converts to an array of object ids" do
+          converted.should eq([ object_id, other_id ])
+        end
+      end
+    end
+  end
+
+  describe '.convert_from_hash' do
+    context "when the hash key is _id" do
+
+      context "when the value is an object id" do
+
+        let(:hash) do
+          { _id: object_id }
+        end
+
+        let(:converted) do
+          BSON::ObjectId.convert_from_hash(Person, hash)
+        end
+
+        it "returns the hash" do
+          converted.should eq(hash)
+        end
+      end
+
+      context "when the value is an array of object ids" do
+
+        let(:other_id) do
+          BSON::ObjectId.new
+        end
+
+        let(:hash) do
+          { _id: [ object_id, other_id ] }
+        end
+
+        let(:converted) do
+          BSON::ObjectId.convert_from_hash(Person, hash)
+        end
+
+        it "returns the hash" do
+          converted.should eq(hash)
+        end
+      end
+
+      context "when the value is a string" do
+
+        let(:hash) do
+          { _id: object_id.to_s }
+        end
+
+        let(:converted) do
+          BSON::ObjectId.convert_from_hash(Person, hash)
+        end
+
+        it "returns the hash with converted value" do
+          converted.should eq({ _id: object_id })
+        end
+      end
+
+      context "when the value is an array of strings" do
+
+        let(:other_id) do
+          BSON::ObjectId.new
+        end
+
+        let(:hash) do
+          { _id: [ object_id.to_s, other_id.to_s ] }
+        end
+
+        let(:converted) do
+          BSON::ObjectId.convert_from_hash(Person, hash)
+        end
+
+        it "returns the hash with converted values" do
+          converted.should eq({ _id: [ object_id, other_id ] })
+        end
+      end
+    end
+
+    context "when the hash key is id" do
+
+      context "when the value is an object id" do
+
+        let(:hash) do
+          { id: object_id }
+        end
+
+        let(:converted) do
+          BSON::ObjectId.convert_from_hash(Person, hash)
+        end
+
+        it "returns the hash" do
+          converted.should eq(hash)
+        end
+      end
+
+      context "when the value is an array of object ids" do
+
+        let(:other_id) do
+          BSON::ObjectId.new
+        end
+
+        let(:hash) do
+          { id: [ object_id, other_id ] }
+        end
+
+        let(:converted) do
+          BSON::ObjectId.convert_from_hash(Person, hash)
+        end
+
+        it "returns the hash" do
+          converted.should eq(hash)
+        end
+      end
+
+      context "when the value is a string" do
+
+        let(:hash) do
+          { id: object_id.to_s }
+        end
+
+        let(:converted) do
+          BSON::ObjectId.convert_from_hash(Person, hash)
+        end
+
+        it "returns the hash with converted value" do
+          converted.should eq({ id: object_id })
+        end
+      end
+
+      context "when the value is an array of strings" do
+
+        let(:other_id) do
+          BSON::ObjectId.new
+        end
+
+        let(:hash) do
+          { id: [ object_id.to_s, other_id.to_s ] }
+        end
+
+        let(:converted) do
+          BSON::ObjectId.convert_from_hash(Person, hash)
+        end
+
+        it "returns the hash with converted values" do
+          converted.should eq({ id: [ object_id, other_id ] })
+        end
+      end
+    end
+
+    context "when the hash key is not an id" do
+
+      context "when the value is a string" do
+
+        let(:hash) do
+          { key: composite_key }
+        end
+
+        let(:converted) do
+          BSON::ObjectId.convert_from_hash(Person, hash)
+        end
+
+        it "returns the hash" do
+          converted.should eq(hash)
+        end
+      end
+
+      context "when the value is an array of strings" do
+
+        let(:hash) do
+          { key: [ composite_key ] }
+        end
+
+        let(:converted) do
+          BSON::ObjectId.convert_from_hash(Person, hash)
+        end
+
+        it "returns the hash" do
+          converted.should eq(hash)
+        end
+      end
+    end
+
   end
 end


### PR DESCRIPTION
I don't know if you think this refactoring is good enough or not. But it's just a start.

The `BSON::ObjectId.convert` method can take a lot of type in params. I extract all of type managed by this method in several method. With this refactoring, the code is a little cleaner.

I add documentation about the third args `reject_blank` pass on this method. There are no documentation before.
