### PR TITLE
Change "orderby" to "sort" in map_reduce

### DIFF
--- a/lib/mongoid/contextual/map_reduce.rb
+++ b/lib/mongoid/contextual/map_reduce.rb
@@ -251,7 +251,7 @@ module Mongoid
       def apply_criteria_options
         command[:query] = criteria.selector
         if sort = criteria.options[:sort]
-          command[:orderby] = sort
+          command[:sort] = sort
         end
         if limit = criteria.options[:limit]
           command[:limit] = limit

--- a/spec/mongoid/contextual/map_reduce_spec.rb
+++ b/spec/mongoid/contextual/map_reduce_spec.rb
@@ -42,13 +42,37 @@ describe Mongoid::Contextual::MapReduce do
       described_class.new(collection, criteria, map, reduce)
     end
 
+    let(:base_command) do
+      {
+          mapreduce: "bands",
+          map: map,
+          reduce: reduce,
+          query: {}
+      }
+    end
+
     it "returns the db command" do
-      map_reduce.command.should eq({
-        mapreduce: "bands",
-        map: map,
-        reduce: reduce,
-        query: {}
-      })
+      map_reduce.command.should eq(base_command)
+    end
+
+    context "with sort" do
+      let(:criteria) do
+        Band.order_by(name: -1)
+      end
+
+      it "returns the db command with a sort option" do
+        map_reduce.command.should eq(base_command.merge(sort: {'name' => -1}))
+      end
+    end
+
+    context "with limit" do
+      let(:criteria) do
+        Band.limit(10)
+      end
+
+      it "returns the db command with a limit option" do
+        map_reduce.command.should eq(base_command.merge(limit: 10))
+      end
     end
   end
 

--- a/spec/mongoid/contextual/mongo_spec.rb
+++ b/spec/mongoid/contextual/mongo_spec.rb
@@ -969,6 +969,11 @@ describe Mongoid::Contextual::Mongo do
 
     context "when sorting is provided" do
 
+      before do
+        Band.index(name: -1)
+        Band.create_indexes
+      end
+
       let(:criteria) do
         Band.desc(:name)
       end


### PR DESCRIPTION
Change "orderby" to "sort" in map_reduce according to MongoDB MapReduce documentation
Add map_reduce specs for "sort" and "limit" options
