### PR TITLE
Fix rake db:mongoid:drop_undefined_indexes

### DIFF
--- a/lib/mongoid/railties/database.rake
+++ b/lib/mongoid/railties/database.rake
@@ -73,9 +73,14 @@ namespace :db do
     end
 
     desc "Remove indexes that exist in the database but aren't specified on the models"
-    task :drop_undefined_indexes => :environment do
+    task :remove_undefined_indexes => :environment do
       ::Rails.application.eager_load!
-      ::Rails::Mongoid.drop_undefined_indexes
+      ::Rails::Mongoid.remove_undefined_indexes
+    end
+
+    desc "DEPRECATED alias for remove_undefined_indexes"
+    task :drop_undefined_indexes => :remove_undefined_indexes do
+      puts "This task is DEPRECATED. Use remove_undefined_indexes in the future."
     end
 
     desc "Remove the indexes defined on your mongoid models without questions!"

--- a/lib/rails/mongoid.rb
+++ b/lib/rails/mongoid.rb
@@ -63,7 +63,7 @@ module Rails
     # models.
     #
     # @example Remove undefined indexes.
-    #   Rails::Mongoid.drop_undefined_indexes
+    #   Rails::Mongoid.remove_undefined_indexes
     #
     # @return [ Hash{Class => Array(Hash)}] The list of indexes that were removed by model.
     #

--- a/spec/rails/mongoid_spec.rb
+++ b/spec/rails/mongoid_spec.rb
@@ -102,7 +102,7 @@ describe "Rails::Mongoid" do
     end
   end
 
-  describe ".drop_undefined_indexes" do
+  describe ".remove_undefined_indexes" do
 
     let(:logger) do
       double


### PR DESCRIPTION
in fact, rename to remove_… for consistency, and deprecate the old name.
