### PR TITLE
Fixed has_one excessive query.

### DIFF
--- a/lib/mongoid/relations/bindings/referenced/in.rb
+++ b/lib/mongoid/relations/bindings/referenced/in.rb
@@ -29,7 +29,7 @@ module Mongoid
                   if base.referenced_many?
                     target.__send__(inverse).push(base) unless Mongoid.using_identity_map?
                   else
-                    target.do_or_do_not(metadata.inverse_setter(target), base)
+                    target.__build__(base.metadata_name, base, target.reflect_on_association(inverse))
                   end
                 end
               end

--- a/spec/mongoid/relations/referenced/in_spec.rb
+++ b/spec/mongoid/relations/referenced/in_spec.rb
@@ -10,6 +10,21 @@ describe Mongoid::Relations::Referenced::In do
     Person.create
   end
 
+  describe "#" do
+    let(:game) do
+      Game.create(person: person)
+    end
+
+    before do
+      game.reload
+    end
+
+    it "calls for game building with a game object, so there's no excessive query" do
+      Person.any_instance.should_receive(:__build__).with(:game, game, anything)
+      game.person
+    end
+  end
+
   describe "#=" do
 
     context "when the relation is named target" do


### PR DESCRIPTION
It really fixes https://github.com/mongoid/mongoid/issues/2701

The problem is that there seems to be no way for a has_one setter to know, whether assigned object is the same without actually getting the object from DB; so I reversed your path and solved the problem in belongs_to setter. I'm not sure that I did it the best way, but at least I didn't break any existing specs and added one spec to cover the bug.
