### PR TITLE
Don`t run only after_callbacks

### DIFF
--- a/lib/mongoid/changeable.rb
+++ b/lib/mongoid/changeable.rb
@@ -91,17 +91,6 @@ module Mongoid
       changed_attributes.clear
     end
 
-    # Things that need to execute after a document has been persisted.
-    #
-    # @example Handle post persistence.
-    #   document.post_persist
-    #
-    # @since 3.0.0
-    def post_persist
-      reset_persisted_children
-      move_changes
-    end
-
     # Get the previous changes on the document.
     #
     # @example Get the previous changes.

--- a/lib/mongoid/persistable.rb
+++ b/lib/mongoid/persistable.rb
@@ -123,7 +123,10 @@ module Mongoid
     #
     # @since 4.0.0
     def post_process_persist(result, options = {})
-      post_persist unless result == false
+      unless result == false
+        reset_persisted_children
+        move_changes
+      end
       errors.clear unless performing_validations?(options)
       true
     end

--- a/lib/mongoid/relations/embedded/batchable.rb
+++ b/lib/mongoid/relations/embedded/batchable.rb
@@ -323,8 +323,6 @@ module Mongoid
         def post_process_batch_insert(docs)
           docs.each do |doc|
             doc.new_record = false
-            doc.run_after_callbacks(:create, :save)
-            doc.post_persist
           end
         end
 
@@ -343,7 +341,6 @@ module Mongoid
         # @since 3.0.0
         def post_process_batch_remove(docs, method)
           docs.each do |doc|
-            doc.run_after_callbacks(:destroy) if method == :destroy
             doc.freeze
             doc.destroyed = true
             IdentityMap.remove(doc)

--- a/lib/mongoid/relations/referenced/many.rb
+++ b/lib/mongoid/relations/referenced/many.rb
@@ -431,8 +431,6 @@ module Mongoid
             collection.insert(inserts)
             docs.each do |doc|
               doc.new_record = false
-              doc.run_after_callbacks(:create, :save)
-              doc.post_persist
             end
           end
         end


### PR DESCRIPTION
Can see here 2b043206ee99e9217dc5bd3ff3b6ede09430574a that some run_callbacks were removed,
However there was some run_after_callbacks left, which make no sense to be ran.

@durran want your opinion on this. IMO it make sense to only run callbacks when both, before and after, are executed. I think that was left over code, also that I didnt have to change any test to remove them.
Also I am removing `post_persist`, which should not belong to the dirty attributes module.
