### PR TITLE
Fix primary_key option on ManyToMany relations

### DIFF
--- a/lib/mongoid/relations/bindings/referenced/many_to_many.rb
+++ b/lib/mongoid/relations/bindings/referenced/many_to_many.rb
@@ -20,7 +20,7 @@ module Mongoid
             binding do
               inverse_keys = doc.you_must(metadata.inverse_foreign_key)
               if inverse_keys
-                inverse_keys.push(record_id(base))
+                inverse_keys.push(inverse_record_id(doc))
                 doc.reset_relation_criteria(metadata.inverse)
               end
               base.synced[metadata.foreign_key] = true
@@ -39,12 +39,26 @@ module Mongoid
               base.send(metadata.foreign_key).delete_one(record_id(doc))
               inverse_keys = doc.you_must(metadata.inverse_foreign_key)
               if inverse_keys
-                inverse_keys.delete_one(record_id(base))
+                inverse_keys.delete_one(inverse_record_id(doc))
                 doc.reset_relation_criteria(metadata.inverse)
               end
               base.synced[metadata.foreign_key] = true
               doc.synced[metadata.inverse_foreign_key] = true
             end
+          end
+
+          # Find the inverse id referenced by inverse_keys
+          def inverse_record_id(doc)
+            inverse_metadata = determine_inverse_metadata(doc)
+            if inverse_metadata
+              base.__send__(inverse_metadata.primary_key)
+            else
+              base.id
+            end
+          end
+
+          def determine_inverse_metadata(doc)
+            doc.relations[base.class.name.demodulize.underscore.pluralize]
           end
         end
       end

--- a/lib/mongoid/relations/referenced/many_to_many.rb
+++ b/lib/mongoid/relations/referenced/many_to_many.rb
@@ -29,7 +29,7 @@ module Mongoid
           return concat(docs) if docs.size > 1
           if doc = docs.first
             append(doc)
-            base.add_to_set(foreign_key => doc.id)
+            base.add_to_set(foreign_key => doc.send(metadata.primary_key))
             if child_persistable?(doc)
               doc.save
             end
@@ -114,7 +114,7 @@ module Mongoid
         def delete(document)
           doc = super
           if doc && persistable?
-            base.pull(foreign_key => doc.id)
+            base.pull(foreign_key => doc.send(metadata.primary_key))
             target._unloaded = criteria
             unsynced(base, foreign_key)
           end

--- a/spec/app/models/dog.rb
+++ b/spec/app/models/dog.rb
@@ -2,5 +2,6 @@ class Dog
   include Mongoid::Document
   field :name, type: String
   has_and_belongs_to_many :breeds
+  has_and_belongs_to_many :fire_hydrants, primary_key: :location
   default_scope asc(:name)
 end

--- a/spec/app/models/fire_hydrant.rb
+++ b/spec/app/models/fire_hydrant.rb
@@ -1,0 +1,6 @@
+class FireHydrant
+  include Mongoid::Document
+  field :location, type: String
+  has_and_belongs_to_many :dogs, primary_key: :name
+  has_and_belongs_to_many :cats, primary_key: :name
+end

--- a/spec/mongoid/relations/referenced/many_to_many_spec.rb
+++ b/spec/mongoid/relations/referenced/many_to_many_spec.rb
@@ -3496,4 +3496,58 @@ describe Mongoid::Relations::Referenced::ManyToMany do
       end
     end
   end
+
+  context "when using a different primary key" do
+
+    let(:dog) do
+      Dog.create(name: 'Doggie')
+    end
+
+    let(:cat) do
+      Cat.create(name: 'Kitty')
+    end
+
+    let(:fire_hydrant) do
+      FireHydrant.create(location: '221B Baker Street')
+    end
+
+    context "when adding to a one-way many to many" do
+      before do
+        fire_hydrant.cats.push(cat)
+      end
+
+      it "adds the pk value to the fk set" do
+        expect(fire_hydrant.cat_ids).to eq([cat.name])
+      end
+    end
+
+    context "when adding to a two-way many to many" do
+      before do
+        fire_hydrant.dogs.push(dog)
+      end
+
+      it "adds the pk value to the fk set" do
+        expect(fire_hydrant.dog_ids).to eq([dog.name])
+      end
+
+      it "adds the base pk value to the inverse fk set" do
+        expect(dog.fire_hydrant_ids).to eq([fire_hydrant.location])
+      end
+    end
+
+    context "when deleting from a two-way many to many" do
+      before do
+        dog.fire_hydrants.push(fire_hydrant)
+        fire_hydrant.dogs.delete(dog)
+      end
+
+      it "removes the pk value from the fk set" do
+        expect(fire_hydrant.dog_ids).to eq([])
+      end
+
+      it "removes the base pk value from the inverse fk set" do
+        expect(dog.fire_hydrant_ids).to eq([])
+      end
+    end
+  end
 end


### PR DESCRIPTION
Consider the following relations

```
class Car
  include Mongoid::Document
  field :vin, type: String
  has_and_belongs_to_many :owner, primary_key: :ssn
end
```

```
class Owner
  include Mongoid::Document
  field :ssn, type: String
  has_and_belongs_to_many :cars, primary_key: :vin
end
```

Queries looks up related objects by primary_key defined on the relation: 

```
owner = Owner.create ssn: '1234'
car = Car.create vin: 'ABCD', owner_ids: ['1234']
car.owners                   # returns [owner]
```

However, inserts uses the primary_key on the base object instead

```
car = Car.create vin: 'ABCD'
owner = Owner.create ssn: '1234'
car.owners << owner    # complains about :ssn field not defined on Car
```

The query and binding behaviors on ManyToMany relations are inconsistent. I think the query behavior is implemented intuitively, so this seems to be a bug on bindings.

Another issue is that car will save owner's ObjectID in its owner_ids set regardless of the primary_key field defined on either side of the relation.

This patch attempts to solve both of these issues. #2809 was used as a reference.
