### PR TITLE
Clarify CHANGELOG: TTL indexes must be on Time-ish field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,12 +159,14 @@ For instructions on upgrading to newer versions, visit
 * \#2465 Documents now have an `attribute_before_type_cast` for proper
   handling of validations. (Gerad Suyderhoud)
 
-* \#2443 `expire_after_seconds` is now a valid index option.
+* \#2443 `expire_after_seconds` is now a valid index option
+  (http://docs.mongodb.org/manual/core/indexes/#ttl-indexes,
+   http://docs.mongodb.org/manual/tutorial/expire-data/).
 
         class Event
           include Mongoid::Document
-          field :status, type: Integer
-          index({ status: 1 }, { expire_after_seconds: 3600 })
+          field :created_at, type: DateTime
+          index({ created_at: 1 }, { expire_after_seconds: 3600 })
         end
 
 * \#2373 Relations with the `touch: true` option will now be automatically


### PR DESCRIPTION
As per the linked mongodb docs:
- the indexed field must be a date BSON type. If the field does not have a date type, the data will not expire.
- you cannot create this index on the _id field, or a field that already has an index.
- the TTL index may not be compound (may not have multiple fields).
- if the field holds an array, and there are multiple date-typed data in the index, the document will expire when the lowest (i.e. earliest) matches the expiration threshold.
- you cannot use a TTL index on a capped collection, because MongoDB cannot remove documents from a capped collection.
