### PR TITLE
counter cache

### DIFF
--- a/lib/mongoid/relations.rb
+++ b/lib/mongoid/relations.rb
@@ -4,6 +4,7 @@ require "mongoid/relations/auto_save"
 require "mongoid/relations/cascading"
 require "mongoid/relations/constraint"
 require "mongoid/relations/conversions"
+require "mongoid/relations/counter_cache"
 require "mongoid/relations/cyclic"
 require "mongoid/relations/proxy"
 require "mongoid/relations/bindings"
@@ -43,6 +44,7 @@ module Mongoid
     include Reflections
     include Synchronization
     include Touchable
+    include CounterCache
 
     attr_accessor :metadata
 

--- a/lib/mongoid/relations/counter_cache.rb
+++ b/lib/mongoid/relations/counter_cache.rb
@@ -1,0 +1,86 @@
+# encoding: utf-8
+module Mongoid
+  module Relations
+    module CounterCache
+      extend ActiveSupport::Concern
+
+      module ClassMethods
+
+        # Reset the given counter using the .count() query from the
+        # db. This method is usuful in case that a counter got
+        # corrupted, or a new counter was added to the collection.
+        #
+        # @example Reset the given counter cache
+        #   Post.reset_counters('50e0edd97c71c17ea9000001', :comments)
+        #
+        # @param [ String ] The id of the object that will be reset.
+        # @param [ Symbol, Array ] One or more counter caches to reset
+        #
+        # @since 3.1.0
+        def reset_counters(id, *counters)
+          object = find(id)
+          counters.each do |name|
+            reflection_meta = reflect_on_association(name)
+            meta = reflection_meta.klass.reflect_on_association(reflection_meta.inverse)
+            counter_name = meta.counter_cache_column_name
+            object.update_attribute(counter_name, object.send(name).count)
+          end
+        end
+
+        # Update the given counters by the value factor. It uses the
+        # atomic $inc command.
+        #
+        # @example Add 5 to comments counter and remove 2 from likes
+        # counter
+        #
+        #   Post.update_counters('50e0edd97c71c17ea9000001',
+        #              :comments_count => 5, :likes_count => -2)
+        #
+        # @param [ String ] The id of the object to update.
+        # @param [ Hash ] Key = counter_cahe and Value = factor.
+        #
+        # @since 3.1.0
+        def update_counters(id, counters)
+          counters.map do |key, value|
+            where(:_id => id).inc(key, value)
+          end
+        end
+
+        # Increment the counter name from the entries that match the
+        # id by one. This method is used on associations callbacks
+        # when counter_cache is enable
+        #
+        # @example Increment comments counter
+        #
+        #   Post.increment_counter(:comments_count, '50e0edd97c71c17ea9000001')
+        #
+        # @param [ Symbol ] Counter cache name
+        # @param [ String ] The id of the object that will be reset.
+        #
+        # @since 3.1.0
+        def increment_counter(counter_name, id)
+          update_counters(id, counter_name.to_sym => 1)
+        end
+
+
+        # Decrement the counter name from the entries that match the
+        # id by one. This method is used on associations callbacks
+        # when counter_cache is enable
+        #
+        # @example Decrement comments counter
+        #
+        #   Post.decrement_counter(:comments_count, '50e0edd97c71c17ea9000001')
+        #
+        # @param [ Symbol ] Counter cache name
+        # @param [ String ] The id of the object that will be reset.
+        #
+        # @since 3.1.0
+        def decrement_counter(counter_name, id)
+          update_counters(id, counter_name.to_sym => -1)
+        end
+
+      end
+
+    end
+  end
+end

--- a/lib/mongoid/relations/macros.rb
+++ b/lib/mongoid/relations/macros.rb
@@ -58,6 +58,7 @@ module Mongoid
           self.embedded = true
           relate(name, meta)
           builder(name, meta).creator(name, meta)
+          add_counter_cache_callbacks(meta) if meta.counter_cached?
           meta
         end
 
@@ -140,7 +141,32 @@ module Mongoid
           meta = reference_one_to_one(name, options, Referenced::In, &block)
           aliased_fields[name.to_s] = meta.foreign_key
           touchable(meta)
