### PR TITLE
Aggregation on contextual objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ For instructions on upgrading to newer versions, visit
 
 ### New Features
 
+* Allow aggregation on contextual objects. (Gosha Arinich)
+
+        Band.where(name: "Depeche Mode").aggregate(
+          {"$group" => { "_id" => "$name", "likes" => { "$sum" => "$likes" }}}
+        )
+
 * Added `Document.first_or_create!` and `Criteria#first_or_create!`. This
   raises a validations error if creation fails validation.
 

--- a/lib/mongoid/contextual/aggregation.rb
+++ b/lib/mongoid/contextual/aggregation.rb
@@ -1,0 +1,82 @@
+# encoding: utf-8
+module Mongoid
+  module Contextual
+    class Aggregation
+      include Enumerable
+      include Command
+
+      delegate :[], to: :results
+      delegate :==, :empty?, :count, to: :entries
+
+      # Initialize the new aggregation directive.
+      #
+      # @example Initialize the aggregation.
+      #   Aggregation.new(collection, criteria, pipeline)
+      #
+      # @param [ Collection ] collection the Mongoid collection.
+      # @param [ Criteria ] criteria The Mongoid criteria.
+      # @param [ Array ] pipeline The Array of pipelines.
+      def initialize(collection, criteria, *pipeline)
+        @collection, @criteria = collection, criteria
+        command[:aggregate] = collection.name.to_s
+        command[:pipeline] = pipeline.flatten
+        apply_criteria_options
+      end
+
+      # Iterates over each of the documents in the aggregation, excluding the
+      # extra information that was passed back from the database.
+      #
+      # @example Iterate over the results.
+      #   aggregation.each do |doc|
+      #     p doc
+      #   end
+      #
+      # @return [ Enumerator ] The enumerator.
+      def each
+        if block_given?
+          documents.each do |doc|
+            yield doc
+          end
+        else
+          to_enum
+        end
+      end
+
+      private
+
+      # Apply criteria specific options - query.
+      #
+      # @api private
+      #
+      # @example Apply the criteria options
+      #   aggregation.apply_criteria_options
+      #
+      # @return [ nil ] Nothing.
+      def apply_criteria_options
+        command[:pipeline].unshift("$match" => criteria.selector)
+      end
+
+      # Get tje result documents from the aggregation.
+      #
+      # @api private
+      #
+      # @example Get the documents.
+      #   aggregation.documents
+      def documents
+        results["result"]
+      end
+
+      # Execute the aggregation command and get the results.
+      #
+      # @api private
+      #
+      # @example Get the results.
+      #   aggregation.results
+      #
+      # @return [ Hash ] The results of the command.
+      def results
+        @results ||= session.with(consistency: :strong).command(command)
+      end
+    end
+  end
+end

--- a/lib/mongoid/contextual/mongo.rb
+++ b/lib/mongoid/contextual/mongo.rb
@@ -5,6 +5,7 @@ require "mongoid/contextual/command"
 require "mongoid/contextual/eager"
 require "mongoid/contextual/find_and_modify"
 require "mongoid/contextual/map_reduce"
+require "mongoid/contextual/aggregation"
 
 module Mongoid
   module Contextual
@@ -256,6 +257,18 @@ module Mongoid
       # @since 3.0.0
       def map_reduce(map, reduce)
         MapReduce.new(collection, criteria, map, reduce)
+      end
+
+      # Initiate an aggregation operation from the context.
+      #
+      # @example Initiate an aggregation.
+      #   context.aggregate(pipeline)
+      #
+      # @param [ Array ] pipeline The Array of pipelines.
+      #
+      # @return [ Aggregation ] The aggregation lazy wrapper.
+      def aggregate(*pipeline)
+        Aggregation.new(collection, criteria, *pipeline)
       end
 
       # Pluck the single field values from the database. Will return duplicates

--- a/spec/mongoid/contextual/aggregation.rb
+++ b/spec/mongoid/contextual/aggregation.rb
@@ -1,0 +1,104 @@
+require "spec_helper"
+
+describe Mongoid::Contextual::Aggregation do
+
+  let(:pipeline) do
+    [
+      {"$project" => { "name" => 1, "likes" => 1 }},
+      {"$group" => { "_id" => "$name", "likes" => { "$sum" => "$likes" }}}
+    ]
+  end
+
+  let!(:depeche_mode) do
+    Band.create(name: "Depeche Mode", likes: 200)
+  end
+
+  let!(:tool) do
+    Band.create(name: "Tool", likes: 100)
+  end
+
+  let!(:collection) do
+    Band.collection
+  end
+
+  describe "#command" do
+
+    let(:criteria) do
+      Band.all
+    end
+
+    let(:aggregation) do
+      described_class.new(collection, criteria, pipeline)
+    end
+
+    let(:base_command) do
+      {
+        aggregate: "bands",
+        pipeline: pipeline.unshift({"$match" => {}})
+      }
+    end
+
+    it "returns the db command" do
+      aggregation.command.should eq(base_command)
+    end
+  end
+
+  describe "#each" do
+
+    let(:criteria) do
+      Band.all
+    end
+
+    let(:aggregation) do
+      described_class.new(collection, criteria, pipeline)
+    end
+
+    let(:results) do
+      aggregation
+    end
+
+    it "iterates over the results" do
+      results.entries.should eq([
+        { "_id" => "Tool", "likes" => 100 },
+        { "_id" => "Depeche Mode", "likes" => 200 }
+      ])
+    end
+  end
+
+  describe "#empty?" do
+
+    let(:aggregation) do
+      described_class.new(collection, criteria, pipeline)
+    end
+
+    context "when the aggregation has results" do
+
+      let(:criteria) do
+        Band.all
+      end
+
+      let(:results) do
+        aggregation
+      end
+
+      it "returns false" do
+        results.should_not be_empty
+      end
+    end
+
+    context "when the aggregation has no results" do
+
+      let(:criteria) do
+        Band.where(name: "Pet Shop Boys")
+      end
+
+      let(:results) do
+        aggregation
+      end
+
+      it "returns true" do
+        results.should be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
Currently, aggregation is only available on the collection, and query has to be added manually:

``` ruby
selector = Band.where(name: "Depeche Mode").query.selector
Band.collection.aggregate([{"$match"=> selector}, ...])
```

With this PR, `#aggregation` will be available on queries and will take selector into account:

``` ruby
Band.where(name: "Depeche Mode").aggregate({"$sort" => { "likes" => -1}})
```

(Having to write aggregate pipeline manually isn't that awesome though, I might try to implement a nicer DSL for that later.)
