### PR TITLE
Allow passing hashes directly to localized fields.

### DIFF
--- a/lib/mongoid/fields/localized.rb
+++ b/lib/mongoid/fields/localized.rb
@@ -43,7 +43,11 @@ module Mongoid
       #
       # @since 2.3.0
       def mongoize(object)
-        { ::I18n.locale.to_s => type.mongoize(object) }
+        if object.is_a?(Hash)
+          object
+        else
+          { ::I18n.locale.to_s => type.mongoize(object) }
+        end
       end
 
       private

--- a/spec/mongoid/fields/localized_spec.rb
+++ b/spec/mongoid/fields/localized_spec.rb
@@ -352,6 +352,17 @@ describe Mongoid::Fields::Localized do
         described_class.new(:description, localize: true, type: Integer)
       end
 
+      context "when a hash is passed" do
+
+        let(:value) do
+          field.mongoize({ "de" => "Deutsch", "en" => "English" })
+        end
+
+        it "it gets passed through" do
+          value.should eq({ "de" => "Deutsch", "en" => "English" })
+        end
+      end
+
       context "when no locale is defined" do
 
         let(:value) do


### PR DESCRIPTION
Allows setting localized fields using mass-assignment:

``` ruby
document.title = { en: 'English', de: 'Deutsch' }
```

I need this functionality the get following code – it reverts to a previous version, using `Mongoid::Versioning` – working:

``` ruby
update_attributes(versions.last.versioned_attributes.except('version'))
```
