### PR TITLE
fix for TimeWithZone.demongoize(nil) and spec for Mongoid::Extensions::TimeWithZone

### DIFF
--- a/lib/mongoid/extensions/time_with_zone.rb
+++ b/lib/mongoid/extensions/time_with_zone.rb
@@ -29,6 +29,7 @@ module Mongoid
         #
         # @since 3.0.0
         def demongoize(object)
+          return nil if object.blank?
           ::Time.demongoize(object).in_time_zone
         end
 

--- a/spec/mongoid/extensions/time_with_zone_spec.rb
+++ b/spec/mongoid/extensions/time_with_zone_spec.rb
@@ -26,7 +26,7 @@ describe Mongoid::Extensions::TimeWithZone do
         end
 
         it "returns the local time" do
-          Time.demongoize(time).utc_offset.should eq(
+          ActiveSupport::TimeWithZone.demongoize(time).utc_offset.should eq(
             Time.local(2010, 11, 19).utc_offset
           )
         end
@@ -39,7 +39,7 @@ describe Mongoid::Extensions::TimeWithZone do
         end
 
         it "returns the local time" do
-          Time.demongoize(time).should eq(time.getlocal)
+          ActiveSupport::TimeWithZone.demongoize(time).should eq(time.getlocal)
         end
       end
 
@@ -50,7 +50,7 @@ describe Mongoid::Extensions::TimeWithZone do
         end
 
         it "changes it back to the equivalent local time" do
-          Time.demongoize(time).should eq(time)
+          ActiveSupport::TimeWithZone.demongoize(time).should eq(time)
         end
       end
 
@@ -67,7 +67,7 @@ describe Mongoid::Extensions::TimeWithZone do
         end
 
         it "returns an ActiveSupport::TimeWithZone" do
-          Time.demongoize(time).class.should eq(ActiveSupport::TimeWithZone)
+          ActiveSupport::TimeWithZone.demongoize(time).class.should eq(ActiveSupport::TimeWithZone)
         end
 
         context "when the local time is not observing daylight saving" do
@@ -77,7 +77,7 @@ describe Mongoid::Extensions::TimeWithZone do
           end
 
           it "returns the local time" do
-            Time.demongoize(new_time).should eq(
+            ActiveSupport::TimeWithZone.demongoize(new_time).should eq(
               Time.zone.local(2010, 11, 19, 13)
             )
           end
@@ -90,7 +90,7 @@ describe Mongoid::Extensions::TimeWithZone do
           end
 
           it "returns the local time" do
-            Time.demongoize(new_time).should eq(
+            ActiveSupport::TimeWithZone.demongoize(new_time).should eq(
               Time.zone.local(2010, 9, 19, 14)
             )
           end
@@ -103,7 +103,7 @@ describe Mongoid::Extensions::TimeWithZone do
           end
 
           it "change it back to the equivalent local time" do
-            Time.demongoize(new_time).should eq(
+            ActiveSupport::TimeWithZone.demongoize(new_time).should eq(
               Time.zone.local(2010, 11, 19, 1, 30)
             )
           end
@@ -122,7 +122,7 @@ describe Mongoid::Extensions::TimeWithZone do
       end
 
       it "returns utc" do
-        Time.demongoize(time.dup.utc).utc_offset.should eq(0)
+        ActiveSupport::TimeWithZone.demongoize(time.dup.utc).utc_offset.should eq(0)
       end
 
       context "when using the ActiveSupport time zone" do
@@ -142,13 +142,13 @@ describe Mongoid::Extensions::TimeWithZone do
         end
 
         it "returns utc" do
-          Time.demongoize(time).should eq(
+          ActiveSupport::TimeWithZone.demongoize(time).should eq(
             ActiveSupport::TimeZone['UTC'].local(2010, 11, 19, 0, 30)
           )
         end
 
         it "returns an ActiveSupport::TimeWithZone" do
-          Time.demongoize(time).class.should eq(
+          ActiveSupport::TimeWithZone.demongoize(time).class.should eq(
             ActiveSupport::TimeWithZone
           )
         end
@@ -158,7 +158,7 @@ describe Mongoid::Extensions::TimeWithZone do
     context "when time is nil" do
 
       it "returns nil" do
-        Time.demongoize(nil).should be_nil
+        ActiveSupport::TimeWithZone.demongoize(nil).should be_nil
       end
     end
   end
@@ -172,14 +172,14 @@ describe Mongoid::Extensions::TimeWithZone do
     context "when given nil" do
 
       it "returns nil" do
-        Time.mongoize(nil).should be_nil
+        ActiveSupport::TimeWithZone.mongoize(nil).should be_nil
       end
     end
 
     context "when string is empty" do
 
       it "returns nil" do
-        Time.mongoize("").should be_nil
+        ActiveSupport::TimeWithZone.mongoize("").should be_nil
       end
     end
 
@@ -188,15 +188,15 @@ describe Mongoid::Extensions::TimeWithZone do
       context "when the string is a valid time" do
 
         it "converts to a utc time" do
-          Time.mongoize(time.to_s).utc_offset.should eq(0)
+          ActiveSupport::TimeWithZone.mongoize(time.to_s).utc_offset.should eq(0)
         end
 
         it "serializes with time parsing" do
-          Time.mongoize(time.to_s).should eq(Time.parse(time.to_s).utc)
+          ActiveSupport::TimeWithZone.mongoize(time.to_s).should eq(Time.parse(time.to_s).utc)
         end
 
         it "returns a local date from the string" do
-          Time.mongoize(time.to_s).should eq(
+          ActiveSupport::TimeWithZone.mongoize(time.to_s).should eq(
             Time.local(time.year, time.month, time.day, time.hour, time.min, time.sec)
           )
         end
@@ -206,7 +206,7 @@ describe Mongoid::Extensions::TimeWithZone do
 
         it "raises an error" do
           expect {
-            Time.mongoize("shitty time")
+            ActiveSupport::TimeWithZone.mongoize("shitty time")
           }.to raise_error(Mongoid::Errors::InvalidTime)
         end
       end
@@ -227,7 +227,7 @@ describe Mongoid::Extensions::TimeWithZone do
         context "when the local time is not observing daylight saving" do
 
           it "returns the local time" do
-            Time.mongoize('2010-11-19 5:00:00').should eq(
+            ActiveSupport::TimeWithZone.mongoize('2010-11-19 5:00:00').should eq(
               Time.utc(2010, 11, 19, 4)
             )
           end
@@ -236,7 +236,7 @@ describe Mongoid::Extensions::TimeWithZone do
         context "when the local time is observing daylight saving" do
 
           it "returns the local time" do
-            Time.mongoize('2010-9-19 5:00:00').should eq(
+            ActiveSupport::TimeWithZone.mongoize('2010-9-19 5:00:00').should eq(
               Time.utc(2010, 9, 19, 3)
             )
           end
@@ -251,7 +251,7 @@ describe Mongoid::Extensions::TimeWithZone do
       end
 
       it "doesn't strip milli- or microseconds" do
-        Time.mongoize(time).to_f.should eq(time.to_f)
+        ActiveSupport::TimeWithZone.mongoize(time).to_f.should eq(time.to_f)
       end
 
       context "when using the ActiveSupport time zone" do
@@ -272,7 +272,7 @@ describe Mongoid::Extensions::TimeWithZone do
         end
 
         it "assumes the given time is local" do
-          Time.mongoize(datetime).should eq(
+          ActiveSupport::TimeWithZone.mongoize(datetime).should eq(
             Time.utc(2010, 11, 19)
           )
         end
@@ -282,19 +282,19 @@ describe Mongoid::Extensions::TimeWithZone do
     context "when given a Time" do
 
       it "converts to a utc time" do
-        Time.mongoize(time).utc_offset.should eq(0)
+        ActiveSupport::TimeWithZone.mongoize(time).utc_offset.should eq(0)
       end
 
       it "returns utc times unchanged" do
-        Time.mongoize(time.utc).should eq(time.utc)
+        ActiveSupport::TimeWithZone.mongoize(time.utc).should eq(time.utc)
       end
 
       it "returns the time as utc" do
-        Time.mongoize(time).should eq(time.utc)
+        ActiveSupport::TimeWithZone.mongoize(time).should eq(time.utc)
       end
 
       it "doesn't strip milli- or microseconds" do
-        Time.mongoize(time).to_f.should eq(time.to_f)
+        ActiveSupport::TimeWithZone.mongoize(time).to_f.should eq(time.to_f)
       end
     end
 
@@ -305,7 +305,7 @@ describe Mongoid::Extensions::TimeWithZone do
       end
 
       it "converts it to utc" do
-        Time.mongoize(time.in_time_zone("Alaska")).should eq(
+        ActiveSupport::TimeWithZone.mongoize(time.in_time_zone("Alaska")).should eq(
           Time.at(time.to_i).utc
         )
       end
@@ -318,11 +318,11 @@ describe Mongoid::Extensions::TimeWithZone do
       end
 
       it "converts to a utc time" do
-        Time.mongoize(date).should eq(Time.local(date.year, date.month, date.day))
+        ActiveSupport::TimeWithZone.mongoize(date).should eq(Time.local(date.year, date.month, date.day))
       end
 
       it "has a zero utc offset" do
-        Time.mongoize(date).utc_offset.should eq(0)
+        ActiveSupport::TimeWithZone.mongoize(date).utc_offset.should eq(0)
       end
 
       context "when using the ActiveSupport time zone" do
@@ -343,7 +343,7 @@ describe Mongoid::Extensions::TimeWithZone do
         end
 
         it "assumes the given time is local" do
-          Time.mongoize(date).should eq(Time.utc(2010, 11, 18, 23))
+          ActiveSupport::TimeWithZone.mongoize(date).should eq(Time.utc(2010, 11, 18, 23))
         end
       end
     end
@@ -355,7 +355,7 @@ describe Mongoid::Extensions::TimeWithZone do
       end
 
       it "returns a time" do
-        Time.mongoize(array).should eq(Time.local(*array))
+        ActiveSupport::TimeWithZone.mongoize(array).should eq(Time.local(*array))
       end
 
       context "when using the ActiveSupport time zone" do
@@ -372,7 +372,7 @@ describe Mongoid::Extensions::TimeWithZone do
         end
 
         it "assumes the given time is local" do
-          Time.mongoize(array).should eq(
+          ActiveSupport::TimeWithZone.mongoize(array).should eq(
             Time.utc(2010, 11, 18, 23, 24, 49)
           )
         end


### PR DESCRIPTION
- TimeWithZone.demongoize(nil) raise NoMethodError. I think should return nil.
- spec/mongoid/extensions/time_with_zone_spec.rb was almost identical with time_spec.rb. Maybe it was copied from time_spec.rb and neglected, doesn't it?

Thanks,
