### PR TITLE
allow activemodel 4.0 to be used

### DIFF
--- a/mongoid.gemspec
+++ b/mongoid.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
   s.rubyforge_project         = "mongoid"
 
-  s.add_dependency("activemodel", ["~> 3.1"])
+  s.add_dependency("activemodel", [">= 3.1"])
   s.add_dependency("tzinfo", ["~> 0.3.22"])
   s.add_dependency("moped", ["~> 1.2"])
   s.add_dependency("origin", ["~> 1.0"])


### PR DESCRIPTION
Had issues trying to use mongoid with Rails 4
