### PR TITLE
delete a singleton require not use

### DIFF
--- a/lib/mongoid/railtie.rb
+++ b/lib/mongoid/railtie.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-require "singleton"
 require "mongoid"
 require "mongoid/config"
 require "mongoid/railties/document"


### PR DESCRIPTION
Singleton module is never used on Mongoid. We can avoid require it.
