### PR TITLE
Fixing Time extension usec precision with JRuby

### DIFF
--- a/lib/mongoid/extensions/time.rb
+++ b/lib/mongoid/extensions/time.rb
@@ -68,8 +68,8 @@ module Mongoid
           return nil if object.blank?
           begin
             time = object.__mongoize_time__
-            if time.respond_to?(:sec_fraction)
-              ::Time.at(time.to_i, time.sec_fraction * 10**6).utc
+            if object.respond_to?(:sec_fraction)
+              ::Time.at(time.to_i, object.sec_fraction * 10**6).utc
             elsif time.respond_to?(:subsec)
               ::Time.at(time.to_i, time.subsec * 10**6).utc
             else


### PR DESCRIPTION
Time extension is truncating usec with JRuby.
