### PR TITLE
Store result hash on Persistence::Operations::Update

### DIFF
--- a/lib/mongoid/persistence.rb
+++ b/lib/mongoid/persistence.rb
@@ -142,8 +142,10 @@ module Mongoid
     #
     # @return [ true, false ] True if succeeded, false if not.
     def update(options = {})
-      Operations.update(self, options).persist
+      Operations.update(self, options).tap { |u| @last_update = u }.persist
     end
+
+    attr_reader :last_update
 
     # Update a single attribute and persist the entire document.
     # This skips validation but fires the callbacks.

--- a/lib/mongoid/persistence/operations/update.rb
+++ b/lib/mongoid/persistence/operations/update.rb
@@ -34,6 +34,8 @@ module Mongoid
         include Operations
         include Mongoid::Atomic::Positionable
 
+        attr_reader :result
+
         # Persist the document that is to be updated to the database. This will
         # only write changed fields via MongoDB's $set modifier operation.
         #
@@ -44,7 +46,7 @@ module Mongoid
         def persist
           prepare do
             unless updates.empty?
-              collection.find(selector).update(positionally(selector, updates))
+              @result = collection.find(selector).update(positionally(selector, updates))
               conflicts.each_pair do |key, value|
                 collection.find(selector).update(
                   positionally(selector, { key => value })


### PR DESCRIPTION
Hi there,

This patch allows access to the most recently run Mongoid::Persistence::Operations::Update by adding a last_update attr_reader to Mongoid::Persistence.

We are also storing the the result of the update operation on the Update object in order to extract information from getlasterror (when running safely).

The specific reason behind wanting to do this is to be able to access the updateExisting information from getlasterror in the mongoid_optimistic_locking gem (https://github.com/burgalon/mongoid_optimistic_locking). Here is an example of how the patch can be used in it:

https://gist.github.com/tomglue/5482520#file-gistfile1-rb-L10

I appreciate that this may not be the correct or best way to achieve this, but was looking to get some feedback on the solution I have come up with.

Cheers
