### PR TITLE
Fix Fields::Localized#lookup to work with boolean

### DIFF
--- a/lib/mongoid/fields/localized.rb
+++ b/lib/mongoid/fields/localized.rb
@@ -63,7 +63,7 @@ module Mongoid
       def lookup(object)
         locale = ::I18n.locale
         if ::I18n.respond_to?(:fallbacks)
-          object[::I18n.fallbacks[locale].map(&:to_s).find{ |loc| object[loc] }]
+          object[::I18n.fallbacks[locale].map(&:to_s).find{ |loc| object.has_key?(loc) }]
         else
           object[locale.to_s]
         end


### PR DESCRIPTION
Fix this case:

``` ruby

class Property
  include Mongoid::Document

  field :value, :localize => true
end

p = Property.new
p.value_translations = { fr: false, en: "random" }
p.save!

I18n.locale = :fr
p.value # returns "random" instead of false

```
