### PR TITLE
Fix for validates_uniqueness with aliased fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ doc/*
 *.profile
 *.profile.pdf
 *.symbols
+.idea

--- a/lib/mongoid/validations/uniqueness.rb
+++ b/lib/mongoid/validations/uniqueness.rb
@@ -124,6 +124,8 @@ module Mongoid
       #
       # @since 2.3.0
       def criterion(document, attribute, value)
+        attribute = document.class.aliased_fields[attribute.to_s] || attribute
+
         if localized?(document, attribute)
           conditions = value.inject([]) { |acc, (k,v)| acc << { "#{attribute}.#{k}" => filter(v) } }
           selector = { "$or" => conditions }

--- a/spec/app/models/definition.rb
+++ b/spec/app/models/definition.rb
@@ -1,7 +1,7 @@
 class Definition
   include Mongoid::Document
   field :description, type: String
-  field :part, type: String
+  field :p, as: :part, type: String
   field :regular, type: Boolean
   embedded_in :word
 end

--- a/spec/mongoid/validations/uniqueness_spec.rb
+++ b/spec/mongoid/validations/uniqueness_spec.rb
@@ -141,6 +141,55 @@ describe Mongoid::Validations::UniquenessValidator do
           end
         end
 
+        context "when the field name is aliased" do
+
+          before do
+            Dictionary.create!(language: "en")
+          end
+
+          let(:dictionary) do
+            Dictionary.new(language: "en")
+          end
+
+          after do
+            Dictionary.reset_callbacks(:validate)
+          end
+
+          context "when the validation uses the aliased name" do
+
+            before do
+              Dictionary.validates_uniqueness_of :language
+            end
+
+            it "correctly detects a uniqueness conflict" do
+              expect(dictionary).to_not be_valid
+            end
+
+            it "adds the uniqueness error to the aliased field name" do
+              dictionary.valid?
+              expect(dictionary.errors).to have_key(:language)
+              expect(dictionary.errors[:language]).to eq([ "is already taken" ])
+            end
+          end
+
+          context "when the validation uses the underlying field name" do
+
+            before do
+              Dictionary.validates_uniqueness_of :l
+            end
+
+            it "correctly detects a uniqueness conflict" do
+              expect(dictionary).to_not be_valid
+            end
+
+            it "adds the uniqueness error to the underlying field name" do
+              dictionary.valid?
+              expect(dictionary.errors).to have_key(:l)
+              expect(dictionary.errors[:l]).to eq([ "is already taken" ])
+            end
+          end
+        end
+
         context "when the field is localized" do
 
           context "when no scope is provided" do
@@ -2017,6 +2066,55 @@ describe Mongoid::Validations::UniquenessValidator do
 
             it "returns true" do
               definition.should be_valid
+            end
+          end
+        end
+
+        context "when the field name is aliased" do
+
+          before do
+            word.definitions.build(part: "noun")
+          end
+
+          let(:definition) do
+            word.definitions.build(part: "noun")
+          end
+
+          after do
+            Definition.reset_callbacks(:validate)
+          end
+
+          context "when the validation uses the aliased name" do
+
+            before do
+              Definition.validates_uniqueness_of :part, case_sensitive: false
+            end
+
+            it "correctly detects a uniqueness conflict" do
+              expect(definition).to_not be_valid
+            end
+
+            it "adds the uniqueness error to the aliased field name" do
+              definition.valid?
+              expect(definition.errors).to have_key(:part)
+              expect(definition.errors[:part]).to eq([ "is already taken" ])
+            end
+          end
+
+          context "when the validation uses the underlying field name" do
+
+            before do
+              Definition.validates_uniqueness_of :p, case_sensitive: false
+            end
+
+            it "correctly detects a uniqueness conflict" do
+              expect(definition).to_not be_valid
+            end
+
+            it "adds the uniqueness error to the underlying field name" do
+              definition.valid?
+              expect(definition.errors).to have_key(:p)
+              expect(definition.errors[:p]).to eq([ "is already taken" ])
             end
           end
         end


### PR DESCRIPTION
(Squashed commits from previous PR #2988)

I discovered that the below does not work, it yields a false positive :warning:

``` ruby
field :n, as: :name, type: String

validates_uniqueness_of :name
```

I've patched this behavior and have added specs for it.

Also includes a trivial commit to add Rubymine (.idea) to .gitignore
