### PR TITLE
Update lib/mongoid/fields/internal/big_decimal.rb

### DIFF
--- a/lib/mongoid/fields/internal/big_decimal.rb
+++ b/lib/mongoid/fields/internal/big_decimal.rb
@@ -21,7 +21,7 @@ module Mongoid #:nodoc:
         def deserialize(object)
           return object unless object
           begin
-            Float(object)
+            Float(object) unless object == 'NaN'
             ::BigDecimal.new(object)
           rescue ArgumentError, TypeError
             object


### PR DESCRIPTION
Account for 'NaN' which is valid for BigDecimal, but not for Float.
