### PR TITLE
Remove double creation dirty reset method

### DIFF
--- a/lib/mongoid/dirty.rb
+++ b/lib/mongoid/dirty.rb
@@ -264,7 +264,6 @@ module Mongoid
         create_dirty_default_change_check(name, meth)
         create_dirty_previous_value_accessor(name, meth)
         create_dirty_reset(name, meth)
-        create_dirty_reset(name, meth)
       end
 
       # Creates the dirty change accessor.


### PR DESCRIPTION
This double call was added by this commit
bfb4a2860df50ad09d53e3a3d235e2fee2fcecca
