### PR TITLE
Fixing spec for jruby

### DIFF
--- a/spec/mongoid/extensions/string_spec.rb
+++ b/spec/mongoid/extensions/string_spec.rb
@@ -90,7 +90,7 @@ describe Mongoid::Extensions::String do
         end
 
         it "converts to a time" do
-          time.should eq(Time.parse(string))
+          time.should eq(Time.configured.parse(string))
         end
 
         it "converts to the as time zone" do


### PR DESCRIPTION
Time was not using the timezone. we need to use Time.configured instead to use the timezone if it is setup
