### PR TITLE
Fix bug in nested attributes with reject_if all_blank and _destroy.

### DIFF
--- a/lib/mongoid/nested_attributes.rb
+++ b/lib/mongoid/nested_attributes.rb
@@ -12,7 +12,7 @@ module Mongoid #:nodoc:
 
     module ClassMethods #:nodoc:
 
-      REJECT_ALL_BLANK_PROC = proc { |attributes| attributes.all? { |_, value| value.blank? } }
+      REJECT_ALL_BLANK_PROC = proc { |attributes| attributes.all? { |key, value| key == '_destroy' || value.blank? } }
 
       # Used when needing to update related models from a parent relation. Can
       # be used on embedded or referenced relations.

--- a/spec/mongoid/nested_attributes_spec.rb
+++ b/spec/mongoid/nested_attributes_spec.rb
@@ -1866,6 +1866,33 @@ describe Mongoid::NestedAttributes do
               end
             end
           end
+
+          context "when 'reject_if: :all_blank' and 'allow_destroy: true' are specified" do
+
+            before(:all) do
+              Person.send(:undef_method, :addresses_attributes=)
+              Person.accepts_nested_attributes_for \
+                :addresses, reject_if: :all_blank, allow_destroy: true
+            end
+
+            after(:all) do
+              Person.send(:undef_method, :addresses_attributes=)
+              Person.accepts_nested_attributes_for :addresses
+            end
+
+            context "when all attributes are blank and _destroy has a truthy, non-blank value" do
+
+              before do
+                person.addresses_attributes = { "3" => { last_name: "", _destroy: "0" } }
+              end
+
+              it "does not add the document" do
+                person.addresses.should be_empty
+              end
+            end
+          end
+
+
         end
 
         context "when the nested document is invalid" do


### PR DESCRIPTION
REJECT_ALL_BLANK_PROC does not work correctly when _destroy has a non-blank,
non-truthy value (like "0" or "false"). This can happen when using a hidden
form field instead of a checkbox, for example.

See https://github.com/rails/rails/blob/master/activerecord/lib/active_record/nested_attributes.rb#L223
