### PR TITLE
The `first` finder should accept conditions for matching

### DIFF
--- a/lib/mongoid/finders.rb
+++ b/lib/mongoid/finders.rb
@@ -135,8 +135,10 @@ module Mongoid
     #   Person.first
     #
     # @return [ Document ] The first matching document.
-    def first
-      with_default_scope.first
+    def first(*args)
+      conditions = {}
+      conditions = args[0][:conditions] if args[0] && args[0][:conditions]
+      find_by(conditions)
     end
 
     # Find the last +Document+ given the conditions.

--- a/spec/mongoid/finders_spec.rb
+++ b/spec/mongoid/finders_spec.rb
@@ -303,6 +303,31 @@ describe Mongoid::Finders do
     end
   end
 
+  describe ".first" do
+
+    let!(:person1) do
+      Person.create(title: "sir")
+    end
+
+    let!(:person2) do
+      Person.create(title: "sir", pets: true)
+    end
+
+    context "when no conditions are supplied" do
+
+      it "returns the first document" do
+        Person.first.should eq(person1)
+      end
+    end
+
+    context "when conditions are supplied" do
+
+      it "returns the first document given the conditions" do
+        Person.first({ conditions: { pets: true }}).should eq(person2)
+      end
+    end
+  end
+
   describe ".first_or_create" do
 
     context "when the document is found" do


### PR DESCRIPTION
In the 2.x branch of mongoid, the `.first` finder accepted a hash of conditions to apply when finding the first match.  In the new 3.x branch, that functionality was removed, making mongoid incompatible with some popular gems like factory girl.  I added the removed functionality back in.

https://github.com/mongoid/mongoid/blob/2.5.0-stable/lib/mongoid/finders.rb#L121-123
https://github.com/mongoid/mongoid/blob/master/lib/mongoid/finders.rb#L138-140
