### PR TITLE
Copy localize fields on model.becomes

### DIFF
--- a/lib/mongoid/copyable.rb
+++ b/lib/mongoid/copyable.rb
@@ -18,18 +18,32 @@ module Mongoid
     #
     # @return [ Document ] The new document.
     def clone
-      doc = as_document
       # @note This next line is here to address #2704, even though having an
       # _id and id field in the document would cause problems with Mongoid
       # elsewhere.
-      attrs = doc.except("_id", "id")
-      attrs["version"] = 1 if attrs.delete("versions")
-      process_localized_attributes(attrs)
+      attrs = clone_document.except("_id", "id")
       self.class.new(attrs, without_protection: true)
     end
     alias :dup :clone
 
     private
+
+    # Clone the document attributes
+    #
+    # @api private
+    #
+    # @example clone document
+    #   model.clone_document
+    #
+    # @param [ Hash ] dcoument The document with hash format
+    #
+    # @since 3.0.22
+    def clone_document
+      attrs = as_document.__deep_copy__
+      attrs["version"] = 1 if attrs.delete("versions")
+      process_localized_attributes(attrs)
+      attrs
+    end
 
     # When cloning, if the document has localized fields we need to ensure they
     # are properly processed in the clone.

--- a/lib/mongoid/document.rb
+++ b/lib/mongoid/document.rb
@@ -240,7 +240,7 @@ module Mongoid
         raise ArgumentError, "A class which includes Mongoid::Document is expected"
       end
 
-      became = klass.new(as_document.__deep_copy__, without_protection: true)
+      became = klass.new(clone_document, without_protection: true)
       became.id = id
       became.instance_variable_set(:@changed_attributes, changed_attributes)
       became.instance_variable_set(:@errors, errors)

--- a/spec/mongoid/document_spec.rb
+++ b/spec/mongoid/document_spec.rb
@@ -1029,6 +1029,21 @@ describe Mongoid::Document do
         end
       end
 
+      context "when the document has a localize field" do
+
+        let(:manager) do
+          Manager.new(title: "Sir", desc: "description")
+        end
+
+        let(:person) do
+          manager.becomes(Person)
+        end
+
+        it "copies the localize attribute" do
+          person.desc.should eq("description")
+        end
+      end
+
       context "when the document is new" do
 
         let(:person) do


### PR DESCRIPTION
Localize fields were not getting copied properly when using
.becomes method. Related to #2772 #2790
