### PR TITLE
scope with a proc which return nil should still be chainable

### DIFF
--- a/lib/mongoid/scoping.rb
+++ b/lib/mongoid/scoping.rb
@@ -277,7 +277,7 @@ module Mongoid
           def #{name}(*args)
             scoping = scopes[:#{name}]
             scope, extension = scoping[:scope][*args], scoping[:extension]
-            criteria = with_default_scope.merge(scope)
+            criteria = with_default_scope.merge(scope || all)
             criteria.extend(extension)
             criteria
           end

--- a/spec/mongoid/scoping_spec.rb
+++ b/spec/mongoid/scoping_spec.rb
@@ -438,6 +438,16 @@ describe Mongoid::Scoping do
           Band.should respond_to(:active)
         end
 
+        context "when proc return nil" do
+          before do
+            Band.scope(:named_by, ->(name) { Band.where(name: name) if name})
+          end
+
+          it "return a all criteral" do
+            Band.named_by(nil).should be_a(Mongoid::Criteria)
+          end
+        end
+
         context "when calling the scope" do
 
           context "when calling from the class" do


### PR DESCRIPTION
just like activerecord, the scope should always be chainable, so we can write

```
scope :before_date, ->(date) { where(:date.lt => date) if date}
```

instead of

```
scope :before_date, ->(date) { date ? where(:date.lt => date) : all}
```
