### PR TITLE
Disable invokedynamic on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,13 @@ matrix:
     - rvm: ruby-head
     - rvm: jruby-19mode
       jdk: oraclejdk7
-      env: JRUBY_OPTS="-Xmx512m"
+      env: JRUBY_OPTS="-Xmx512m -Xcext.enabled=false -Xcompile.invokedynamic=false"
     - rvm: jruby-19mode
       jdk: openjdk7
-      env: JRUBY_OPTS="-Xmx512m"
+      env: JRUBY_OPTS="-Xmx512m -Xcext.enabled=false -Xcompile.invokedynamic=false"
     - rvm: jruby-head
       jdk: oraclejdk7
-      env: JRUBY_OPTS="-Xmx512m"
+      env: JRUBY_OPTS="-Xmx512m -Xcext.enabled=false -Xcompile.invokedynamic=false"
     - rvm: jruby-head
       jdk: openjdk7
-      env: JRUBY_OPTS="-Xmx512m"
+      env: JRUBY_OPTS="-Xmx512m -Xcext.enabled=false -Xcompile.invokedynamic=false"


### PR DESCRIPTION
We will soon change JRUBY_OPTS to disable invokedynamic by default. This
helps with sporadic 32 bit JVM segfaults. Long story short, indy
is young and JRuby's code paths that use indy are even younger, and the
two have a lot to work out together in the upcoming couple of years.

Unfortunately, we cannot easily get newer OpenJDK 7 for the Travis CI env, although Oracle JDK 7 should be updated briefly after new releases
(7u6, 7u8, etc). Because the problem is JRuby and 32-bit-specific, our
best option right now is to disable indy. But since Mongoid
overrides JRUBY_OPTS, I had to submit this PR.

JRuby folks agree this is a good idea until we can update OpenJDK 7 and
even Oracle JDK 7.
