### PR TITLE
Remove selector to use #atomic_selector

### DIFF
--- a/lib/mongoid/persistence/operations/remove.rb
+++ b/lib/mongoid/persistence/operations/remove.rb
@@ -24,7 +24,7 @@ module Mongoid
         # @return [ true ] Always true.
         def persist
           prepare do |doc|
-            collection.find({ _id: doc.id }).remove
+            collection.find(doc.atomic_selector).remove
           end
         end
       end

--- a/spec/mongoid/persistence/operations/remove_spec.rb
+++ b/spec/mongoid/persistence/operations/remove_spec.rb
@@ -45,7 +45,7 @@ describe Mongoid::Persistence::Operations::Remove do
 
     def root_delete_expectation
       ->{
-        collection.expects(:find).with({ _id: document.id }).returns(query)
+        collection.expects(:find).with({ "_id" => document.id }).returns(query)
         query.expects(:remove).returns(true)
       }
     end


### PR DESCRIPTION
Hey Durran, I'm overriding #atomic_selector for a optimistic locking plugin, which Update uses, but not Remove.  Any reason not to use #atomic_selector for Remove?
