### PR TITLE
Provide the type casted attribute for validation by default

### DIFF
--- a/lib/mongoid/validations.rb
+++ b/lib/mongoid/validations.rb
@@ -62,8 +62,6 @@ module Mongoid
         relation.do_or_do_not(:in_memory) || relation
       elsif fields[attribute].try(:localized?)
         attributes[attribute]
-      elsif respond_to?("#{attr}_before_type_cast")
-        send("#{attr}_before_type_cast")
       else
         send(attr)
       end


### PR DESCRIPTION
In ActiveModel, it seems to be a convention to let each validator call the value before type cast if it needs to. (And the numericality validator seems to be the only one doing this right now.)

This pull request is very simple and has no tests. I thought a lot about this and the only way to properly do this would be creating examples to test the expected behavior of each validator in ActiveModel. In one way this is strange, because we would test something completely outside mongoid. If we are just following an (undocumented) ActiveModel convention that should be sufficient. In other way, these tests are the only way to avoid regressions. Can we see them as a sort of _integration_ tests? What do you think?

Closes #2828.
