### PR TITLE
Added ability to specify fields in includes

### DIFF
--- a/lib/mongoid/relations/referenced/in.rb
+++ b/lib/mongoid/relations/referenced/in.rb
@@ -136,8 +136,11 @@ module Mongoid
           # @since 2.2.0
           def eager_load(metadata, ids)
             raise Errors::EagerLoad.new(metadata.name) if metadata.polymorphic?
-            klass, _ = metadata.klass, metadata.foreign_key
-            klass.any_in("_id" => ids.uniq).each do |doc|
+            criteria, _ = metadata.klass.scoped, metadata.foreign_key
+            [:only, :without].each do |option|
+              criteria = criteria.public_send(option, *metadata[option]) if metadata[option]
+            end
+            criteria.any_in("_id" => ids.uniq).each do |doc|
               IdentityMap.set(doc)
             end
           end

--- a/lib/mongoid/relations/referenced/many_to_many.rb
+++ b/lib/mongoid/relations/referenced/many_to_many.rb
@@ -307,7 +307,11 @@ module Mongoid
           #
           # @since 2.2.0
           def eager_load(metadata, ids)
-            metadata.klass.any_in(_id: ids).each do |doc|
+            criteria = metadata.klass.scoped
+            [:only, :without].each do |option|
+              criteria = criteria.public_send(option, *metadata[option]) if metadata[option]
+            end
+            criteria.any_in(_id: ids).each do |doc|
               IdentityMap.set(doc)
             end
           end


### PR DESCRIPTION
Now it's possible to specify which fiels we want to eager load.
The result is exactly like usual `includes`, except that, regardless
of the fields specified, foreign key of the current relation always
loads. This is needed for the identity map.

Some examples:

```
# Actually eager loads people with 'name' and 'company_id' fields
Company.includes(people: {only: :name})

# The same, but with 'name', 'age' and 'company_id'
Company.includes(people: {only: [:name, :company_id]})

# Ignores :company_id in 'without', loads all except 'info'
Company.includes(people: {without: [:family_info, :company_id]})

# Of course, multiple relations can be specified
Company.includes(people: {without: :family_info}, equipment: {only: [:type, :model]})
```

I would appreciate additions and corrections.
