### PR TITLE
call to_hash before sanitizing to allow Hashie::Mash support

### DIFF
--- a/lib/mongoid/attributes/processing.rb
+++ b/lib/mongoid/attributes/processing.rb
@@ -19,7 +19,7 @@ module Mongoid
       def process_attributes(attrs = nil)
         attrs ||= {}
         if !attrs.empty?
-          attrs = sanitize_for_mass_assignment(attrs)
+          attrs = sanitize_for_mass_assignment(attrs.to_hash)
           attrs.each_pair do |key, value|
             next if pending_attribute?(key, value)
             process_attribute(key, value)


### PR DESCRIPTION
Here's a console session before and after with the following name document:

```
class Name
  include Mongoid::Document
  field :given, type: String
end
```

Before (errors!)

```
> Name.new Hashie::Mash.new(given: 'aj')
ActiveModel::ForbiddenAttributesError: ActiveModel::ForbiddenAttributesError
```

And after:

```
> Name.new Hashie::Mash.new(given: 'aj')
=> #<Name _id: 52a64109777061a1ed000000, given: "aj">
```

It's a good idea to fix this so that embedded documents do not break with the Grape framework.
