### PR TITLE
Update configuration to add hosts and database in the uri case.

### DIFF
--- a/lib/mongoid/sessions/factory.rb
+++ b/lib/mongoid/sessions/factory.rb
@@ -59,7 +59,7 @@ module Mongoid
       # @since 3.0.0
       def create_session(configuration)
         config, options = parse(configuration)
-        configuration.merge!(config)
+        configuration.merge!(config) if configuration.delete(:uri)
         session = Moped::Session.new(config[:hosts], options)
         session.use(config[:database])
         if authenticated?(config)

--- a/spec/mongoid/sessions/factory_spec.rb
+++ b/spec/mongoid/sessions/factory_spec.rb
@@ -73,14 +73,19 @@ describe Mongoid::Sessions::Factory do
               session.options[:database].should eq("mongoid_test")
             end
 
-            it "merges database into Mongoid::Config.sessions[:secondary]" do
+            it "sets the database in the configuration" do
               session
               Mongoid.sessions[:secondary].should include(:database)
             end
 
-            it "merges hosts into Mongoid::Config.sessions[:secondary]" do
+            it "sets the hosts in the configuration" do
               session
               Mongoid.sessions[:secondary].should include(:hosts)
+            end
+
+            it "removes the uri from the configuration" do
+              session
+              Mongoid.sessions[:secondary].should_not include(:uri)
             end
           end
 
@@ -115,6 +120,21 @@ describe Mongoid::Sessions::Factory do
 
             it "sets the database" do
               session.options[:database].should eq("mongoid_test")
+            end
+
+            it "sets the database in the configuration" do
+              session
+              Mongoid.sessions[:secondary].should include(:database)
+            end
+
+            it "sets the hosts in the configuration" do
+              session
+              Mongoid.sessions[:secondary].should include(:hosts)
+            end
+
+            it "removes the uri from the configuration" do
+              session
+              Mongoid.sessions[:secondary].should_not include(:uri)
             end
           end
         end


### PR DESCRIPTION
Fixes https://github.com/mongoid/moped/issues/10.
Thanks to @mikezter.

The Problem was that the configuration contained only the uri and not the database and hosts. That worked initially, but when calling #mongo_session(https://github.com/i0rek/mongoid/blob/uri_fix/lib/mongoid/sessions.rb) looking up the database name doesn't work because its not there.

Edit: I'm aware that I'm modifying the configuration. Not sure what to do about it.
