### PR TITLE
Merge options given to #store_in so that previous settings are not lost

### DIFF
--- a/lib/mongoid/sessions.rb
+++ b/lib/mongoid/sessions.rb
@@ -293,7 +293,8 @@ module Mongoid
       def store_in(options)
         Validators::Storage.validate(self, options)
         @collection_name, @database_name = nil, nil
-        self.storage_options = options
+        self.storage_options ||= {}
+        self.storage_options.merge! options
       end
 
       # Tell the next persistance operation to store in a specific collection,

--- a/spec/mongoid/sessions_spec.rb
+++ b/spec/mongoid/sessions_spec.rb
@@ -85,6 +85,20 @@ describe Mongoid::Sessions do
         Band.send(:remove_instance_variable, :@collection_name)
       end
 
+      context "when called multiple times with different options" do
+        before do
+          Band.store_in collection: "artists"
+          Band.store_in session: "another"
+        end
+
+        it "should merge the options together" do
+          Band.storage_options.should == {
+            collection: "artists",
+            session: "another"
+          }
+        end
+      end
+
       context "when overriding with a proc" do
 
         before do


### PR DESCRIPTION
Currently, the result of the following...

```
class Band
  include Mongoid::Document
  store_in collection: "one"
  store_in session: "two"
end
```

...will result in `Band.storage_options == { session: "two" }`, losing the earlier configuration. This is a contrived example. In my case, I was including modules into the class which themselves made calls to `#store_in`; this made the issue much more difficult to track down.

I think the current functionality is not the expected result. This pull request merges configurations together, instead of replacing them entirely, so that the above example would produce `Band.storage_options == { collection: "one", session: "two" }`. Later calls to `#store_in` still take precedence over earlier ones.
