### PR TITLE
use the limit criteria when you use it on Embedded document

### DIFF
--- a/lib/mongoid/contextual/memory.rb
+++ b/lib/mongoid/contextual/memory.rb
@@ -137,8 +137,9 @@ module Mongoid
         @documents = criteria.documents.select do |doc|
           doc.matches?(criteria.selector)
         end
-        apply_sorting
+        apply_options
       end
+
 
       # Get the last document in the database for the criteria's selector.
       #
@@ -285,6 +286,31 @@ module Mongoid
           documents.sort! do |a, b|
             dir > 0 ? a[field] <=> b[field] : b[field] <=> a[field]
           end
+        end
+      end
+
+      # Apply all the optional criterion.
+      #
+      # @example Apply the options.
+      #   context.apply_options
+      #
+      # @since 3.0.0
+      def apply_options
+        apply_sorting
+        apply_limit
+      end
+
+      # Apply the limit option.
+      #
+      # @api private
+      #
+      # @example Apply the limit option.
+      #   context.apply_limit
+      #
+      # @since 3.0.0
+      def apply_limit
+        if spec = criteria.options[:limit]
+          self.limit(spec)
         end
       end
     end

--- a/spec/mongoid/contextual/memory_spec.rb
+++ b/spec/mongoid/contextual/memory_spec.rb
@@ -455,7 +455,7 @@ describe Mongoid::Contextual::Memory do
     end
 
     let(:criteria) do
-      Address.where(street: "hobrecht").tap do |crit|
+      Address.where(street: "hobrecht").limit(4).tap do |crit|
         crit.documents = [ hobrecht, friedel ]
       end
     end
@@ -474,6 +474,10 @@ describe Mongoid::Contextual::Memory do
 
     it "sets the matching documents" do
       context.documents.should eq([ hobrecht ])
+    end
+
+    it 'sets the limiting' do
+      context.send(:limiting).should == 4
     end
   end
 

--- a/spec/mongoid/criteria_spec.rb
+++ b/spec/mongoid/criteria_spec.rb
@@ -2935,6 +2935,42 @@ describe Mongoid::Criteria do
     end
   end
 
+  describe "#limit" do
+    context "on non embed document" do
+      let!(:bands) do
+        3.times { |i|
+          Band.create(name: "Depeche Mode #{i}")
+        }
+      end
+      let(:criteria) {
+        Band.limit(2)
+      }
+
+      it 'limit result' do
+        # TODO; need merge of https://github.com/mongoid/moped/pull/7 to works
+        # criteria.count.should == 2
+        criteria.entries.size.should == 2
+      end
+    end
+
+    context "on embed document" do
+      let(:person) { Person.create }
+      let!(:videos) {
+        3.times { person.videos.create(:title => 'ok') }
+      }
+
+      let(:criteria) {
+        person.videos.limit(2)
+      }
+
+      it 'limit result' do
+        criteria.count.should == 2
+      end
+
+    end
+
+  end
+
   describe "#within_box" do
 
     before do


### PR DESCRIPTION
If you do some limit on your embedded document is never used. I think it's a regression from Mongoid 2.4 series.

This commit fis this issue.
