### PR TITLE
Improved performance of Mongoid::Relations::Referenced::In

### DIFF
--- a/lib/mongoid/relations/referenced/in.rb
+++ b/lib/mongoid/relations/referenced/in.rb
@@ -137,7 +137,7 @@ module Mongoid # :nodoc:
           def eager_load(metadata, ids)
             raise Errors::EagerLoad.new(metadata.name) if metadata.polymorphic?
             klass, _ = metadata.klass, metadata.foreign_key
-            klass.any_in("_id" => ids).each do |doc|
+            klass.any_in("_id" => ids.uniq).each do |doc|
               IdentityMap.set(doc)
             end
           end

--- a/spec/mongoid/relations/referenced/in_spec.rb
+++ b/spec/mongoid/relations/referenced/in_spec.rb
@@ -1015,6 +1015,30 @@ describe Mongoid::Relations::Referenced::In do
         }.to raise_error(Mongoid::Errors::EagerLoad)
       end
     end
+
+    context "when the ids has been duplicated" do
+
+      let!(:person) do
+        Person.create
+      end
+
+      let!(:posts) do
+        2.times {|i| person.posts.create(title: "testing#{i}") }
+        person.posts
+      end
+
+      let(:metadata) do
+        Post.relations["person"]
+      end
+
+      let(:eager) do
+        described_class.eager_load(metadata, posts.map(&:person_id))
+      end
+
+      it "duplication should be removed" do
+        eager.selector["_id"]["$in"].count.should eq 1
+      end
+    end
   end
 
   describe ".embedded?" do


### PR DESCRIPTION
I've improved performance of Mongoid::Relations::Referenced::In.

When the ids has been duplicated:

``` ruby
@person = Person.create
@posts = 100.times { @person.posts.create }

Post.includes(:person)
# => find({"_id" => {"$in" => [BSON::ObjectId(snip) x 100]}})
```

Will be as follows: When you apply this patch.

``` ruby
Post.includes(:person)
# => find({"_id" => {"$in" => [BSON::ObjectId(snip)]}})
```

Is it possible for you to merge this patch into your repository?

Regards,
Dai Akatsuka.