+          add_counter_cache_callbacks(meta) if meta.counter_cached?
           meta
+        end
+
+        # Add the callbacks responsible for update the counter cache field
+        #
+        # @example Add the touchable.
+        #   Person.add_counter_callbacks(meta)
+        #
+        # @param [ Metadata ] metadata The metadata for the relation.
+        #
+        # @since 3.1.0
+        def add_counter_cache_callbacks(meta)
+          name = meta.name
+          cache_column = meta.counter_cache_column_name.to_sym
+
+          after_create do
+            record = __send__(name)
+            record.class.increment_counter(cache_column, record.id) if record.try(:persisted?)
+          end
+
+          before_destroy do
+            record = __send__(name)
+            record.class.decrement_counter(cache_column, record.id) if record.try(:persisted?)
+          end
+
         end
 
         # Adds a relational association from a parent Document to many

--- a/lib/mongoid/relations/metadata.rb
+++ b/lib/mongoid/relations/metadata.rb
@@ -138,6 +138,31 @@ module Mongoid
         @constraint ||= Constraint.new(self)
       end
 
+      # Does the metadata have a counter cache?
+      #
+      # @example Is the metadata counter_cached?
+      #   metadata.counter_cached?
+      #
+      # @return [ true, false ] If the metadata has counter_cache
+      #
+      # @since 3.1.0
+      def counter_cached?
+        !!self[:counter_cache]
+      end
+
+      # Returns the counter cache column name
+      #
+      # @example Get the counter cache column.
+      #   metadata.counter_cache_column_name
+      #
+      # @return [ String ] The counter cache column
+      #
+      # @since 3.1.0
+      def counter_cache_column_name
+        return "#{inverse_class_name.demodulize.underscore.pluralize}_count" if self[:counter_cache] == true
+        self[:counter_cache].to_s
+      end
+
       # Get the criteria that is used to query for this metadata's relation.
       #
       # @example Get the criteria.
@@ -361,6 +386,7 @@ module Mongoid
   autobuild:    #{autobuilding?}
   class_name:   #{class_name}
   cyclic:       #{cyclic.inspect}
+  counter_cache:#{counter_cached?}
   dependent:    #{dependent.inspect}
   inverse_of:   #{inverse_of.inspect}
   key:          #{key}

