### PR TITLE
add attribute_before_type_cast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ For instructions on upgrading to newer versions, visit
 
 ### New Features
 
+* Added `*_before_type_cast` to access attributes before type cast on
+  assignment.
+
 * Added `Document.first_or_create!` and `Criteria#first_or_create!`. This
   raises a validations error if creation fails validation.
 

--- a/lib/mongoid/document.rb
+++ b/lib/mongoid/document.rb
@@ -143,6 +143,7 @@ module Mongoid
       _building do
         @new_record = true
         @attributes ||= {}
+        @attributes_before_type_cast ||= {}
         options ||= {}
         apply_pre_processed_defaults
         process_attributes(attrs, options[:as] || :default, !options[:without_protection]) do
@@ -314,6 +315,7 @@ module Mongoid
         doc = allocate
         doc.criteria_instance_id = criteria_instance_id
         doc.instance_variable_set(:@attributes, attributes)
+        doc.instance_variable_set(:@attributes_before_type_cast, {})
         doc.apply_defaults
         IdentityMap.set(doc) unless _loading_revision?
         doc.run_callbacks(:find) unless doc._find_callbacks.empty?

--- a/lib/mongoid/extensions/string.rb
+++ b/lib/mongoid/extensions/string.rb
@@ -93,7 +93,7 @@ module Mongoid
       #
       # @since 1.0.0
       def reader
-        delete("=")
+        delete("=").sub(/\_before\_type\_cast$/, '')
       end
 
       # Convert the string to an array with the string in it.
@@ -118,6 +118,18 @@ module Mongoid
       # @since 1.0.0
       def writer?
         include?("=")
+      end
+
+      # Does the string end with _before_type_cast?
+      #
+      # @example Is the string a setter method?
+      #   "price_before_type_cast".before_type_cast?
+      #
+      # @return [ true, false ] If the string ends with "_before_type_cast"
+      #
+      # @since 3.1.0
+      def before_type_cast?
+        ends_with?('_before_type_cast')
       end
 
       # Is the object not to be converted to bson on criteria creation?

--- a/lib/mongoid/reloading.rb
+++ b/lib/mongoid/reloading.rb
@@ -21,6 +21,7 @@ module Mongoid
         raise Errors::DocumentNotFound.new(self.class, id, id)
       end
       @attributes = reloaded
+      @attributes_before_type_cast = {}
       changed_attributes.clear
       apply_defaults
       reload_relations

--- a/spec/mongoid/attributes_spec.rb
+++ b/spec/mongoid/attributes_spec.rb
@@ -547,6 +547,10 @@ describe Mongoid::Attributes do
         person.testing.should eq("Test")
       end
 
+      it "allows the getter before_type_cast" do
+        person.testing_before_type_cast.should eq("Testing")
+      end
+
       it "returns true for respond_to?" do
         person.respond_to?(:testing).should be_true
       end
@@ -845,6 +849,28 @@ describe Mongoid::Attributes do
     end
   end
 
+  describe "#read_attribute_before_type_cast" do
+    let(:person) do
+      Person.create
+    end
+
+    context "when the attribute has not yet been assigned" do
+
+      it "returns the default value" do
+        person.age_before_type_cast.should eq(100)
+      end
+    end
+
+    context "after the attribute has been assigned" do
+
+      it "returns the default value" do
+        person.age = "old"
+        person.age_before_type_cast.should eq("old")
+      end
+    end
+  end
+
+
   describe "#attribute_present?" do
 
     context "when document is a new record" do
@@ -959,6 +985,28 @@ describe Mongoid::Attributes do
 
       it "returns false" do
         person.has_attribute?(:employer_id).should be_false
+      end
+    end
+  end
+
+  describe '#has_attribute_before_type_cast?' do
+
+    let(:person) do
+      Person.new
+    end
+
+    context "before the attribute has been assigned" do
+
+      it "returns false" do
+        person.has_attribute_before_type_cast?(:age).should be_false
+      end
+    end
+
+    context "after the attribute has been assigned" do
+
+      it "returns true" do
+        person.age = 'old'
+        person.has_attribute_before_type_cast?(:age).should be_true
       end
     end
   end
@@ -1142,6 +1190,16 @@ describe Mongoid::Attributes do
 
       it "returns the default value" do
         person.age.should eq(100)
+      end
+    end
+
+    context "when setting an attribute that needs type casting" do
+      let(:person) do
+        Person.new(age: "old")
+      end
+
+      it "should store the attribute before type cast" do
+        person.age_before_type_cast.should eq("old")
       end
     end
 
@@ -1407,6 +1465,11 @@ describe Mongoid::Attributes do
       it "aliases reset_*!" do
         product.reset_cost!
         product.cost.should be_nil
+      end
+
+      it "aliases *_before_type_cast" do
+        product.cost = "expensive"
+        product.cost_before_type_cast.should eq("expensive")
       end
     end
 

--- a/spec/mongoid/extensions/string_spec.rb
+++ b/spec/mongoid/extensions/string_spec.rb
@@ -263,6 +263,13 @@ describe Mongoid::Extensions::String do
         "attribute=".reader.should eq("attribute")
       end
     end
+
+    context "when the string is before_type_cast" do
+
+      it "returns the reader" do
+        "attribute_before_type_cast".reader.should eq("attribute")
+      end
+    end
   end
 
   describe "#numeric?" do
@@ -340,4 +347,22 @@ describe Mongoid::Extensions::String do
       end
     end
   end
+
+  describe "#before_type_cast?" do
+
+    context "when string is a reader" do
+
+      it "returns false" do
+        "attribute".before_type_cast?.should be_false
+      end
+    end
+
+    context "when string is before_type_cast" do
+
+      it "returns true" do
+        "attribute_before_type_cast".before_type_cast?.should be_true
+      end
+    end
+  end
+
 end

--- a/spec/mongoid/fields_spec.rb
+++ b/spec/mongoid/fields_spec.rb
@@ -395,6 +395,27 @@ describe Mongoid::Fields do
     end
   end
 
+  describe "#getter_before_type_cast" do
+    let(:person) do
+      Person.new
+    end
+
+    context "when the attribute has not been assigned" do
+
+      it "delgates to the getter" do
+        person.age_before_type_cast.should eq(person.age)
+      end
+    end
+
+    context "when the attribute has been assigned" do
+
+      it "returns the attribute before type cast" do
+        person.age = "old"
+        person.age_before_type_cast.should eq("old")
+      end
+    end
+  end
+
   describe "#setter=" do
 
     let(:product) do

--- a/spec/mongoid/reloading_spec.rb
+++ b/spec/mongoid/reloading_spec.rb
@@ -80,6 +80,10 @@ describe Mongoid::Reloading do
       it "resets the dirty modifications" do
         person.changes.should be_empty
       end
+
+      it "resets attributes_before_type_cast" do
+        person.attributes_before_type_cast.should be_empty
+      end
     end
 
     context "when document not saved" do


### PR DESCRIPTION
Among other things, this fixes numericality validation. If this looks good, and
it's deemed necessary, I'm happy to add a configuration option which disables
the functionality for people with memory overhead concerns.

See #2137, #2237, #2436, #2429, #2450.
