### PR TITLE
Including _id attribute on versions

### DIFF
--- a/lib/mongoid/versioning.rb
+++ b/lib/mongoid/versioning.rb
@@ -38,7 +38,7 @@ module Mongoid #:nodoc:
       if previous && versioned_attributes_changed?
         versions.build(
           previous.versioned_attributes, without_protection: true
-        ).attributes.delete("_id")
+        )
         if version_max.present? && versions.length > version_max
           deleted = versions.first
           if deleted.paranoid?

--- a/spec/mongoid/versioning_spec.rb
+++ b/spec/mongoid/versioning_spec.rb
@@ -243,10 +243,6 @@ describe Mongoid::Versioning do
           page.versions.count.should eq(1)
         end
 
-        it "does not version the _id" do
-          version._id.should be_nil
-        end
-
         it "does version the updated_at timestamp" do
           version.updated_at.should_not be_nil
         end


### PR DESCRIPTION
It's necessary include _id to find what document this version belongs.

Other possibility, but more complicated, is to include a method parent_document to discover what document has this version.
