### PR TITLE
Fix Persistence#touch for aliased fields

### DIFF
--- a/lib/mongoid/persistence.rb
+++ b/lib/mongoid/persistence.rb
@@ -120,6 +120,7 @@ module Mongoid
     def touch(field = nil)
       return false if _root.new_record?
       current = Time.now
+      field   = database_field_name(field)
       write_attribute(:updated_at, current) if respond_to?("updated_at=")
       write_attribute(field, current) if field
 

--- a/spec/app/models/person.rb
+++ b/spec/app/models/person.rb
@@ -26,6 +26,7 @@ class Person
   field :bson_id, type: Moped::BSON::ObjectId
   field :pattern, type: Regexp
   field :override_me, type: Integer
+  field :at, as: :aliased_timestamp, type: Time
   field :t, as: :test, type: String
   field :i, as: :inte, type: Integer
   field :a, as: :array, type: Array

--- a/spec/mongoid/persistence_spec.rb
+++ b/spec/mongoid/persistence_spec.rb
@@ -741,6 +741,25 @@ describe Mongoid::Persistence do
             touched.should be_true
           end
         end
+
+        context "when an attribute alias is provided" do
+
+          let!(:touched) do
+            person.touch(:aliased_timestamp)
+          end
+
+          it "sets the attribute to the current time" do
+            person.aliased_timestamp.should be_within(5).of(Time.now)
+          end
+
+          it "persists the change" do
+            person.reload.aliased_timestamp.should be_within(5).of(Time.now)
+          end
+
+          it "returns true" do
+            touched.should be_true
+          end
+        end
       end
 
       context "when an updated at is defined" do


### PR DESCRIPTION
Before:

``` ruby
class A
  include Mongoid::Document

  field :at, as: :aliased_timestamp, type: Time
end

a = A.create
a.touch(:aliased_timestamp)
a.reload.aliased_timestamp # => nil
```

After:

``` ruby
class A
  include Mongoid::Document

  field :at, as: :aliased_timestamp, type: Time
end

a = A.create
a.touch(:aliased_timestamp)
a.reload.aliased_timestamp # => Time
```
