### PR TITLE
Require ostruct in lib/mongoid/indexable.rb to load OpenStruct.

### DIFF
--- a/lib/mongoid/indexable.rb
+++ b/lib/mongoid/indexable.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 require "mongoid/indexable/specification"
 require "mongoid/indexable/validators/options"
+require "ostruct"
 
 module Mongoid
 


### PR DESCRIPTION
This makes CI green again for 1.9.3.
