### PR TITLE
Make sure destroy callbacks are only run once when document is destroyed through nested attributes.

### DIFF
--- a/lib/mongoid/relations/builders/nested_attributes/many.rb
+++ b/lib/mongoid/relations/builders/nested_attributes/many.rb
@@ -97,7 +97,7 @@ module Mongoid
               doc = existing.find(converted)
               if destroyable?(attrs)
                 existing.delete(doc)
-                doc.destroy unless doc.embedded?
+                doc.destroy unless doc.embedded? || doc.destroyed?
               else
                 attrs.delete_id
                 metadata.embedded? ? doc.attributes = attrs : doc.update_attributes(attrs)


### PR DESCRIPTION
The document may already have been destroyed as a result of `existing.delete(doc)`, so don't destroy it again.
