### PR TITLE
fix pushing to n-to-n in a embedded in doc will raise nil error when not assign parent

### DIFF
--- a/lib/mongoid/atomic.rb
+++ b/lib/mongoid/atomic.rb
@@ -189,7 +189,8 @@ module Mongoid
     #
     # @since 2.1.0
     def atomic_paths
-      @atomic_paths ||= metadata ? metadata.path(self) : Atomic::Paths::Root.new(self)
+      # TODO: smarty cache return value and auto refresh when relation changed
+      metadata ? metadata.path(self) : Atomic::Paths::Root.new(self)
     end
 
     # Get all the attributes that need to be pulled.

--- a/lib/mongoid/selectable.rb
+++ b/lib/mongoid/selectable.rb
@@ -18,8 +18,8 @@ module Mongoid
     #
     # @since 1.0.0
     def atomic_selector
-      @atomic_selector ||=
-        (embedded? ? embedded_atomic_selector : root_atomic_selector)
+      # TODO: smarty cache return value and auto refresh when relation changed
+      embedded? ? embedded_atomic_selector : root_atomic_selector
     end
 
     private
@@ -37,8 +37,10 @@ module Mongoid
     def embedded_atomic_selector
       if persisted? && _id_changed?
         _parent.atomic_selector
-      else
+      elsif _parent
         _parent.atomic_selector.merge("#{atomic_path}._id" => _id)
+      else
+        {}
       end
     end
 

--- a/spec/app/models/message.rb
+++ b/spec/app/models/message.rb
@@ -1,0 +1,8 @@
+class Message
+  include Mongoid::Document
+
+  field :body, type: String
+
+  embedded_in :person
+  has_and_belongs_to_many :receviers, class_name: "Person", inverse_of: nil
+end

--- a/spec/app/models/person.rb
+++ b/spec/app/models/person.rb
@@ -64,6 +64,7 @@ class Person
   embeds_many :services, cascade_callbacks: true, validate: false
   embeds_many :symptoms, validate: false
   embeds_many :appointments, validate: false
+  embeds_many :messages, validate: false
 
   embeds_one :passport, autobuild: true, store_as: :pass, validate: false
   embeds_one :pet, class_name: "Animal", validate: false

--- a/spec/mongoid/relations/embedded/many_spec.rb
+++ b/spec/mongoid/relations/embedded/many_spec.rb
@@ -208,6 +208,37 @@ describe Mongoid::Relations::Embedded::Many do
           end
         end
       end
+
+      context "when the child has one sided many to many relation" do
+        let(:person) do
+          Person.create
+        end
+
+        let(:message) do
+          Message.new
+        end
+
+        context "assign parent first" do
+          before do
+            message.person = person
+            message.receviers.send(method, person)
+          end
+
+          it "appends to the relation array" do
+            expect(message.receviers).to include(person)
+          end
+        end
+
+        context "not assign parent" do
+          before do
+            message.receviers.send(method, person)
+          end
+
+          it "appends to the relation array" do
+            expect(message.receviers).to include(person)
+          end
+        end
+      end
     end
   end
 


### PR DESCRIPTION
situation has described in #3019

we could return a empty hash when not assign a parent, but there is a problem is `atomic_paths` and `atomic_selector` are cached and will not change whatever association changing.
e.g

``` ruby
2.0.0p353 :012 >   a1 = A.create
 => #<A _id: 52a6450a4a6173a58b000000, >
2.0.0p353 :013 > a2 = A.create
 => #<A _id: 52a6450a4a6173a58b010000, >
2.0.0p353 :014 >
2.0.0p353 :015 >   b = B.new
 => #<B _id: 52a6450b4a6173a58b020000, c_ids: nil>
2.0.0p353 :016 > b.a = a1
 => #<A _id: 52a6450a4a6173a58b000000, >
2.0.0p353 :017 > b.atomic_path
 => "b"
2.0.0p353 :018 > b.atomic_selector
 => {"_id"=>BSON::ObjectId('52a6450a4a6173a58b000000'), "b._id"=>BSON::ObjectId('52a6450b4a6173a58b020000')}
2.0.0p353 :019 > a1
 => #<A _id: 52a6450a4a6173a58b000000, >
2.0.0p353 :020 > b.a = a2
 => #<A _id: 52a6450a4a6173a58b010000, >
2.0.0p353 :021 > b.atomic_path
 => "b"
2.0.0p353 :022 > b.atomic_selector
 => {"_id"=>BSON::ObjectId('52a6450a4a6173a58b000000'), "b._id"=>BSON::ObjectId('52a6450b4a6173a58b020000')}
2.0.0p353 :023 > a2
 => #<A _id: 52a6450a4a6173a58b010000, >
```

that will made some problems, so I think we need a smarty way to caching them
