### PR TITLE
Splitting $pushAll and $pull conflicting operations into multiple update...

### DIFF
--- a/lib/mongoid/persistable/updatable.rb
+++ b/lib/mongoid/persistable/updatable.rb
@@ -28,7 +28,9 @@ module Mongoid
             selector = atomic_selector
             coll.find(selector).update(positionally(selector, updates))
             conflicts.each_pair do |key, value|
-              coll.find(selector).update(positionally(selector, { key => value }))
+              value.each do |val|
+                coll.find(selector).update(positionally(selector, { key => val }))
+              end
             end
           end
         end

--- a/spec/mongoid/atomic/modifiers_spec.rb
+++ b/spec/mongoid/atomic/modifiers_spec.rb
@@ -86,7 +86,7 @@ describe Mongoid::Atomic::Modifiers do
           modifiers.pull(pulls)
         end
 
-        it "adds the push all modifiers" do
+        it "adds the pull modifiers" do
           expect(modifiers).to eq(
             { "$pull" => { "addresses" => { "_id" => { "$in" => [ "one" ]}}}}
           )
@@ -111,6 +111,41 @@ describe Mongoid::Atomic::Modifiers do
         it "overwrites the previous pulls" do
           expect(modifiers).to eq(
             { "$pull" => { "addresses" => { "_id" => { "$in" => [ "two" ]}}}}
+          )
+        end
+      end
+    end
+
+    context "when a conflicting modification exists" do
+
+      context "when the conflicting modification is a pull" do
+
+        let(:conflicting_pulls) do
+          { "addresses.0.locations" => { "_id" => { "$in" => [ "two" ]}} }
+        end
+
+        let(:pulls) do
+          { "addresses" => { "_id" => { "$in" => [ "one" ]}} }
+        end
+
+        before do
+          modifiers.pull(conflicting_pulls)
+          modifiers.pull(pulls)
+        end
+
+        it "adds the pull modifiers to the conflicts hash" do
+          expect(modifiers).to eq(
+            { "$pull" => {
+              "addresses.0.locations" => { "_id" => { "$in" => [ "two" ]}}},
+              conflicts: { "$pull" => [
+                  {
+                    "addresses" => {
+                      "_id" => { "$in" => [ "one" ]}
+                    }
+                  }
+                ]
+              }
+            }
           )
         end
       end
@@ -270,11 +305,12 @@ describe Mongoid::Atomic::Modifiers do
         it "adds the push all modifiers to the conflicts hash" do
           expect(modifiers).to eq(
             { "$set" => { "addresses.0.street" => "Bond" },
-              conflicts: { "$pushAll" =>
-                { "addresses" => [
-                    { "street" => "Oxford St" }
-                  ]
-                }
+              conflicts: { "$pushAll" => [
+                  { "addresses" => [
+                      { "street" => "Oxford St" }
+                    ]
+                  }
+                ]
               }
             }
           )
@@ -300,11 +336,12 @@ describe Mongoid::Atomic::Modifiers do
           expect(modifiers).to eq(
             { "$pullAll" => {
               "addresses" => { "street" => "Bond St" }},
-              conflicts: { "$pushAll" =>
-                { "addresses" => [
-                    { "street" => "Oxford St" }
-                  ]
-                }
+              conflicts: { "$pushAll" => [
+                  { "addresses" => [
+                      { "street" => "Oxford St" }
+                    ]
+                  }
+                ]
               }
             }
           )
@@ -330,14 +367,163 @@ describe Mongoid::Atomic::Modifiers do
           expect(modifiers).to eq(
             { "$pushAll" => {
               "addresses.0.locations" => [{ "street" => "Bond St" }]},
-              conflicts: { "$pushAll" =>
-                { "addresses" => [
-                    { "street" => "Oxford St" }
-                  ]
-                }
+              conflicts: { "$pushAll" => [
+                  { "addresses" => [
+                      { "street" => "Oxford St" }
+                    ]
+                  }
+                ]
               }
             }
           )
+        end
+      end
+
+      context "when there is a conflicting set and push modifications" do
+
+        let(:sets) do
+          { "addresses.0.street" => "Bond" }
+        end
+
+        let(:nested) do
+          { "addresses.0.locations" => { "street" => "Bond St" } }
+        end
+
+        let(:pushes) do
+          { "addresses" => { "street" => "Oxford St" } }
+        end
+
+        before do
+          modifiers.set(sets)
+          modifiers.push(nested)
+          modifiers.push(pushes)
+        end
+
+        it "adds the push all modifiers to the conflicts hash, in a new array item" do
+          expect(modifiers).to eq(
+            { "$set" => { "addresses.0.street" => "Bond" },
+              conflicts: { "$pushAll" =>
+                [
+                  {
+                    "addresses.0.locations" => [
+                      { "street" => "Bond St" }
+                    ],
+                  },
+                  {
+                    "addresses" => [
+                      { "street" => "Oxford St" }
+                    ]
+                  }
+                ]
+              }
+            }
+          )
+        end
+
+        context "with another nested push on the same key" do
+          let(:other_nested) do
+            { "addresses.0.locations" => { "street" => "Holmes St" } }
+          end
+
+          before do
+            modifiers.push(other_nested)
+          end
+
+          it "adds the push all modifiers to the conflicts hash, in the same array item" do
+            expect(modifiers).to eq(
+              { "$set" => { "addresses.0.street" => "Bond" },
+                conflicts: { "$pushAll" =>
+                  [
+                    {
+                      "addresses.0.locations" => [
+                        { "street" => "Bond St" },
+                        { "street" => "Holmes St" }
+                      ],
+                    },
+                    {
+                      "addresses" => [
+                        { "street" => "Oxford St" }
+                      ]
+                    }
+                  ]
+                }
+              }
+            )
+          end
+        end
+      end
+
+      context "when there is only conflicting push modifications" do
+
+        let(:nested) do
+          { "addresses.0.locations" => { "street" => "Bond St" } }
+        end
+
+        let(:other_nested_key) do
+          { "addresses.1.locations" => { "street" => "Holmes St" } }
+        end
+
+        let(:pushes) do
+          { "addresses" => { "street" => "Oxford St" } }
+        end
+
+        before do
+          modifiers.push(nested)
+          modifiers.push(other_nested_key)
+          modifiers.push(pushes)
+        end
+
+        it "adds the push all modifiers to the conflicts hash, in a new array item" do
+          expect(modifiers).to eq(
+            { "$pushAll" => { "addresses.0.locations" => [{ "street" => "Bond St" }] },
+              conflicts: { "$pushAll" =>
+                [
+                  {
+                    "addresses.1.locations" => [
+                      { "street" => "Holmes St" }
+                    ],
+                  },
+                  {
+                    "addresses" => [
+                      { "street" => "Oxford St" }
+                    ]
+                  }
+                ]
+              }
+            }
+          )
+        end
+
+        context "with another nested push on the same key" do
+          let(:other_nested) do
+            { "addresses.1.locations" => { "street" => "Watson St" } }
+          end
+
+          before do
+            modifiers.push(other_nested)
+          end
+
+          it "adds the push all modifiers to the conflicts hash, in the same array item" do
+            expect(modifiers).to eq(
+              { "$pushAll" => { "addresses.0.locations" => [{ "street" => "Bond St" }] },
+                conflicts: { "$pushAll" =>
+                  [
+                    {
+                      "addresses.1.locations" => [
+                        { "street" => "Holmes St" },
+                        { "street" => "Watson St" }
+                      ],
+                    },
+                    {
+                      "addresses" => [
+                        { "street" => "Oxford St" }
+                      ]
+                    }
+                  ]
+                }
+              }
+            )
+          end
         end
       end
     end
@@ -414,7 +600,7 @@ describe Mongoid::Atomic::Modifiers do
                 ]
               },
               conflicts:
-                { "$set" => { "addresses.0.title" => "Sir" }}
+                { "$set" => [{ "addresses.0.title" => "Sir" }]}
             }
           )
         end

