### PR TITLE
Fix broken in/nin matchables where attribute is nil

### DIFF
--- a/lib/mongoid/matchable/in.rb
+++ b/lib/mongoid/matchable/in.rb
@@ -14,7 +14,7 @@ module Mongoid
       #
       # @return [ true, false ] If a value exists.
       def matches?(value)
-        attribute_array = Array.wrap(@attribute)
+        attribute_array = @attribute.nil? ? [nil] : Array.wrap(@attribute)
         value.values.first.any? do |e|
           attribute_array.any? { |_attribute| e === _attribute }
         end

--- a/lib/mongoid/matchable/nin.rb
+++ b/lib/mongoid/matchable/nin.rb
@@ -14,7 +14,8 @@ module Mongoid
       #
       # @return [ true, false ] If a value exists.
       def matches?(value)
-        Array.wrap(@attribute).none? { |e| value.values.first.include?(e) }
+        attribute_array = @attribute.nil? ? [nil] : Array.wrap(@attribute)
+        attribute_array.none? { |e| value.values.first.include?(e) }
       end
     end
   end

--- a/spec/mongoid/matchable/in_spec.rb
+++ b/spec/mongoid/matchable/in_spec.rb
@@ -2,23 +2,47 @@ require "spec_helper"
 
 describe Mongoid::Matchable::In do
 
-  let(:matcher) do
-    described_class.new("first")
-  end
-
   describe "#matches?" do
 
-    context "when the values include the attribute" do
+    context 'when the attribute is not nil' do
 
-      it "returns true" do
-        expect(matcher.matches?("$in" => [/\Afir.*\z/, "second"])).to be_true
+      let(:matcher) do
+        described_class.new("first")
+      end
+
+      context "when the values include the attribute" do
+
+        it "returns true" do
+          expect(matcher.matches?("$in" => [/\Afir.*\z/, "second"])).to be_true
+        end
+      end
+
+      context "when the values don't include the attribute" do
+
+        it "returns false" do
+          expect(matcher.matches?("$in" => ["third"])).to be_false
+        end
       end
     end
 
-    context "when the values don't include the attribute" do
+    context 'when the attribute is nil' do
 
-      it "returns false" do
-        expect(matcher.matches?("$in" => ["third"])).to be_false
+      let(:matcher) do
+        described_class.new(nil)
+      end
+
+      context "when the values include the attribute" do
+
+        it "returns true" do
+          expect(matcher.matches?("$in" => [/\Afir.*\z/, nil])).to be_true
+        end
+      end
+
+      context "when the values don't include the attribute" do
+
+        it "returns false" do
+          expect(matcher.matches?("$in" => ["third"])).to be_false
+        end
       end
     end
   end

--- a/spec/mongoid/matchable/nin_spec.rb
+++ b/spec/mongoid/matchable/nin_spec.rb
@@ -2,23 +2,46 @@ require "spec_helper"
 
 describe Mongoid::Matchable::Nin do
 
-  let(:matcher) do
-    described_class.new("first")
-  end
-
   describe "#matches?" do
 
-    context "when the values do not contain the attribute" do
+    context 'when the attribute is not nil' do
 
-      it "returns true" do
-        expect(matcher.matches?("$nin" => ["second", "third"])).to be_true
+    let(:matcher) do
+      described_class.new("first")
+    end
+
+      context "when the values do not contain the attribute" do
+
+        it "returns true" do
+          expect(matcher.matches?("$nin" => ["second", "third"])).to be_true
+        end
+      end
+
+      context "when the values contain the attribute" do
+
+        it "returns false" do
+          expect(matcher.matches?("$nin" => ["first"])).to be_false
+        end
       end
     end
 
-    context "when the values contain the attribute" do
+    context 'when the attribute is nil' do
+      let(:matcher) do
+        described_class.new(nil)
+      end
 
-      it "returns false" do
-        expect(matcher.matches?("$nin" => ["first"])).to be_false
+      context "when the values do not contain the attribute" do
+
+        it "returns true" do
+          expect(matcher.matches?("$nin" => ["third"])).to be_true
+        end
+      end
+
+      context "when the values contain the attribute" do
+
+        it "returns false" do
+          expect(matcher.matches?("$nin" => [/\Afir.*\z/, nil])).to be_false
+        end
       end
     end
   end


### PR DESCRIPTION
``` ruby
class ParentDoc
  include Mongoid::Document

  embeds_many :child_docs
end

class ChildDoc
  include Mongoid::Document

  field :attribute

  embedded_in :parent_doc
end

ParentDoc.create!(child_docs: [ { attribute: nil } ])

ParentDoc.in(:'child_docs.attribute' => [nil]).count => 1
ParentDoc.in(:'child_docs.attribute' => [nil]).first.child_docs.in(:attribute => [nil]).count => 0
```
