### PR TITLE
Preventing a NoMethodError when calling #as_document on an embedded relation that is nil.

### DIFF
--- a/lib/mongoid/document.rb
+++ b/lib/mongoid/document.rb
@@ -196,7 +196,7 @@ module Mongoid
       embedded_relations.each_pair do |name, meta|
         without_autobuild do
           relation, stored = send(name), meta.store_as
-          if attributes.has_key?(stored) || !relation.blank?
+          if (attributes.has_key?(stored) && !relation.nil?) || !relation.blank?
             attributes[stored] = relation.as_document
           end
         end

--- a/spec/mongoid/document_spec.rb
+++ b/spec/mongoid/document_spec.rb
@@ -672,6 +672,23 @@ describe Mongoid::Document do
         person.as_document["addresses"].should be_empty
       end
     end
+
+    context "when an embedded relation has been set to nil" do
+
+      before do
+        # Save the doc, then set an embeds_one relation to nil
+        person.save
+        person.name = nil
+        person.save
+
+        # Reload the document so the underlying document updates
+        person.reload
+      end
+
+      it "does not include the document in the hash" do
+        person.as_document.should_not have_key("name")
+      end
+    end
   end
 
   describe "#to_key" do


### PR DESCRIPTION
If you have an `embeds_one` relationship that at some point gets set to nil, calling #as_document on the model will cause a NoMethodError. I ran into this where my destroy callback ended up calling #as_document and I got this error:

``` ruby
p = Person.new(title: "Sir")
p.build_name(first_name: "James")
p.save
p.name = nil
p.save
p.reload

# This line will throw a NoMethodError
p.as_document
```

This patch fixes it and adds a spec.

Also, in doing this, I realized that the "as_document" doesn't update until the document is re-pulled from Mongo. That is, in my above example if you don't call `p.reload`, then `p.as_document` will return `{ "name" : {"first_name" : "James" } }` even if the document is saved. @durran, is this expected behavior? Seems like a bug but wanted to ask you first.
