### PR TITLE
Added a "delete" method to Mongoid::Generators::ActiveModel

### DIFF
--- a/lib/rails/generators/mongoid_generator.rb
+++ b/lib/rails/generators/mongoid_generator.rb
@@ -50,6 +50,10 @@ module Mongoid
         "#{name}.errors"
       end
 
+      def delete
+        "#{name}.delete"
+      end
+
       def destroy
         "#{name}.destroy"
       end


### PR DESCRIPTION
- Added a "delete" method to Mongoid::Generators::ActiveModel so that controller generator templates using Paranoid can use "orm_instance.delete" to generate a delete call instead of a destroy call.

I couldn't find an appropriate spec to update. If you want one, where do you prefer it to be?
