### PR TITLE
Fixing addToSet and push

### DIFF
--- a/lib/mongoid/persistable/pushable.rb
+++ b/lib/mongoid/persistable/pushable.rb
@@ -23,8 +23,11 @@ module Mongoid
         prepare_atomic_operation do |ops|
           process_atomic_operations(adds) do |field, value|
             existing = send(field) || (attributes[field] ||= [])
-            existing.push(value) unless existing.include?(value)
-            ops[atomic_attribute_name(field)] = value
+            values = [ value ].flatten
+            values.each do |val|
+              existing.push(val) unless existing.include?(val)
+            end
+            ops[atomic_attribute_name(field)] = { "$each" => values }
           end
           { "$addToSet" => ops }
         end

--- a/spec/mongoid/persistable/pushable_spec.rb
+++ b/spec/mongoid/persistable/pushable_spec.rb
@@ -44,7 +44,7 @@ describe Mongoid::Persistable::Pushable do
       context "when provided string fields" do
 
         let!(:add) do
-          person.add_to_set("aliases" => 4, "array" => 4, "test_array" => 1)
+          person.add_to_set("aliases" => 4, "array" => [4, 5], "test_array" => 1)
         end
 
         it_behaves_like "a unique pushable root document"
@@ -53,7 +53,7 @@ describe Mongoid::Persistable::Pushable do
       context "when provided symbol fields" do
 
         let!(:add) do
-          person.add_to_set(aliases: 4, array: 4, test_array: 1)
+          person.add_to_set(aliases: 4, array: [4, 5], test_array: 1)
         end
 
         it_behaves_like "a unique pushable root document"


### PR DESCRIPTION
push method uses always $pushAll, which bahaves correctly when one
or multiple values
