### PR TITLE
Adds default test config

### DIFF
--- a/lib/rails/generators/mongoid/config/templates/mongoid.yml
+++ b/lib/rails/generators/mongoid/config/templates/mongoid.yml
@@ -58,3 +58,12 @@ development:
 
     # Ensure all times are UTC in the app side. (default: false)
     # use_utc: false
+test:
+  sessions:
+    default:
+      database: dmarc_web_test
+      hosts:
+        - localhost:27017
+      options:
+        consistency: :strong
+  options:


### PR DESCRIPTION
I upgraded a pet project to 3.0rc today.  I found that not having a default config for the test environment generates some pretty strange errors.  Specifically, the test suite (and Rails) initializes fine, and only throws errors when you try to save models.  I think it's reasonable to at least include a sample test config since not having one can prevent you from getting up and running quickly.  It's reasonable not to have a production config since that would require work anyways to specify the server info.
