### PR TITLE
Add overwrite option to field

### DIFF
--- a/lib/mongoid/fields/validators/macro.rb
+++ b/lib/mongoid/fields/validators/macro.rb
@@ -16,7 +16,8 @@ module Mongoid
           :metadata,
           :pre_processed,
           :subtype,
-          :type
+          :type,
+          :overwrite
         ]
 
         # Validate the field definition.
@@ -30,7 +31,7 @@ module Mongoid
         #
         # @since 3.0.0
         def validate(klass, name, options)
-          validate_name(klass, name)
+          validate_name(klass, name, options)
           validate_options(klass, name, options)
         end
 
@@ -49,13 +50,13 @@ module Mongoid
         # @raise [ Errors::InvalidField ] If the name is not allowed.
         #
         # @since 3.0.0
-        def validate_name(klass, name)
+        def validate_name(klass, name, options)
           if Mongoid.destructive_fields.include?(name)
             raise Errors::InvalidField.new(klass, name)
           end
 
           # if field alredy defined
-          if klass.fields.keys.include?(name.to_s)
+          if ! options[:overwrite] && klass.fields.keys.include?(name.to_s)
             if Mongoid.duplicate_fields_exception
               raise Errors::InvalidField.new(klass, name)
             else

--- a/lib/mongoid/traversable.rb
+++ b/lib/mongoid/traversable.rb
@@ -185,7 +185,7 @@ module Mongoid
           field(:_type, default: self.name, type: String)
         end
         subclass_default = subclass.name || ->{ self.class.name }
-        subclass.field(:_type, default: subclass_default, type: String)
+        subclass.field(:_type, default: subclass_default, type: String, overwrite: true)
       end
     end
   end

--- a/spec/mongoid/fields_spec.rb
+++ b/spec/mongoid/fields_spec.rb
@@ -752,6 +752,12 @@ describe Mongoid::Fields do
           Person.field(:title)
         }.to raise_error(Mongoid::Errors::InvalidField)
       end
+
+      it "doesn't raise an error" do
+        expect {
+          Class.new(Person)
+        }.to_not raise_error(Mongoid::Errors::InvalidField)
+      end
     end
 
     context "when the field is a time" do


### PR DESCRIPTION
Add `overwrite` option to `field`, when it is true, it will not check for duplicate field definition.

[ fix #3140 ]
