### PR TITLE
Added compatibility for rails 4.1

### DIFF
--- a/mongoid.gemspec
+++ b/mongoid.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.rubyforge_project         = "mongoid"
 
   s.add_dependency("activemodel", [">= 4.0.0"])
-  s.add_dependency("tzinfo", ["~> 0.3.37"])
+  s.add_dependency("tzinfo", [">= 0.3.37"])
   s.add_dependency("moped", ["~> 2.0.beta4"])
   s.add_dependency("origin", ["~> 2.0"])
 


### PR DESCRIPTION
Rails 4.1 depends on new versions of active model and tzinfo, I just added the `>=` to allow to add newer versions, and it worked, however, I don't know if there's a restriction from you to add that rule to the gem.
