### PR TITLE
Dont duplicate embedded docs after becomes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ For instructions on upgrading to newer versions, visit
 
 ### Resolved Issues
 
+* Dont duplicate embedded documents when saving after calling becomes method.
+
 * \#2867 `pluck` now properly handles aliased fields.
 
 * \#2862 Autosaving no longer performs extra unnecessary queries.

--- a/lib/mongoid/document.rb
+++ b/lib/mongoid/document.rb
@@ -190,6 +190,17 @@ module Mongoid
       became.instance_variable_set(:@destroyed, destroyed?)
       became.changed_attributes["_type"] = self.class.to_s
       became._type = klass.to_s
+
+      # mark embedded docs as persisted
+      embedded_relations.each_pair do |name, meta|
+        without_autobuild do
+          relation = became.__send__(name)
+          Array.wrap(relation).each do |r|
+            r.instance_variable_set(:@new_record, new_record?)
+          end
+        end
+      end
+
       IdentityMap.set(became) unless became.new_record?
       became
     end

--- a/spec/mongoid/document_spec.rb
+++ b/spec/mongoid/document_spec.rb
@@ -783,20 +783,50 @@ describe Mongoid::Document do
 
         context "when the attributes are not protected" do
 
-          let!(:address) do
-            manager.addresses.build(street: "hobrecht")
+          context "when embedded doc is not persisted" do
+
+            let!(:address) do
+              manager.addresses.build(street: "hobrecht")
+            end
+
+            let(:person) do
+              manager.becomes(Person)
+            end
+
+            it "copies the embedded documents" do
+              person.addresses.first.should eq(address)
+            end
+
+            it "returns new instances" do
+              person.addresses.first.should_not equal(address)
+            end
           end
 
-          let(:person) do
-            manager.becomes(Person)
-          end
+          context "when embedded doc is persisted" do
 
-          it "copies the embedded documents" do
-            person.addresses.first.should eq(address)
-          end
+            let(:manager) do
+              Manager.create(title: "Sir")
+            end
 
-          it "returns new instances" do
-            person.addresses.first.should_not equal(address)
+            let!(:address) do
+              manager.addresses.create(street: "hobrecht")
+            end
+
+            let(:person) do
+              manager.becomes(Person)
+            end
+
+            before do
+              person.save!
+            end
+
+            it "copies the embedded documents" do
+              person.addresses.first.should eq(address)
+            end
+
+            it "copies the embedded documents only once" do
+              person.reload.addresses.length.should eq(1)
+            end
           end
         end
       end


### PR DESCRIPTION
``` ruby
person.becomes(Manager).tap do |p|
  p.save!
end
```

would duplicate all embeds_many docs.
