### PR TITLE
Add required ruby version to gemspec

### DIFF
--- a/mongoid.gemspec
+++ b/mongoid.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |s|
   s.summary     = "Elegant Persistance in Ruby for MongoDB."
   s.description = "Mongoid is an ODM (Object Document Mapper) Framework for MongoDB, written in Ruby."
 
+  s.required_ruby_version     = ">= 1.9"
   s.required_rubygems_version = ">= 1.3.6"
   s.rubyforge_project         = "mongoid"
 


### PR DESCRIPTION
Just deployed on a Ruby 1.8.7 server and got an error on application start due to 1.9 style hash syntax. Looks like only Ruby 1.9.3 or higher is supported as of 3.0.0, but there is no restriction in the gemspec to enforce that.

Note that the requirement is set to " >= 1.9" to allow JRuby in 1.9 mode (which reports its version as "1.9") to work as well.
