### PR TITLE
support for MongoDB 2.4 new index types

### DIFF
--- a/lib/config/locales/en.yml
+++ b/lib/config/locales/en.yml
@@ -135,7 +135,8 @@ en:
             \_\_max: 1\n
             \_\_bits: 26\n
             \_\_bucket_size : 1\n
-            Valid types are: 1, -1, '2d', 'geoHaystack'\n\n
+            \_\_weights: { content: 1, title: 2 }\n
+            Valid types are: 1, -1, '2d', '2dsphere', 'geoHaystack', 'text', 'hashed'\n\n
             Example:\n
             \_\_class Band\n
             \_\_\_\_include Mongoid::Document\n

--- a/lib/mongoid/indexes/validators/options.rb
+++ b/lib/mongoid/indexes/validators/options.rb
@@ -18,10 +18,19 @@ module Mongoid
           :min,
           :bits,
           :bucket_size,
-          :expire_after_seconds
+          :expire_after_seconds,
+          :weights
         ]
 
-        VALID_TYPES = [ 1, -1, "2d", "geoHaystack" ]
+        VALID_TYPES = [
+          1,
+          -1,
+          "2d",
+          "2dsphere",
+          "geoHaystack",
+          "text",
+          "hashed"
+        ]
 
         # Validate the index specification.
         #

--- a/spec/mongoid/indexes_spec.rb
+++ b/spec/mongoid/indexes_spec.rb
@@ -296,6 +296,66 @@ describe Mongoid::Indexes do
       end
     end
 
+    context "when providing a Spherical Geospatial index" do
+
+      before do
+        klass.index({ location: "2dsphere" })
+      end
+
+      let(:options) do
+        klass.index_options[location: "2dsphere"]
+      end
+
+      it "sets the spherical geospatial index" do
+        options.should be_empty
+      end
+    end
+
+    context "when providing a hashed index" do
+
+      before do
+        klass.index({ a: "hashed" })
+      end
+
+      let(:options) do
+        klass.index_options[a: "hashed"]
+      end
+
+      it "sets the hashed index" do
+        options.should be_empty
+      end
+    end
+
+    context "when providing a text index" do
+
+      before do
+        klass.index({ content: "text" })
+      end
+
+      let(:options) do
+        klass.index_options[content: "text"]
+      end
+
+      it "sets the text index" do
+        options.should be_empty
+      end
+    end
+
+    context "when providing a compound text index" do
+
+      before do
+        klass.index({ content: "text", title: "text" }, { weights: { content: 1, title: 2 } })
+      end
+
+      let(:options) do
+        klass.index_options[content: "text", title: "text"]
+      end
+
+      it "sets the compound text index" do
+        options.should eq(weights: { content: 1, title: 2 })
+      end
+    end
+
     context "when providing an expire_after_seconds option" do
 
       before do


### PR DESCRIPTION
added support for the new index types `2dsphere`, `text` and `hashed`
added specs for `2dsphere`, `text`, `hashed` index types
