### PR TITLE
Ability to specify hints to the query optimizer

### DIFF
--- a/lib/mongoid/contextual/mongo.rb
+++ b/lib/mongoid/contextual/mongo.rb
@@ -389,6 +389,18 @@ module Mongoid
         end
       end
 
+      # Apply the hint option
+      #
+      # @example Apply the hint params.
+      #   context.apply_hint
+      #
+      # @since 3.0.0
+      def apply_hint
+        if spec = criteria.options[:hint]
+          query.hint(spec)
+        end
+      end
+
       # Map the inverse sort symbols to the correct MongoDB values.
       #
       # @example Apply the inverse sorting params.
@@ -496,6 +508,7 @@ module Mongoid
         apply_limit
         apply_skip
         apply_sorting
+        apply_hint
       end
 
       # If we are limiting results, we need to set the field limitations on a

--- a/spec/mongoid/criteria_spec.rb
+++ b/spec/mongoid/criteria_spec.rb
@@ -2971,6 +2971,36 @@ describe Mongoid::Criteria do
     end
   end
 
+  describe "#extras with a hint" do
+
+    let!(:band) do
+      Band.create(name: "Depeche Mode")
+    end
+
+    let(:criteria) do
+      Band.where(name: "Depeche Mode").extras(:hint => {:bad_hint => 1})
+    end
+
+    it "executes the criteria while properly giving the hint to Mongo" do
+      expect { criteria.to_ary }.to raise_error(Moped::Errors::QueryFailure,  %r{failed with error 10113: "bad hint"})
+    end
+  end
+
+  describe "#hint" do
+
+    let!(:band) do
+      Band.create(name: "Depeche Mode")
+    end
+
+    let(:criteria) do
+      Band.where(name: "Depeche Mode").hint(bad_hint: 1)
+    end
+
+    it "executes the criteria while properly giving the hint to Mongo" do
+      expect { criteria.to_ary }.to raise_error(Moped::Errors::QueryFailure,  %r{failed with error 10113: "bad hint"})
+    end
+  end
+
   describe "#to_criteria" do
 
     let(:criteria) do


### PR DESCRIPTION
Since this pull request mongoid/moped#19, Moped handles query hints. This changes applies the hints defined via origin and applies them when running the Moped queries.
