### PR TITLE
Add support for first_or_create

### DIFF
--- a/lib/mongoid/finders.rb
+++ b/lib/mongoid/finders.rb
@@ -119,6 +119,19 @@ module Mongoid
       with_default_scope.first
     end
 
+    # Find the first +Document+, or creates a new document
+    # with the conditions that were supplied.
+    #
+    # @example First or create the document.
+    #   Person.first_or_create(:attribute => "value")
+    #
+    # @param [ Hash ] attrs The attributes to check.
+    #
+    # @return [ Document ] A matching or newly created document.
+    def first_or_create(attrs = {}, &block)
+      first_or(:create, attrs, &block)
+    end
+
     # Find the last +Document+ given the conditions.
     #
     # @example Find the last document.
@@ -142,6 +155,19 @@ module Mongoid
     # @return [ Document ] The first or new document.
     def find_or(method, attrs = {}, &block)
       where(attrs).first || send(method, attrs, &block)
+    end
+
+    # Find the first document or create/initialize it.
+    #
+    # @example First or perform an action.
+    #   Person.first_or(:create, :name => "Dev")
+    #
+    # @param [ Symbol ] method The method to invoke.
+    # @param [ Hash ] attrs The attributes to query or set.
+    #
+    # @return [ Document ] The first or new document.
+    def first_or(method, attrs = {}, &block)
+      with_default_scope.first || send(method, attrs, &block)
     end
   end
 end

--- a/spec/mongoid/finders_spec.rb
+++ b/spec/mongoid/finders_spec.rb
@@ -289,6 +289,74 @@ describe Mongoid::Finders do
     end
   end
 
+  describe ".first_or_create" do
+
+    context "when the document is found" do
+
+      let!(:person) do
+        Person.create
+      end
+
+      it "returns the document" do
+        Person.first_or_create.should eq(person)
+      end
+    end
+
+    context "when the document is not found" do
+
+      context "when providing a document" do
+
+        let!(:person) do
+          Person.create
+        end
+
+        let(:from_db) do
+          Game.first_or_create(person: person)
+        end
+
+        it "returns the new document" do
+          from_db.person.should eq(person)
+        end
+      end
+
+      context "when not providing a block" do
+
+        let!(:person) do
+          Person.first_or_create(title: "Senorita")
+        end
+
+        it "creates a persisted document" do
+          person.should be_persisted
+        end
+
+        it "sets the attributes" do
+          person.title.should eq("Senorita")
+        end
+      end
+
+      context "when providing a block" do
+
+        let!(:person) do
+          Person.first_or_create(title: "Senorita") do |person|
+            person.pets = true
+          end
+        end
+
+        it "creates a persisted document" do
+          person.should be_persisted
+        end
+
+        it "sets the attributes" do
+          person.title.should eq("Senorita")
+        end
+
+        it "calls the block" do
+          person.pets.should be_true
+        end
+      end
+    end
+  end
+
   Origin::Selectable.forwardables.each do |method|
 
     describe "##{method}" do


### PR DESCRIPTION
Adds support for the finder 'first_or_create'.   Finder delegates to 'first_or' which will return the first document in the collection or create an object accordingly.
