### PR TITLE
Skip any module part that is blank

### DIFF
--- a/lib/mongoid/relations/metadata.rb
+++ b/lib/mongoid/relations/metadata.rb
@@ -910,6 +910,7 @@ module Mongoid
       # @since 3.0.0
       def find_from_parts(modules)
         modules.find do |mod|
+          next nil if mod.blank?
           ActiveSupport::Inflector.constantize(mod).constants.include?(
             name.to_s.classify.to_sym
           )


### PR DESCRIPTION
Getting a `NameError` with `wrong constant name` because it seems to pass to `ActiveSupport::Inflector.constantize` (4.1.beta1) a blank value

[here is some context (backtrace, models and offending call in a controller)](https://gist.github.com/elia/3400212c37a9f6fce2b0)
