### PR TITLE
Fix polymorphic has_many 

### DIFF
--- a/lib/mongoid/relations/referenced/many.rb
+++ b/lib/mongoid/relations/referenced/many.rb
@@ -751,7 +751,7 @@ module Mongoid
           # @since 3.0.0
           def with_polymorphic_criterion(criteria, metadata, type = nil)
             if metadata.polymorphic?
-              criteria.where(metadata.type => type.name)
+              criteria.where(metadata.type => metadata.inverse_class_name)
             else
               criteria
             end


### PR DESCRIPTION
Fix polymorphic has_many class name to correspont to builder class name:

How to reproduce error:

``` ruby
class Product; has_many :addresses, as: 'addressable'; end

class SuperProduct < Product; end;

super_product.addresses.build # sets addressable_type: "Product" for address

super_product.addresses #generates selector "addressable_type"=>"SuperProduct"
```

after fix:

super_product.addresses #generates selector "addressable_type"=>"Product"}
