### PR TITLE
(Unlikely) Fix #2769: use a positional operator for inserting L1 embedded documents.

### DIFF
--- a/lib/mongoid/atomic.rb
+++ b/lib/mongoid/atomic.rb
@@ -167,7 +167,7 @@ module Mongoid
     #
     # @return [ String ] The positional operator with indexes.
     def atomic_position
-      atomic_paths.position
+      atomic_paths.atomic_position
     end
 
     # Returns path of the attribute for modification

--- a/lib/mongoid/atomic/paths/embedded/many.rb
+++ b/lib/mongoid/atomic/paths/embedded/many.rb
@@ -37,6 +37,20 @@ module Mongoid
             locator = document.new_record? ? "" : ".#{document._index}"
             "#{pos}#{"." unless pos.blank?}#{document.metadata.store_as}#{locator}"
           end
+
+          # Get the position of the document in the hierarchy for update. This will
+          # This is the same as position.
+          #
+          # @example Get the atomic position.
+          #   many.atomic_position
+          #
+          # @return [ String ] The atomic position of the document.
+          #
+          # @since 3.1.0
+          def atomic_position
+            position
+          end
+
         end
       end
     end

--- a/lib/mongoid/atomic/paths/embedded/one.rb
+++ b/lib/mongoid/atomic/paths/embedded/one.rb
@@ -36,6 +36,24 @@ module Mongoid
             pos = parent.atomic_position
             "#{pos}#{"." unless pos.blank?}#{document.metadata.store_as}"
           end
+
+          # Get the atomic position of the document in the hierarchy.
+          # Same as position except for 1st level embedded documents.
+          #
+          # @example Get the atomic position.
+          #   one.atomic_position
+          #
+          # @return [ String ] The atomic position of the document.
+          #
+          # @since 3.1.0
+          def atomic_position
+            if positionally_operable?
+              position.sub(/\.\d+/, ".$")
+            else
+              position
+            end
+          end
+
         end
       end
     end

--- a/lib/mongoid/atomic/paths/root.rb
+++ b/lib/mongoid/atomic/paths/root.rb
@@ -46,6 +46,19 @@ module Mongoid
         def selector
           { "_id" => document._id }.merge!(document.shard_key_selector)
         end
+
+        # Get the atomic position of the document.
+        #
+        # @example Get the atomic position of the document.
+        #   root.atomic_position
+        #
+        # @return [ String ] The atomic position of the document.
+        #
+        # @since 3.1.0
+        def atomic_position
+          position
+        end
+
       end
     end
   end

--- a/spec/mongoid/atomic/paths/embedded/one_spec.rb
+++ b/spec/mongoid/atomic/paths/embedded/one_spec.rb
@@ -105,7 +105,44 @@ describe Mongoid::Atomic::Paths::Embedded::One do
       it "returns the nested position to the relation" do
         one.position.should eq("phone_numbers.0.country_code")
       end
+
+      it "returns a positionally operated update_selector" do
+        one.update_selector.should eq("phone_numbers.$.country_code")
+      end
     end
+
+    context "when the document is embedded inside another embedded document" do
+
+      let(:dokument) do
+        Dokument.create!
+      end
+
+      let(:address) do
+        Address.new
+      end
+
+      let(:code) do
+        Code.new
+      end
+
+      before do
+        dokument.addresses << address
+        address.code = code
+      end
+
+      let(:one) do
+        described_class.new(code)
+      end
+
+      it "returns the nested position to the relation" do
+        one.position.should eq("addresses.0.code")
+      end
+
+      it "returns a positionally operated update_selector" do
+        code.atomic_position.should eq("addresses.$.code")
+      end
+    end
+
   end
 
   describe "#selector" do


### PR DESCRIPTION
This does pass all the specs, but the implementation feels very wrong. It should be in something like `Mongoid::Atomic::Paths::Embedded`, but I failed to find another place to insert similar path-like behavior for an insert. 

Curious to see what the proper fix would be.

This is an attempt for #2769.
