### PR TITLE
Re-added Multi-Parameter Attributes

### DIFF
--- a/lib/mongoid.rb
+++ b/lib/mongoid.rb
@@ -20,6 +20,7 @@ require "mongoid/loggable"
 require "mongoid/sessions"
 require "mongoid/document"
 require "mongoid/unit_of_work"
+require "mongoid/multi_parameter_attributes"
 
 # If we are using Rails then we will include the Mongoid railtie. This has all
 # the nifty initializers that Mongoid needs.

--- a/lib/mongoid/multi_parameter_attributes.rb
+++ b/lib/mongoid/multi_parameter_attributes.rb
@@ -50,7 +50,7 @@ module Mongoid
       if attrs
         errors = []
         attributes = attrs.class.new
-        attributes.permitted = true if attrs.respond_to?(:permitted?) && attrs.permitted?
+        attributes.permit! if attrs.respond_to?(:permitted?) && attrs.permitted?
         multi_parameter_attributes = {}
 
         attrs.each_pair do |key, value|


### PR DESCRIPTION
I wasn't able to use datetime_select with mongoid, so I updated the permit method on the old Multi-Parameter Attributes extension and re-integrated it into mongoid. 

I raised this concern with Issue #3094.
