### PR TITLE
Fix #2755: Positional operator update broken for > 10 objects.

### DIFF
--- a/lib/mongoid/atomic/paths/embedded.rb
+++ b/lib/mongoid/atomic/paths/embedded.rb
@@ -57,7 +57,7 @@ module Mongoid
         # @since 3.1.0
         def update_selector
           if positionally_operable?
-            position.sub(/\.\d/, ".$")
+            position.sub(/\.\d+/, ".$")
           else
             position
           end

--- a/spec/mongoid/atomic_spec.rb
+++ b/spec/mongoid/atomic_spec.rb
@@ -75,6 +75,24 @@ describe Mongoid::Atomic do
         band.records.create(name: "Undertow")
       end
 
+      context "when embedded with 10 other documents" do
+        context "when using the positional operator" do
+          it "returns the update selector with positional operator" do
+            10.times { |i| band.records.create(name: i.to_s) }
+            band.records.last.atomic_prefix.should eq("records.$")
+          end
+        end
+      end
+
+      context "when embedded with 100 other documents" do
+        context "when using the positional operator" do
+          it "returns the update selector with positional operator" do
+            100.times { |i| band.records.create(name: i.to_s) }
+            band.records.last.atomic_prefix.should eq("records.$")
+          end
+        end
+      end
+
       context "when embedded one level" do
 
         context "when using the positional operator" do


### PR DESCRIPTION
The regex replaces only a single digit, it needs to replace the whole number.
