### PR TITLE
Have presence validator on relation respect autosave = false

### DIFF
--- a/lib/mongoid/validations.rb
+++ b/lib/mongoid/validations.rb
@@ -194,7 +194,9 @@ module Mongoid
         if args.first == PresenceValidator
           args.last[:attributes].each do |name|
             metadata = relations[name.to_s]
-            autosave(metadata.merge!(autosave: true)) if metadata
+            if metadata && metadata[:autosave] != false
+              autosave(metadata.merge!(autosave: true))
+            end
           end
         end
         super

--- a/spec/mongoid/validations/presence_spec.rb
+++ b/spec/mongoid/validations/presence_spec.rb
@@ -167,6 +167,51 @@ describe Mongoid::Validations::PresenceValidator do
       end
     end
 
+    context "when the relation is a has one and autosave is false" do
+
+      before do
+        Person.relations["game"][:autosave] = false
+        Person.validates :game, presence: true
+      end
+
+      after do
+        Person.reset_callbacks(:validate)
+      end
+
+      it "does not change autosave on the relation" do
+        Person.relations["game"][:autosave].should be_false
+      end
+
+      it "does not add any autosaved relations" do
+        Person.autosaved_relations.should be_empty
+      end
+
+      context "when the relation is new" do
+
+        let(:person) do
+          Person.new
+        end
+
+        context "when the base is valid" do
+
+          let!(:game) do
+            person.build_game
+          end
+
+          context "when saving the base" do
+
+            before do
+              person.save
+            end
+
+            it "does not save the relation" do
+              expect { game.reload }.should raise_error
+            end
+          end
+        end
+      end
+    end
+
     context "when the relation is a belongs to" do
 
       let(:product) do


### PR DESCRIPTION
The patch for issue #1675 changed the behavior of the presence validator so that it enables `autosave` on the relation. However, there are circumstances where this is undesirable. The only way to get around this it to assign the presence validator _before_ the relation which is a bit clunky.

This patch allows you to explicitly set the `autosave` field on the relation to `false` to disable this behavior. If you do not specify anything for `autosave`, or set it to `true`, it will apply the current behavior. For example:

``` ruby
class Tag
  include Mongoid::Document
  belongs_to :post
end

class Post
  include Mongoid::Document
  has_many :tags, autosave: false
  validates_presence_of :tags # does not enable autosave on tags
end
```
