### PR TITLE
Support limit and skip criteria in Mongoid::Contextual::Aggregable::Mongo

### DIFF
--- a/lib/mongoid/contextual/aggregable/mongo.rb
+++ b/lib/mongoid/contextual/aggregable/mongo.rb
@@ -129,6 +129,8 @@ module Mongoid
           db_field = "$#{database_field_name(field)}"
           pipeline = []
           pipeline << { "$match" => criteria.nin(field => nil).selector }
+          pipeline << { "$sort" => criteria.options[:sort] } if criteria.options[:sort]
+          pipeline << { "$skip" => criteria.options[:skip] } if criteria.options[:skip]
           pipeline << { "$limit" => criteria.options[:limit] } if criteria.options[:limit]
           pipeline << {
             "$group"  => {

--- a/spec/mongoid/contextual/aggregable/mongo_spec.rb
+++ b/spec/mongoid/contextual/aggregable/mongo_spec.rb
@@ -108,6 +108,38 @@ describe Mongoid::Contextual::Aggregable::Mongo do
             aggregates["sum"].should eq(1000)
           end
         end
+
+        context "when only 1 document is emitted because of sorting, skip and limit" do
+
+          let(:criteria) do
+            Band.desc(:name).skip(1).limit(1)
+          end
+
+          let(:aggregates) do
+            context.aggregates(:likes)
+          end
+
+          it "returns an avg" do
+            expect(aggregates["avg"]).to eq(1000)
+          end
+
+          it "returns a count of documents with that field" do
+            expect(aggregates["count"]).to eq(1)
+          end
+
+          it "returns a max" do
+            expect(aggregates["max"]).to eq(1000)
+          end
+
+          it "returns a min" do
+            expect(aggregates["min"]).to eq(1000)
+          end
+
+          it "returns a sum" do
+            expect(aggregates["sum"]).to eq(1000)
+          end
+        end
+
       end
 
       context "when the field does not exist" do


### PR DESCRIPTION
Backport sort and limit to 3.1 stable
