### PR TITLE
created_at *exactly* equals updated_at on new records

### DIFF
--- a/lib/mongoid/timestamps/created.rb
+++ b/lib/mongoid/timestamps/created.rb
@@ -17,7 +17,11 @@ module Mongoid #:nodoc:
       # @example Set the created at time.
       #   person.set_created_at
       def set_created_at
-        self.created_at = Time.now.utc if !created_at
+        if !created_at
+          time = Time.now.utc
+          self.updated_at = time if is_a?(Updated)
+          self.created_at = time
+        end
       end
     end
   end

--- a/spec/mongoid/timestamps_spec.rb
+++ b/spec/mongoid/timestamps_spec.rb
@@ -33,6 +33,10 @@ describe Mongoid::Timestamps do
       document.updated_at.should be_within(10).of(Time.now.utc)
     end
 
+    it "ensures created_at equals updated_at on new records" do
+      document.updated_at.should eq(document.created_at)
+    end
+
     it "includes a record_timestamps class_accessor to ease AR compatibility" do
       Dokument.should.respond_to? :record_timestamps
     end
@@ -78,7 +82,7 @@ describe Mongoid::Timestamps do
     end
 
     it "runs the update callbacks" do
-      document.updated_at.should be_within(10).of(Time.now.utc)
+      document.updated_at.should eq(document.created_at)
     end
   end
 


### PR DESCRIPTION
currently mongoid sets updated_at and created_at incorrectly on new records.  that is to say they are different by a handful of milliseconds when, in fact, they should be precisely the same for new records.  i recently hit this issue looking for records that had been updated ever: aka created_at!=updated_at and was sad to see that the small difference semantically means that _all_ my database records have, apparently, been updated at some point when, in fact, they have not.  this small patch fixes this behavior.  up next is a patch that implements transactions for mongoid and marks all records created inside one with the same timestamp ;-)
