### PR TITLE
DocumentNotFound shouldn't require the 3rd argument when we're calling with a hash, .find_by-style.

### DIFF
--- a/lib/mongoid/errors/document_not_found.rb
+++ b/lib/mongoid/errors/document_not_found.rb
@@ -18,8 +18,12 @@ module Mongoid #:nodoc
       #   DocumentNotFound.new(Person, :ssn => "1234", :name => "Helen")
       #
       # @param [ Class ] klass The model class.
-      # @param [ Hash, Array, Object ] attrs The attributes or ids.
-      def initialize(klass, params, unmatched)
+      # @param [ Hash, Array, Object ] params The attributes or ids.
+      # @param [ Array ] unmatched The unmatched ids, if appropriate
+      def initialize(klass, params, unmatched = nil)
+        if !unmatched && !params.is_a?(Hash)
+          raise ArgumentError, 'please also supply the unmatched ids'
+        end
         super(
           compose_message(
             message_key(params),

--- a/lib/mongoid/finders.rb
+++ b/lib/mongoid/finders.rb
@@ -117,7 +117,7 @@ module Mongoid #:nodoc:
     #
     # @since 3.0.0
     def find_by(attrs = {})
-      where(attrs).first || raise(Errors::DocumentNotFound.new(self, attrs, attrs))
+      where(attrs).first || raise(Errors::DocumentNotFound.new(self, attrs))
     end
 
     # Find the first +Document+ given the conditions.


### PR DESCRIPTION
Also document the arguments.
