### PR TITLE
Dont call touch on parent, unless touch: true

### DIFF
--- a/lib/mongoid/relations/macros.rb
+++ b/lib/mongoid/relations/macros.rb
@@ -140,7 +140,7 @@ module Mongoid
         def belongs_to(name, options = {}, &block)
           meta = reference_one_to_one(name, options, Referenced::In, &block)
           aliased_fields[name.to_s] = meta.foreign_key
-          touchable(meta)
+          touchable(meta) if meta.touchable?
           add_counter_cache_callbacks(meta) if meta.counter_cached?
           meta
         end

--- a/lib/mongoid/relations/touchable.rb
+++ b/lib/mongoid/relations/touchable.rb
@@ -4,11 +4,6 @@ module Mongoid
     module Touchable
       extend ActiveSupport::Concern
 
-      included do
-        class_attribute :touchables
-        self.touchables = []
-      end
-
       module ClassMethods
 
         # Add the metadata to the touchable relations if the touch option was
@@ -24,7 +19,6 @@ module Mongoid
         # @since 3.0.0
         def touchable(metadata)
           name = metadata.name
-          touchables.push(name) if metadata.touchable?
           method_name = define_relation_touch_method(name)
           after_create method_name
           after_destroy method_name

--- a/spec/app/models/cookie.rb
+++ b/spec/app/models/cookie.rb
@@ -1,4 +1,6 @@
 class Cookie
   include Mongoid::Document
+  include Mongoid::Timestamps::Updated
+
   belongs_to :jar
 end

--- a/spec/app/models/jar.rb
+++ b/spec/app/models/jar.rb
@@ -1,5 +1,7 @@
 class Jar
   include Mongoid::Document
+  include Mongoid::Timestamps::Updated
+
   field :_id, type: Integer
   has_many :cookies, class_name: "Cookie"
 end

--- a/spec/mongoid/persistence_spec.rb
+++ b/spec/mongoid/persistence_spec.rb
@@ -982,6 +982,27 @@ describe Mongoid::Persistence do
           end
         end
       end
+
+      context "when creating the child" do
+
+        let(:time) do
+          Time.utc(2012, 4, 3, 12)
+        end
+
+        let(:jar) do
+          Jar.new(_id: 1, updated_at: time).tap do |jar|
+            jar.save!
+          end
+        end
+
+        let!(:cookie) do
+          jar.cookies.create!(updated_at: time)
+        end
+
+        it "does not touch the parent" do
+          jar.updated_at.should eq(time)
+        end
+      end
     end
 
     context "when relations have touch options" do


### PR DESCRIPTION
.touch method was being called on the parent even if the belongs_to relation
was not set to touch: true.
Related to [ #2800 ]
