### PR TITLE
Perform reloads with strong consistency

### DIFF
--- a/lib/mongoid/reloading.rb
+++ b/lib/mongoid/reloading.rb
@@ -54,7 +54,7 @@ module Mongoid
     #
     # @since 2.3.2
     def reload_root_document
-      {}.merge(collection.find(_id: id).one || {})
+      {}.merge(with(consistency: :strong).collection.find(_id: id).one || {})
     end
 
     # Reload the embedded document.
@@ -67,7 +67,7 @@ module Mongoid
     # @since 2.3.2
     def reload_embedded_document
       extract_embedded_attributes({}.merge(
-        _root.collection.find(_id: _root.id).one
+        _root.with(consistency: :strong).collection.find(_id: _root.id).one
       ))
     end
 


### PR DESCRIPTION
In our production setup we noticed that calling reload after saving changes to a document would often result in the document as it was prior to the changes, because the document would be loaded from one of the secondary nodes. This pull request changes the reload method to always execute with strong consistency to ensure a reload always pulls in the latest version.

I'm not sure how I could modify the tests to verify that strong consistency is used when reloading, the existing specs do still pass of course.
