### PR TITLE
Don't execute update command when concatenating empty array

### DIFF
--- a/lib/mongoid/relations/embedded/many.rb
+++ b/lib/mongoid/relations/embedded/many.rb
@@ -59,7 +59,7 @@ module Mongoid
         #
         # @since 2.4.0
         def concat(docs)
-          batch_insert(docs)
+          batch_insert(docs) unless docs.empty?
           self
         end
 

--- a/spec/mongoid/relations/embedded/many_spec.rb
+++ b/spec/mongoid/relations/embedded/many_spec.rb
@@ -1231,6 +1231,22 @@ describe Mongoid::Relations::Embedded::Many do
       end
     end
 
+    context "when concatenating an empty array" do
+
+      let(:person) do
+        Person.create
+      end
+
+      before do
+        person.addresses.should_not_receive(:batch_insert)
+        person.addresses.concat([])
+      end
+
+      it "doesn't update the target" do
+        person.addresses.should be_empty
+      end
+    end
+
     context "when appending more than one document at once" do
 
       let(:person) do


### PR DESCRIPTION
Current implementation of `Mongoid::Relations::Embedded::Many#concat` will always run `#batch_insert`, even if the supplied `docs` array is empty. This could have a small performance impact on code relying on `#concat` but can also lead to an issue in `Batchable#path` where `#atomic_path` will be sent to `nil`.

This also brings the approach of `#concat` closer to the implementation of `#<<` where an empty list of arguments will leave the target untouched.
