### PR TITLE
Fixing dynamic fields to recognize changes that are done nested more than one level down

### DIFF
--- a/lib/mongoid/attributes.rb
+++ b/lib/mongoid/attributes.rb
@@ -252,6 +252,7 @@ module Mongoid
 
       class_eval <<-READER
         def #{name}
+          attribute_will_change!(#{name.inspect})
           read_attribute(#{name.inspect})
         end
       READER
@@ -270,6 +271,7 @@ module Mongoid
     def define_dynamic_before_type_cast_reader(name)
       class_eval <<-READER
         def #{name}_before_type_cast
+          attribute_will_change!(#{name.inspect})
           read_attribute_before_type_cast(#{name.inspect})
         end
       READER
@@ -322,10 +324,12 @@ module Mongoid
         write_attribute(getter, args.first)
       elsif attr.before_type_cast?
         define_dynamic_before_type_cast_reader(attr.reader)
+        attribute_will_change!(attr.reader)
         read_attribute_before_type_cast(attr.reader)
       else
         getter = attr.reader
         define_dynamic_reader(getter)
+        attribute_will_change!(attr.reader)
         read_attribute(getter)
       end
     end

--- a/spec/mongoid/dirty_spec.rb
+++ b/spec/mongoid/dirty_spec.rb
@@ -775,6 +775,23 @@ describe Mongoid::Dirty do
           person.should be_changed
         end
       end
+
+      context "when a dynamic field is changed in place" do
+
+        let(:person) do
+          Person.create(other_name: { full: {first: 'first', last: 'last'} })
+        end
+
+        before do
+          Mongoid.configure.allow_dynamic_fields = true
+          person.other_name[:full][:first] = 'Name'
+        end
+
+        it "returns true" do
+          person.changes.should_not be_empty
+          person.should be_changed
+        end
+      end
     end
 
     context "when the document has not changed" do


### PR DESCRIPTION
This probably will want to be cherry picked to master. As shown in the test case in the pull request, when using dynamic fields and changing an object that is nested more than one level down, no changes are reported and so the subsequent save call does not change any data. This issue does not exist when the field is declared as a Hash.
