### PR TITLE
Model.create with multiple documents [#2688]

### DIFF
--- a/lib/mongoid/persistence.rb
+++ b/lib/mongoid/persistence.rb
@@ -233,9 +233,13 @@ module Mongoid
       # @return [ Document ] The newly created document.
       def create(attributes = {}, options = {}, &block)
         _creating do
-          doc = new(attributes, options, &block)
-          doc.save
-          doc
+          if attributes.is_a?(Array)
+            attributes.collect { |attr| create(attr, options, &block) }
+          else
+            doc = new(attributes, options, &block)
+            doc.save
+            doc
+          end
         end
       end
 

--- a/spec/mongoid/persistence_spec.rb
+++ b/spec/mongoid/persistence_spec.rb
@@ -152,6 +152,24 @@ describe Mongoid::Persistence do
         end
       end
     end
+
+    context "when providing an array" do
+
+      let(:people) { Person.create( [ { title: "Sensei" }, { title: "Ninja" } ] ) }
+
+      it "creates two people" do
+        expect { people }.to change(Person, :count).by(2)
+      end
+
+      it "returns an array" do
+        people.should be_a_kind_of Array
+      end
+
+      it "returns an array with Person objects" do
+        people.each { |p| p.should be_a_kind_of Person }
+      end
+
+    end
   end
 
   describe ".create!" do


### PR DESCRIPTION
Followed the same interface as ActiveRecord to implement the feature requested on #2688 
