### PR TITLE
session.rb refactor

### DIFF
--- a/lib/mongoid/sessions.rb
+++ b/lib/mongoid/sessions.rb
@@ -1,25 +1,18 @@
 # encoding: utf-8
 require "mongoid/sessions/factory"
 require "mongoid/sessions/validators"
+require "mongoid/sessions/storage_options"
+require "mongoid/sessions/thread_options"
 require "mongoid/sessions/options"
 
 module Mongoid
   module Sessions
     extend ActiveSupport::Concern
+    include StorageOptions
+    include ThreadOptions
     include Options
 
-    included do
-      cattr_accessor :default_collection_name do
-        self.name.collectionize.to_sym
-      end
-
-      cattr_accessor :storage_options, instance_writer: false do
-        {}
-      end
-    end
-
     class << self
-
       # Clear all sessions from the current thread.
       #
       # @example Clear all sessions.
@@ -88,68 +81,14 @@ module Mongoid
     end
 
     def mongo_session
-      persistence_options ? self.class.mongo_session.with(persistence_options) : self.class.mongo_session
+      super || self.class.mongo_session
     end
 
     def collection_name
-      persistence_options.try { |opts| opts[:collection] } || self.class.collection_name
+      super || self.class.collection_name
     end
 
     module ClassMethods
-
-      # Get the collection for this model from the session. Will check for an
-      # overridden collection name from the store_in macro or the collection
-      # with a pluralized model name.
-      #
-      # @example Get the model's collection.
-      #   Model.collection
-      #
-      # @return [ Moped::Collection ] The collection.
-      #
-      # @since 3.0.0
-      def collection
-        mongo_session[collection_name]
-      end
-
-      # Get the name of the collection this model persists to. This will be
-      # either the pluralized class name or the option defined in the store_in
-      # macro.
-      #
-      # @example Get the collection name.
-      #   Model.collection_name
-      #
-      # @return [ Symbol ] The name of the collection.
-      #
-      # @since 3.0.0
-      def collection_name
-        __collection_name__
-      end
-
-      # Get the default database name for this model.
-      #
-      # @example Get the default database name.
-      #   Model.database_name
-      #
-      # @return [ Symbol ] The name of the database.
-      #
-      # @since 3.0.0
-      def database_name
-        __database_name__
-      end
-
-      # Get the overridden database name. This either can be overridden by
-      # using +Model.with+ or by overriding at the global level via
-      # +Mongoid.override_database(:name)+.
-      #
-      # @example Get the overridden database name.
-      #   Model.database_override
-      #
-      # @return [ String, Symbol ] The overridden database name.
-      #
-      # @since 3.0.0
-      def database_override
-        self.persistence_options.try { |opts| opts[:database] } || Threaded.database_override
-      end
 
       # Get the session for this model. This is determined in the following order:
       #
@@ -163,171 +102,23 @@ module Mongoid
       #
       # @since 3.0.0
       def mongo_session
-        session = __session__
-        session.use(database_override || current_database_name(session))
+        session = Sessions.with_name(session_name)
+        session.use(database_name)
         self.persistence_options ? session.with(self.persistence_options) : session
       end
 
-      # Get the overridden session name. This either can be overridden by
-      # using +Model.with+ or by overriding at the global level via
-      # +Mongoid.override_session(:name)+.
+      # Get the collection for this model from the session. Will check for an
+      # overridden collection name from the store_in macro or the collection
+      # with a pluralized model name.
       #
-      # @example Get the overridden session name.
-      #   Model.session_override
+      # @example Get the model's collection.
+      #   Model.collection
       #
-      # @return [ String, Symbol ] The overridden session name.
-      #
-      # @since 3.0.0
-      def session_override
-        self.persistence_options.try { |opts| opts[:session] } || Threaded.session_override
-      end
-
-      # Give this model specific custom default storage options.
-      #
-      # @example Store this model by default in "artists"
-      #   class Band
-      #     include Mongoid::Document
-      #     store_in collection: "artists"
-      #   end
-      #
-      # @example Store this model by default in the sharded db.
-      #   class Band
-      #     include Mongoid::Document
-      #     store_in database: "echo_shard"
-      #   end
-      #
-      # @example Store this model by default in a different session.
-      #   class Band
-      #     include Mongoid::Document
-      #     store_in session: "secondary"
-      #   end
-      #
-      # @example Store this model with a combination of options.
-      #   class Band
-      #     include Mongoid::Document
-      #     store_in collection: "artists", database: "secondary"
-      #   end
-      #
-      # @param [ Hash ] options The storage options.
-      #
-      # @option options [ String, Symbol ] :collection The collection name.
-      # @option options [ String, Symbol ] :database The database name.
-      # @option options [ String, Symbol ] :session The session name.
-      #
-      # @return [ Class ] The model class.
+      # @return [ Moped::Collection ] The collection.
       #
       # @since 3.0.0
