### PR TITLE
Recursive mongoization

### DIFF
--- a/lib/mongoid/extensions/array.rb
+++ b/lib/mongoid/extensions/array.rb
@@ -156,7 +156,7 @@ module Mongoid
           if object.is_a?(::Array)
             evolve(object).collect{ |obj| obj.class.mongoize(obj) }
           else
-            object
+            evolve(object)
           end
         end
 


### PR DESCRIPTION
Mongoization does not work for values within arrays. This patch adds recursion into arrays.

I discovered this with the Money class, which now properly serializes using this example:

```
Product.new(:data => {:price => Money.new(1099), :variants => [{:sku => "1234", :sale_price => Money.new(899)}]}).as_document
```
