### PR TITLE
Geo haystack and 'bits' parameters for 2d indexes

### DIFF
--- a/lib/config/locales/en.yml
+++ b/lib/config/locales/en.yml
@@ -159,8 +159,12 @@ en:
             \_\_drop_dups: true|false\n
             \_\_name: 'index_name'\n
             \_\_sparse: true|false\n
-            \_\_unique: true|false\n\n
-            Valid types are: 1, -1, '2d'\n\n
+            \_\_unique: true|false\n
+            \_\_min: 1\n
+            \_\_max: 1\n
+            \_\_bits: 26\n
+            \_\_bucket_size : 1\n
+            Valid types are: 1, -1, '2d', 'geoHaystack'\n\n
             Example:\n
             \_\_class Band\n
             \_\_\_\_include Mongoid::Document\n

--- a/lib/mongoid/indexes.rb
+++ b/lib/mongoid/indexes.rb
@@ -98,6 +98,7 @@ module Mongoid
       def normalize_index_options(options)
         opts = options || {}
         opts[:dropDups] = opts.delete(:drop_dups) if opts.has_key?(:drop_dups)
+        opts[:bucketSize] = opts.delete(:bucket_size) if opts.has_key?(:bucket_size)
         opts
       end
     end

--- a/lib/mongoid/indexes/validators/options.rb
+++ b/lib/mongoid/indexes/validators/options.rb
@@ -7,7 +7,7 @@ module Mongoid
       module Options
         extend self
 
-        VALID_OPTIONS = [ :background, :drop_dups, :name, :sparse, :unique, :max, :min, :bucketSize ]
+        VALID_OPTIONS = [ :background, :drop_dups, :name, :sparse, :unique, :max, :min, :bits, :bucket_size ]
         VALID_TYPES = [ 1, -1, "2d", "geoHaystack" ]
 
         # Validate the index specification.

--- a/spec/mongoid/indexes_spec.rb
+++ b/spec/mongoid/indexes_spec.rb
@@ -184,7 +184,7 @@ describe Mongoid::Indexes do
     context "when providing a geospacial index" do
 
       before do
-        klass.index({ location: "2d" }, { min: -200, max: 200 })
+        klass.index({ location: "2d" }, { min: -200, max: 200, bits: 32 })
       end
 
       let(:options) do
@@ -192,7 +192,22 @@ describe Mongoid::Indexes do
       end
 
       it "sets the geospacial index" do
-        options.should eq({ min: -200, max: 200 })
+        options.should eq({ min: -200, max: 200, bits: 32 })
+      end
+    end
+
+    context "when providing a geo haystack index" do
+
+      before do
+        klass.index({ location: "geoHaystack" }, { min: -200, max: 200, bucket_size: 0.5 })
+      end
+
+      let(:options) do
+        klass.index_options[location: "geoHaystack"]
+      end
+
+      it "sets the geo haystack index" do
+        options.should eq({ min: -200, max: 200, bucketSize: 0.5 })
       end
     end
 


### PR DESCRIPTION
This adds support for the geoHaystack type of index to be created. It also enables the bits parameter to be added to a 2d index.

http://www.mongodb.org/display/DOCS/Geospatial+Haystack+Indexing
http://www.mongodb.org/display/DOCS/Geospatial+Indexing
