### PR TITLE
Document#becomes doesn't properly set the reference to @base in the errors object.

### DIFF
--- a/lib/mongoid/document.rb
+++ b/lib/mongoid/document.rb
@@ -204,7 +204,8 @@ module Mongoid
       became = klass.new(clone_document)
       became.id = id
       became.instance_variable_set(:@changed_attributes, changed_attributes)
-      became.instance_variable_set(:@errors, errors)
+      became.instance_variable_set(:@errors, ActiveModel::Errors.new(became))
+      became.errors.instance_variable_set(:@messages, errors.instance_variable_get(:@messages))
       became.instance_variable_set(:@new_record, new_record?)
       became.instance_variable_set(:@destroyed, destroyed?)
       became.changed_attributes["_type"] = self.class.to_s

--- a/spec/mongoid/document_spec.rb
+++ b/spec/mongoid/document_spec.rb
@@ -1109,6 +1109,24 @@ describe Mongoid::Document do
         it "copies the errors" do
           expect(manager.errors).to include(:ssn)
         end
+        
+      end
+      
+      context "when the subclass validates attributes not present on the parent class" do
+        
+        before do
+          Manager.validates_inclusion_of(:level, in: [1, 2])
+        end
+        
+        let(:manager) do
+          person.becomes(Manager)
+        end
+        
+        it "validates the instance of the subclass" do
+          manager.level = 3
+          expect(manager.valid?).to be_false
+        end
+        
       end
 
       context "when the subclass has defaults" do


### PR DESCRIPTION
I ran into this problem when using Document#becomes to create a subclass and then validate it. Super simplified reproduction below. Just a rails 3.2.13 app with two models, one inheriting from the other.

``` ruby
class Klass
  include Mongoid::Document
end

class SubKlass < Klass
  field :attr, type: String
  validates :attr, presence: true
end
```

``` irb
Loading development environment (Rails 3.2.13)
1.9.3p392 :001 > k = Klass.new
 => #<Klass _id: 519aeff6be8a5cf65f000001, > 
1.9.3p392 :002 > k.errors.inspect
 => "#<ActiveModel::Errors:0x007ff5bf98a758 @base=#<Klass _id: 519aeff6be8a5cf65f000001, >, @messages={}>" 
1.9.3p392 :003 > sk = k.becomes SubKlass
 => #<SubKlass _id: 519aeff6be8a5cf65f000001, _type: "SubKlass", attr: nil> 
1.9.3p392 :004 > sk.errors.inspect
 => "#<ActiveModel::Errors:0x007ff5bf98a758 @base=#<Klass _id: 519aeff6be8a5cf65f000001, _type: nil>, @messages={}>" 
1.9.3p392 :005 > sk.valid?
NoMethodError: undefined method `attr' for #<Klass _id: 519aeff6be8a5cf65f000001, _type: nil>
1.9.3p392 :007 >   sk.instance_variable_set(:@errors, ActiveModel::Errors.new(sk))
 => #<ActiveModel::Errors:0x007ff5bf9df348 @base=#<SubKlass _id: 519aeff6be8a5cf65f000001, _type: "SubKlass", attr: nil>, @messages={}> 
1.9.3p392 :008 > sk.valid?
 => false 
```

I added one spec to test against the issue, and made the appropriate changes to Document#becomes.
