### PR TITLE
fix pushing to n-to-n in a embedded in doc will raise nil error when not assign parent

### DIFF
--- a/lib/mongoid/selectable.rb
+++ b/lib/mongoid/selectable.rb
@@ -19,7 +19,7 @@ module Mongoid
     # @since 1.0.0
     def atomic_selector
       @atomic_selector ||=
-        (embedded? ? embedded_atomic_selector : root_atomic_selector)
+          (embedded? && _parent ? embedded_atomic_selector : root_atomic_selector)
     end
 
     private

--- a/spec/app/models/message.rb
+++ b/spec/app/models/message.rb
@@ -1,0 +1,8 @@
+class Message
+  include Mongoid::Document
+
+  field :body, type: String
+
+  embedded_in :person
+  has_and_belongs_to_many :receviers, class_name: "Person", inverse_of: nil
+end

--- a/spec/app/models/person.rb
+++ b/spec/app/models/person.rb
@@ -64,6 +64,7 @@ class Person
   embeds_many :services, cascade_callbacks: true, validate: false
   embeds_many :symptoms, validate: false
   embeds_many :appointments, validate: false
+  embeds_many :messages, validate: false
 
   embeds_one :passport, autobuild: true, store_as: :pass, validate: false
   embeds_one :pet, class_name: "Animal", validate: false

--- a/spec/mongoid/relations/embedded/many_spec.rb
+++ b/spec/mongoid/relations/embedded/many_spec.rb
@@ -208,6 +208,37 @@ describe Mongoid::Relations::Embedded::Many do
           end
         end
       end
+
+      context "when the child has one sided many to many relation" do
+        let(:person) do
+          Person.create
+        end
+
+        let(:message) do
+          Message.new
+        end
+
+        context "assign parent first" do
+          before do
+            message.person = person
+            message.receviers.send(method, person)
+          end
+
+          it "appends to the relation array" do
+            expect(message.receviers).to include(person)
+          end
+        end
+
+        context "not assign parent" do
+          before do
+            message.receviers.send(method, person)
+          end
+
+          it "appends to the relation array" do
+            expect(message.receviers).to include(person)
+          end
+        end
+      end
     end
   end
 


### PR DESCRIPTION
situation has described in #3019
when embedded in document not assign a parent, can return `root_atomic_selector` directly, there is no side-effect.
