### PR TITLE
Add Factory#from_map_or_db for identity map use on criteria based queries

### DIFF
--- a/lib/mongoid/contextual/eager.rb
+++ b/lib/mongoid/contextual/eager.rb
@@ -148,7 +148,7 @@ module Mongoid
       def with_eager_loading(document)
         selecting do
           return nil unless document
-          doc = Factory.from_db(klass, document, criteria.object_id)
+          doc = Factory.from_map_or_db(klass, document, criteria.object_id)
           eager_load_one(doc) if eager_loadable?(doc)
           doc
         end

--- a/lib/mongoid/contextual/mongo.rb
+++ b/lib/mongoid/contextual/mongo.rb
@@ -589,7 +589,7 @@ module Mongoid
         if cached? && !documents.empty?
           documents
         elsif eager_loadable?
-          docs = query.map{ |doc| Factory.from_db(klass, doc) }
+          docs = query.map{ |doc| Factory.from_map_or_db(klass, doc) }
           eager_load(docs)
           docs
         else
@@ -632,7 +632,7 @@ module Mongoid
       # @since 3.0.0
       def yield_document(document, &block)
         doc = document.respond_to?(:_id) ?
-          document : Factory.from_db(klass, document, criteria.object_id)
+          document : Factory.from_map_or_db(klass, document, criteria.object_id)
         yield(doc)
         documents.push(doc) if cacheable?
       end

--- a/lib/mongoid/factory.rb
+++ b/lib/mongoid/factory.rb
@@ -36,11 +36,26 @@ module Mongoid
     # @return [ Document ] The instantiated document.
     def from_db(klass, attributes = nil, criteria_instance_id = nil)
       type = (attributes || {})["_type"]
-      if type.blank?
-        klass.instantiate(attributes, criteria_instance_id)
-      else
-        type.camelize.constantize.instantiate(attributes, criteria_instance_id)
-      end
+      
+      klass = type.blank? ? klass : type.camelize.constantize
+      
+      klass.instantiate(attributes, criteria_instance_id)
+    end
+    
+    # Retrieves a +Document+ from the Identity map or builds a new +Document+
+    # from the supplied attributes loaded from the database.
+    #
+    # @param [ Class ] klass The class to instantiate from if _type is not present.
+    # @param [ Hash ] attributes The document attributes.
+    #
+    # @return [ Document ] The found or instantiated document.
+    def from_map_or_db(klass, attributes = nil, criteria_instance_id = nil)
+      type = (attributes || {})["_type"]
+      id = (attributes || {})["_id"]
+      
+      klass = type.blank? ? klass : type.camelize.constantize
+      result = IdentityMap.get(klass, id)
+      result ||= klass.instantiate(attributes, criteria_instance_id)
     end
   end
 end

--- a/lib/mongoid/relations/builders/embedded/in.rb
+++ b/lib/mongoid/relations/builders/embedded/in.rb
@@ -17,7 +17,7 @@ module Mongoid
           def build(type = nil)
             return object unless object.is_a?(Hash)
             if _loading?
-              Factory.from_db(klass, object)
+              Factory.from_map_or_db(klass, object)
             else
               Factory.build(klass, object)
             end

--- a/lib/mongoid/relations/builders/embedded/many.rb
+++ b/lib/mongoid/relations/builders/embedded/many.rb
@@ -22,7 +22,7 @@ module Mongoid
             docs = []
             object.each do |attrs|
               if _loading? && base.persisted?
-                docs.push(Factory.from_db(klass, attrs))
+                docs.push(Factory.from_map_or_db(klass, attrs))
               else
                 docs.push(Factory.build(klass, attrs))
               end

--- a/lib/mongoid/relations/builders/embedded/one.rb
+++ b/lib/mongoid/relations/builders/embedded/one.rb
@@ -18,7 +18,7 @@ module Mongoid
           def build(type = nil)
             return object unless object.is_a?(Hash)
             if _loading? && base.persisted?
-              Factory.from_db(klass, object)
+              Factory.from_map_or_db(klass, object)
             else
               Factory.build(klass, object)
             end


### PR DESCRIPTION
This pull request adds Factory.from_map_or_db, which will load previously instantiated documents from the identity map before instantiating a new document for a given id.  In addition, this pull request changes criteria-based queries and relations to use this new method instead of Factory.from_db.  This allows for statements like this to be true:

``` ruby
Person.find("1").object_id == Person.where(id:"1").first.object_id
```

This change makes the IdentityMap semantics less complicated, IMO.
