### PR TITLE
Allowing Criteria#only to accept an array in addition to being variadic.

### DIFF
--- a/lib/mongoid/criteria.rb
+++ b/lib/mongoid/criteria.rb
@@ -438,6 +438,7 @@ module Mongoid
     # @since 1.0.0
     def only(*args)
       return clone if args.empty?
+      args = args.flatten
       if klass.hereditary?
         super(*args.push(:_type))
       else

--- a/spec/mongoid/criteria_spec.rb
+++ b/spec/mongoid/criteria_spec.rb
@@ -2743,7 +2743,7 @@ describe Mongoid::Criteria do
   describe "#only" do
 
     let!(:band) do
-      Band.create(name: "Depeche Mode")
+      Band.create(name: "Depeche Mode", likes: 3, views: 10)
     end
 
     context "when not using inheritance" do
@@ -2758,6 +2758,13 @@ describe Mongoid::Criteria do
 
       it "does not add _type to the fields" do
         criteria.options[:fields]["_type"].should be_nil
+      end
+
+      it "can accept an array parameter" do
+        band = Band.only([:name, :likes]).first
+        band.name.should_not be_nil
+        band.likes.should_not be_nil
+        band.views.should be_nil
       end
     end
 


### PR DESCRIPTION
While upgrading to Mongoid 3, I noticed a good amount of my app broke because I had an array for Criteria#only. E.g., `Band.only([:name, :likes])` instead of it being variadic, `Band.only(:name, :likes)`.

This pull request allows the function to accept both forms.
