### PR TITLE
add license information to the gemspec

### DIFF
--- a/mongoid.gemspec
+++ b/mongoid.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |s|
   s.homepage    = "http://mongoid.org"
   s.summary     = "Elegant Persistance in Ruby for MongoDB."
   s.description = "Mongoid is an ODM (Object Document Mapper) Framework for MongoDB, written in Ruby."
+  s.license     = "MIT"
 
   s.required_ruby_version     = ">= 1.9"
   s.required_rubygems_version = ">= 1.3.6"


### PR DESCRIPTION
This way it can be used with the rubygems.org API
