### PR TITLE
Map over fields with some optimization

### DIFF
--- a/lib/mongoid/contextual/mongo.rb
+++ b/lib/mongoid/contextual/mongo.rb
@@ -194,6 +194,30 @@ module Mongoid
       end
       alias :one :first
 
+      # Invoke the block for each element of Contextual. Create a new array
+      # containing the values returned by the block.
+      #
+      # If the symbol field name is passed instead of the block, additional
+      # optimizations would be used.
+      #
+      # @example Map by some field.
+      #   context.map(:field1)
+      #
+      # @exmaple Map with block.
+      #   context.map(&:field1)
+      #
+      # @param [ Symbol ] field The field name.
+      #
+      # @return [ Array ] The result of mapping.
+      def map(field = nil, &block)
+        if block_given?
+          super(&block)
+        else
+          field = field.to_sym
+          criteria.only(field).map(&field.to_proc)
+        end
+      end
+
       # Create the new Mongo context. This delegates operations to the
       # underlying driver - in Mongoid's case Moped.
       #

--- a/spec/mongoid/contextual/mongo_spec.rb
+++ b/spec/mongoid/contextual/mongo_spec.rb
@@ -988,6 +988,41 @@ describe Mongoid::Contextual::Mongo do
     end
   end
 
+  describe "#map" do
+
+    before do
+      Band.create(name: "Depeche Mode")
+      Band.create(name: "New Order")
+    end
+
+    let(:criteria) do
+      Band.all
+    end
+
+    let(:context) do
+      described_class.new(criteria)
+    end
+
+    context "when passed the symbol field name" do
+
+      it "limits query to that field" do
+        criteria.should_receive(:only).with(:name).and_call_original
+        context.map(:name)
+      end
+
+      it "performs mapping" do
+        context.map(:name).should eq ["Depeche Mode", "New Order"]
+      end
+    end
+
+    context "when passed a block" do
+
+      it "performs mapping" do
+        context.map(&:name).should eq ["Depeche Mode", "New Order"]
+      end
+    end
+  end
+
   describe "#map_reduce" do
 
     let!(:depeche_mode) do


### PR DESCRIPTION
Allow to map over fields by their symbol name on contextuals. Not only that, it will also do `#only` for that field for performance reasons. It is about 4x faster. [Benchmark](https://gist.github.com/goshakkk/4734548).
