### PR TITLE
Renamed method process into process_attributes

### DIFF
--- a/lib/mongoid/attributes.rb
+++ b/lib/mongoid/attributes.rb
@@ -154,7 +154,7 @@ module Mongoid #:nodoc:
     # @since 2.2.1
     def assign_attributes(attrs = nil, options = {})
       _assigning do
-        process(attrs, options[:as] || :default, !options[:without_protection])
+        process_attributes(attrs, options[:as] || :default, !options[:without_protection])
       end
     end
 

--- a/lib/mongoid/attributes/processing.rb
+++ b/lib/mongoid/attributes/processing.rb
@@ -11,14 +11,14 @@ module Mongoid #:nodoc:
       # put into the document's attributes.
       #
       # @example Process the attributes.
-      #   person.process(:title => "sir", :age => 40)
+      #   person.process_attributes(:title => "sir", :age => 40)
       #
       # @param [ Hash ] attrs The attributes to set.
       # @param [ Symbol ] role A role for scoped mass assignment.
       # @param [ Boolean ] guard_protected_attributes False to skip mass assignment protection.
       #
       # @since 2.0.0.rc.7
-      def process(attrs = nil, role = :default, guard_protected_attributes = true)
+      def process_attributes(attrs = nil, role = :default, guard_protected_attributes = true)
         attrs ||= {}
         attrs = sanitize_for_mass_assignment(attrs, role) if guard_protected_attributes
         attrs.each_pair do |key, value|

--- a/lib/mongoid/document.rb
+++ b/lib/mongoid/document.rb
@@ -118,7 +118,7 @@ module Mongoid #:nodoc:
         @attributes ||= {}
         options ||= {}
         apply_pre_processed_defaults
-        process(attrs, options[:as] || :default, !options[:without_protection]) do
+        process_attributes(attrs, options[:as] || :default, !options[:without_protection]) do
           yield(self) if block_given?
         end
         apply_post_processed_defaults

--- a/lib/mongoid/multi_parameter_attributes.rb
+++ b/lib/mongoid/multi_parameter_attributes.rb
@@ -41,14 +41,14 @@ module Mongoid #:nodoc:
     # put into the document's attributes.
     #
     # @example Process the attributes.
-    #   person.process(:title => "sir", :age => 40)
+    #   person.process_attributes(:title => "sir", :age => 40)
     #
     # @param [ Hash ] attrs The attributes to set.
     # @param [ Symbol ] role A role for scoped mass assignment.
     # @param [ Boolean ] guard_protected_attributes False to skip mass assignment protection.
     #
     # @since 2.0.0.rc.7
-    def process(attrs = nil, role = :default, guard_protected_attributes = true)
+    def process_attributes(attrs = nil, role = :default, guard_protected_attributes = true)
       if attrs
         errors = []
         attributes = {}

--- a/lib/mongoid/relations/builders/nested_attributes/many.rb
+++ b/lib/mongoid/relations/builders/nested_attributes/many.rb
@@ -25,9 +25,9 @@ module Mongoid # :nodoc:
             end
             attributes.each do |attrs|
               if attrs.respond_to?(:with_indifferent_access)
-                process(parent, attrs)
+                process_attributes(parent, attrs)
               else
-                process(parent, attrs[1])
+                process_attributes(parent, attrs[1])
               end
             end
           end
@@ -86,10 +86,10 @@ module Mongoid # :nodoc:
           # new, existing, or ignored document.
           #
           # @example Process the attributes
-          #   builder.process({ "id" => 1, "street" => "Bond" })
+          #   builder.process_attributes({ "id" => 1, "street" => "Bond" })
           #
           # @param [ Hash ] attrs The single document attributes to process.
-          def process(parent, attrs)
+          def process_attributes(parent, attrs)
             return if reject?(parent, attrs)
             if id = attrs.extract_id
               first = existing.first

--- a/spec/mongoid/attributes_spec.rb
+++ b/spec/mongoid/attributes_spec.rb
@@ -782,7 +782,7 @@ describe Mongoid::Attributes do
     end
 
     before do
-      person.process(attributes)
+      person.process_attributes(attributes)
     end
 
     it "only overwrites supplied attributes" do

--- a/spec/mongoid/config_spec.rb
+++ b/spec/mongoid/config_spec.rb
@@ -43,7 +43,7 @@ describe Mongoid::Config do
   describe ".destructive_fields" do
 
     it "returns a list of method names" do
-      described_class.destructive_fields.should include(:process)
+      described_class.destructive_fields.should include(:process_attributes)
     end
   end
 


### PR DESCRIPTION
"process" is a little too general and used more in the context of queueing and messaging.
