### PR TITLE
fixes alias for atomic operations in the context [ #2673 ]

### DIFF
--- a/lib/mongoid/contextual/atomic.rb
+++ b/lib/mongoid/contextual/atomic.rb
@@ -15,7 +15,7 @@ module Mongoid
       #
       # @since 3.0.0
       def add_to_set(field, value)
-        query.update_all("$addToSet" => { field => value })
+        query.update_all("$addToSet" => { database_field_name(field) => value })
       end
 
       # Perform an atomic $bit operation on the matching documents.
@@ -31,7 +31,7 @@ module Mongoid
       #
       # @since 3.0.0
       def bit(field, value)
-        query.update_all("$bit" => { field => value })
+        query.update_all("$bit" => { database_field_name(field) => value })
       end
 
       # Perform an atomic $inc operation on the matching documents.
@@ -46,7 +46,7 @@ module Mongoid
       #
       # @since 3.0.0
       def inc(field, value)
-        query.update_all("$inc" => { field => value })
+        query.update_all("$inc" => { database_field_name(field) => value })
       end
 
       # Perform an atomic $pop operation on the matching documents.
@@ -66,7 +66,7 @@ module Mongoid
       #
       # @since 3.0.0
       def pop(field, value)
-        query.update_all("$pop" => { field => value })
+        query.update_all("$pop" => { database_field_name(field) => value })
       end
 
       # Perform an atomic $pull operation on the matching documents.
@@ -83,7 +83,7 @@ module Mongoid
       #
       # @since 3.0.0
       def pull(field, value)
-        query.update_all("$pull" => { field => value })
+        query.update_all("$pull" => { database_field_name(field) => value })
       end
 
       # Perform an atomic $pullAll operation on the matching documents.
@@ -98,7 +98,7 @@ module Mongoid
       #
       # @since 3.0.0
       def pull_all(field, values)
-        query.update_all("$pullAll" => { field => values })
+        query.update_all("$pullAll" => { database_field_name(field) => values })
       end
 
       # Perform an atomic $push operation on the matching documents.
@@ -113,7 +113,7 @@ module Mongoid
       #
       # @since 3.0.0
       def push(field, value)
-        query.update_all("$push" => { field => value })
+        query.update_all("$push" => { database_field_name(field) => value })
       end
 
       # Perform an atomic $pushAll operation on the matching documents.
@@ -128,7 +128,7 @@ module Mongoid
       #
       # @since 3.0.0
       def push_all(field, values)
-        query.update_all("$pushAll" => { field => values })
+        query.update_all("$pushAll" => { database_field_name(field) => values })
       end
 
       # Perform an atomic $rename of fields on the matching documents.
@@ -143,7 +143,7 @@ module Mongoid
       #
       # @since 3.0.0
       def rename(old_name, new_name)
-        query.update_all("$rename" => { old_name.to_s => new_name.to_s })
+        query.update_all("$rename" => { database_field_name(old_name) => new_name.to_s })
       end
 
       # Perform an atomic $set of fields on the matching documents.
@@ -158,7 +158,7 @@ module Mongoid
       #
       # @since 3.0.0
       def set(field, value)
-        query.update_all("$set" => { field => value })
+        query.update_all("$set" => { database_field_name(field) => value })
       end
 
       # Perform an atomic $unset of a field on the matching documents.
@@ -172,7 +172,7 @@ module Mongoid
       #
       # @since 3.0.0
       def unset(field)
-        query.update_all("$unset" => { field => true })
+        query.update_all("$unset" => { database_field_name(field) => true })
       end
     end
   end

--- a/lib/mongoid/contextual/mongo.rb
+++ b/lib/mongoid/contextual/mongo.rb
@@ -204,6 +204,8 @@ module Mongoid
         apply_options
       end
 
+      delegate(:database_field_name, to: :@klass)
+
       # Get the last document in the database for the criteria's selector.
       #
       # @example Get the last document.

--- a/spec/app/models/band.rb
+++ b/spec/app/models/band.rb
@@ -5,7 +5,7 @@ class Band
   field :origin, type: String
   field :genres, type: Array
   field :member_count, type: Integer
-  field :members, type: Array
+  field :mems, as: :members, type: Array
   field :likes, type: Integer
   field :views, type: Integer
   field :rating, type: Float

--- a/spec/mongoid/contextual/atomic_spec.rb
+++ b/spec/mongoid/contextual/atomic_spec.rb
@@ -145,6 +145,10 @@ describe Mongoid::Contextual::Atomic do
       Band.create
     end
 
+    let!(:beatles) do
+      Band.create(years: 2)
+    end
+
     let(:criteria) do
       Band.all
     end
@@ -168,6 +172,19 @@ describe Mongoid::Contextual::Atomic do
 
       it "does not error on the inc" do
         smiths.likes.should be_nil
+      end
+    end
+
+    context "when using the alias" do
+
+      before do
+        context.inc(:years, 1)
+      end
+      it "incs the value and read from alias" do
+        beatles.reload.years.should eq(3)
+      end
+      it "incs the value and read from field" do
+        beatles.reload.y.should eq(3)
       end
     end
   end


### PR DESCRIPTION
Fixed contextual/atomic.rb to use database_field_name to resolve alias
