### PR TITLE
Ensure that .sort method change criteria

### DIFF
--- a/spec/mongoid/contextual/mongo_spec.rb
+++ b/spec/mongoid/contextual/mongo_spec.rb
@@ -679,6 +679,58 @@ describe Mongoid::Contextual::Mongo do
         end
       end
 
+      context "when using .desc" do
+
+        let(:criteria) do
+          Band.desc(:name)
+        end
+
+        let(:context) do
+          described_class.new(criteria)
+        end
+
+        context "when there is sort on the context" do
+
+          it "follows the main sort" do
+            context.send(method).should eq(new_order)
+          end
+        end
+
+        context "when subsequently calling #last" do
+
+          it "returns the correnct document" do
+            context.send(method).should eq(new_order)
+            context.last.should eq(depeche_mode)
+          end
+        end
+      end
+
+      context "when using .sort" do
+
+        let(:criteria) do
+          Band.all.sort(:name => -1).criteria
+        end
+
+        let(:context) do
+          described_class.new(criteria)
+        end
+
+        context "when there is sort on the context" do
+
+          it "follows the main sort" do
+            context.send(method).should eq(new_order)
+          end
+        end
+
+        context "when subsequently calling #last" do
+
+          it "returns the correnct document" do
+            context.send(method).should eq(new_order)
+            context.last.should eq(depeche_mode)
+          end
+        end
+      end
+
       context "when the context is cached" do
 
         let(:criteria) do


### PR DESCRIPTION
This is not working on the latest version of mongoid:

``` ruby
 UserThemeVersion.where(parent_id: theme.id, user: current_user.id).sort(version: -1).first
```

it was ignoring the sort on the first query.

This pull request fix that issue. and also:

1- .sort method was not changing the criteria, so when .first applied it assumed there was no sort and it was ignoring it

2 - making apply_sorting a block function to unsure it will reset the query after execution of .first or .last
