### PR TITLE
added a configuration option to silence the config/mongoid.yml not found...

### DIFF
--- a/lib/mongoid/config.rb
+++ b/lib/mongoid/config.rb
@@ -21,6 +21,7 @@ module Mongoid
     option :protect_sensitive_fields, default: true
     option :raise_not_found_error, default: true
     option :scope_overwrite_exception, default: false
+    option :warn_config_not_found, default: true
     # @todo: Remove at 4.0
     option :skip_version_check, default: false
     option :use_activesupport_time_zone, default: true

--- a/lib/mongoid/railtie.rb
+++ b/lib/mongoid/railtie.rb
@@ -95,7 +95,7 @@ module Rails
       # alert to create one.
       initializer "warn when configuration is missing" do
         config.after_initialize do
-          unless Rails.root.join("config", "mongoid.yml").file?
+          unless Rails.root.join("config", "mongoid.yml").file? && !::Mongoid.warn_config_not_found
             puts "\nMongoid config not found. Create a config file at: config/mongoid.yml"
             puts "to generate one run: rails generate mongoid:config\n\n"
           end


### PR DESCRIPTION
This solves #2409, some tests are failing but after inspecting them its nothing related to the configuration nor the initializer responsible for the warning
