### PR TITLE
Remove move_changes call from touch

### DIFF
--- a/lib/mongoid/persistence.rb
+++ b/lib/mongoid/persistence.rb
@@ -129,7 +129,7 @@ module Mongoid
         _root.collection.find(selector).update(positionally(selector, touches))
       end
       run_callbacks(:touch, :after)
-      move_changes and true
+      true
     end
 
     # Update the document in the database.

--- a/spec/mongoid/persistence_spec.rb
+++ b/spec/mongoid/persistence_spec.rb
@@ -913,8 +913,8 @@ describe Mongoid::Persistence do
             touched.should be_true
           end
 
-          it "clears the dirty tracking" do
-            agent.changes.should be_empty
+          it "keeps changes for next callback" do
+            agent.changes.should_not be_empty
           end
         end
 
@@ -948,8 +948,8 @@ describe Mongoid::Persistence do
             touched.should be_true
           end
 
-          it "clears the dirty tracking" do
-            agent.changes.should be_empty
+          it "keeps changes for next callback" do
+            agent.changes.should_not be_empty
           end
         end
       end


### PR DESCRIPTION
Removing move_changes from touch method, so next callbacks dont lose
them. [ fixes #2800 ]
