### PR TITLE
Added activesupport load hooks.

### DIFF
--- a/lib/mongoid/document.rb
+++ b/lib/mongoid/document.rb
@@ -319,3 +319,5 @@ module Mongoid #:nodoc:
     end
   end
 end
+
+ActiveSupport.run_load_hooks(:mongoid, Mongoid::Document)


### PR DESCRIPTION
Why not? It will be usefull for i.e. OrmAdapter.
