### PR TITLE
Failing spec shows that parent#collection#concat on a new parent followed by parent#save persists the concated docs when collection is embedded but doesn't when it's referenced

### DIFF
--- a/spec/mongoid/relations/embedded/many_spec.rb
+++ b/spec/mongoid/relations/embedded/many_spec.rb
@@ -1237,6 +1237,16 @@ describe Mongoid::Relations::Embedded::Many do
       it "sets the index on the child" do
         address._index.should eq(0)
       end
+
+      context "when the parent is saved" do
+        before do
+          person.save!
+        end
+
+        it "does saves the new document" do
+          address.should be_persisted
+        end
+      end
     end
 
     context "when the parent is not a new record" do

--- a/spec/mongoid/relations/referenced/many_spec.rb
+++ b/spec/mongoid/relations/referenced/many_spec.rb
@@ -1198,6 +1198,16 @@ describe Mongoid::Relations::Referenced::Many do
         it "adds the document to the target" do
           person.posts.size.should eq(1)
         end
+
+        context "when the parent is saved" do
+          before do
+            person.save!
+          end
+
+          it "does save the target" do
+            post.should be_persisted
+          end
+        end
       end
 
       context "when appending in a parent create block" do


### PR DESCRIPTION
Personally I find this "silent failure" behavior unintuitive. I'd be happy to write a fix if you guys agree. I'd prefer either failing noisily by raising, or else saving the parent and concated objects both at that point.
