### PR TITLE
$gt $gte $lt $lte works with embedded collection when you use the dot notation

### DIFF
--- a/lib/mongoid/matchers/all.rb
+++ b/lib/mongoid/matchers/all.rb
@@ -15,7 +15,7 @@ module Mongoid #:nodoc:
       # @return [ true, false ] If the values match.
       def matches?(value)
         attribute_array = Array.wrap(@attribute)
-        value.values.first.all? do |e| 
+        first(value).all? do |e|
           attribute_array.any? { |_attribute| e === _attribute }
         end
       end

--- a/lib/mongoid/matchers/and.rb
+++ b/lib/mongoid/matchers/and.rb
@@ -8,7 +8,7 @@ module Mongoid #:nodoc:
       # Does the supplied query match the attribute?
       #
       # @example Does this match?
-      #   matcher.matches?("$and" => [ { field => value } ])
+      #   matcher.matches?([ { field => value } ])
       #
       # @param [ Array ] conditions The or expression.
       #

--- a/lib/mongoid/matchers/default.rb
+++ b/lib/mongoid/matchers/default.rb
@@ -63,7 +63,9 @@ module Mongoid #:nodoc:
       #
       # @since 1.0.0
       def determine(value, operator)
-        attribute ? attribute.send(operator, first(value)) : false
+        Array(attribute).any? {|attr|
+          attr ? attr.send(operator, first(value)) : false
+        }
       end
     end
   end

--- a/spec/mongoid/matchers/gt_spec.rb
+++ b/spec/mongoid/matchers/gt_spec.rb
@@ -15,6 +15,17 @@ describe Mongoid::Matchers::Gt do
       end
     end
 
+    context "when the value is equal" do
+
+      let(:matcher) do
+        described_class.new(3)
+      end
+
+      it "returns false" do
+        matcher.matches?("$gt" => 3).should be_false
+      end
+    end
+
     context "when the value is smaller" do
 
       let(:matcher) do
@@ -37,5 +48,27 @@ describe Mongoid::Matchers::Gt do
       end
     end
 
+    context "when the value is an array" do
+      context "there are value valid" do
+        let(:matcher) do
+          described_class.new([6,4])
+        end
+
+        it "returns false" do
+          matcher.matches?("$gt" => 5).should be_true
+        end
+      end
+
+      context "there are not value valid" do
+        let(:matcher) do
+          described_class.new([3,4])
+        end
+
+        it "returns false" do
+          matcher.matches?("$gt" => 5).should be_false
+        end
+
+      end
+    end
   end
 end

--- a/spec/mongoid/matchers/gte_spec.rb
+++ b/spec/mongoid/matchers/gte_spec.rb
@@ -48,5 +48,27 @@ describe Mongoid::Matchers::Gte do
       end
     end
 
+    context "when the value is an array" do
+      context "there are value valid" do
+        let(:matcher) do
+          described_class.new([6,4])
+        end
+
+        it "returns false" do
+          matcher.matches?("$gte" => 5).should be_true
+        end
+      end
+
+      context "there are not value valid" do
+        let(:matcher) do
+          described_class.new([3,4])
+        end
+
+        it "returns false" do
+          matcher.matches?("$gte" => 5).should be_false
+        end
+
+      end
+    end
   end
 end

--- a/spec/mongoid/matchers/lt_spec.rb
+++ b/spec/mongoid/matchers/lt_spec.rb
@@ -15,6 +15,17 @@ describe Mongoid::Matchers::Lt do
       end
     end
 
+    context "when the value is equal" do
+
+      let(:matcher) do
+        described_class.new(3)
+      end
+
+      it "returns false" do
+        matcher.matches?("$lt" => 3).should be_false
+      end
+    end
+
     context "when the value is smaller" do
 
       let(:matcher) do
@@ -34,6 +45,29 @@ describe Mongoid::Matchers::Lt do
 
       it "returns false" do
         matcher.matches?("$lt" => 5).should be_false
+      end
+    end
+
+    context "when the value is an array" do
+      context "there are value valid" do
+        let(:matcher) do
+          described_class.new([3, 4])
+        end
+
+        it "returns true" do
+          matcher.matches?("$lt" => 5).should be_true
+        end
+      end
+
+      context "there are not value valid" do
+        let(:matcher) do
+          described_class.new([5,6])
+        end
+
+        it "returns false" do
+          matcher.matches?("$lt" => 5).should be_false
+        end
+
       end
     end
   end

--- a/spec/mongoid/matchers/lte_spec.rb
+++ b/spec/mongoid/matchers/lte_spec.rb
@@ -47,5 +47,28 @@ describe Mongoid::Matchers::Lte do
         matcher.matches?("$lte" => 5).should be_false
       end
     end
+
+    context "when the value is an array" do
+      context "there are value valid" do
+        let(:matcher) do
+          described_class.new([3, 4])
+        end
+
+        it "returns true" do
+          matcher.matches?("$lte" => 5).should be_true
+        end
+      end
+
+      context "there are not value valid" do
+        let(:matcher) do
+          described_class.new([7,6])
+        end
+
+        it "returns false" do
+          matcher.matches?("$lte" => 5).should be_false
+        end
+
+      end
+    end
   end
 end


### PR DESCRIPTION
This pull request can fix the issue #1782.

When you do a criteria with dot notation on a embedded document, you get an array of result. Before this commit. You can't manage this array in Gt/Gte/Lt/Lte matcher.

I change spec in gte_spec.rb to use described_class instead of Mongoid::Matcher::Gte like other spec in matcher.

I fix spec to use $gte instead of $gt in gt_spec.rb
