### PR TITLE
validates_associated should handle options

### DIFF
--- a/lib/mongoid/validations/associated.rb
+++ b/lib/mongoid/validations/associated.rb
@@ -39,7 +39,7 @@ module Mongoid
         ensure
           document.exit_validate
         end
-        document.errors.add(attribute, :invalid) unless valid
+        document.errors.add(attribute, :invalid, options) unless valid
       end
     end
   end


### PR DESCRIPTION
validates_associated should handle options as described in doc (http://mongoid.org/en/mongoid/docs/validation.html). Without it impossible to change useless default validation message.
