### PR TITLE
Create indexes in background by default.

### DIFF
--- a/lib/mongoid/indexes.rb
+++ b/lib/mongoid/indexes.rb
@@ -111,6 +111,9 @@ module Mongoid
         if opts.has_key?(:expire_after_seconds)
           opts[:expireAfterSeconds] = opts.delete(:expire_after_seconds)
         end
+        unless opts.has_key?(:background)
+          opts[:background] = true
+        end
         opts
       end
 


### PR DESCRIPTION
For safety, all indexes should be created in the background by default (in my opinion).  I forgot to include "background: true" on an index spec, which just caused our production website to go down while the DB created the index.  Would very much like that to never happen again.
