### PR TITLE
Enable identity map locally within a unit of work.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -200,6 +200,18 @@ For instructions on upgrading to newer versions, visit
 
 ### New Features
 
+* \#3172 Enable identity map locally inside a `unit_of_work` without globally
+  setting `Mongoid.identity_map_enabled = true`. (Daniel Doubrovkine)
+  Example:
+
+      Mpngoid.identity_map_enabled = false
+
+      Mongoid.unit_of_work(enable: :current) do
+        # will use identity map to eager-load comments for each account
+        # with a single $in query
+        Account.all.includes(:comment)
+      end
+
 * \#3146 Adding :overwrite field option, when it`s true, it wont check duplicates.
  (Daniel Libanori)
 

--- a/lib/mongoid/threaded.rb
+++ b/lib/mongoid/threaded.rb
@@ -186,7 +186,19 @@ module Mongoid
     #
     # @since 3.0.0
     def identity_map_enabled?
-      Thread.current["[mongoid]:identity-map-enabled"] != false
+      Thread.current["[mongoid]:identity-map-enabled"] == true
+    end
+
+    # Is the identity map disabled on the current thread?
+    #
+    # @example Is the identity map disabled?
+    #   Threaded.identity_map_disabled?
+    #
+    # @return [ true, false ] If the identity map is disabled.
+    #
+    # @since 4.0.0
+    def identity_map_disabled?
+      Thread.current["[mongoid]:identity-map-enabled"] == false
     end
 
     # Disable the identity map on either the current thread or all threads.

--- a/lib/mongoid/unit_of_work.rb
+++ b/lib/mongoid/unit_of_work.rb
@@ -34,12 +34,17 @@ module Mongoid
     # @since 2.1.0
     def unit_of_work(options = {})
       disable = options[:disable]
+      enable = options[:enable]
       begin
         Threaded.disable_identity_map(disable) if disable
+        Threaded.enable_identity_map(enable) if enable
         yield if block_given?
       ensure
         if disable
           Threaded.enable_identity_map(disable)
+        elsif enable
+          Threaded.disable_identity_map(enable)
+          IdentityMap.clear
         else
           IdentityMap.clear
         end
@@ -55,7 +60,7 @@ module Mongoid
     #
     # @since 3.0.0
     def using_identity_map?
-      Mongoid.identity_map_enabled? && Threaded.identity_map_enabled?
+      (Mongoid.identity_map_enabled? && ! Threaded.identity_map_disabled?) || Threaded.identity_map_enabled?
     end
   end
 end


### PR DESCRIPTION
Enable the identity map locally for a unit of work. This lets you use `incudes` to do eager loading for a single query without enabling identity map globally.

Fixes https://github.com/mongoid/mongoid/issues/3172.
