### PR TITLE
adding logger get/set to Config module

### DIFF
--- a/lib/mongoid.rb
+++ b/lib/mongoid.rb
@@ -159,6 +159,6 @@ module Mongoid
   #
   # @since 1.0.0
   delegate(*(Config.public_instance_methods(false) +
-    ActiveModel::Observing::ClassMethods.public_instance_methods(false) <<
+    ActiveModel::Observing::ClassMethods.public_instance_methods(false) - [:logger=, :logger] <<
     { to: Config }))
 end

--- a/lib/mongoid/config.rb
+++ b/lib/mongoid/config.rb
@@ -13,6 +13,9 @@ module Mongoid
     extend Options
     include ActiveModel::Observing
 
+    delegate :logger=, to: ::Mongoid
+    delegate :logger, to: ::Mongoid
+    
     LOCK = Mutex.new
 
     option :allow_dynamic_fields, default: true


### PR DESCRIPTION
``` ruby
config.mongoid.logger = Logger.new($stdout, :warn)
```

used to work on mongoid 2: https://github.com/mongoid/mongoid/blob/2.5.0-stable/lib/mongoid/config.rb#L146

and mongoid 3, following the docs should support the custom logger:
http://mongoid.org/en/mongoid/docs/rails.html#railties
