### PR TITLE
Make fields of type Array or Hash initialize to empty Array or Hash (instead of nil)

### DIFF
--- a/lib/mongoid/fields/standard.rb
+++ b/lib/mongoid/fields/standard.rb
@@ -85,6 +85,14 @@ module Mongoid
         @name = name
         @options = options
         @label = options[:label]
+
+        unless options.has_key? :default
+          if options[:type] == Array
+            options[:default] = []
+          elsif options[:type] == Hash
+            options[:default] = {}
+          end
+        end
         @default_val = options[:default]
 
         # @todo: Durran, change API in 4.0 to take the class as a parameter.


### PR DESCRIPTION
I found this to be very useful, but I don't know if it's in line with your overall strategy.

**Explanation:** When using relations, a "many" reference (e.g.: has_many, embeds_many) initializes as an empty array, which allows you to use array-specific methods (e.g.: `Array#<<`) with no worries.  This behavior is nice.  When defining a regular field of type Array, it initializes as nil, so if you're not sure whether the array already has elements in it, then you can't use array-specific methods without first testing whether it actually _is_ an array.  A similar argument applies to operating on fields of type Hash.  This update just sets Array and Hash fields as "empty" instead of nil.
