### PR TITLE
RFC: Uri support for mongoid.yml

### DIFF
--- a/lib/mongoid/config/validators/session.rb
+++ b/lib/mongoid/config/validators/session.rb
@@ -20,8 +20,10 @@ module Mongoid
             raise Errors::NoDefaultSession.new(sessions.keys)
           end
           sessions.each_pair do |name, config|
-            validate_session_database(name, config)
-            validate_session_hosts(name, config)
+            unless config.has_key?(:uri)
+              validate_session_database(name, config)
+              validate_session_hosts(name, config)
+            end
           end
         end
 

--- a/lib/mongoid/sessions/factory.rb
+++ b/lib/mongoid/sessions/factory.rb
@@ -57,6 +57,9 @@ module Mongoid
       # @since 3.0.0
       def create_session(config)
         options = (config[:options] || {}).dup
+        if uri?(config)
+          config = expand_uri(config)
+        end
         session = Moped::Session.new(config[:hosts], options)
         session.use(config[:database])
         if authenticated?(config)

--- a/spec/mongoid/sessions/factory_spec.rb
+++ b/spec/mongoid/sessions/factory_spec.rb
@@ -8,31 +8,64 @@ describe Mongoid::Sessions::Factory do
 
       context "when the configuration exists" do
 
-        let(:config) do
-          {
-            default: { hosts: [ "localhost:27017" ], database: database_id },
-            secondary: { hosts: [ "localhost:27017" ], database: database_id }
-          }
+        context "when no uri provided" do
+
+          let(:config) do
+            {
+              default: { hosts: [ "localhost:27017" ], database: database_id },
+              secondary: { hosts: [ "localhost:27017" ], database: database_id }
+            }
+          end
+
+          before do
+            Mongoid::Config.sessions = config
+          end
+
+          let(:session) do
+            described_class.create(:secondary)
+          end
+
+          let(:cluster) do
+            session.cluster
+          end
+
+          it "returns a session" do
+            session.should be_a(Moped::Session)
+          end
+
+          it "sets the cluster's seeds" do
+            cluster.seeds.should eq([ "localhost:27017" ])
+          end
         end
 
-        before do
-          Mongoid::Config.sessions = config
-        end
+        context "when uri provided" do
 
-        let(:session) do
-          described_class.create(:secondary)
-        end
+          let(:config) do
+            {
+              default: { uri: "mongodb://localhost:27017/#{database_id}" },
+              secondary: { uri: "mongodb://localhost:27017/#{database_id}" }
+            }
+          end
 
-        let(:cluster) do
-          session.cluster
-        end
+          before do
+            Mongoid::Config.sessions = config
+          end
 
-        it "returns a session" do
-          session.should be_a(Moped::Session)
-        end
+          let(:session) do
+            described_class.create(:secondary)
+          end
 
-        it "sets the cluster's seeds" do
-          cluster.seeds.should eq([ "localhost:27017" ])
+          let(:cluster) do
+            session.cluster
+          end
+
+          it "returns a session" do
+            session.should be_a(Moped::Session)
+          end
+
+          it "sets the cluster's seeds" do
+            cluster.seeds.should eq([ "localhost:27017" ])
+          end
         end
       end
 


### PR DESCRIPTION
As discussed here: http://groups.google.com/group/mongoid/browse_thread/thread/c3f44cb2f9377546 it seems that mongoid doesn't support the uri format any more.

I added uri parsing in the session factory here, which is not enough as mongoid still cannot figure out the database name for example: https://github.com/i0rek/mongoid/blob/uri/lib/mongoid/sessions.rb#L316.

Any thoughts?
