### PR TITLE
Fix: Error messages were not localized cause locale :en was hardcoded.

### DIFF
--- a/lib/mongoid/errors/mongoid_error.rb
+++ b/lib/mongoid/errors/mongoid_error.rb
@@ -40,7 +40,7 @@ module Mongoid
       #
       # @return [ String ] A localized error message string.
       def translate(key, options)
-        ::I18n.translate("#{BASE_KEY}.#{key}", { locale: :en }.merge(options))
+        ::I18n.translate("#{BASE_KEY}.#{key}", { locale: ::I18n.locale }.merge(options))
       end
 
       # Create the problem.


### PR DESCRIPTION
Error messages did not get localized. Seems this was causes by a hardcoded locale :en. 
