### PR TITLE
Allow origin 2.0

### DIFF
--- a/mongoid.gemspec
+++ b/mongoid.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency("activemodel", ["~> 4.0.0"])
   s.add_dependency("tzinfo", ["~> 0.3.37"])
   s.add_dependency("moped", ["~> 2.0.beta3"])
-  s.add_dependency("origin", ["~> 1.0"])
+  s.add_dependency("origin", [">= 1.0", "< 3.0"])
 
   s.files        = Dir.glob("lib/**/*") + %w(CHANGELOG.md LICENSE README.md Rakefile)
   s.test_files   = Dir.glob("spec/**/*")


### PR DESCRIPTION
The master branch of [mongoid/origin](http://github.com/mongoid/origin) has [a bug fix](https://github.com/mongoid/origin/pull/91) merged in that I am hitting when I recently upgraded to the master branch of mongoid. However, the master branch of origin has been bumped to version 2.0, while mongoid's master currently requires origin ~> 1.0.

I'm not sure what Mongoid's versioning policies are, but would it be possible to update the gemspec to allow origin >=1.0, < 3.0?
