### PR TITLE
Simplify Document#<<. Round #2.

### DIFF
--- a/lib/mongoid/relations/referenced/many_to_many.rb
+++ b/lib/mongoid/relations/referenced/many_to_many.rb
@@ -27,13 +27,14 @@ module Mongoid
         def <<(*args)
           batched do
             docs = args.flatten.compact
+            ids = docs.map(&:_id)
             docs.map{ |doc| append(doc) }
 
             if persistable? || _creating?
               docs.map(&:save)
-              base.push_all(metadata.foreign_key, docs.map(&:_id))
+              base.push_all(metadata.foreign_key, ids)
             else
-              base.send(metadata.foreign_key).push(*docs.map(&:_id))
+              base.send(metadata.foreign_key).push(*ids)
             end
             base.synced[metadata.foreign_key] = false
           end


### PR DESCRIPTION
This is the second approach to refactor Document#<<. The first was here #1942.
I tried to be very verbose this time in order to avoid writing specs for things which are difficult to test. The benefits of the pull request are 2 branches and 1 loop are gone and thus its more readable by having the _same_ functionality.

I just cannot let go this one. Correct me and I promise I won't try another time :).
