### PR TITLE
Fallback blank localized field, not just nil

### DIFF
--- a/lib/mongoid/fields/localized.rb
+++ b/lib/mongoid/fields/localized.rb
@@ -63,7 +63,7 @@ module Mongoid
       def lookup(object)
         locale = ::I18n.locale
         if ::I18n.respond_to?(:fallbacks)
-          object[::I18n.fallbacks[locale].map(&:to_s).find{ |loc| object[loc] }]
+          object[::I18n.fallbacks[locale].map(&:to_s).find{ |loc| object[loc].presence }]
         else
           object[locale.to_s]
         end

--- a/spec/mongoid/fields/localized_spec.rb
+++ b/spec/mongoid/fields/localized_spec.rb
@@ -157,6 +157,17 @@ describe Mongoid::Fields::Localized do
                   expect(value).to be_nil
                 end
               end
+
+              context "when the value is an empty string" do
+
+                let(:value) do
+                  field.demongoize({ "de" => "", "en" => "testing" })
+                end
+
+                it "returns the fallback translation" do
+                  expect(value).to eq("testing")
+                end
+              end
             end
 
             context "when no fallbacks are defined" do


### PR DESCRIPTION
It makes more sense to me to fallback localized field if they are blank and not just nil, and also to not fallback on a blank value, so I added `presence` to the lookup.
