### PR TITLE
Add timestamps macros for setting up timestamps

### DIFF
--- a/lib/mongoid/composable.rb
+++ b/lib/mongoid/composable.rb
@@ -11,6 +11,7 @@ require "mongoid/selectable"
 require "mongoid/scopable"
 require "mongoid/serializable"
 require "mongoid/shardable"
+require "mongoid/timestamps/macros"
 require "mongoid/traversable"
 require "mongoid/validatable"
 
@@ -28,6 +29,8 @@ module Mongoid
       extend ActiveModel::Translation
       extend Findable
     end
+
+
 
     include ActiveModel::Conversion
     include ActiveModel::ForbiddenAttributesProtection
@@ -51,6 +54,7 @@ module Mongoid
     include Sessions
     include Shardable
     include State
+    include Timestamps::Macros
     include Threaded::Lifecycle
     include Traversable
     include Validatable

--- a/lib/mongoid/timestamps/macros.rb
+++ b/lib/mongoid/timestamps/macros.rb
@@ -1,0 +1,34 @@
+# encoding: utf-8
+module Mongoid
+  module Timestamps
+    module Macros
+      extend ActiveSupport::Concern
+
+      module ClassMethods
+
+        # timestamps
+        # timestamps :both
+        # timestamps both: :short
+        # timestamps :created
+        # timestamps :updated
+        # timestamps :short
+        # timestamps created: :short
+        # timestamps updated: :short
+        # timestamps created: true
+        # timestamps updated: true
+        # timestamps both: true
+        def timestamps(options = :both)
+          options = { options => true } if options.is_a?(Symbol)
+
+          created_option = options.values_at(:created, :both)
+          updated_option = options.values_at(:updated, :both)
+
+          include Created if created_option.include?(true)
+          include Updated if updated_option.include?(true)
+          include Created::Short if created_option.include?(:short) || options[:short]
+          include Updated::Short if updated_option.include?(:short) || options[:short]
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
It will be in this way

``` ruby
class Product
  include Mongoid::Document
  field :name, type: String
  field :description, type: String

  timestamps
  # timestamps :created
  # timestamps :updated
  # timestamps :short
  # timestamps created: :short
  # timestamps updated: :short
```

What do you think? 
If you will accept I will re-factor and add specs
