### PR TITLE
Enumerable.matching_document _unloaded double query fix

### DIFF
--- a/lib/mongoid/relations/targets/enumerable.rb
+++ b/lib/mongoid/relations/targets/enumerable.rb
@@ -444,8 +444,8 @@ module Mongoid
 
         def matching_document(location)
           _loaded.try(:values).try(location) ||
-            _added[_unloaded.try(location).try(:id)] ||
-            _unloaded.try(location) ||
+            _added[(ul = _unloaded.try(location)).try(:id)] ||
+            ul ||
             _added.values.try(location)
         end
 

--- a/spec/mongoid/relations/targets/enumerable_spec.rb
+++ b/spec/mongoid/relations/targets/enumerable_spec.rb
@@ -739,6 +739,11 @@ describe Mongoid::Relations::Targets::Enumerable do
           it "does not load the enumerable" do
             enumerable.should_not be__loaded
           end
+
+          it "receives query only once" do
+            criteria.should_receive(:first).once
+            first
+          end
         end
 
         context "when added is not empty" do
@@ -1158,6 +1163,11 @@ describe Mongoid::Relations::Targets::Enumerable do
 
         it "does not load the enumerable" do
           enumerable.should_not be__loaded
+        end
+
+        it "receives query only once" do
+          criteria.should_receive(:last).once
+          last
         end
       end
 


### PR DESCRIPTION
After debugging #2761, I realize that has_and_belongs_to_many were querying the DB twice with the same selector.

When there was a many to many, and the target was not loaded and target.first was called, _unloaded was calling the db twice in order to load.
