### PR TITLE
Splitting $pushAll and $pull conflicting operations into multiple update...

### DIFF
--- a/lib/mongoid/persistence/operations/update.rb
+++ b/lib/mongoid/persistence/operations/update.rb
@@ -46,9 +46,11 @@ module Mongoid
             unless updates.empty?
               collection.find(selector).update(positionally(selector, updates))
               conflicts.each_pair do |key, value|
-                collection.find(selector).update(
-                  positionally(selector, { key => value })
-                )
+                value.each do |val|
+                  collection.find(selector).update(
+                    positionally(selector, { key => val })
+                  )
+                end
               end
             end
           end

--- a/spec/mongoid/atomic_spec.rb
+++ b/spec/mongoid/atomic_spec.rb
@@ -197,9 +197,9 @@ describe Mongoid::Atomic do
                       "addresses.0.street" => "Bond St"
                     },
                     conflicts: {
-                      "$pushAll" => {
+                      "$pushAll" => [{
                         "addresses.0.locations" => [{ "_id" => location.id, "name" => "Home" }]
-                      }
+                      }]
                     }
                   }
                 )
@@ -215,9 +215,9 @@ describe Mongoid::Atomic do
                       "addresses.0.street" => "Bond St"
                     },
                     conflicts: {
-                      "$pushAll" => {
+                      "$pushAll" => [{
                         "addresses.0.locations" => [{ "_id" => location.id, "name" => "Home" }]
-                      }
+                      }]
                     }
                   }
                 )
@@ -263,7 +263,7 @@ describe Mongoid::Atomic do
                       "addresses.0.street" => "Bond St"
                     },
                     conflicts: {
-                      "$pushAll" => {
+                      "$pushAll" => [{
                         "addresses" => [{
                           "_id" => new_address.id,
                           "street" => "Another",
@@ -272,7 +272,7 @@ describe Mongoid::Atomic do
                             "name" => "Home"
                           ]
                         }]
-                      }
+                      }]
                     }
                   }
                 )
@@ -321,7 +321,7 @@ describe Mongoid::Atomic do
                     }]
                   },
                   conflicts: {
-                    "$set" => { "addresses.0.street"=>"Bond St" }
+                    "$set" => [{ "addresses.0.street"=>"Bond St" }]
                   }
                 }
               )

--- a/spec/mongoid/persistence/operations_spec.rb
+++ b/spec/mongoid/persistence/operations_spec.rb
@@ -262,9 +262,9 @@ describe Mongoid::Persistence::Operations do
       it "sets the conflicts" do
         conflicts.should eq(
           {
-            "$pushAll" => {
+            "$pushAll" => [{
             "addresses" => [ { "street" => "Freiderichstr", "_id" => "freiderichstr" } ]
-            }
+            }]
           }
         )
       end


### PR DESCRIPTION
...s

When pushing or pulling values of embedded documents in different levels on a document in a single update mongoid complains with a "have conflicting mods in update" error. This change splits the conflicting operations into multiple ones, thus avoiding the error.

For example, before this change when you had two pulls like this:

``` ruby
{ "addresses.0.locations" => { "_id" => { "$in" => [ "two" ]}} }   # $pull
{ "addresses" => { "_id" => { "$in" => [ "one" ]}} }               # $pull
```

Mongoid would generate a single update, and MongoDB would complain with a "have conflicting mods in update" error.

Also if you had a set and two conflicting pushes like this:

``` ruby
{ "addresses.0.street" => "Bond" }                                           # $set
{ "addresses.0.locations" => { "street" => "Bond St" } }                     # $pushAll
{ "addresses" => { "street" => "Oxford St" } }                               # $pushAll
```

It would also generate an update with the $set and other with two $pushAll, and this second update would fail.

The change makes any conflict like this to generate an update.
