### PR TITLE
allow write_attribute to work with an aliased field name

### DIFF
--- a/lib/mongoid/attributes.rb
+++ b/lib/mongoid/attributes.rb
@@ -119,7 +119,7 @@ module Mongoid
     #
     # @since 1.0.0
     def write_attribute(name, value)
-      access = name.to_s
+      access = database_field_name(name.to_s)
       if attribute_writable?(access)
         _assigning do
           localized = fields[access].try(:localized?)

--- a/spec/mongoid/attributes_spec.rb
+++ b/spec/mongoid/attributes_spec.rb
@@ -1170,6 +1170,21 @@ describe Mongoid::Attributes do
         person.terms.should be_true
       end
     end
+
+    context "when attribute has an aliased name" do
+
+      let(:person) do
+        Person.new
+      end
+
+      before(:each) do
+        person.write_attribute(:test, "aliased field to test")
+      end
+
+      it "allows the field name to be udpated" do
+        person.t.should eq("aliased field to test")
+      end
+    end
   end
 
   describe "#typed_value_for" do


### PR DESCRIPTION
Using field aliasing, write_attribute does not work using alias name

Similar to this [prev issue](https://github.com/mongoid/mongoid/issues/2353) but this time for [attributes.rb#write_attribute](https://github.com/mongoid/mongoid/blob/master/lib/mongoid/attributes.rb#L121).
