### PR TITLE
Fix #from_map_or_db when used with a selector instead of an id.

### DIFF
--- a/lib/mongoid/criterion/findable.rb
+++ b/lib/mongoid/criterion/findable.rb
@@ -73,6 +73,7 @@ module Mongoid
         id = extract_id
         id = klass.fields["_id"].mongoize(id) if id
         doc = IdentityMap.get(klass, id || selector.except("_type"))
+        return nil if doc.is_a?(Hash) && doc.length == 0
         doc && doc.matches?(selector) ? doc : first
       end
 


### PR DESCRIPTION
I ran into this bug when I eagerly loaded a `has_one` relation and then read the relation.
