### PR TITLE
allow read_attribute to work with an aliased field name

### DIFF
--- a/lib/mongoid/attributes.rb
+++ b/lib/mongoid/attributes.rb
@@ -89,7 +89,7 @@ module Mongoid
     #
     # @since 1.0.0
     def read_attribute(name)
-      normalized = name.to_s
+      normalized = database_field_name(name.to_s)
       if hash_dot_syntax?(normalized)
         attributes.__nested__(normalized)
       else

--- a/spec/mongoid/attributes_spec.rb
+++ b/spec/mongoid/attributes_spec.rb
@@ -616,6 +616,21 @@ describe Mongoid::Attributes do
         end
       end
     end
+
+    context "when attribute has an aliased name" do
+
+      let(:person) do
+        Person.new
+      end
+
+      before(:each) do
+        person.write_attribute(:t, "aliased field to test")
+      end
+
+      it "returns the value of the aliased field" do
+        expect(person.read_attribute(:test)).to eq("aliased field to test")
+      end
+    end
   end
 
   describe "#read_attribute_before_type_cast" do


### PR DESCRIPTION
pull request for issue #3053
