### PR TITLE
Subclass scopes

### DIFF
--- a/lib/mongoid/scopable.rb
+++ b/lib/mongoid/scopable.rb
@@ -10,11 +10,33 @@ module Mongoid
 
     included do
       class_attribute :default_scoping
-      class_attribute :scopes
-      self.scopes = {}
+      class_attribute :_declared_scopes
+      self._declared_scopes = {}
     end
 
     module ClassMethods
+
+      # Returns a hash of all the scopes defined for this class, including
+      # scopes defined on ancestor classes.
+      #
+      # @example Get the defined scopes for a class
+      #   class Band
+      #     include Mongoid::Document
+      #     field :active, type: Boolean
+      #
+      #     scope :active, where(active: true)
+      #   end
+      #   Band.scopes
+      #
+      # @return [ Hash ] The scopes defined for this class
+      #
+      # @since 4.0.0
+      def scopes
+        ancestors.reverse.inject({}) do |s,klass|
+          s.merge!(klass._declared_scopes) if klass.respond_to?(:_declared_scopes)
+          s
+        end.freeze
+      end
 
       # Add a default scope to the model. This scope will be applied to all
       # criteria unless #unscoped is specified.
@@ -96,7 +118,7 @@ module Mongoid
         normalized = name.to_sym
         check_scope_validity(value)
         check_scope_name(normalized)
-        scopes[normalized] = {
+        _declared_scopes[normalized] = {
           scope: strip_default_scope(value),
           extension: Module.new(&block)
         }
@@ -228,7 +250,7 @@ module Mongoid
       #
       # @since 2.1.0
       def check_scope_name(name)
-        if scopes[name] || respond_to?(name, true)
+        if _declared_scopes[name] || respond_to?(name, true)
           if Mongoid.scope_overwrite_exception
             raise Errors::ScopeOverwrite.new(self.name, name)
           else
@@ -275,9 +297,9 @@ module Mongoid
       #
       # @since 3.0.0
       def define_scope_method(name)
-        (class << self; self; end).class_eval <<-SCOPE
+        (class << self; self; end).class_eval <<-SCOPE, __FILE__, __LINE__ + 1
           def #{name}(*args)
-            scoping = scopes[:#{name}]
+            scoping = _declared_scopes[:#{name}]
             scope, extension = scoping[:scope][*args], scoping[:extension]
             criteria = with_default_scope.merge(scope || queryable)
             criteria.extend(extension)

--- a/lib/mongoid/traversable.rb
+++ b/lib/mongoid/traversable.rb
@@ -176,7 +176,7 @@ module Mongoid
         subclass.fields = fields.dup
         subclass.pre_processed_defaults = pre_processed_defaults.dup
         subclass.post_processed_defaults = post_processed_defaults.dup
-        subclass.scopes = scopes.dup
+        subclass._declared_scopes = Hash.new { |hash,key| self._declared_scopes[key] }
         subclass.autosaved_relations = autosaved_relations.dup
 
         # We only need the _type field if inheritance is in play, but need to

--- a/spec/mongoid/criterion/scoping_spec.rb
+++ b/spec/mongoid/criterion/scoping_spec.rb
@@ -377,7 +377,7 @@ describe Mongoid::Criterion::Scoping do
           class << Band
             undef_method :skipped
           end
-          Band.scopes.clear
+          Band._declared_scopes.clear
         end
 
         it "does not allow the default scope to be applied" do

--- a/spec/mongoid/scopable_spec.rb
+++ b/spec/mongoid/scopable_spec.rb
@@ -198,7 +198,7 @@ describe Mongoid::Scopable do
           class << Band
             undef_method :active
           end
-          Band.scopes.clear
+          Band._declared_scopes.clear
         end
 
         let(:scope) do
@@ -223,7 +223,7 @@ describe Mongoid::Scopable do
           class << Record
             undef_method :tool
           end
-          Record.scopes.clear
+          Record._declared_scopes.clear
         end
 
         context "when calling the scope" do
@@ -256,7 +256,7 @@ describe Mongoid::Scopable do
           class << Band
             undef_method :active
           end
-          Band.scopes.clear
+          Band._declared_scopes.clear
         end
 
         it "adds a method for the scope" do
@@ -294,7 +294,7 @@ describe Mongoid::Scopable do
               class << Band
                 undef_method :english
               end
-              Band.scopes.clear
+              Band._declared_scopes.clear
             end
 
             let(:scope) do
@@ -364,7 +364,7 @@ describe Mongoid::Scopable do
             class << Band
               undef_method :active
             end
-            Band.scopes.clear
+            Band._declared_scopes.clear
           end
 
           it "raises an exception" do
@@ -382,7 +382,7 @@ describe Mongoid::Scopable do
             class << Band
               undef_method :active
             end
-            Band.scopes.clear
+            Band._declared_scopes.clear
           end
 
           it "raises no exception" do
@@ -409,7 +409,7 @@ describe Mongoid::Scopable do
           class << Band
             undef_method :active
           end
-          Band.scopes.clear
+          Band._declared_scopes.clear
         end
 
         let(:scope) do
@@ -433,7 +433,7 @@ describe Mongoid::Scopable do
             undef_method :active
             undef_method :named_by
           end
-          Band.scopes.clear
+          Band._declared_scopes.clear
         end
 
         it "adds a method for the scope" do
@@ -478,7 +478,7 @@ describe Mongoid::Scopable do
               class << Band
                 undef_method :english
               end
-              Band.scopes.clear
+              Band._declared_scopes.clear
             end
 
             let(:scope) do
@@ -548,7 +548,7 @@ describe Mongoid::Scopable do
             class << Band
               undef_method :active
             end
-            Band.scopes.clear
+            Band._declared_scopes.clear
           end
 
           it "raises an exception" do
@@ -566,7 +566,7 @@ describe Mongoid::Scopable do
             class << Band
               undef_method :active
             end
-            Band.scopes.clear
+            Band._declared_scopes.clear
           end
 
           it "raises no exception" do
@@ -604,7 +604,7 @@ describe Mongoid::Scopable do
             undef_method :xxx
             undef_method :yyy
           end
-          Band.scopes.clear
+          Band._declared_scopes.clear
         end
 
         let(:criteria) do
@@ -621,6 +621,49 @@ describe Mongoid::Scopable do
             ]
           })
         end
