### PR TITLE
Add support for once persist many embedded documents with parent document

### DIFF
--- a/lib/mongoid/relations/many.rb
+++ b/lib/mongoid/relations/many.rb
@@ -41,7 +41,7 @@ module Mongoid
       #
       # @since 2.0.0.beta.1
       def create(attributes = nil, type = nil, &block)
-        return attributes.collect{|attribute| create(attribute)} if attributes.class == Array
+        return attributes.collect{|attribute| create(attribute,type,&block)} if attributes.class == Array
         doc = build(attributes, type, &block)
         base.persisted? ? doc.save : raise_unsaved(doc)
         doc
@@ -69,7 +69,7 @@ module Mongoid
       #
       # @since 2.0.0.beta.1
       def create!(attributes = nil, type = nil, &block)
-        return attributes.collect{|attribute| create!(attribute)} if attributes.class == Array
+        return attributes.collect{|attribute| create!(attribute,type,&block)} if attributes.class == Array
         doc = build(attributes, type, &block)
         base.persisted? ? doc.save! : raise_unsaved(doc)
         doc


### PR DESCRIPTION
Before you only can once persist on embedded document with parent document.
Now add support for can once persist many embedded documents with parent documents.

``` ruby
class User
  include Mongoid::Document
  embeds_many :items  
end

class Item
    include Mongoid::Document
    field :name,type:String
    embedded_in :user
end
# you can persist many embedded documents such as 
User.create.items.create([{:name => 'foo'},{:name => 'bar'}])
User.create.items.create!([{:name => 'foo'},{:name => 'bar'}])
```
