### PR TITLE
add `mongoid:drop_undefined_indexes` rake task

### DIFF
--- a/lib/mongoid/railties/database.rake
+++ b/lib/mongoid/railties/database.rake
@@ -72,6 +72,12 @@ namespace :db do
       ::Rails::Mongoid.create_indexes
     end
 
+    desc "Remove indexes that exist in the database but aren't specified on the models"
+    task :drop_undefined_indexes => :environment do
+      ::Rails.application.eager_load!
+      ::Rails::Mongoid.drop_undefined_indexes
+    end
+
     desc "Remove the indexes defined on your mongoid models without questions!"
     task :remove_indexes => :environment do
       ::Rails.application.eager_load!

--- a/spec/rails/mongoid_spec.rb
+++ b/spec/rails/mongoid_spec.rb
@@ -72,6 +72,55 @@ describe "Rails::Mongoid" do
     end
   end
 
+  describe ".undefined_indexes" do
+
+    before(:each) do
+      Rails::Mongoid.create_indexes
+    end
+
+    subject do
+      Rails::Mongoid.undefined_indexes
+    end
+
+    it { should eq({}) }
+
+    context "with extra index on model collection" do
+      before(:each) do
+        User.collection.indexes.create(account_expires: 1)
+      end
+
+      its(:keys) { should eq([User]) }
+
+      it "should have single index returned" do
+        names = subject[User].map{ |index| index['name'] }
+        expect(names).to eq(['account_expires_1'])
+      end
+    end
+  end
+
+  describe ".drop_undefined_indexes" do
+
+    let(:logger) do
+      stub
+    end
+
+    let(:indexes) do
+      User.collection.indexes
+    end
+
+    before(:each) do
+      Rails::Mongoid.create_indexes
+      indexes.create(account_expires: 1)
+      Rails::Mongoid.drop_undefined_indexes
+    end
+
+    subject do
+      Rails::Mongoid.undefined_indexes
+    end
+
+    it { should eq({}) }
+  end
+
   describe ".remove_indexes" do
 
     let(:logger) do


### PR DESCRIPTION
Removes indexes that exist in the database but aren't specified on the models.  Useful as an application evolves over time and indexes are changed on the models, where it's easy to forget to remove the old ones.
