### PR TITLE
Fixes comment accuracy

### DIFF
--- a/lib/mongoid/timestamps/updated/short.rb
+++ b/lib/mongoid/timestamps/updated/short.rb
@@ -3,8 +3,8 @@ module Mongoid
   module Timestamps
     module Updated
 
-      # Adds a created_at timestamp to the document, but it is stored as c_at
-      # with a created_at alias.
+      # Adds an updated_at timestamp to the document, but it is stored as u_at
+      # with an updated_at alias.
       module Short
         extend ActiveSupport::Concern
 


### PR DESCRIPTION
This pull request provides a small doc patch that fixes comments that incorrectly referred to the `c_at` alias on the `u_at` code.
