### PR TITLE
Hand through batch_size option.

### DIFF
--- a/lib/mongoid/contextual/mongo.rb
+++ b/lib/mongoid/contextual/mongo.rb
@@ -383,7 +383,7 @@ module Mongoid
       # @since 3.1.0
       def apply_options
         apply_fields
-        [ :hint, :limit, :skip, :sort ].each do |name|
+        [ :hint, :limit, :skip, :sort, :batch_size ].each do |name|
           apply_option(name)
         end
       end


### PR DESCRIPTION
We created branches in Moped and Mongoid that make the cursor respect the batch size, but we're not sure how to best test that, as to the client the usage of a batch size should be transparent.

Maybe someone has a good idea how to best test this?

The pull request for moped is here:
https://github.com/mongoid/moped/pull/123
