### PR TITLE
Add default_locale option to presence validator

### DIFF
--- a/lib/mongoid/validatable/presence.rb
+++ b/lib/mongoid/validatable/presence.rb
@@ -28,12 +28,16 @@ module Mongoid
       def validate_each(document, attribute, value)
         field = document.fields[attribute.to_s]
         if field.try(:localized?) && !value.blank?
-          value.each_pair do |_locale, _value|
-            document.errors.add(
-              attribute,
-              :blank_in_locale,
-              options.merge(location: _locale)
-            ) if not_present?(_value)
+          if options[:default_locale] == true
+            document.errors.add(attribute, :blank, options) if not_present?(value[I18n.default_locale.to_s])
+          else
+            value.each_pair do |_locale, _value|
+              document.errors.add(
+                attribute,
+                :blank_in_locale,
+                options.merge(location: _locale)
+              ) if not_present?(_value)
+            end
           end
         elsif document.relations.has_key?(attribute.to_s)
           if relation_or_fk_missing?(document, attribute, value)

--- a/spec/app/models/product.rb
+++ b/spec/app/models/product.rb
@@ -1,6 +1,6 @@
 class Product
   include Mongoid::Document
-  field :description, localize: true
+  field :description, localize: true, default: "no desc translation"
   field :name, localize: true, default: "no translation"
   field :price, type: Integer
   field :brand_name
@@ -10,6 +10,7 @@ class Product
 
   validates :name, presence: true
   validates :website, format: { with: URI.regexp, allow_blank: true }
+  validates :description, presence: { default_locale: true }
 
   embeds_one :seo, as: :seo_tags, cascade_callbacks: true, autobuild: true
 end

--- a/spec/mongoid/fields_spec.rb
+++ b/spec/mongoid/fields_spec.rb
@@ -46,7 +46,7 @@ describe Mongoid::Fields do
         context "when no default is provided" do
 
           it "returns an empty hash" do
-            expect(product.description_translations).to be_empty
+            expect(product.website_translations).to be_empty
           end
         end
 

--- a/spec/mongoid/validatable/presence_spec.rb
+++ b/spec/mongoid/validatable/presence_spec.rb
@@ -374,6 +374,23 @@ describe Mongoid::Validatable::PresenceValidator do
 
       before do
         product.name_translations = { "en" => "test" }
+        product.description_translations = { "en" => "desc test" }
+      end
+
+      it "is a valid document" do
+        expect(product).to be_valid
+      end
+    end
+
+    context "when only the default locale is present" do
+
+      let(:product) do
+        Product.new
+      end
+
+      before do
+        product.name_translations = { "en" => "test" }
+        product.description_translations = { "en" => "desc test", "fr" => "" }
       end
 
       it "is a valid document" do


### PR DESCRIPTION
This allows to only validate presence of a localized attribute in the default locale, e.g.:

```
validates :description, presence: { default_locale: true }
```

This is quite usefull when using fallbacks, because other locale keys might be present in the hash but you may not want to validate them.
