### PR TITLE
Reset descendants' cache when new one is created

### DIFF
--- a/lib/mongoid/document.rb
+++ b/lib/mongoid/document.rb
@@ -282,6 +282,12 @@ module Mongoid
 
     module ClassMethods
 
+      # Resets descendants' cache
+      def inherited(*)
+        @_type = nil
+        super
+      end
+
       # Performs class equality checking.
       #
       # @example Compare the classes.

--- a/spec/mongoid/document_spec.rb
+++ b/spec/mongoid/document_spec.rb
@@ -220,6 +220,21 @@ describe Mongoid::Document do
         types.should eq([ "Address" ])
       end
     end
+
+    context "when ._types had been called before class declaration" do
+      let(:descendant) do
+        Class.new(Person)
+      end
+
+      before do
+        Person._types
+        descendant
+      end
+
+      it "should clear descendants' cache" do
+        Person._types.should include(descendant.to_s)
+      end
+    end
   end
 
   describe "#attributes" do


### PR DESCRIPTION
If ._types method had been called before declaration
the subclass, Factory.build method will not be able
to create object of its subclass.