-      def store_in(options)
-        Validators::Storage.validate(self, options)
-        storage_options.merge!(options)
-      end
-
-      private
-
-      # Get the name of the collection this model persists to.
-      #
-      # @example Get the collection name.
-      #   Model.__collection_name__
-      #
-      # @return [ Symbol ] The name of the collection.
-      #
-      # @since 3.0.0
-      def __collection_name__
-        if coll = self.persistence_options.try(:[], :collection)
-          return coll
-        end
-
-        if storage_options && name = storage_options[:collection]
-          __evaluate__(name)
-        else
-          default_collection_name
-        end
-      end
-
-      # Get the database name for the model.
-      #
-      # @example Get the database name.
-      #   Model.__database_name__
-      #
-      # @return [ Symbol ] The name of the database.
-      #
-      # @since 3.0.0
-      def __database_name__
-        if storage_options && name = storage_options[:database]
-          __evaluate__(name)
-        else
-          Mongoid.sessions[__session_name__][:database]
-        end
-      end
-
-      # Get the session name for the model.
-      #
-      # @example Get the session name.
-      #   Model.__session_name__
-      #
-      # @return [ Symbol ] The name of the session.
-      #
-      # @since 3.0.0
-      def __session_name__
-        if storage_options && name = storage_options[:session]
-          __evaluate__(name)
-        else
-          :default
-        end
-      end
-
-      # Get the session for this class.
-      #
-      # @example Get the session.
-      #   Model.__session__
-      #
-      # @return [ Moped::Session ] The moped session.
-      #
-      # @since 3.0.0
-      def __session__
-        if !(name = session_override).nil?
-          Sessions.with_name(name)
-        else
-          Sessions.with_name(__session_name__)
-        end
-      end
-
-      # Eval the provided value, either byt calling it if it responds to call
-      # or returning the value itself.
-      #
-      # @api private
-      #
-      # @example Evaluate the name.
-      #   Model.__evaluate__(:name)
-      #
-      # @param [ String, Symbol, Proc ] name The name.
-      #
-      # @return [ Symbol ] The value as a symbol.
-      #
-      # @since 3.1.0
-      def __evaluate__(name)
-        name.respond_to?(:call) ? name.call.to_sym : name.to_sym
-      end
-
-      # Get the name of the current database to use. Will check for a session
-      # override with a database first, then database name.
-      #
-      # @api private
-      #
-      # @example Get the current database name.
-      #   Model.current_database_name
-      #
-      # @param [ Moped::Session ] session The current session.
-      #
-      # @return [ Symbol ] The current database name.
-      #
-      # @since 3.1.0
-      def current_database_name(session)
-        if session_override && name = session.options[:database]
-          name
-        else
-          database_name
-        end
+      def collection
+        mongo_session[collection_name]
       end
     end
   end

--- a/lib/mongoid/sessions/options.rb
+++ b/lib/mongoid/sessions/options.rb
@@ -36,6 +36,16 @@ module Mongoid
         @persistence_options
       end
 
+      def mongo_session
+        self.class.mongo_session.with(persistence_options) if persistence_options
+      end
+
+      def collection_name
+        if persistence_options && v = persistence_options[:collection]
+          return v.to_sym
+        end
+      end
+
       module Threaded
 
         # Get the persistence options for the current thread.
@@ -73,6 +83,27 @@ module Mongoid
 
       module ClassMethods
         include Threaded
+
+        def session_name
+          if persistence_options && v = persistence_options[:session]
+            return v.to_sym
+          end
+          super
+        end
+
+        def collection_name
+          if persistence_options && v = persistence_options[:collection]
+            return v.to_sym
+          end
+          super
+        end
+
+        def database_name
+          if persistence_options && v = persistence_options[:database]
+            return v.to_sym
+          end
+          super
+        end
 
         # Tell the next persistance operation to store in a specific collection,
         # database or session.

