### PR TITLE
Convert DateTime to Time to avoid strip of decimal part in DateTime#__mongoize_time__.

### DIFF
--- a/lib/mongoid/extensions/date_time.rb
+++ b/lib/mongoid/extensions/date_time.rb
@@ -12,9 +12,9 @@ module Mongoid
       #
       # @since 3.0.0
       def __mongoize_time__
-        return self if utc? && Mongoid.use_utc?
+        return self.to_time if utc? && Mongoid.use_utc?
         if Mongoid.use_activesupport_time_zone?
-          in_time_zone(::Time.zone)
+          in_time_zone(::Time.zone).to_time
         else
           time = to_time
           time.respond_to?(:getlocal) ? time.getlocal : time

--- a/spec/mongoid/extensions/date_time_spec.rb
+++ b/spec/mongoid/extensions/date_time_spec.rb
@@ -14,8 +14,27 @@ describe Mongoid::Extensions::DateTime do
         date_time.__mongoize_time__
       end
 
-      pending "does not drop the precision" do
-        expect(mongoized.to_f.to_s).to match(/\.123/)
+      context 'does not drop the precision' do
+
+        it "for utc DateTime" do
+          date_time.stub(:utc?).and_return(true)
+          Mongoid.stub(:use_utc?).and_return(true)
+          expect(mongoized.to_f.to_s).to match(/\.123/)
+        end
+
+        it "when using Active Support timezone" do
+          date_time.stub(:utc?).and_return(false)
+          Mongoid.stub(:use_utc?).and_return(false)
+          Mongoid.stub(:use_activesupport_time_zone?).and_return(true)
+          expect(mongoized.to_f.to_s).to match(/\.123/)
+        end
+
+        it "for DateTime without zone" do
+          date_time.stub(:utc?).and_return(false)
+          Mongoid.stub(:use_utc?).and_return(false)
+          Mongoid.stub(:use_activesupport_time_zone?).and_return(false)
+          expect(mongoized.to_f.to_s).to match(/\.123/)
+        end
       end
     end
 


### PR DESCRIPTION
I believe there is some way how to write better spec for this.
