### PR TITLE
instance_delegate takes one hash as parameter in Ruby 2.0.0-p247

### DIFF
--- a/lib/mongoid/serializable.rb
+++ b/lib/mongoid/serializable.rb
@@ -12,7 +12,7 @@ module Mongoid
     # similar to +ActiveRecord+.
     included do
       undef_method :include_root_in_json
-      delegate :include_root_in_json, to: ::Mongoid
+      delegate include_root_in_json: ::Mongoid
     end
 
     # Gets the document as a serializable hash, used by ActiveModel's JSON


### PR DESCRIPTION
I had to add this fix for Ruby 2.0.0-p247
