### PR TITLE
Dont clear persistence_options when loading revision [ Fixes #2743]

### DIFF
--- a/lib/mongoid/sessions.rb
+++ b/lib/mongoid/sessions.rb
@@ -165,7 +165,7 @@ module Mongoid
       def collection
         if opts = persistence_options
           coll = mongo_session.with(opts)[opts[:collection] || collection_name]
-          clear_persistence_options unless validating_with_query?
+          clear_persistence_options unless validating_with_query? || _loading_revision?
           coll
         else
           mongo_session[collection_name]


### PR DESCRIPTION
This probably will be removed in version 4.0 as we are removing Versioning module, but this is a fix for version 3, which was cleaning the persistence options on the Versioning select https://github.com/mongoid/mongoid/blob/master/lib/mongoid/versioning.rb#L131