--- a/lib/mongoid/relations/options.rb
+++ b/lib/mongoid/relations/options.rb
@@ -10,6 +10,7 @@ module Mongoid
       # These options are available to all relations.
       COMMON = [
         :class_name,
+        :counter_cache,
         :extend,
         :inverse_class_name,
         :inverse_of,

--- a/spec/app/models/drug.rb
+++ b/spec/app/models/drug.rb
@@ -2,7 +2,7 @@ class Drug
   include Mongoid::Document
   field :name, type: String
   field :generic, type: Boolean
-  belongs_to :person
+  belongs_to :person, counter_cache: true
   attr_accessible :name, as: [ :default, :admin ]
   attr_accessible :person_id
 end

--- a/spec/app/models/post.rb
+++ b/spec/app/models/post.rb
@@ -8,7 +8,7 @@ class Post
 
   attr_accessor :before_add_called, :after_add_called, :before_remove_called, :after_remove_called
 
-  belongs_to :person
+  belongs_to :person, counter_cache: true
   belongs_to :author, foreign_key: :author_id, class_name: "User"
   has_and_belongs_to_many :tags, before_add: :before_add_tag, after_add: :after_add_tag, before_remove: :before_remove_tag, after_remove: :after_remove_tag
   has_many :videos, validate: false

--- a/spec/mongoid/relations/counter_cache_spec.rb
+++ b/spec/mongoid/relations/counter_cache_spec.rb
@@ -1,0 +1,186 @@
+require "spec_helper"
+
+describe Mongoid::Relations::CounterCache do
+
+  describe '#reset_counters' do
+
+    context 'when counter is reset' do
+
+      let(:person) do
+        Person.create do |person|
+          person[:drugs_count] = 3
+        end
+      end
+
+      before do
+        Person.reset_counters person.id, :drugs
+      end
+
+      it 'returns zero' do
+        person.reload.drugs_count.should eq(0)
+      end
+    end
+
+    context 'when counter is reset with wrong id' do
+
+      it 'expect to raise an error' do
+        expect {
+          Person.reset_counters '1', :drugs
+        }.to raise_error
+      end
+    end
+
+    context 'when reset with invalid name' do
+
+      let(:person) do
+        Person.create
+      end
+
+      it 'expect to raise an error' do
+        expect {
+          Person.reset_counters person.id, :not_exist
+        }.to raise_error
+      end
+    end
+
+    context 'when counter gets messy' do
+
+      let(:person) do
+        Person.create
+      end
+
+      let!(:post) do
+        person.posts.create(title: "my first post")
+      end
+
+      before do
+        Person.update_counters(person.id, :posts_count => 10)
+        Person.reset_counters(person.id, :posts)
+      end
+
+      it 'resets to the right value' do
+        person.reload.posts_count.should eq(1)
+      end
+    end
+  end
+
+  describe '#update_counters' do
+
+    context 'when was 3 ' do
+
+      let(:person) do
+        Person.create do |person|
+          person[:drugs_count] = 3
+        end
+      end
+
+      context 'and update counter with 5' do
+
+        before do
+          Person.update_counters person.id, :drugs_count => 5
+        end
+
+        it 'return 8' do
+          person.reload.drugs_count.should eq(8)
+        end
+      end
+
+      context 'and update counter with -5' do
+
+        before do
+          Person.update_counters person.id, :drugs_count => -5
+        end
+
+        it 'return -2' do
+          person.reload.drugs_count.should eq(-2)
+        end
+      end
+    end
+    context 'when update with 2 and use a string argument' do
+
+      let(:person) { Person.create }
+
+      before do
+        Person.update_counters person.id, 'drugs_count' => 2
+      end
+
+      it 'returns 2' do
+        person.reload.drugs_count.should eq(2)
+      end
+    end
+
+    context 'when update more multiple counters' do
+
+      let(:person) { Person.create }
+
+      before do
+        Person.update_counters(person.id, :drugs_count => 2, :second_counter => 5)
+      end
+
+      it 'updates drugs_counter' do
+        person.reload.drugs_count.should eq(2)
+      end
+
+      it 'updates second_counter' do
+        person.reload.second_counter.should eq(5)
+      end
+    end
+  end
+
+  describe '#increment_counter' do
+
+    let(:person) { Person.create }
+
+    context 'when increment 3 times' do
+
+      before do
+        3.times { Person.increment_counter(:drugs_count, person.id) }
+      end
+
+      it 'returns 3' do
+        person.reload.drugs_count.should eq(3)
+      end
+    end
+
+    context 'when increment 3 times using string as argument' do
+
+      before do
+        3.times { Person.increment_counter('drugs_count', person.id) }
+      end
+
+      it 'returns 3' do
+        person.reload.drugs_count.should eq(3)
+      end
+    end
+  end
+
+  describe '#decrement_counter' do
+
+    let(:person) do
+      Person.create do |p|
+        p[:drugs_count] = 3
+      end
+    end
+
+    context 'when decrement 3 times' do
+
+      before do
+        3.times { Person.decrement_counter(:drugs_count, person.id) }
+      end
+
+      it 'returns 0' do
+        person.reload.drugs_count.should eq(0)
+      end
+    end
+    context 'when increment 3 times using string as argument' do
+
+      before do
+        3.times { Person.decrement_counter('drugs_count', person.id) }
+      end
+
+      it 'returns 0' do
+        person.reload.drugs_count.should eq(0)
+      end
+    end
+  end
+end

--- a/spec/mongoid/relations/metadata_spec.rb
+++ b/spec/mongoid/relations/metadata_spec.rb
@@ -2,6 +2,104 @@ require "spec_helper"
 
 describe Mongoid::Relations::Metadata do
 
+  describe "#counter_cached?" do
+
+    context "when counter_cache is false" do
+
+      let(:metadata) do
+        described_class.new(
+          name: :car,
+          relation: Mongoid::Relations::Referenced::In,
+          counter_cache: false
+        )
+      end
+
+      it "returns false" do
+        metadata.should_not be_counter_cached
+      end
+    end
+
+    context "when counter_cache is true" do
+
+      let(:metadata) do
+        described_class.new(
+          name: :car,
+          relation: Mongoid::Relations::Referenced::In,
+          counter_cache: true
+        )
+      end
+
+      it "returns true" do
+        metadata.should be_counter_cached
+      end
+    end
+
+    context "when counter_cache is name for column" do
+
+      let(:metadata) do
+        described_class.new(
+          name: :car,
+          relation: Mongoid::Relations::Referenced::In,
+          counter_cache: 'counter'
+        )
+      end
+
+      it "returns true" do
+        metadata.should be_counter_cached
+      end
+    end
+
+    context "when counter_cache is nil" do
+
+      let(:metadata) do
+        described_class.new(
+          name: :car,
+          relation: Mongoid::Relations::Referenced::In,
+        )
+      end
+
+      it "returns false" do
+        metadata.should_not be_counter_cached
+      end
+    end
+  end
+
+  describe "#counter_cache_column_name" do
+    let(:inverse_class_name) { "Wheel" }
+
+    context "when the counter_cache is true" do
+
+      let(:metadata) do
+        described_class.new(
+          name: :car,
+          relation: Mongoid::Relations::Referenced::In,
+          inverse_class_name: inverse_class_name,
+          counter_cache: true
+        )
+      end
+
+      it "returns inveser_class_name + _count" do
+        metadata.counter_cache_column_name.should eq("#{inverse_class_name.demodulize.underscore.pluralize}_count")
+      end
+    end
+
+    context "when given a custom name for counter cache" do
+      let(:counter_cache_name) { 'counte_cache_for_wheels' }
+      let(:metadata) do
+        described_class.new(
+          name: :car,
+          relation: Mongoid::Relations::Referenced::In,
+          inverse_class_name: inverse_class_name,
+          counter_cache: counter_cache_name
+        )
+      end
+
+      it "returns the name given" do
+        metadata.counter_cache_column_name.should eq(counter_cache_name)
+      end
+    end
+  end
+
   describe "#autobuilding?" do
 
     context "when the option is true" do

--- a/spec/mongoid/relations/referenced/many_spec.rb
+++ b/spec/mongoid/relations/referenced/many_spec.rb
@@ -164,6 +164,10 @@ describe Mongoid::Relations::Referenced::Many do
             person.posts.count.should eq(1)
           end
 
+          it "increments the counter cache" do
+            person.reload.posts_count.should eq(1)
+          end
+
           context "when documents already exist on the relation" do
 
             let(:post_two) do
@@ -192,6 +196,10 @@ describe Mongoid::Relations::Referenced::Many do
 
             it "adds the document to the target" do
               person.posts.count.should eq(2)
+            end
+
+            it "increments the counter cache" do
+              person.reload.posts_count.should eq(2)
             end
 
             it "contains the initial document in the target" do
@@ -1912,6 +1920,7 @@ describe Mongoid::Relations::Referenced::Many do
           it "removes the correct posts" do
             person.posts.send(method, conditions: { title: "Testing" })
             person.posts.count.should eq(1)
+            person.reload.posts_count.should eq(1) if method == :destroy_all
           end
 
           it "deletes the documents from the database" do


### PR DESCRIPTION
as request on #2215 this is the counter cache implementation for mongoid.

It should work simliar as the Rails activerecord counter cache, which increment the number of children when A new children is created and has a foreign_key to its parent.

Example:

``` ruby
  class Person
    include Mongoid::Document
    has_many :pets
  end

  class Pet
    include Mongoid::Document
    belongs_to :person, counter_cache: true
  end
```

```
person.pets.create! #should increment person.pets_count

pet = Pet.new
pet.person = person
pet.save #should incremente person.pets_count


pet.destroy # should decrement person.pets_count

pet.delete # should NOT decrement person.pets_count
```

Also added some useful methods like `Person.reset_counters(person.id, :pets)` and `Person.update_counters(person.id, pets_count: 5)`
