### PR TITLE
model.touch when using alias

### DIFF
--- a/lib/mongoid/persistence.rb
+++ b/lib/mongoid/persistence.rb
@@ -120,7 +120,7 @@ module Mongoid
     def touch(field = nil)
       return false if _root.new_record?
       current = Time.now
-      write_attribute(:updated_at, current) if fields["updated_at"]
+      write_attribute(:updated_at, current) if respond_to?("updated_at=")
       write_attribute(field, current) if field
 
       touches = touch_atomic_updates(field)

--- a/spec/app/models/label.rb
+++ b/spec/app/models/label.rb
@@ -1,6 +1,6 @@
 class Label
   include Mongoid::Document
-  include Mongoid::Timestamps::Updated
+  include Mongoid::Timestamps::Updated::Short
 
   field :name, type: String
   field :after_create_called, type: Boolean, default: false


### PR DESCRIPTION
Making touch method update the updated_at field, even when using alias
