### PR TITLE
Fix selecting leak 2439

### DIFF
--- a/lib/mongoid/contextual/mongo.rb
+++ b/lib/mongoid/contextual/mongo.rb
@@ -602,7 +602,7 @@ module Mongoid
           Threaded.set_selection(criteria.object_id, fields) unless fields.blank?
           yield
         ensure
-          Threaded.set_selection(criteria.object_id, nil)
+          Threaded.delete_selection(criteria.object_id)
         end
       end
 

--- a/lib/mongoid/threaded.rb
+++ b/lib/mongoid/threaded.rb
@@ -307,7 +307,8 @@ module Mongoid
     #
     # @since 2.4.4
     def selection(criteria_instance_id)
-      Thread.current["[mongoid][#{criteria_instance_id}]:selection"]
+      selections = Thread.current["[mongoid][selections]"]
+      selections[criteria_instance_id] if selections
     end
 
     # Set the field selection on the current thread.
@@ -322,7 +323,24 @@ module Mongoid
     #
     # @since 2.4.4
     def set_selection(criteria_instance_id, value)
-      Thread.current["[mongoid][#{criteria_instance_id}]:selection"] = value
+      Thread.current["[mongoid][selections]"] ||= {}
+      Thread.current["[mongoid][selections]"][criteria_instance_id] = value
+    end
+
+    # Delete the field selection on the current thread.
+    #
+    # @example Delete the field selection.
+    #   Threaded.delete_selection(Person)
+    #
+    # @param [ Integer ] criteria_instance_id The criteria instance id.
+    #
+    # @return [ Boolean ] Whether there was a field selection.
+    #
+    # @since 3.0.7
+    def delete_selection(criteria_instance_id)
+      selections = Thread.current["[mongoid][selections]"]
+      return false unless selections
+      !!selections.delete(criteria_instance_id)
     end
 
     # Get the global session override.


### PR DESCRIPTION
This is a fix for #2439 (memory leak caused by storing selections as separate thread locals;  it appears overwriting thread locals with nil does not prevent a leak)
