### PR TITLE
Fixes touch frozen docs [ #2779 ]

### DIFF
--- a/lib/mongoid/persistence.rb
+++ b/lib/mongoid/persistence.rb
@@ -119,9 +119,11 @@ module Mongoid
     # @since 3.0.0
     def touch(field = nil)
       return false if _root.new_record?
-      current = Time.now
-      write_attribute(:updated_at, current) if fields["updated_at"]
-      write_attribute(field, current) if field
+      unless attributes.frozen?
+        current = Time.now
+        write_attribute(:updated_at, current) if fields["updated_at"]
+        write_attribute(field, current) if field
+      end
 
       touches = touch_atomic_updates(field)
       unless touches.empty?

--- a/spec/app/models/agent.rb
+++ b/spec/app/models/agent.rb
@@ -8,5 +8,9 @@ class Agent
   belongs_to :game
   belongs_to :agency, touch: true, autobuild: true
 
+  def destroy_agency
+    self.agency.destroy if self.agency
+  end
+
   has_and_belongs_to_many :accounts
 end

--- a/spec/mongoid/persistence_spec.rb
+++ b/spec/mongoid/persistence_spec.rb
@@ -1069,6 +1069,21 @@ describe Mongoid::Persistence do
         it "updates the parent's updated at" do
           agency.updated_at.should_not eq(updated)
         end
+
+        context "when child removes parent before" do
+
+          before do
+            Agent.before_destroy :destroy_agency
+          end
+
+          after do
+            Agent.reset_callbacks :destroy
+          end
+
+          it "destroys the child without error" do
+            expect { agent.destroy }.not_to raise_error
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
When trying to touch a document that is frozen(delete , for instance), write_attribute cannot happen.
