### PR TITLE
fix IdentityMap not storing relation keys properly

### DIFF
--- a/lib/mongoid/relations/proxy.rb
+++ b/lib/mongoid/relations/proxy.rb
@@ -247,11 +247,11 @@ module Mongoid
           klass, foreign_key = metadata.klass, metadata.foreign_key
           eager_loaded = klass.any_in(foreign_key => ids).entries
           ids.each do |id|
-            IdentityMap.clear_many(klass, metadata.type_relation.merge!(foreign_key => id))
+            IdentityMap.clear_many(klass, metadata.criteria(id, metadata.inverse_klass).selector)
           end
           eager_loaded.each do |doc|
             base_id = doc.__send__(foreign_key)
-            yield(doc,  metadata.type_relation.merge!(foreign_key => base_id))
+            yield(doc, metadata.criteria(base_id, metadata.inverse_klass).selector)
           end
         end
       end


### PR DESCRIPTION
also reported in Issue #2877

This appears to be the right thing to do when storing these keys in the `IdentityMap`. At least it fixes the N+1 problem (which previously was not fixed).

Tested with variants of the following:

``` ruby
Mongoid.identity_map_enabled = true
Mongoid.unit_of_work do
  Band.includes(:albums).each do |band|
    puts "\n\nShould not see a QUERY log below this line"
    p band.albums.first.title # Does not hit the database again. Not true; it does!
  end
end
```

and separately with polymorphism, where the classes were structured like this:

``` ruby
class Band
  include Mongoid::Document
  has_many :albums, as: :commentable
  field :name
end

class Album
  include Mongoid::Document
  belongs_to :commentable, polymorphic: true
  field :title
end
```
