### PR TITLE
Allow querying with multi-level inheritance

### DIFF
--- a/lib/mongoid/attributes/processing.rb
+++ b/lib/mongoid/attributes/processing.rb
@@ -92,6 +92,16 @@ module Mongoid #:nodoc:
       #
       # @since 2.0.0.rc.7
       def process_attribute(name, value)
+        if name.to_s == '_type' && value.is_a?(String)
+          array_value = []
+          array_value << self.class.name
+          superklass = self.class.superclass
+          while superklass.include?(Mongoid::Document)
+            array_value << superklass.name
+            superklass = superklass.superclass
+          end
+          value = array_value
+        end
         if Mongoid.allow_dynamic_fields && !respond_to?("#{name}=")
           write_attribute(name, value)
         else

--- a/lib/mongoid/document.rb
+++ b/lib/mongoid/document.rb
@@ -207,7 +207,15 @@ module Mongoid #:nodoc:
         became.instance_variable_set(:@errors, errors)
         became.instance_variable_set(:@new_record, new_record?)
         became.instance_variable_set(:@destroyed, destroyed?)
-        became._type = klass.to_s
+
+        became._type = []
+        became._type << klass.to_s
+        superklass = klass.superclass
+        while superklass.include?(Mongoid::Document)
+          became._type << superklass.name
+          superklass = superklass.superclass
+        end
+
       end
     end
 

--- a/lib/mongoid/factory.rb
+++ b/lib/mongoid/factory.rb
@@ -39,7 +39,7 @@ module Mongoid #:nodoc:
       if type.blank?
         klass.instantiate(attributes)
       else
-        type.camelize.constantize.instantiate(attributes)
+        Array(type).first.camelize.constantize.instantiate(attributes)
       end
     end
   end

--- a/lib/mongoid/fields.rb
+++ b/lib/mongoid/fields.rb
@@ -45,7 +45,7 @@ module Mongoid #:nodoc
       self.non_proc_defaults = []
       self.proc_defaults = []
 
-      field(:_type, :type => String)
+      field(:_type, :type => Array)
       field(:_id, :type => BSON::ObjectId)
 
       alias :id :_id

--- a/lib/mongoid/identity.rb
+++ b/lib/mongoid/identity.rb
@@ -59,7 +59,16 @@ module Mongoid #:nodoc:
     # @example Set the type.
     #   identity.type
     def type
-      document._type = document.class.name if typed?
+      if typed?
+        document._type = []
+        document._type << document.class.name
+        superklass = document.class.superclass
+        while superklass.include?(Mongoid::Document)
+          document._type << superklass.name
+          superklass = superklass.superclass
+        end
+      end
+      document._type
     end
 
     # Generates the array of keys to build the id.

--- a/spec/functional/mongoid/document_spec.rb
+++ b/spec/functional/mongoid/document_spec.rb
@@ -141,7 +141,11 @@ describe Mongoid::Document do
 
         it "sets the class type" do
           became = @obj.becomes(@to_become)
-          became._type.should == @to_become.to_s
+          if ctx == 'upcasting'
+            became._type.should == [@to_become.to_s]
+          else
+            became._type.should == [@to_become.to_s, @klass.to_s]
+          end
         end
 
         it "raises an error when inappropriate class is provided" do

--- a/spec/functional/mongoid/inheritance_spec.rb
+++ b/spec/functional/mongoid/inheritance_spec.rb
@@ -27,7 +27,7 @@ describe Mongoid::Document do
     end
 
     it "persists the type" do
-      attributes["_type"].should == "Browser"
+      attributes["_type"].should == ["Browser", "Canvas"]
     end
 
     it "persists the attributes" do
@@ -58,7 +58,7 @@ describe Mongoid::Document do
     end
 
     it "persists the type" do
-      attributes["_type"].should == "Firefox"
+      attributes["_type"].should == ["Firefox", "Browser", "Canvas"]
     end
 
     it "persists the attributes" do

--- a/spec/unit/mongoid/identity_spec.rb
+++ b/spec/unit/mongoid/identity_spec.rb
@@ -19,7 +19,7 @@ describe Mongoid::Identity do
       end
 
       it "sets the document type to the class name" do
-        movie._type.should == "Movie"
+        movie._type.should == ["Movie"]
       end
     end
 
@@ -34,7 +34,7 @@ describe Mongoid::Identity do
       end
 
       it "sets the document _type to the class name" do
-        canvas._type.should == "Canvas"
+        canvas._type.should == ["Canvas"]
       end
     end
 
@@ -47,7 +47,7 @@ describe Mongoid::Identity do
         let(:browser){ Browser.new }
 
         it "sets the document _type to the class name" do
-          browser._type.should == "Browser"
+          browser._type.should == ["Browser", "Canvas"]
         end
       end
 
@@ -55,7 +55,7 @@ describe Mongoid::Identity do
         let(:browser){ Browser.new :id => 1234 }
 
         it "sets the document _type to the class name" do
-          browser._type.should == "Browser"
+          browser._type.should == ["Browser", "Canvas"]
         end
       end
     end


### PR DESCRIPTION
For example, with `C < B` and `B < A`, one can call not only `A.all` and `C.all`, but also `B.all`. This commit is not meant to be officially pulled, of course, as it changes the behavior around the :_type field (but it could still be retro-compatible), and it's just of dirty proof of concept.
I'd love to have some feedback on the concept, instead of the code.

``` ruby
class A
  include Mongoid::Document
end

class B < A
end

class C < B
end

C.create # => #<C _id: 4fa3bd6f3500003301000002, _type: ["C", "B", "A"]>]
A.all.to_a # => [#<C _id: 4fa3bd6f3500003301000002, _type: ["C", "B", "A"]>]
B.all.to_a # => [#<C _id: 4fa3bd6f3500003301000002, _type: ["C", "B", "A"]>]
C.all.to_a # => [#<C _id: 4fa3bd6f3500003301000002, _type: ["C", "B", "A"]>]
```
