### PR TITLE
use a uniq list of models for the Rails::Mogoid create / remove _indexes

### DIFF
--- a/lib/rails/mongoid.rb
+++ b/lib/rails/mongoid.rb
@@ -92,7 +92,7 @@ module Rails
 
       models = (::Mongoid.models | models) if all_possible_models
 
-      models.compact.sort_by { |model| model.name || '' }
+      models.compact.uniq { |model| model.name }.sort_by { |model| model.name || '' }
     end
 
     # Use the application configuration to get every model and require it, so


### PR DESCRIPTION
Milestone: 3.1.6 

`rake db:mongoid:*_indexes` tasks are using a non-uniq list of models, possibly creating / removing indexes multiple times
