### PR TITLE
Uniqueness validation ignores the default scope.

### DIFF
--- a/lib/mongoid/validations/uniqueness.rb
+++ b/lib/mongoid/validations/uniqueness.rb
@@ -56,7 +56,7 @@ module Mongoid #:nodoc:
             )
           end
         else
-          criteria = klass.where(criterion(document, attrib, val))
+          criteria = klass.unscoped.where(criterion(document, attrib, val))
           criteria = scope(criteria, document, attrib)
           if criteria.exists?
             document.errors.add(
@@ -146,7 +146,7 @@ module Mongoid #:nodoc:
         !document._parent || document.embedded_one?
       end
 
-      # Scope reference has changed? 
+      # Scope reference has changed?
       #
       # @example Has scope reference changed?
       #   validator.scope_value_changed?(doc)
@@ -155,7 +155,7 @@ module Mongoid #:nodoc:
       #
       # @return [ true, false ] If the scope reference has changed.
       #
-      # @since 
+      # @since
       def scope_value_changed?(document)
         Array.wrap(options[:scope]).any? do |item|
           document.send("attribute_changed?", item.to_s)

--- a/spec/mongoid/validations/uniqueness_spec.rb
+++ b/spec/mongoid/validations/uniqueness_spec.rb
@@ -124,6 +124,36 @@ describe Mongoid::Validations::UniquenessValidator do
           end
         end
 
+        context "when a default scope is on the model" do
+
+          before do
+            Dictionary.validates_uniqueness_of :name
+            Dictionary.default_scope(Dictionary.where(year: 1990))
+          end
+
+          after do
+            Dictionary.send(:strip_default_scope, Dictionary.where(year: 1990))
+            Dictionary.reset_callbacks(:validate)
+          end
+
+          context "when the document with the unqiue attribute is not in default scope" do
+            context "when the attribute is not unique" do
+
+              before do
+                Dictionary.create(name: "Oxford")
+              end
+
+              let(:dictionary) do
+                Dictionary.new(name: "Oxford")
+              end
+
+              it "returns false" do
+                dictionary.should_not be_valid
+              end
+            end
+          end
+        end
+
         context "when a single scope is provided" do
 
           before do


### PR DESCRIPTION
Fixes #1913.
