### PR TITLE
Array#uniq_by is deprecated in favor of Array#uniq

### DIFF
--- a/lib/mongoid/extensions/array.rb
+++ b/lib/mongoid/extensions/array.rb
@@ -25,7 +25,7 @@ module Mongoid
       #
       # @since 3.0.0
       def __find_args__
-        flat_map{ |a| a.__find_args__ }.uniq_by{ |a| a.to_s }
+        flat_map{ |a| a.__find_args__ }.uniq{ |a| a.to_s }
       end
 
       # Mongoize the array into an array of object ids.


### PR DESCRIPTION
In rails/rails@c4df2d0b6e0c1f4e0df4a66bfae91a684f3d9f71
