### PR TITLE
More intuitive map_reduce laziness

### DIFF
--- a/lib/config/locales/en.yml
+++ b/lib/config/locales/en.yml
@@ -20,6 +20,12 @@ en:
         \_\_relation:     %{relation},\n
         \_\_setter:       %{setter},\n
         \_\_versioned:    %{versioned}>\n"
+      map_reduce: "#<Mongoid::Contextual::MapReduce\n
+        \_\_criteria: %{criteria},\n
+        \_\_map:      %{map},\n
+        \_\_reduce:   %{reduce},\n
+        \_\_finalize: %{finalize},\n
+        \_\_out:      %{out},\n"
     errors:
       messages:
         blank:

--- a/lib/mongoid/contextual/map_reduce.rb
+++ b/lib/mongoid/contextual/map_reduce.rb
@@ -6,7 +6,7 @@ module Mongoid
       include Command
 
       delegate :[], to: :results
-      delegate :==, :empty?, :inspect, to: :entries
+      delegate :==, :empty?, to: :entries
 
       # Get all the counts returned by the map/reduce.
       #
@@ -162,6 +162,16 @@ module Mongoid
         results
       end
 
+      # Execute the map/reduce, returning the raw output.
+      # Useful when you don't care about map/reduce's ouptut.
+      #
+      # @example Run the map reduce
+      #   map_reduce.execute
+      #
+      # @return [ Hash ] The raw output
+      # @since 3.1.0
+      alias :execute :raw
+
       # Get the number of documents reduced by the map/reduce.
       #
       # @example Get the reduced document count.
@@ -199,6 +209,28 @@ module Mongoid
       # @since 3.0.0
       def time
         results["timeMillis"]
+      end
+
+      # Get a pretty string representation of the map/reduce, including the
+      # criteria, map, reduce, finalize, and out option.
+      #
+      # @example Inspect the map_reduce.
+      #   map_reduce.inspect
+      #
+      # @return [ String ] The inspection string.
+      #
+      # @since 3.1.0
+      def inspect
+        ::I18n.translate(
+          "mongoid.inspection.map_reduce",
+          {
+            criteria:   criteria.inspect.chomp,
+            map:        command[:map].inspect,
+            reduce:     command[:reduce].inspect,
+            finalize:   command[:finalize].inspect,
+            out:        command[:out].inspect
+          }
+        )
       end
 
       private

--- a/spec/mongoid/contextual/map_reduce_spec.rb
+++ b/spec/mongoid/contextual/map_reduce_spec.rb
@@ -371,4 +371,66 @@ describe Mongoid::Contextual::MapReduce do
       time.should_not be_nil
     end
   end
+
+  describe "#execute" do
+
+    let(:criteria) do
+      Band.all
+    end
+
+    let(:map_reduce) do
+      described_class.new(collection, criteria, map, reduce)
+    end
+
+    let(:execution_results) do
+      map_reduce.out(inline: 1).execute
+    end
+
+    it "returns a hash" do
+      execution_results.should be_a_kind_of Hash
+    end
+  end
+
+  describe "#inspect" do
+
+    let(:criteria) do
+      Band.all
+    end
+
+    let(:out) do
+      {inline: 1}
+    end
+
+    let(:map_reduce) do
+      described_class.new(collection, criteria, map, reduce).out(out)
+    end
+
+    let(:inspection) do
+      map_reduce.inspect
+    end
+
+    it "returns a string" do
+      inspection.should be_a_kind_of String
+    end
+
+    it "includes the criteria" do
+      inspection.should include("criteria:")
+    end
+
+    it "includes the map function" do
+      inspection.should include("map:")
+    end
+
+    it "includes the reduce function" do
+      inspection.should include("reduce:")
+    end
+
+    it "includes the finalize function" do
+      inspection.should include("finalize:")
+    end
+
+    it "includes the out option" do
+      inspection.should include("out:")
+    end
+  end
 end


### PR DESCRIPTION
Fix for #2258.

I added `map_reduce#inspect` and `map_reduce#execute`

Let me know what you think. The one thing that bummed me out a little is that I don't do a good job indenting the `#inspect` output, since it has criteria's inspect embedded in it (give it a try to see what I mean).
