### PR TITLE
Inherit attrs permit status

### DIFF
--- a/lib/mongoid/multi_parameter_attributes.rb
+++ b/lib/mongoid/multi_parameter_attributes.rb
@@ -52,6 +52,7 @@ module Mongoid
       if attrs
         errors = []
         attributes = attrs.class.new
+        attributes.permitted = true if attrs.respond_to?(:permitted?) && attrs.permitted?
         multi_parameter_attributes = {}
 
         attrs.each_pair do |key, value|


### PR DESCRIPTION
Hi, I've realized that with my previous commit [#30b410a](https://github.com/mongoid/mongoid/pull/2600) I didn't care about if the `attrs` parameter was permitted or not, so `attributes` would never be permitted, resulting always in `ActiveModel::ForbiddenAttributes` exception when using MultiParameter Attributes. This solves the issue and makes multiparameter attributes work with strong parameters.