+      end
+    end
+
+    context "when working with a subclass" do
+      before do
+        Shape.scope(:located_at, ->(x,y) {Shape.where(x: x, y: y)})
+        Circle.scope(:with_radius, ->(r) {Circle.where(radius: r)})
+      end
+
+      after do
+        class << Shape
+          undef_method :located_at
+        end
+        Shape._declared_scopes.clear
+
+        class << Circle
+          undef_method :with_radius
+        end
+        Circle._declared_scopes.clear
+      end
+
+      let(:shape_scope_keys) do
+        Shape.scopes.keys
+      end
+
+      let(:circle_located_at) do
+        Circle.located_at(0,0)
+      end
+
+      let(:circle_scope_keys) do
+        Circle.scopes.keys
+      end
+
+      it "doesn't include subclass scopes in superclass scope list" do
+        expect(shape_scope_keys).to match_array([:located_at])
+      end
+
+      it "includes superclass scope methods on subclass" do
+        expect(circle_located_at).to be_a(Mongoid::Criteria)
+      end
+
+      it "includes superclass scopes in subclass scope list" do
+        expect(circle_scope_keys).to match_array([:located_at, :with_radius])
       end
     end
   end
@@ -795,7 +838,7 @@ describe Mongoid::Scopable do
           class << Band
             undef_method :skipped
           end
-          Band.scopes.clear
+          Band._declared_scopes.clear
         end
 
         it "does not allow the default scope to be applied" do


### PR DESCRIPTION
This diff fixes an edge case for scope methods. Previously, when a scope was added to a parent class after both the parent and a child class had been loaded, calling the scope method via the subclass resulted in an exception. With this patch, calling the scope method via the subclass works as expected.

One implementation detail of this patch is that the #scopes method on a Mongoid-mapped class will only return the scopes directly defined on the class itself, not any scopes defined on its parent classes.

Also, since the #scopes attribute is effectively used as an internal implementation detail of the scope methods, it would probably be nice to protect it a little better. As it stands now, the scope descriptor can be overwritten by outside code or the entire data structure can be cleared with scopes.clear, leading every scope method to start throwing exceptions. For what it's worth, ActiveRecord doesn't provide the equivalent of a #scopes method, it just defines the scope methods directly and has no way to enumerate them.
