### PR TITLE
fix uniqueness validation problem with inheritance

### DIFF
--- a/lib/mongoid/validations/uniqueness.rb
+++ b/lib/mongoid/validations/uniqueness.rb
@@ -91,7 +91,8 @@ module Mongoid
       # @since 2.4.10
       def create_criteria(base, document, attribute, value)
         field = document.fields[attribute.to_s]
-        criteria = scope(base.unscoped, document, attribute)
+        klass = base.embedded? ? base : field.options[:klass] || base
+        criteria = scope(klass.unscoped, document, attribute)
         if field.try(:localized?)
           criteria.selector.update(criterion(document, attribute, value))
         else

--- a/spec/mongoid/validations/uniqueness_spec.rb
+++ b/spec/mongoid/validations/uniqueness_spec.rb
@@ -2009,4 +2009,31 @@ describe Mongoid::Validations::UniquenessValidator do
       validators.should eq([ described_class ])
     end
   end
+
+  context "when validation works with inheritance" do
+
+    before do
+      Actor.delete_all
+      Actor.validates_uniqueness_of :name
+      @johnny_depp = Actor.create!(name: "Johnny Depp")
+    end
+
+    after do
+      # @johnny_depp.delete
+      Actor.reset_callbacks(:validate)
+      Actor.delete_all
+    end
+
+    let!(:subclass_document_with_duplicated_name) do
+      Actress.new(name: "Johnny Depp")
+    end
+
+    it "should be invalid" do
+      subclass_document_with_duplicated_name.tap do |d|
+        d.should be_invalid
+        d.errors[:name].should eq([ "is already taken" ])
+      end
+    end
+
+  end
 end


### PR DESCRIPTION
switch the class to create criteria for uniqueness validation when the field is defined in ancestor class.
[ fix #2783 ]