--- a/lib/mongoid/sessions/storage_options.rb
+++ b/lib/mongoid/sessions/storage_options.rb
@@ -1,0 +1,118 @@
+module Mongoid
+  module Sessions
+    module StorageOptions
+      extend ActiveSupport::Concern
+
+      included do
+
+        cattr_accessor :storage_options, instance_writer: false do
+          self.storage_options_defaults
+        end
+      end
+
+      module ClassMethods
+
+        # Give this model specific custom default storage options.
+        #
+        # @example Store this model by default in "artists"
+        #   class Band
+        #     include Mongoid::Document
+        #     store_in collection: "artists"
+        #   end
+        #
+        # @example Store this model by default in the sharded db.
+        #   class Band
+        #     include Mongoid::Document
+        #     store_in database: "echo_shard"
+        #   end
+        #
+        # @example Store this model by default in a different session.
+        #   class Band
+        #     include Mongoid::Document
+        #     store_in session: "secondary"
+        #   end
+        #
+        # @example Store this model with a combination of options.
+        #   class Band
+        #     include Mongoid::Document
+        #     store_in collection: "artists", database: "secondary"
+        #   end
+        #
+        # @param [ Hash ] options The storage options.
+        #
+        # @option options [ String, Symbol ] :collection The collection name.
+        # @option options [ String, Symbol ] :database The database name.
+        # @option options [ String, Symbol ] :session The session name.
+        #
+        # @return [ Class ] The model class.
+        #
+        # @since 3.0.0
+        def store_in(options)
+          Validators::Storage.validate(self, options)
+          self.storage_options.merge!(options)
+        end
+
+        def reset_storage_options!
+          self.storage_options = storage_options_defaults.dup
+        end
+
+        def storage_options_defaults
+          {
+            collection: self.name.collectionize.to_sym,
+            session: :default,
+            database: Mongoid.sessions[:default][:database]
+          }
+        end
+
+        # Get the name of the collection this model persists to.
+        #
+        # @example Get the collection name.
+        #   Model.collection_name
+        #
+        # @return [ Symbol ] The name of the collection.
+        #
+        # @since 3.0.0
+        def collection_name
+          __evaluate__(self.storage_options[:collection])
+        end
+
+        # Get the session name for the model.
+        #
+        # @example Get the session name.
+        #   Model.session_name
+        #
+        # @return [ Symbol ] The name of the session.
+        #
+        # @since 3.0.0
+        def session_name
+          __evaluate__(self.storage_options[:session])
+        end
+
+        def database_name
+          __evaluate__(self.storage_options[:database])
+        end
+
+        private
+
+        # Eval the provided value, either byt calling it if it responds to call
+        # or returning the value itself.
+        #
+        # @api private
+        #
+        # @example Evaluate the name.
+        #   Model.__evaluate__(:name)
+        #
+        # @param [ String, Symbol, Proc ] name The name.
+        #
+        # @return [ Symbol ] The value as a symbol.
+        #
+        # @since 3.1.0
+        def __evaluate__(name)
+          return nil unless name
+          name.respond_to?(:call) ? name.call.to_sym : name.to_sym
+        end
+
+      end
+    end
+  end
+end

--- a/lib/mongoid/sessions/thread_options.rb
+++ b/lib/mongoid/sessions/thread_options.rb
@@ -1,0 +1,18 @@
+module Mongoid
+  module Sessions
+    module ThreadOptions
+      extend ActiveSupport::Concern
+
+      module ClassMethods
+
+        def session_name
+          Threaded.session_override || super
+        end
+
+        def database_name
+          Threaded.database_override || super
+        end
+      end
+    end
+  end
+end

--- a/spec/mongoid/sessions/options_spec.rb
+++ b/spec/mongoid/sessions/options_spec.rb
@@ -68,4 +68,25 @@ describe Mongoid::Sessions::Options do
       }.to raise_error(NoMethodError)
     end
   end
+
+  describe ".persistence_options" do
+
+    context "when options exist on the current thread" do
+
+      let(:klass) do
+        Band.with(safe: { w: 2 })
+      end
+
+      it "returns the options" do
+        expect(klass.persistence_options).to eq(safe: { w: 2 })
+      end
+    end
+
+    context "when there are no options on the current thread" do
+
+      it "returns nil" do
+        expect(Band.persistence_options).to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Problem

Logic to get database, collection, session overwrites was way to confusing, as we have multiple source of data, and they were all handled case by case on the session.rb module.
### Solution

Split those storage options into 3 layers of modules,

``` ruby
StorageOptions ## Responsible for dealing with class level overwrites
ThreadOptions ## Responsible for dealing with thread level overwrites
Options ## Responsible for dealing with .with() options
```

They are defined in that order so the chain of methods will be preserved.

Let me know what do you think @durran before I merge this in. 
