### PR TITLE
Allow array parameter for eager loading

### DIFF
--- a/lib/mongoid/criteria.rb
+++ b/lib/mongoid/criteria.rb
@@ -360,7 +360,7 @@ module Mongoid
     #
     # @since 2.2.0
     def includes(*relations)
-      relations.each do |name|
+      relations.flatten.each do |name|
         metadata = klass.reflect_on_association(name)
         raise Errors::InvalidIncludes.new(klass, relations) unless metadata
         inclusions.push(metadata) unless inclusions.include?(metadata)


### PR DESCRIPTION
I was getting the eager loading error in a new Rails app using RailsAdmin.

This is because their code sends includes as arrays. And Mongoid seems to create an array from a param list.

This patch allows mongoid to handle Foo.includes([:bar]) and Foo.includes(:bar)
# Before the patch:

```
1.9.3-p0 :002 > Account.includes([:user]).first
Mongoid::Errors::InvalidIncludes: 
Problem:
  Invalid includes directive: Account.includes(["user"])
Summary:
  Eager loading in Mongoid only supports providing arguments to Account.includes that are the names of relations on the Account model, and only supports one level of eager loading. (ie, eager loading associations not on the Account but one step away via another relation is not allowed.
Resolution:
  Ensure that each parameter passed to Account.includes is a valid name of a relation on the Account model. These are: "user".
  from /Users/franc/.rvm/gems/ruby-1.9.3-p0@fisheagle/bundler/gems/mongoid-24ca957fb077/lib/mongoid/criteria.rb:365:in `block in includes'
  from /Users/franc/.rvm/gems/ruby-1.9.3-p0@fisheagle/bundler/gems/mongoid-24ca957fb077/lib/mongoid/criteria.rb:363:in `each'
  from /Users/franc/.rvm/gems/ruby-1.9.3-p0@fisheagle/bundler/gems/mongoid-24ca957fb077/lib/mongoid/criteria.rb:363:in `includes'
  from /Users/franc/.rvm/gems/ruby-1.9.3-p0@fisheagle/bundler/gems/mongoid-24ca957fb077/lib/mongoid/finders.rb:10:in `includes'
  from (irb):2
  from /Users/franc/.rvm/gems/ruby-1.9.3-p0@fisheagle/gems/railties-3.2.6/lib/rails/commands/console.rb:47:in `start'
  from /Users/franc/.rvm/gems/ruby-1.9.3-p0@fisheagle/gems/railties-3.2.6/lib/rails/commands/console.rb:8:in `start'
  from /Users/franc/.rvm/gems/ruby-1.9.3-p0@fisheagle/gems/railties-3.2.6/lib/rails/commands.rb:41:in `<top (required)>'
  from script/rails:6:in `require'
  from script/rails:6:in `<main>'

1.9.3-p0 :003 > Account.includes(:user).first
 => #<Account _id: 501004fb040515f246000001, _type: nil, name: "Current Account", number: "46213123914", other_numbers: ["123"], type: "basic", balance: 12300, available_balance: 11500, currency: "ZAR", user_id: "500f9e86040515c019000003"> 
```
## After the patch:

```
1.9.3-p0 :004 > Account.includes([:user]).first
 => #<Account _id: 501004fb040515f246000001, _type: nil, name: "Current Account", number: "46213123914", other_numbers: ["123"], type: "basic", balance: 12300, available_balance: 11500, currency: "ZAR", user_id: "500f9e86040515c019000003">

1.9.3-p0 :003 > Account.includes(:user).first
 => #<Account _id: 501004fb040515f246000001, _type: nil, name: "Current Account", number: "46213123914", other_numbers: ["123"], type: "basic", balance: 12300, available_balance: 11500, currency: "ZAR", user_id: "500f9e86040515c019000003"> 
```

tests remain green and RailsAdmin works.
