### PR TITLE
add method #touch methode to update the updated_at field if Mongoid::Timestamps.:Updated is include

### DIFF
--- a/lib/mongoid/persistence.rb
+++ b/lib/mongoid/persistence.rb
@@ -164,7 +164,17 @@ module Mongoid
     end
     alias :save :upsert
 
-    module ClassMethods
+    # change the updated_at field to now
+    #
+    def touch
+      if is_a?(Mongoid::Timestamps::Updated)
+        collection.update( self.atomic_selector,
+                          {'$set' => { updated_at: Time.now.utc}} )
+      end
+      true
+    end
+
+    module ClassMethods #:nodoc:
 
       # Create a new document. This will instantiate a new document and
       # insert it in a single call. Will always return the document

--- a/spec/mongoid/persistence_spec.rb
+++ b/spec/mongoid/persistence_spec.rb
@@ -622,6 +622,35 @@ describe Mongoid::Persistence do
     end
   end
 
+  describe "#touch" do
+
+    context "with a document include Mongoid::Timestamps::Updated" do
+      let(:updated_at) { 2.days.ago }
+      let(:agent) { Agent.create(:updated_at => updated_at) }
+      before { agent.touch }
+      let(:agent_updated_at) { Agent.find(agent.id).updated_at }
+
+      it 'should update updated_at field' do
+        agent_updated_at.should_not be_within(1).of(updated_at)
+      end
+
+      it 'should define updated_at field to now' do
+        agent_updated_at.should be_within(1).of(Time.now.utc)
+      end
+
+    end
+
+    context "with a document not include Mongoid::Timestamps::Updated" do
+      let(:person) { Person.create }
+      before { person.touch }
+      it 'should not update updated_at field' do
+        Person.collection.find_one({:_id => person.id}).keys.should_not include("updated_at")
+      end
+
+    end
+
+  end
+
   describe "#update_attribute" do
 
     let(:post) do


### PR DESCRIPTION
A feature in ActiveRecord can be good to have in Mongoid is the #touch method. When you call it on one of your object, the `updated_at` field is update to now.

This methode works only when Mongoid::Timestamps::Updated is include by himself or by Mongoid::Timestamps.
