### PR TITLE
Match also on class name when looking up inverse.

### DIFF
--- a/lib/mongoid/relations/metadata.rb
+++ b/lib/mongoid/relations/metadata.rb
@@ -1119,7 +1119,9 @@ module Mongoid
         if other
           matches = []
           other.class.relations.values.each do |meta|
-            matches.push(meta.name) if meta.as == name
+            if meta.as == name && meta.class_name == inverse_class_name
+              matches.push(meta.name)
+            end
           end
           matches
         end

--- a/spec/app/models/eye.rb
+++ b/spec/app/models/eye.rb
@@ -4,4 +4,6 @@ class Eye
   field :pupil_dilation, type: Integer
 
   belongs_to :eyeable, polymorphic: true
+
+  belongs_to :suspended_in, polymorphic: true
 end

--- a/spec/app/models/eye_bowl.rb
+++ b/spec/app/models/eye_bowl.rb
@@ -3,4 +3,7 @@ class EyeBowl
 
   has_many :blue_eyes, class_name: "Eye", as: :eyeable
   has_many :brown_eyes, class_name: "Eye", as: :eyeable
+
+  has_one :face, as: :suspended_in
+  has_one :eye, as: :suspended_in
 end

--- a/spec/app/models/face.rb
+++ b/spec/app/models/face.rb
@@ -3,4 +3,6 @@ class Face
 
   has_one :left_eye, class_name: "Eye", as: :eyeable
   has_one :right_eye, class_name: "Eye", as: :eyeable
+
+  belongs_to :suspended_in, polymorphic: true
 end

--- a/spec/mongoid/relations/metadata_spec.rb
+++ b/spec/mongoid/relations/metadata_spec.rb
@@ -1342,7 +1342,7 @@ describe Mongoid::Relations::Metadata do
         let(:metadata) do
           described_class.new(
             name: :ratable,
-            inverse_class_name: "Movie",
+            inverse_class_name: "Rating",
             polymorphic: true,
             relation: Mongoid::Relations::Referenced::In
           )

--- a/spec/mongoid/relations/referenced/in_spec.rb
+++ b/spec/mongoid/relations/referenced/in_spec.rb
@@ -310,6 +310,22 @@ describe Mongoid::Relations::Referenced::In do
           end
         end
 
+        context "when multiple relations of the same name but different class exist" do
+
+          let(:eye) do
+            Eye.new
+          end
+
+          let(:eye_bowl) do
+            EyeBowl.new
+          end
+
+          it "should assign as expected" do
+            eye.suspended_in = eye_bowl
+            eye.suspended_in.target.should eq(eye_bowl)
+          end
+        end
+
         context "when one relation against the same class exists" do
 
           context "when the child is a new record" do


### PR DESCRIPTION
Hit a snag when upgrading to Mongoid 3 with an app that makes good use of polymorphic models. Here's the setup:

``` ruby
class User
  has_many :notifications, as: :interest
  has_many :icons, as: :interest
end

class Notification
  belongs_to :interest, polymorphic: true
end

class Icon
  belongs_to :interest, polymorphic: true
end
```

Setting `icon.interest = user` in Mongoid 3 causes an InvalidSetPolymorphicRelation exception. Mongoid is unhappy that `User` has two polymorphic relations called 'interest` and believes the assignment is ambiguous. 

However, the situation isn't ambiguous if we look at the relation classes. Because we're assigning from the `Icon` class, we know which `interest` on `User` the assignment pertains to.

This patch adds logic to `Metadata#lookup_inverses` to only add a match when the inverse class and the potential match's class are equal.

I added a spec w/ a simliar scenario to this that fails due to the InvalidSetPolymorphicRelation exception w/ the old code and passes with the patch. I also had to update one line in the metadata spec which, though it passed before, I believe was conceptually a hair off and broke w/ the patch (as a false negative).
