### PR TITLE
Document.last considers default scope.

### DIFF
--- a/lib/mongoid/contextual/mongo.rb
+++ b/lib/mongoid/contextual/mongo.rb
@@ -218,7 +218,7 @@ module Mongoid
       #
       # @since 3.0.0
       def last
-        with_eager_loading(query.sort(_id: -1).first)
+        with_eager_loading(query.entries.last)
       end
 
       # Get's the number of documents matching the query selector.

--- a/spec/mongoid/contextual/mongo_spec.rb
+++ b/spec/mongoid/contextual/mongo_spec.rb
@@ -579,24 +579,50 @@ describe Mongoid::Contextual::Mongo do
 
   describe "#last" do
 
-    let!(:depeche_mode) do
-      Band.create(name: "Depeche Mode")
+    context "when no default scope" do
+
+      let!(:depeche_mode) do
+        Band.create(name: "Depeche Mode")
+      end
+
+      let!(:new_order) do
+        Band.create(name: "New Order")
+      end
+
+      let(:criteria) do
+        Band.all
+      end
+
+      let(:context) do
+        described_class.new(criteria)
+      end
+
+      it "returns the last matching document" do
+        context.last.should eq(new_order)
+      end
     end
 
-    let!(:new_order) do
-      Band.create(name: "New Order")
-    end
+    context "when default scope" do
 
-    let(:criteria) do
-      Band.all
-    end
+      let!(:palm) do
+        Tree.create(name: "Palm")
+      end
 
-    let(:context) do
-      described_class.new(criteria)
-    end
+      let!(:maple) do
+        Tree.create(name: "Maple")
+      end
 
-    it "returns the last matching document" do
-      context.last.should eq(new_order)
+      let(:criteria) do
+        Tree.all
+      end
+
+      let(:context) do
+        described_class.new(criteria)
+      end
+
+      it "respects default scope" do
+        context.last.should eq(palm)
+      end
     end
   end
 


### PR DESCRIPTION
Fixes #1974.

The implementation can become quite slow, because it requests all documents to choose the last one. Perhaps moped can support query.last?

/cc @bernerdschaefer
