### PR TITLE
dup/clone method has an unexpected behavior when an 'id' field is present in the document

### DIFF
--- a/lib/mongoid/copyable.rb
+++ b/lib/mongoid/copyable.rb
@@ -18,7 +18,7 @@ module Mongoid
     #
     # @return [ Document ] The new document.
     def clone
-      attrs = as_document.except("_id")
+      attrs = as_document.except("_id", "id")
       if attrs.delete("versions")
         attrs["version"] = 1
       end


### PR DESCRIPTION
I have a problem duplicating documents. Some of my mongodb documents are containing a field `id` different from the real identifier `_id`. 

`{"_id" : ObjectId("4f243f6910d344d6400001cf"), "score" : 1.2, "id" : 290421 }`

When I duplicate documents with both `_id` and `id` fields the duplicated record is saved with the value of the `id` in the `_id` field because of the aliasing resulting in: 

`{"_id" : 290421, "score" : 1.2 }`

I don't know if the solution in this pull request is general enough, but it seems to make sense with the created aliasing.

Sorry about the missing test but I didn't know how exactly create a test case for it.
