### PR TITLE
`find` should support _ids of type hash, array etc. 

### DIFF
--- a/lib/mongoid/extensions/array.rb
+++ b/lib/mongoid/extensions/array.rb
@@ -74,7 +74,7 @@ module Mongoid
       #
       # @since 3.0.0
       def multi_arged?
-        first.resizable? || size > 1
+        !first.is_a?(Hash) && first.resizable? || size > 1
       end
 
       # Turn the object from the ruby type we deal with to a Mongo friendly

--- a/spec/mongoid/criteria_spec.rb
+++ b/spec/mongoid/criteria_spec.rb
@@ -1191,6 +1191,202 @@ describe Mongoid::Criteria do
       end
     end
 
+    context "when using hash ids" do
+
+      before(:all) do
+        Band.field :_id, type: Hash
+      end
+
+      after(:all) do
+        Band.field :_id, type: Moped::BSON::ObjectId, default: ->{ Moped::BSON::ObjectId.new }
+      end
+
+      let!(:band) do
+        Band.create do |band|
+          band.id = {"new-order" => true, "Depeche Mode" => false}
+        end
+      end
+
+      context "when providing a single id" do
+
+        context "when the id matches" do
+
+          let(:found) do
+            Band.find(band.id)
+          end
+
+          it "returns the matching document" do
+            found.should eq(band)
+          end
+        end
+
+        context "when the id does not match" do
+
+          context "when raising a not found error" do
+
+            before do
+              Mongoid.raise_not_found_error = true
+            end
+
+            let(:found) do
+              Band.find({"new-order" => false, "Faith no More" => true})
+            end
+
+            it "raises an error" do
+              expect {
+                found
+              }.to raise_error(Mongoid::Errors::DocumentNotFound)
+            end
+          end
+
+          context "when raising no error" do
+
+            before do
+              Mongoid.raise_not_found_error = false
+            end
+
+            after do
+              Mongoid.raise_not_found_error = true
+            end
+
+            let(:found) do
+              Band.find({"new-order" => false, "Faith no More" => true})
+            end
+
+            it "returns nil" do
+              found.should be_nil
+            end
+          end
+        end
+      end
+
+      context "when providing a splat of ids" do
+
+        let!(:band_two) do
+          Band.create do |band|
+            band.id = {"Radiohead" => false, "Nirvana"=> true}
+          end
+        end
+
+        context "when all ids match" do
+
+          let(:found) do
+            Band.find(band.id, band_two.id)
+          end
+
+          it "contains the first match" do
+            found.should include(band)
+          end
+
+          it "contains the second match" do
+            found.should include(band_two)
+          end
+        end
+
+        context "when any id does not match" do
+
+          context "when raising a not found error" do
+
+            before do
+              Mongoid.raise_not_found_error = true
+            end
+
+            let(:found) do
+              Band.find(band.id, {"Radiohead" => true, "Nirvana"=> false})
+            end
+
+            it "raises an error" do
+              expect {
+                found
+              }.to raise_error(Mongoid::Errors::DocumentNotFound)
+            end
+          end
+
+          context "when raising no error" do
+
+            before do
+              Mongoid.raise_not_found_error = false
+            end
+
+            after do
+              Mongoid.raise_not_found_error = true
+            end
+
+            let(:found) do
+              Band.find(band.id, {"Radiohead" => true, "Nirvana"=> false})
+            end
+
+            it "returns only the matching documents" do
+              found.should eq([ band ])
+            end
+          end
+        end
+      end
+
+      context "when providing an array of ids" do
+
+        let!(:band_two) do
+          Band.create do |band|
+            band.id = {"Radiohead" => false, "Nirvana"=> true}
+          end
+        end
+
+        context "when all ids match" do
+
+          let(:found) do
+            Band.find([ band.id, band_two.id ])
+          end
+
+          it "contains the first match" do
+            found.should include(band)
+          end
+
+          it "contains the second match" do
+            found.should include(band_two)
+          end
+        end
+
+        context "when any id does not match" do
+
+          context "when raising a not found error" do
+
+            before do
+              Mongoid.raise_not_found_error = true
+            end
+
+            let(:found) do
+              Band.find([ band.id, {"Radiohead" => true, "Nirvana"=> false} ])
+            end
+
+            it "raises an error" do
+              expect {
+                found
+              }.to raise_error(Mongoid::Errors::DocumentNotFound)
+            end
+          end
+
+          context "when raising no error" do
+
+            before do
+              Mongoid.raise_not_found_error = false
+            end
+
+            after do
+              Mongoid.raise_not_found_error = true
+            end
+
+            let(:found) do
+              Band.find([ band.id, {"Radiohead" => true, "Nirvana"=> false} ])
+            end
+
+            it "returns only the matching documents" do
+              found.should eq([ band ])
+            end
+          end
+        end
+      end
+    end
+
     context "when using integer ids" do
 
       before(:all) do

--- a/spec/mongoid/extensions/array_spec.rb
+++ b/spec/mongoid/extensions/array_spec.rb
@@ -576,6 +576,28 @@ describe Mongoid::Extensions::Array do
         end
       end
 
+      context "when the element is resizable Hash instance" do
+
+        let(:array) do
+          [{'key' => 'value'}]
+        end
+
+        it "returns false" do
+          array.should_not be_multi_arged
+        end
+      end
+
+      context "when the element is array of resizable Hash instances" do
+
+        let(:array) do
+          [[{'key1' => 'value2'},{'key1' => 'value2'}]]
+        end
+
+        it "returns true" do
+          array.should be_multi_arged
+        end
+      end
+
       context "when the element is an array" do
 
         let(:array) do


### PR DESCRIPTION
The problem seems to be in Mongoid Array class extension - method "multi_arged?".
Although Hash instance is "resizable", we should treat it as a single "_id" when passed to "find" method, assuming that "_id" field is type of Hash.

Issue: [#2535]

Also author of the issue should bear in mind that Mongoid supports Hash key stored as String, not as Symbol instance [#2390] 
