### PR TITLE
Add field option :only_alias to skip destructive methods for the primary name.

### DIFF
--- a/lib/mongoid/fields.rb
+++ b/lib/mongoid/fields.rb
@@ -311,10 +311,10 @@ module Mongoid
         field = field_for(name, options)
         fields[name] = field
         add_defaults(field)
-        create_accessors(name, name, options)
+        create_accessors(name, name, options) unless aliased && options[:only_alias]
         create_accessors(name, aliased, options) if aliased
         process_options(field)
-        create_dirty_methods(name, name)
+        create_dirty_methods(name, name) unless aliased && options[:only_alias]
         create_dirty_methods(name, aliased) if aliased
         field
       end

--- a/lib/mongoid/fields/validators/macro.rb
+++ b/lib/mongoid/fields/validators/macro.rb
@@ -17,7 +17,8 @@ module Mongoid
           :pre_processed,
           :subtype,
           :type,
-          :overwrite
+          :overwrite,
+          :only_alias,
         ]
 
         # Validate the field definition.
@@ -52,7 +53,7 @@ module Mongoid
         # @since 3.0.0
         def validate_name(klass, name, options)
           if Mongoid.destructive_fields.include?(name)
-            raise Errors::InvalidField.new(klass, name)
+            raise Errors::InvalidField.new(klass, name) unless options[:as] && options[:only_alias]
           end
 
           if !options[:overwrite] && klass.fields.keys.include?(name.to_s)

--- a/spec/mongoid/fields_spec.rb
+++ b/spec/mongoid/fields_spec.rb
@@ -736,6 +736,12 @@ describe Mongoid::Fields do
             Person.field(:metadata)
           }.to raise_error(Mongoid::Errors::InvalidField)
         end
+
+        it "doesn't raise an error if the field is aliased and only using the alias" do
+          expect {
+            Person.field(:metadata, :as => :info, :only_alias => true)
+          }.not_to raise_error(Mongoid::Errors::InvalidField)
+        end
       end
     end
 


### PR DESCRIPTION
The idea of this is that protected field names, such as :metadata
can be accessed via their aliases but the accessors for the protected
name are skipped, allowing access to these protected fields via the
alias.

See closed issue #3362.
