### PR TITLE
Implemented server-side timestampting

### DIFF
--- a/lib/mongoid/timestamps.rb
+++ b/lib/mongoid/timestamps.rb
@@ -2,6 +2,7 @@
 require "mongoid/timestamps/created"
 require "mongoid/timestamps/updated"
 require "mongoid/timestamps/short"
+require "mongoid/timestamps/serverside"
 
 module Mongoid
 

--- a/lib/mongoid/timestamps/serverside.rb
+++ b/lib/mongoid/timestamps/serverside.rb
@@ -1,0 +1,19 @@
+module Mongoid
+  module Timestamps
+    module Serverside
+      extend ActiveSupport::Concern
+
+      included do
+        raise "Mongoid::Timestamps::Serverside should be included before any fields definition to work properly" if fields.size > 1
+
+        field :ts, type: Moped::BSON::Timestamp
+        set_callback :create, :before, :set_ts
+        set_callback :save, :before, :set_ts
+      end
+
+      def set_ts
+        self.ts = Moped::BSON::Timestamp.new(0, 0)
+      end
+    end
+  end
+end

--- a/spec/app/models/serverside_timestamped_doc.rb
+++ b/spec/app/models/serverside_timestamped_doc.rb
@@ -1,0 +1,6 @@
+class ServersideTimestampedDoc
+  include Mongoid::Document
+  include Mongoid::Timestamps::Serverside
+
+  field :title, type: String
+end

--- a/spec/mongoid/timestamps/serverside_spec.rb
+++ b/spec/mongoid/timestamps/serverside_spec.rb
@@ -1,0 +1,32 @@
+require "spec_helper"
+
+describe Mongoid::Timestamps::Serverside do
+  shared_examples "ts" do
+    let(:fields) { doc.fields }
+
+    it "adds ts field to the document" do
+      expect(fields["ts"]).to_not be_nil
+    end
+
+    it "should be first or second field in class to work properly (see https://jira.mongodb.org/browse/SERVER-1650)" do
+      expect(fields.keys[0..1]).to include("ts")
+    end
+  end
+
+  describe ".included" do
+    let(:doc) { ServersideTimestampedDoc.new }
+
+    before do
+      doc.run_callbacks(:initialize)
+      doc.run_callbacks(:save)
+    end
+
+    include_examples "ts"
+  end
+
+  describe "when document is created" do
+    let(:doc) { ServersideTimestampedDoc.create }
+
+    include_examples "ts"
+  end
+end


### PR DESCRIPTION
Added `Mongoid::Timestapms::Serverside` with spec for it.

To use you should include 1Mongoid::Timestapms::Serverside` before any field definitions. 

This concern add field `ts` with type `Moped::BSON::Timestamp` which is updated on each save operation.
