### PR TITLE
to_json should behave like vanilla Moped, or at least be consistent when used in an array (or hash)

### DIFF
--- a/lib/mongoid/extensions.rb
+++ b/lib/mongoid/extensions.rb
@@ -1,9 +1,9 @@
 # encoding: utf-8
 class Moped::BSON::ObjectId
-  undef :as_json
   def as_json(options = nil)
-    to_s
+    {'$oid' => to_s}
   end
+
   def to_xml(options = nil)
     ActiveSupport::XmlMini.to_tag(options[:root], self.to_s, options)
   end


### PR DESCRIPTION
Consider this test program:

``` ruby
#!/usr/bin/env ruby
require 'json'
require 'moped'
puts Moped::BSON::ObjectId.new.to_json
puts [Moped::BSON::ObjectId.new].to_json
require 'mongoid'
puts Moped::BSON::ObjectId.new.to_json
puts [Moped::BSON::ObjectId.new].to_json
```

The output with the current Mongoid is:

```
$ ./test.rb
{"$oid": "516224fe9fc87efb83000001"}
[{"$oid": "516224fe9fc87efb83000002"}]
{"$oid": "516224fe9fc87efb83000003"}
["516224fe9fc87efb83000004"]
```

The output with this commit applied:

```
$ ./test.rb
{"$oid": "516225259fc87e6200000001"}
[{"$oid": "516225259fc87e6200000002"}]
{"$oid": "516225259fc87e6200000003"}
[{"$oid":"516225259fc87e6200000004"}]
```

---

Note that this commit does not break any tests.

The sad thing is that this commit may break existing systems. The other route is to stop doing $oid tricks in Moped, but that would break existing systems as well.
