### PR TITLE
Use for_ids within multiple_from_map_or_db

### DIFF
--- a/lib/mongoid/criteria.rb
+++ b/lib/mongoid/criteria.rb
@@ -367,7 +367,7 @@ module Mongoid #:nodoc:
       result, not_in_map = ids.
         map{ |id| IdentityMap.get(klass, id) || id }.
         partition{ |id| id.is_a?(klass) }
-      result += klass.where(:_id.in => not_in_map).entries
+      result += for_ids(not_in_map).entries
       result.select{ |e| e.matches?(selector) }
     end
 


### PR DESCRIPTION
So, mongoid-slug currently works by overloading #for_ids, so #1906 broke it because the find for those not_in_map doesn't get the slug treatment.

Is it appropriate to use for_ids here, or should mongoid-slug be overloading something else? I see #for_ids recently became a private api.
