### PR TITLE
Faster exists? method

### DIFF
--- a/lib/mongoid/contextual/mongo.rb
+++ b/lib/mongoid/contextual/mongo.rb
@@ -151,10 +151,8 @@ module Mongoid
       #
       # @since 3.0.0
       def exists?
-        Mongoid.unit_of_work(disable: :current) do
-          # Don't use count here since Mongo does not use counted b-tree indexes
-          !criteria.dup.only(:_id).limit(1).entries.first.nil?
-        end
+        # Don't use count here since Mongo does not use counted b-tree indexes
+        !query.dup.select(_id: 1).limit(1).entries.first.nil?
       end
 
       # Run an explain on the criteria.

--- a/lib/mongoid/criteria.rb
+++ b/lib/mongoid/criteria.rb
@@ -18,6 +18,7 @@ module Mongoid
     include Criterion::Scoping
 
     attr_accessor :embedded, :klass
+    delegate :exists?, to: :context
 
     # Returns true if the supplied +Enumerable+ or +Criteria+ is equal to the results
     # of this +Criteria+ or the criteria itself.
@@ -176,21 +177,6 @@ module Mongoid
       result = multiple_from_map_or_db(ids)
       check_for_missing_documents!(result, ids)
       multi ? result : result.first
-    end
-
-    # Return true if the criteria has some Document or not.
-    #
-    # @example Are there any documents for the criteria?
-    #   criteria.exists?
-    #
-    # @return [ true, false ] If documents match.
-    #
-    # @since 1.0.0
-    def exists?
-      Mongoid.unit_of_work(disable: :current) do
-        # Don't use count here since Mongo does not use counted b-tree indexes
-        !context.dup.criteria.only(:_id).limit(1).entries.first.nil?
-      end
     end
 
     # Extract a single id from the provided criteria. Could be in an $and

--- a/lib/mongoid/relations/many.rb
+++ b/lib/mongoid/relations/many.rb
@@ -79,14 +79,7 @@ module Mongoid
       #
       # @return [ true, false ] True is persisted documents exist, false if not.
       def exists?
-        if criteria.embedded?
-          count > 0
-        else
-          Mongoid.unit_of_work(disable: :current) do
-            # Don't use count here since Mongo does not use counted b-tree indexes
-            !criteria.dup.only(:_id).limit(1).entries.first.nil?
-          end
-        end
+        criteria.embedded? ? count > 0 : criteria.exists?
       end
 
       # Find the first document given the conditions, or creates a new document


### PR DESCRIPTION
Mongo does not use counted b-tree indexes: https://jira.mongodb.org/browse/SERVER-1752?page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel&focusedCommentId=147517#comment-147517

As such, `Model.where(...).count` can be very slow. When checking for the existence of some document set, there's no need to suffer through the slowness of count only to check > 0 (since, if one document is found, `exists?` should return true, no need to keep looking).

This pull request updates the `exists?` method to try to find a lone document instead of checking against the count.
