### PR TITLE
Ordering embedded documents by id raises exception

### DIFF
--- a/spec/mongoid/relations/embedded/many_spec.rb
+++ b/spec/mongoid/relations/embedded/many_spec.rb
@@ -3306,8 +3306,22 @@ describe Mongoid::Relations::Embedded::Many do
     it "orders properly with the boolean" do
       circuit.reload.buses.should eq([ bus_two, bus_one ])
     end
+  end
 
-    it "orders by id" do
+  context "when the embedded relation sorts on id" do
+    let(:circuit) do
+      Circuit.create
+    end
+
+    let!(:bus_one) do
+      circuit.buses.create(saturday: true)
+    end
+
+    let!(:bus_two) do
+      circuit.buses.create(saturday: false)
+    end
+
+    it "orders properly by id" do
       circuit.reload.buses.asc(:id).should eq([ bus_one, bus_two ])
     end
   end


### PR DESCRIPTION
I've added a spec to illustrate the behavior. The spec fails with:

```
    Failures:

      1) Mongoid::Relations::Embedded::Many when the embedded relation sorts on a boolean orders by id
         Failure/Error: circuit.reload.buses.asc(:id).should eq([ bus_one, bus_two ])
         ArgumentError:
           comparison of Bus with Bus failed
         # ./lib/mongoid/contextual/memory.rb:379:in `sort!'
         # ./lib/mongoid/contextual/memory.rb:379:in `block in in_place_sort'
         # ./lib/mongoid/contextual/memory.rb:378:in `each_pair'
         # ./lib/mongoid/contextual/memory.rb:378:in `in_place_sort'
         # ./lib/mongoid/contextual/memory.rb:344:in `apply_sorting'
         # ./lib/mongoid/contextual/memory.rb:168:in `initialize'
         # ./lib/mongoid/contextual.rb:47:in `new'
         # ./lib/mongoid/contextual.rb:47:in `create_context'
         # ./lib/mongoid/contextual.rb:30:in `context'
         # ./lib/mongoid/contextual.rb:18:in `each'
         # ./lib/mongoid/criteria.rb:34:in `entries'
         # ./lib/mongoid/criteria.rb:34:in `=='
         # ./spec/mongoid/relations/embedded/many_spec.rb:3311:in `block (3 levels) in <top (required)>'
```
