### PR TITLE
Fix broken milliseconds precision

### DIFF
--- a/lib/mongoid/extensions/time.rb
+++ b/lib/mongoid/extensions/time.rb
@@ -67,6 +67,8 @@ module Mongoid
             time = object.__mongoize_time__
             if time.respond_to?(:sec_fraction)
               ::Time.at(time.to_i, time.sec_fraction * 10**6).utc
+            elsif time.respond_to?(:subsec)
+              ::Time.at(time.to_i, time.subsec * 10**6).utc
             else
               ::Time.at(time.to_i, time.usec).utc
             end

--- a/spec/mongoid/extensions/time_spec.rb
+++ b/spec/mongoid/extensions/time_spec.rb
@@ -278,6 +278,10 @@ describe Mongoid::Extensions::Time do
         (eom_time_mongoized.usec).should eq(999999)
       end
 
+      it "does not alter seconds with fractions" do
+        DateTime.mongoize(11.11).to_f.should eq(11.11)
+      end
+
       context "when using the ActiveSupport time zone" do
 
         let(:datetime) do
@@ -335,6 +339,10 @@ describe Mongoid::Extensions::Time do
 
       it "doesn't strip milli- or microseconds" do
         Time.mongoize(time).to_f.should eq(time.to_f)
+      end
+
+      it "does not alter seconds with fractions" do
+        Time.mongoize(102.63).to_f.should eq(102.63)
       end
     end
 


### PR DESCRIPTION
Hi! issue #2741 has returned
It was back in release v3.0.21, after being fixed in v3.0.20.
(The Float decimal inaccuracy problem.)

Commit where it broke again: c25e1fe7b80f558b50dd4f8e3fe6fe6785e74395

This time I tried to fix it myself. The problem was that `Time` does not respond to `sec_fraction` (`Date` [does](http://apidock.com/ruby/Date/sec_fraction)). Instead it uses the [method](http://apidock.com/ruby/Time/subsec) `subsec` for that purpose.

I added the case and specs. The specs don't cover the 100% (because you can't check every number in existence), but it's better than nothing.
