### PR TITLE
Make multi params attr module behave more like AR

### DIFF
--- a/lib/mongoid/fields/internal/date.rb
+++ b/lib/mongoid/fields/internal/date.rb
@@ -42,7 +42,15 @@ module Mongoid #:nodoc:
         # @since 2.1.0
         def convert_to_time(value)
           value = ::Date.parse(value) if value.is_a?(::String)
-          value = ::Date.civil(*value) if value.is_a?(::Array)
+
+          if value.is_a?(::Array)
+            begin
+              value = ::Date.civil(*value)
+            rescue ArgumentError
+              value = ::Time.new(*value).to_date
+            end
+          end
+
           ::Time.utc(value.year, value.month, value.day)
         end
       end

--- a/spec/mongoid/multi_parameter_attributes_spec.rb
+++ b/spec/mongoid/multi_parameter_attributes_spec.rb
@@ -52,17 +52,16 @@ describe Mongoid::MultiParameterAttributes do
 
       context "with an invalid DOB" do
 
-        it "raises an exception" do
-          expect {
-            Multi.new({
-              "dob(1i)" => "1980",
-              "dob(2i)" => "2",
-              "dob(3i)" => "31"
-            })
-          }.to raise_exception(
-            Mongoid::MultiParameterAttributes::Errors::MultiparameterAssignmentErrors,
-            "1 error(s) on assignment of multiparameter attributes"
-          )
+        let(:invalid_multi) do
+          Multi.new({
+            "dob(1i)" => "1980",
+            "dob(2i)" => "2",
+            "dob(3i)" => "31"
+          })
+        end
+
+        it "uses Time's logic to convert the invalid date to valid" do
+          invalid_multi.dob.should eq(Time.new(1980, 2, 31).to_date)
         end
       end
     end


### PR DESCRIPTION
When you do multi parameters assignment of Date fields in
ActiveRecord the params are first given to Date.civil and then in a case
of invalid date exception they are passed through Time.new which
includes logic to wrap the invalid date to a valid one - i.e 31st
February 1980 becomes 2nd March 1980. For reference see rails source
code which implements this logic:

https://github.com/rails/rails/blob/3-2-stable/activerecord/lib/active_record/attribute_assignment.rb#L174

Look at the rescue in the method read_date_parameter_value.

This patch implements the same behaviour in Mongoid. It has been verified to work with Ruby 1.9.3-p125 and JRuby 1.6.7.

You can take a look at a new Rails project that has specs that reproduce the problem at https://github.com/svetlins/mongoid_playground

bundle exec rspec spec/models/person_spec.rb -> mongoid model - fails with exception
bundle exec rspec spec/models/relational_person_spec.rb -> active record model - no exception
