### PR TITLE
Allow matches? to work with symbol keys in the selector.

### DIFF
--- a/lib/mongoid/matchers/strategies.rb
+++ b/lib/mongoid/matchers/strategies.rb
@@ -21,7 +21,7 @@ module Mongoid
     module Strategies
       extend self
 
-      MATCHERS = {
+      MATCHERS = HashWithIndifferentAccess.new({
         "$all" => Matchers::All,
         "$and" => Matchers::And,
         "$exists" => Matchers::Exists,
@@ -34,7 +34,7 @@ module Mongoid
         "$nin" => Matchers::Nin,
         "$or" => Matchers::Or,
         "$size" => Matchers::Size
-      }
+      })
 
       # Get the matcher for the supplied key and value. Will determine the class
       # name from the key.
@@ -59,8 +59,8 @@ module Mongoid
           end
         else
           case key
-            when "$or" then Matchers::Or.new(value, document)
-            when "$and" then Matchers::And.new(value, document)
+            when "$or", :$or then Matchers::Or.new(value, document)
+            when "$and", :$and then Matchers::And.new(value, document)
             else Default.new(extract_attribute(document, key))
           end
         end

--- a/spec/mongoid/matchers_spec.rb
+++ b/spec/mongoid/matchers_spec.rb
@@ -228,6 +228,31 @@ describe Mongoid::Matchers do
         end
       end
 
+      context "with a $gt selector as a symbol" do
+
+        context "when the attributes match" do
+
+          let(:selector) do
+            { number: { :$gt => 50 } }
+          end
+
+          it "returns true" do
+            document.matches?(selector).should be_true
+          end
+        end
+
+        context "when the attributes do not match" do
+
+          let(:selector) do
+            { number: { :$gt => 200 } }
+          end
+
+          it "returns false" do
+            document.matches?(selector).should be_false
+          end
+        end
+      end
+
       context "with a $gte selector" do
 
         context "when the attributes match" do


### PR DESCRIPTION
`#matches?` was failing me due to having symbol keys in the selector. That is:

``` ruby
class Book
  include Mongoid::Document
  field :pages, :type => Integer
end

b = Book.create(:pages => 10)
b.matches?(:pages => {:$gt => 5})
# => false
```

If I change `:$gt` to `"$gt"` it works fine.

This pull request allows you to specify :$gt or "$gt" as your selector key.

I added somewhat of a narrow spec for this by only testing one operation: I wasn't sure if you want to test every single operation ($in, $gte, $nin, $in, $all, etc.) for this change because it might clutter up the tests for the same fix, but let me know and I can add additional ones.
