### PR TITLE
Mongoid wraps arrays with another array

### DIFF
--- a/spec/mongoid/criteria_spec.rb
+++ b/spec/mongoid/criteria_spec.rb
@@ -2878,6 +2878,18 @@ describe Mongoid::Criteria do
       Band.create(name: "Tool")
     end
 
+    context "when provided an array" do
+      it "returns the matching documents" do
+        account = Account.create!(name: "savings", balance: "100")
+        agent = account.agents.create!
+        agent_ids = [agent.id]
+        old_agent_ids = agent_ids.clone
+        criteria = Account.where(agent_ids: agent_ids).to_a
+        criteria.should == [account]
+        agent_ids.should == old_agent_ids
+      end
+    end
+
     context "when provided a string" do
 
       context "when the criteria is embedded" do


### PR DESCRIPTION
This commit adds a spec which is trying to retrieve a record with the exact same array of ids (i.e: not $in).
The problem seems to be related to the has_many_belongs_to relationship.
Notice how the 'agent_ids' variable is changed and wrapper in another array after the call to where(...)
