### PR TITLE
Adding option to validate duplicate fields

### DIFF
--- a/lib/mongoid/config.rb
+++ b/lib/mongoid/config.rb
@@ -24,6 +24,7 @@ module Mongoid
     option :preload_models, default: false
     option :raise_not_found_error, default: true
     option :scope_overwrite_exception, default: false
+    option :duplicate_fields_exception, default: false
     option :use_activesupport_time_zone, default: true
     option :use_utc, default: false
 

--- a/lib/mongoid/fields/validators/macro.rb
+++ b/lib/mongoid/fields/validators/macro.rb
@@ -53,6 +53,15 @@ module Mongoid
           if Mongoid.destructive_fields.include?(name)
             raise Errors::InvalidField.new(klass, name)
           end
+
+          # if field alredy defined
+          if klass.fields.keys.include?(name.to_s)
+            if Mongoid.duplicate_fields_exception
+              raise Errors::InvalidField.new(klass, name)
+            else
+              Mongoid.logger.warn("Overwriting existing field #{name}.") if Mongoid.logger
+            end
+          end
         end
 
         # Validate that the field options are allowed.

--- a/spec/mongoid/fields_spec.rb
+++ b/spec/mongoid/fields_spec.rb
@@ -702,7 +702,7 @@ describe Mongoid::Fields do
   describe ".field" do
 
     it "returns the generated field" do
-      expect(Person.field(:testing)).to equal Person.fields["testing"]
+      expect(Person.field(:testing)).to eq(Person.fields["testing"])
     end
 
     context "when the field name conflicts with mongoid's internals" do
@@ -714,6 +714,23 @@ describe Mongoid::Fields do
             Person.field(:metadata)
           }.to raise_error(Mongoid::Errors::InvalidField)
         end
+      end
+    end
+
+    context "when field already exist and validate_duplicate is enable" do
+
+      before do
+        Mongoid.duplicate_fields_exception = true
+      end
+
+      after do
+        Mongoid.duplicate_fields_exception = false
+      end
+
+      it "raises an error" do
+        expect {
+          Person.field(:title)
+        }.to raise_error(Mongoid::Errors::InvalidField)
       end
     end
 


### PR DESCRIPTION
As requested on #2869 , this is adding a new option, validate_duplicate_fields,
which, when on, should raise an error if there is a 2 fields with same name.
