### PR TITLE
more accurate model tracking makes tasks non-broken

### DIFF
--- a/lib/mongoid.rb
+++ b/lib/mongoid.rb
@@ -151,6 +151,15 @@ module Mongoid
     Sessions.with_name(name)
   end
 
+  # Return the list of all known Mongoid models
+  #
+  # @return [ Array<Class> ] All Mongoid models
+  #
+  # @since 3.1.0
+  def models
+    Document.models
+  end
+
   # Take all the public instance methods from the Config singleton and allow
   # them to be accessed through the Mongoid module directly.
   #

--- a/lib/mongoid/document.rb
+++ b/lib/mongoid/document.rb
@@ -357,6 +357,28 @@ module Mongoid
         Mongoid.logger
       end
     end
+
+    # Track all document classes
+    #
+    # @return [ Array<Class> ] All document classes
+    #
+    # @since 3.1.0
+    def Document.included(other)
+      super
+    ensure
+      Mongoid.models.delete_if{|model| model.name == other.name}
+      Mongoid.models.push(other)
+    end
+
+    # Returns the list of all classes known to have included
+    # Mongoid::Document
+    #
+    # @return [ Array<Class> ] All document classes
+    #
+    # @since 3.1.0
+    def Document.models
+      @models ||= []
+    end
   end
 end
 

--- a/lib/mongoid/railties/database.rake
+++ b/lib/mongoid/railties/database.rake
@@ -66,31 +66,14 @@ namespace :db do
   end
 
   namespace :mongoid do
-
     desc "Create the indexes defined on your mongoid models"
     task :create_indexes => :environment do
-      engines_models_paths = Rails.application.railties.engines.map do |engine|
-        engine.paths["app/models"].expanded
-      end
-      root_models_paths = Rails.application.paths["app/models"]
-      models_paths = engines_models_paths.push(root_models_paths).flatten
-
-      models_paths.each do |path|
-        ::Rails::Mongoid.create_indexes("#{path}/**/*.rb")
-      end
+      ::Rails::Mongoid.create_indexes
     end
 
     desc "Remove the indexes defined on your mongoid models without questions!"
     task :remove_indexes => :environment do
-      engines_models_paths = Rails.application.railties.engines.map do |engine|
-        engine.paths["app/models"].expanded
-      end
-      root_models_paths = Rails.application.paths["app/models"]
-      models_paths = engines_models_paths.push(root_models_paths).flatten
-
-      models_paths.each do |path|
-        ::Rails::Mongoid.remove_indexes("#{path}/**/*.rb")
-      end
+      ::Rails::Mongoid.remove_indexes
     end
 
     desc "Drops the database for the current Rails.env"

--- a/spec/mongoid/document_spec.rb
+++ b/spec/mongoid/document_spec.rb
@@ -14,6 +14,62 @@ describe Mongoid::Document do
     person.should_not respond_to(:_destroy)
   end
 
+  describe ".included" do
+    let(:models) do
+      Mongoid::Document.models
+    end
+
+    let(:new_klass_name) do
+      'NewKlassName'
+    end
+
+    let(:new_klass) do
+      Class.new do
+        class << self; attr_accessor :name; end
+      end.tap{|new_klass| new_klass.name = new_klass_name}
+    end
+
+    let(:new_model) do
+      new_klass.tap do
+        new_klass.send(:include, ::Mongoid::Document)
+      end
+    end
+
+    let(:twice_a_new_model) do
+      new_klass.tap do
+        2.times{ new_klass.send(:include, ::Mongoid::Document) }
+      end
+    end
+
+    it "should respond to :models" do
+      Mongoid::Document.should respond_to(:models)
+    end
+
+    context "when Document has been included in a model" do
+      it ".models should include that model" do
+        models.should include(klass)
+      end
+    end
+
+    context "before Document has been included" do
+      it ".models should *not* include that model" do
+        models.should_not include(new_klass)
+      end
+    end
+
+    context "after Document has been included" do
+      it ".models should include that model" do
+        models.should include(new_model)
+      end
+    end
+
+    context "after Document has been included multiple times" do
+      it ".models should include that model just once" do
+        models.count(twice_a_new_model).should be_eql(1)
+      end
+    end
+  end
+
   describe "#==" do
 
     context "when comparable is not a document" do

--- a/spec/mongoid_spec.rb
+++ b/spec/mongoid_spec.rb
@@ -64,4 +64,10 @@ describe Mongoid do
       Mongoid.session(:default).should eq(Mongoid::Sessions.default)
     end
   end
+
+  describe ".models" do
+    it "returns the list of known models" do
+      Mongoid.models.should eq(Mongoid::Document.models)
+    end
+  end
 end

--- a/spec/rails/mongoid_spec.rb
+++ b/spec/rails/mongoid_spec.rb
@@ -30,14 +30,12 @@ describe "Rails::Mongoid" do
 
     before do
       Dir.should_receive(:glob).once.with(pattern).and_return(model_paths)
-      Logger.should_receive(:new).twice.and_return(logger)
     end
 
     context "with ordinary Rails models" do
 
       it "creates the indexes for the models" do
         klass.should_receive(:create_indexes).once
-        logger.should_receive(:info).twice
         indexes
       end
     end
@@ -83,7 +81,6 @@ describe "Rails::Mongoid" do
 
       it "does nothing, but logging" do
         klass.should_receive(:create_indexes).never
-        logger.should_receive(:info).once
         indexes
       end
     end
@@ -109,8 +106,6 @@ describe "Rails::Mongoid" do
 
     before do
       Dir.should_receive(:glob).with(pattern).exactly(2).times.and_return(model_paths)
-      Logger.should_receive(:new).exactly(4).times.and_return(logger)
-      logger.should_receive(:info).exactly(3).times
     end
 
     let(:indexes) do


### PR DESCRIPTION
previous versions of mongoid attempted to guess models from file names.  this is broken when and model is defined any place outside the 'normal' search path, and leads to such errors as missing uniq indexes on models.  these commits
- add reload safe ability for mongoid to know all it's models deterministically via Mongoid::Document.included
- adds non-broken created_indexes and remove_indexes (backwards compatible)
