### PR TITLE
create_indexes should not fail when cannot constantize class [Fix #2758]

### DIFF
--- a/lib/rails/mongoid.rb
+++ b/lib/rails/mongoid.rb
@@ -166,9 +166,9 @@ module Rails
         klass = name.constantize
       rescue NameError, LoadError
         logger.info("MONGOID: Attempted to constantize #{name}, trying without namespacing.")
-        klass = parts.last.constantize
+        klass = parts.last.constantize rescue nil
       end
-      klass if klass.ancestors.include?(::Mongoid::Document)
+      klass if klass && klass.ancestors.include?(::Mongoid::Document)
     end
 
     def logger

--- a/spec/rails/mongoid_spec.rb
+++ b/spec/rails/mongoid_spec.rb
@@ -175,6 +175,9 @@ describe "Rails::Mongoid" do
       Rails::Mongoid.send(:determine_model, file, logger)
     end
 
+    class EasyURI
+    end
+
     module Twitter
       class Follow
         include Mongoid::Document
@@ -220,6 +223,21 @@ describe "Rails::Mongoid" do
       end
     end
 
+    context "when file cannot be constantize" do
+
+      let(:file) do
+        "app/models/easy_uri.rb"
+      end
+
+      before do
+        logger.should_receive(:info)
+      end
+
+      it "returns nil" do
+        model.should be_nil
+      end
+    end
+
     context "when file is not in a subdir" do
 
       context "when file is from normal model" do
@@ -239,9 +257,9 @@ describe "Rails::Mongoid" do
           "app/models/follow.rb"
         end
 
-        it "raises NameError" do
+        it "logs the class without an error" do
           logger.should_receive(:info)
-          expect { model.should eq(klass) }.to raise_error(NameError)
+          expect { model.should eq(klass) }.not_to raise_error(NameError)
         end
       end
     end


### PR DESCRIPTION
rake task db:mongoid:create_indexes should not fail if the name of the
file doest not match the class name.
