### PR TITLE
[ #2645 ] - adding cache for count method 

### DIFF
--- a/lib/mongoid/contextual/mongo.rb
+++ b/lib/mongoid/contextual/mongo.rb
@@ -50,7 +50,9 @@ module Mongoid
       # @since 3.0.0
       def count(document = nil, &block)
         return super(&block) if block_given?
-        return query.count unless document
+        return (@count || query.count).tap do |count|
+          @count ||= count if cached?
+        end unless document
         collection.find(criteria.and(_id: document.id).selector).count
       end
 
@@ -63,7 +65,7 @@ module Mongoid
       #
       # @since 3.0.0
       def delete
-        query.count.tap do
+        self.count.tap do
           query.remove_all
         end
       end
@@ -78,7 +80,7 @@ module Mongoid
       #
       # @since 3.0.0
       def destroy
-        destroyed = query.count
+        destroyed = self.count
         each do |doc|
           doc.destroy
         end
@@ -226,7 +228,7 @@ module Mongoid
       #
       # @since 3.0.0
       def length
-        @length ||= query.count
+        @length ||= self.count
       end
       alias :size :length
 

--- a/spec/mongoid/contextual/mongo_spec.rb
+++ b/spec/mongoid/contextual/mongo_spec.rb
@@ -100,6 +100,21 @@ describe Mongoid::Contextual::Mongo do
       end
     end
 
+    context "when context is cached" do
+
+      let(:context) do
+        described_class.new(criteria.cache)
+      end
+
+      before do
+        context.query.should_receive(:count).once.and_return(1)
+      end
+
+      it "returns the count cached value after first call" do
+        2.times { context.count.should eq(1) }
+      end
+    end
+
     context "when provided a document" do
 
       let(:context) do


### PR DESCRIPTION
I also changed the local methods on mongo.rb to use the local count method so it will take advantage of the cache. 
