### PR TITLE
Make attributes class same as attrs in MultiParameterAttributes process_attributes

### DIFF
--- a/lib/mongoid/multi_parameter_attributes.rb
+++ b/lib/mongoid/multi_parameter_attributes.rb
@@ -51,7 +51,7 @@ module Mongoid
     def process_attributes(attrs = nil, role = :default, guard_protected_attributes = true)
       if attrs
         errors = []
-        attributes = {}
+        attributes = attrs.class.new
         multi_parameter_attributes = {}
 
         attrs.each_pair do |key, value|
@@ -79,7 +79,7 @@ module Mongoid
           raise Errors::MultiparameterAssignmentErrors.new(errors),
             "#{errors.size} error(s) on assignment of multiparameter attributes"
         end
-
+        
         super attributes, role, guard_protected_attributes
       else
         super


### PR DESCRIPTION
I wrote a fix for the problem I was having in this issue: 
https://github.com/mongoid/mongoid/issues/2599
Now when calling super, the parameter `attributes` will be the same class as the parameter `attrs` in order to works with the `strong_parameters` gem.
