### PR TITLE
Remove default :blank error message

### DIFF
--- a/lib/config/locales/en.yml
+++ b/lib/config/locales/en.yml
@@ -29,8 +29,6 @@ en:
         \_\_out:      %{out}>\n"
     errors:
       messages:
-        blank:
-          "can't be blank"
         blank_in_locale:
           "can't be blank in %{location}"
         ambiguous_relationship:


### PR DESCRIPTION
Mongoid sets a default `:blank` error message in it's locale file. This is confusing when trying to override error messages within your own app as every overriden message will work except `:blank`

I added an error message to `config/locales/en.yml`

```
en:
  errors:
    messages:
      blank: 'please complete'
```

This works for other all the other validation messages apart from `:blank` as Mongoid supplies it's own default.

I think Mongoid should use the ActiveModel default. This will save confusion for others when overriding error messages.

What do you think?