--- a/spec/mongoid/atomic_spec.rb
+++ b/spec/mongoid/atomic_spec.rb
@@ -197,9 +197,9 @@ describe Mongoid::Atomic do
                       "addresses.0.street" => "Bond St"
                     },
                     conflicts: {
-                      "$pushAll" => {
+                      "$pushAll" => [{
                         "addresses.0.locations" => [{ "_id" => location.id, "name" => "Home" }]
-                      }
+                      }]
                     }
                   }
                 )
@@ -215,9 +215,9 @@ describe Mongoid::Atomic do
                       "addresses.0.street" => "Bond St"
                     },
                     conflicts: {
-                      "$pushAll" => {
+                      "$pushAll" => [{
                         "addresses.0.locations" => [{ "_id" => location.id, "name" => "Home" }]
-                      }
+                      }]
                     }
                   }
                 )
@@ -263,7 +263,7 @@ describe Mongoid::Atomic do
                       "addresses.0.street" => "Bond St"
                     },
                     conflicts: {
-                      "$pushAll" => {
+                      "$pushAll" => [{
                         "addresses" => [{
                           "_id" => new_address.id,
                           "street" => "Another",
@@ -272,7 +272,7 @@ describe Mongoid::Atomic do
                             "name" => "Home"
                           ]
                         }]
-                      }
+                      }]
                     }
                   }
                 )
@@ -321,7 +321,7 @@ describe Mongoid::Atomic do
                     }]
                   },
                   conflicts: {
-                    "$set" => { "addresses.0.street"=>"Bond St" }
+                    "$set" => [{ "addresses.0.street"=>"Bond St" }]
                   }
                 }
               )


### PR DESCRIPTION
...s

When pushing or pulling values of embedded documents in different levels on a document in a single update mongoid complains with a "have conflicting mods in update" error. This change splits the conflicting operations into multiple ones, thus avoiding the error.

For example, before this change when you had two pulls like this:

```ruby
{ "addresses.0.locations" => { "_id" => { "$in" => [ "two" ]}} }   # $pull
{ "addresses" => { "_id" => { "$in" => [ "one" ]}} }               # $pull
```

Mongoid would generate a single update, and MongoDB would complain with a "have conflicting mods in update" error.

Also if you had a set and two conflicting pushes like this:

```ruby
{ "addresses.0.street" => "Bond" }                                           # $set
{ "addresses.0.locations" => { "street" => "Bond St" } }                     # $pushAll
{ "addresses" => { "street" => "Oxford St" } }                               # $pushAll
```

It would also generate an update with the $set and other with two $pushAll, and this second update would fail.

The change makes any conflict like this to generate an update.