### PR TITLE
Fixes a bug when passes blank values to _ids accessor

### DIFF
--- a/lib/mongoid/relations/accessors.rb
+++ b/lib/mongoid/relations/accessors.rb
@@ -228,7 +228,7 @@ module Mongoid
         def ids_setter(name, metadata)
           ids_method = "#{name.to_s.singularize}_ids="
           re_define_method(ids_method) do |ids|
-            send(metadata.setter, metadata.klass.find(ids))
+            send(metadata.setter, metadata.klass.find(ids.reject(&:blank?)))
           end
           self
         end

--- a/spec/mongoid/relations/accessors_spec.rb
+++ b/spec/mongoid/relations/accessors_spec.rb
@@ -743,6 +743,22 @@ describe Mongoid::Relations::Accessors do
           post.person.should be_nil
         end
       end
+
+      context "when setting the _ids accessor" do
+
+        let(:post) do
+          Post.create
+        end
+
+        before do
+          person.post_ids = [ "" ]
+        end
+
+        it "ignore blank values" do
+          person.post_ids.should be_empty
+        end
+
+      end
     end
 
     context "when the document is a references many to many" do


### PR DESCRIPTION
**SimpleForm** appends a hidden field to make sure something will be sent back to the server if all checkboxes are unchecked.

``` html
<label class="checkbox">
  <input checked="checked" class="check_boxes optional" id="category_product_ids_505c8762788d053b0d000001" name="category[product_ids][]" type="checkbox" value="505c8762788d053b0d000001">
  1808
</label>
<input name="category[product_ids][]" type="hidden">
```

Mongoid receives `"category" => {"product_ids"=>[""]}` and return **DocumentNotFound**.

This errors only occurs on **has_many** relations.

An exemple: http://rocky-castle-8756.herokuapp.com/categories/506075152491220200000002/edit
