### PR TITLE
Prevent end of month time from rounding up when mongoized

### DIFF
--- a/lib/mongoid/extensions/time.rb
+++ b/lib/mongoid/extensions/time.rb
@@ -64,7 +64,9 @@ module Mongoid
         def mongoize(object)
           return nil if object.blank?
           begin
-            ::Time.at(object.__mongoize_time__.to_f).utc
+            t = object.__mongoize_time__
+            usec = t.strftime("%9N").to_i / 10**3.0
+            ::Time.at(t.to_i, usec).utc
           rescue ArgumentError
             raise Errors::InvalidTime.new(object)
           end


### PR DESCRIPTION
This pull request is in reference to issue #2574, and fixes the problem where a Time/DateTime set to  `#end_of_month` is rounded up to the next month when being mongoized.
