### PR TITLE
Translations are being stored as a double hash

### DIFF
--- a/lib/mongoid/versioning.rb
+++ b/lib/mongoid/versioning.rb
@@ -174,7 +174,12 @@ module Mongoid
       versioned = {}
       hash.except("versions").each_pair do |name, value|
         field = fields[name]
-        versioned[name] = value if !field || field.versioned?
+
+        if field.is_a?(Mongoid::Fields::Localized)
+          versioned["#{name}_translations"] = value if !field || field.versioned?
+        else
+          versioned[name] = value if !field || field.versioned?
+        end
       end
       versioned
     end


### PR DESCRIPTION
It seems that translations are being stored wrong because the versioning stuff is simply copying over the key => value and Mongoid::Fields::Localized trying to store that wrongly.

This is just a quick change, it's probably very ugly and needs tests and all sorts but I just kinda thought rather than say there was an issue i'd have a go at trying to fix it
