### PR TITLE
document.atomically can take multiple of the same operation. fixes #3057

### DIFF
--- a/lib/mongoid/persistable.rb
+++ b/lib/mongoid/persistable.rb
@@ -180,7 +180,10 @@ module Mongoid
     # @since 4.0.0
     def persist_or_delay_atomic_operation(operation)
       if executing_atomically?
-        @atomic_updates_to_execute.merge!(operation)
+        operation.each do |(name, hash)|
+          @atomic_updates_to_execute[name] ||= {}
+          @atomic_updates_to_execute[name].merge!(hash)
+        end
       else
         persist_atomic_operations(operation)
       end


### PR DESCRIPTION
Prior to this commit, the second etc operation of a certain type would not execute.

``` ruby
doc.atomically do
  doc.inc(:views).
    inc(:other)
end
```

Would have only incremented `:other`. Now it works as expected.
