### PR TITLE
Allow specifying which models do you want to load. Allows using Mongoid ...

### DIFF
--- a/lib/rails/mongoid.rb
+++ b/lib/rails/mongoid.rb
@@ -82,7 +82,13 @@ module Rails
     # @param [ Application ] app The rails application.
     def load_models(app)
       app.config.paths["app/models"].each do |path|
-        Dir.glob("#{path}/**/*.rb").sort.each do |file|
+        files = if ::Mongoid.preload_models.is_a? Array
+                  ::Mongoid.preload_models.map { |model| "#{path}/#{model}.rb" }
+                else
+                  Dir.glob("#{path}/**/*.rb")
+                end
+
+        files.sort.each do |file|
           load_model(file.gsub("#{path}/" , "").gsub(".rb", ""))
         end
       end

--- a/spec/rails/mongoid_spec.rb
+++ b/spec/rails/mongoid_spec.rb
@@ -424,5 +424,27 @@ describe "Rails::Mongoid" do
         Rails::Mongoid.load_models(app)
       end
     end
+
+    context "when list of models to load was configured" do
+
+      let(:files) do
+        [
+          "/rails/root/app/models/user.rb",
+          "/rails/root/app/models/address.rb"
+        ]
+      end
+
+      before(:all) do
+        Mongoid.preload_models = ["user"]
+        Dir.stubs(:glob).with("/rails/root/app/models/**/*.rb").returns(files)
+      end
+
+      it "loads selected models only" do
+        Rails::Mongoid.expects(:load_model).with("user")
+        Rails::Mongoid.expects(:load_model).with("address").never
+        Rails::Mongoid.load_models(app)
+      end
+    end
+
   end
 end


### PR DESCRIPTION
...along ActiveRecord in the same application, without breaking db:migrate rake task

I have an application, that is moslty ActiveRecord-based. However, for some information I use MongoDB and Mongoid as this is more suitable. Current release of Mongoid does not allow this, because "rake db:migrate" breaks -- Mongoid tries to load all models, including ActiveRecord-based classes. This causes error, because tables are not created/changed in database yet, which in turns, prevents rake task from creating those required tables.

This pull request fixes this situation without breaking current API. After my patch is applied, you can do:

Mongoid.preload_models = true
Mongoid.preload_models = false # is ignored when running rake tasks anyway (railtie.rb line 120)
and
Mongoid.preload_models = ["user", "app_logger/request", "statistics/request/get"]
