### PR TITLE
Add correct index for indexed polymorphic belongs_to relations.

### DIFF
--- a/lib/mongoid/relations/macros.rb
+++ b/lib/mongoid/relations/macros.rb
@@ -308,7 +308,7 @@ module Mongoid
             )
             if metadata.indexed?
               if metadata.polymorphic?
-                index({ key => 1, metadata.type => 1 }, { background: true })
+                index({ key => 1, metadata.inverse_type => 1 }, { background: true })
               else
                 index({ key => 1 }, { background: true })
               end


### PR DESCRIPTION
The index being created was `{ relation_id: 1, _type: 1 }`, which doesn't help us at all. We need `{ relation_id: 1, relation_type: 1 }`. It looks like this bug has been in place ever since this feature was added, over a year ago: #1081 / 5deb1d55aabff82316f546d449b0678962e259e7

`metadata.type` returns `#{as}_type` which does the trick for `has_many` side of a polymorphic relation, but for the `belongs_to` side, `as == nil`, thus having `metadata.type` evaluate to `_type`. On this side, we need `metadata.inverse_type`, which returns `#{name}_type`, which _is_ what we want.
