### PR TITLE
Overwriting a HABTM relation twice leads to empty inverse foreign key

### DIFF
--- a/spec/mongoid/relations/referenced/many_to_many_spec.rb
+++ b/spec/mongoid/relations/referenced/many_to_many_spec.rb
@@ -663,6 +663,18 @@ describe Mongoid::Relations::Referenced::ManyToMany do
             preference.person_ids.should be_empty
           end
 
+          context "and then overwriting it again with the same value" do
+
+            before do
+              person.preferences = [ another_preference ]
+            end
+
+            it "persists the relation between another_preference and person" do
+              another_preference.reload.people.should eq([ person ])
+            end
+
+          end
+
           context "and person reloaded instead of saved" do
 
             before do


### PR DESCRIPTION
When overwriting a HABTM relation twice with the same value, the inverse foreign key ends up being empty:

``` ruby
class A
  include Mongoid::Document
  has_and_belongs_to_many :bs, inverse_of: :as
end

class B
  include Mongoid::Document
  has_and_belongs_to_many :as, inverse_of: :bs
end

a = A.create
b = B.create

a.bs = [b]
puts a.reload.b_ids.inspect # => [id]
puts b.reload.a_ids.inspect # => [id]

a.bs = [b]
puts a.reload.b_ids.inspect # => [id]
puts b.reload.a_ids.inspect # => []
```

Please see attached pull request for a corresponding failing spec. The commit also applies cleanly to master and the spec fails there as well.
