### PR TITLE
Document.last considers default scope.

### DIFF
--- a/lib/mongoid/contextual/mongo.rb
+++ b/lib/mongoid/contextual/mongo.rb
@@ -218,7 +218,8 @@ module Mongoid
       #
       # @since 3.0.0
       def last
-        with_eager_loading(query.sort(_id: -1).first)
+        apply_inverse_sorting
+        with_eager_loading(query.first)
       end
 
       # Get's the number of documents matching the query selector.
@@ -378,6 +379,22 @@ module Mongoid
       def apply_sorting
         if spec = criteria.options[:sort]
           query.sort(spec)
+        end
+      end
+
+      # Map the inverse sort symbols to the correct MongoDB values.
+      #
+      # @todo: Durran: Temporary.
+      #
+      # @example Apply the inverse sorting params.
+      #   context.apply_inverse_sorting
+      #
+      # @since 3.0.0
+      def apply_inverse_sorting
+        if spec = criteria.options[:sort]
+          query.sort(Hash[spec.map{|k, v| [k, -1*v]}])
+        else
+          query.sort({:_id => -1})
         end
       end
 

--- a/spec/mongoid/contextual/mongo_spec.rb
+++ b/spec/mongoid/contextual/mongo_spec.rb
@@ -579,24 +579,50 @@ describe Mongoid::Contextual::Mongo do
 
   describe "#last" do
 
-    let!(:depeche_mode) do
-      Band.create(name: "Depeche Mode")
+    context "when no default scope" do
+
+      let!(:depeche_mode) do
+        Band.create(name: "Depeche Mode")
+      end
+
+      let!(:new_order) do
+        Band.create(name: "New Order")
+      end
+
+      let(:criteria) do
+        Band.all
+      end
+
+      let(:context) do
+        described_class.new(criteria)
+      end
+
+      it "returns the last matching document" do
+        context.last.should eq(new_order)
+      end
     end
 
-    let!(:new_order) do
-      Band.create(name: "New Order")
-    end
+    context "when default scope" do
 
-    let(:criteria) do
-      Band.all
-    end
+      let!(:palm) do
+        Tree.create(name: "Palm")
+      end
 
-    let(:context) do
-      described_class.new(criteria)
-    end
+      let!(:maple) do
+        Tree.create(name: "Maple")
+      end
 
-    it "returns the last matching document" do
-      context.last.should eq(new_order)
+      let(:criteria) do
+        Tree.all
+      end
+
+      let(:context) do
+        described_class.new(criteria)
+      end
+
+      it "respects default scope" do
+        context.last.should eq(palm)
+      end
     end
   end
 


### PR DESCRIPTION
Fixes #1974. First attempt was here: #1978. 
Now without loading everything in memory :).
