### PR TITLE
Don't require rack/mongoid. It was removed with IdentityMap (7180173).

### DIFF
--- a/lib/mongoid.rb
+++ b/lib/mongoid.rb
@@ -27,12 +27,6 @@ if defined?(Rails)
   require "mongoid/railtie"
 end
 
-# If we are using any Rack based application then we need the Mongoid rack
-# middleware to ensure our app is running properly.
-if defined?(Rack)
-  require "rack/mongoid"
-end
-
 # add english load path by default
 I18n.load_path << File.join(File.dirname(__FILE__), "config", "locales", "en.yml")
 


### PR DESCRIPTION
Fix #3367.
