### PR TITLE
remove !_assigning? check on batch_remove

### DIFF
--- a/lib/mongoid/relations/embedded/batchable.rb
+++ b/lib/mongoid/relations/embedded/batchable.rb
@@ -56,7 +56,7 @@ module Mongoid
         # @since 3.0.0
         def batch_remove(docs, method = :delete)
           removals = pre_process_batch_remove(docs, method)
-          if !docs.empty? && !_assigning?
+          if !docs.empty?
             collection.find(selector).update(
               positionally(selector, "$pullAll" => { path => removals })
             )

--- a/spec/app/models/pet.rb
+++ b/spec/app/models/pet.rb
@@ -15,4 +15,9 @@ class Pet
   def destroy_flag
     @destroy_flag ||= false
   end
+
+  def visits_count=(count)
+    vet_visits.destroy_all
+    count.times { vet_visits.new }
+  end
 end

--- a/spec/mongoid/attributes_spec.rb
+++ b/spec/mongoid/attributes_spec.rb
@@ -1124,6 +1124,30 @@ describe Mongoid::Attributes do
           end
         end
 
+        context "when parent destroy all child on setter" do
+
+          let(:owner) do
+            PetOwner.create!(title: "Mr")
+          end
+
+          let(:pet) do
+            Pet.create!(name: "Kika", pet_owner: owner)
+          end
+
+          let!(:vet_visit) do
+            pet.vet_visits.create!(date: Date.today)
+          end
+
+          before do
+            pet.send(method, { visits_count: 3 })
+            pet.save!
+          end
+
+          it "has 3 new entries" do
+            pet.vet_visits.count.should eq(3)
+          end
+        end
+
         context "when the parent has an empty embeds_many" do
 
           let(:person) do

--- a/spec/mongoid/relations/embedded/many_spec.rb
+++ b/spec/mongoid/relations/embedded/many_spec.rb
@@ -724,8 +724,8 @@ describe Mongoid::Relations::Embedded::Many do
             person.addresses.should be_empty
           end
 
-          it "does not delete the child document" do
-            address.should_not be_destroyed
+          it "deletes the child document" do
+            address.should be_destroyed
           end
 
           context "when saving the parent" do


### PR DESCRIPTION
Remove the _assigning check, so we can destroy embedded docs inside
a setter. [ #2841 ]
