### PR TITLE
to_param will now return nil again for new paranoid models.

### DIFF
--- a/lib/mongoid/paranoia.rb
+++ b/lib/mongoid/paranoia.rb
@@ -98,7 +98,7 @@ module Mongoid
 
     # Returns a string representing the documents's key suitable for use in URLs.
     def to_param
-      to_key.join('-')
+      new_record? ? nil : to_key.join('-')
     end
 
     private

--- a/spec/mongoid/paranoia_spec.rb
+++ b/spec/mongoid/paranoia_spec.rb
@@ -520,10 +520,21 @@ describe Mongoid::Paranoia do
   describe "#to_param" do
 
     let(:post) do
-      ParanoidPost.create(title: "testing")
+      ParanoidPost.new(title: "testing")
+    end
+
+    context "when the document is new" do
+
+      it "still returns nil" do
+        post.to_param.should be_nil
+      end
     end
 
     context "when the document is not deleted" do
+
+      before do
+        post.save
+      end
 
       it "returns the id as a string" do
         post.to_param.should eq(post.id.to_s)
@@ -533,6 +544,7 @@ describe Mongoid::Paranoia do
     context "when the document is deleted" do
 
       before do
+        post.save
         post.delete
       end
 


### PR DESCRIPTION
Extension for #2226.
