### PR TITLE
ruby-debug is compatible with ruby 1.9.3 now

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,6 @@ gem "rake"
 
 platforms :mri_19 do
   unless ENV["CI"]
-    gem "ruby-debug19", :require => "ruby-debug" if RUBY_VERSION < "1.9.3"
+    gem "ruby-debug19", :require => "ruby-debug"
   end
 end


### PR DESCRIPTION
This constraint was added ~10 months ago: ef40717a2b7dd8e58856d745c9
