### PR TITLE
Allow using either "_destroy" and :destroy to delete relation by passing nested attributes 

### DIFF
--- a/lib/mongoid/relations/builders/nested_attributes/many.rb
+++ b/lib/mongoid/relations/builders/nested_attributes/many.rb
@@ -64,7 +64,7 @@ module Mongoid
           #
           # @return [ true, false ] If the relation can potentially be deleted.
           def destroyable?(attributes)
-            destroy = attributes.delete(:_destroy)
+            destroy = attributes.delete(:_destroy) || attributes.delete("_destroy")
             [ 1, "1", true, "true" ].include?(destroy) && allow_destroy?
           end
 

--- a/lib/mongoid/relations/builders/nested_attributes/one.rb
+++ b/lib/mongoid/relations/builders/nested_attributes/one.rb
@@ -50,7 +50,7 @@ module Mongoid
             @attributes = attributes.with_indifferent_access
             @metadata = metadata
             @options = options
-            @destroy = @attributes.delete(:_destroy)
+            @destroy = @attributes.delete(:_destroy) || @attributes.delete("_destroy")
           end
 
           private


### PR DESCRIPTION
Fixes #2911
