### PR TITLE
allow options to concat so validate can be turned off

### DIFF
--- a/lib/mongoid/relations/referenced/many.rb
+++ b/lib/mongoid/relations/referenced/many.rb
@@ -514,13 +514,13 @@ module Mongoid
         # @param [ Array<Document> ] inserts The inserts.
         #
         # @since 3.0.0
-        def save_or_delay(doc, docs, inserts)
+        def save_or_delay(doc, docs, inserts, options = {})
           if doc.new_record? && doc.valid?(:create)
             doc.run_before_callbacks(:save, :create)
             docs.push(doc)
             inserts.push(doc.as_document)
           else
-            doc.save
+            doc.save(options)
           end
         end
 

--- a/lib/mongoid/relations/referenced/many_to_many.rb
+++ b/lib/mongoid/relations/referenced/many_to_many.rb
@@ -45,18 +45,19 @@ module Mongoid
         #   person.posts.concat([ post_one, post_two ])
         #
         # @param [ Array<Document> ] documents The docs to add.
+        # @param [ Hash ] options Options to pass to the save.
         #
         # @return [ Array<Document> ] The documents.
         #
         # @since 2.4.0
-        def concat(documents)
+        def concat(documents, options = {})
           ids, docs, inserts = {}, [], []
           documents.each do |doc|
             next unless doc
             append(doc)
             if persistable? || _creating?
               ids[doc.id] = true
-              save_or_delay(doc, docs, inserts)
+              save_or_delay(doc, docs, inserts, options)
             else
               existing = base.send(foreign_key)
               unless existing.include?(doc.id)


### PR DESCRIPTION
I needed to turn off the validations on the related items when using concat but I was unable to do it. I've dig in the code and I noticed with a slight change we can pass `validate: false` to the `save` method from concat.
I am not too familiar with rspec and not sure how to write a test for this. Can someone give me some pointers? Maybe and example spec for a similar feature?
Thanks
