### PR TITLE
Fail spec: Children should not override parental collection

### DIFF
--- a/spec/mongoid/sessions_spec.rb
+++ b/spec/mongoid/sessions_spec.rb
@@ -1114,4 +1114,21 @@ describe Mongoid::Sessions do
       end
     end
   end
+
+  context "when inherited" do
+    context "and children override collection" do
+      before do
+        Actress.store_in collection: :actresses
+      end
+
+      it "should override children collection" do
+        Actress.collection_name.should eq(:actresses)
+      end
+
+      it "should not override parental collection" do
+        Actor.collection_name.should eq(:actors)
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
Mongoid::Sessions when inherited and children override collection should not override parental collection

```
$ rake spec SPEC=spec/mongoid/sessions_spec.rb SPEC_OPTS="-e \"when inherited\""
/home/user/.rvm/rubies/ruby-1.9.3-p392/bin/ruby -S rspec spec/mongoid/sessions_spec.rb
Run options:
  include {:full_description=>/when\ inherited/}
  exclude {:config=>#<Proc:./spec/spec_helper.rb:73>}

Mongoid::Sessions
  when inherited
    and children override collection
      should override children collection
      should not override parental collection (FAILED - 1)

Failures:

  1) Mongoid::Sessions when inherited and children override collection should not override parental collection
     Failure/Error: Actor.collection_name.should eq(:actors)

       expected: :actors
            got: :actresses

       (compared using ==)

       Diff:
       @@ -1,2 +1,2 @@
       -:actors
       +:actresses

     # ./spec/mongoid/sessions_spec.rb:1129:in `block (4 levels) in <top (required)>'

Finished in 0.07592 seconds
2 examples, 1 failure

Failed examples:

rspec ./spec/mongoid/sessions_spec.rb:1128 # Mongoid::Sessions when inherited and children override collection should not override parental collection
rake aborted!
/home/user/.rvm/rubies/ruby-1.9.3-p392/bin/ruby -S rspec spec/mongoid/sessions_spec.rb failed
/home/user/.rvm/gems/ruby-1.9.3-p392@mongoid/gems/rspec-core-2.13.1/lib/rspec/core/rake_task.rb:156:in `run_task'
/home/user/.rvm/gems/ruby-1.9.3-p392@mongoid/gems/rspec-core-2.13.1/lib/rspec/core/rake_task.rb:124:in `block (2 levels) in initialize'
/home/user/.rvm/gems/ruby-1.9.3-p392@mongoid/gems/rspec-core-2.13.1/lib/rspec/core/rake_task.rb:122:in `block in initialize'
/home/user/.rvm/gems/ruby-1.9.3-p392@mongoid/bin/ruby_noexec_wrapper:14:in `eval'
/home/user/.rvm/gems/ruby-1.9.3-p392@mongoid/bin/ruby_noexec_wrapper:14:in `<main>'
```
