### PR TITLE
Add class name to overwriting existing field warning message

### DIFF
--- a/lib/mongoid/fields/validators/macro.rb
+++ b/lib/mongoid/fields/validators/macro.rb
@@ -60,7 +60,7 @@ module Mongoid
             if Mongoid.duplicate_fields_exception
               raise Errors::InvalidField.new(klass, name)
             else
-              Mongoid.logger.warn("Overwriting existing field #{name}.") if Mongoid.logger
+              Mongoid.logger.warn("Overwriting existing field #{name} in class #{klass.name}.") if Mongoid.logger
             end
           end
         end


### PR DESCRIPTION
I find it useful to locate where the warning comes from.
