### PR TITLE
Added to_param to Mongoid::Paranoia.

### DIFF
--- a/lib/mongoid/paranoia.rb
+++ b/lib/mongoid/paranoia.rb
@@ -96,6 +96,11 @@ module Mongoid
       attributes.delete("deleted_at")
     end
 
+    # Returns a string representing the documents's key suitable for use in URLs.
+    def to_param
+      to_key.join('-')
+    end
+
     private
 
     # Get the collection to be used for paranoid operations.

--- a/spec/mongoid/paranoia_spec.rb
+++ b/spec/mongoid/paranoia_spec.rb
@@ -516,4 +516,29 @@ describe Mongoid::Paranoia do
       unscoped.selector.should eq({})
     end
   end
+
+  describe "#to_param" do
+
+    let(:post) do
+      ParanoidPost.create(title: "testing")
+    end
+
+    context "when the document is not deleted" do
+
+      it "returns the id as a string" do
+        post.to_param.should eq(post.id.to_s)
+      end
+    end
+
+    context "when the document is deleted" do
+
+      before do
+        post.delete
+      end
+
+      it "returns the id as a string" do
+        post.to_param.should eq(post.id.to_s)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Allows the generation of URLs of deleted models. Makes it easier to
create a list of trashed models (a.k.a Trash view). Helps me with #2226.
