### PR TITLE
Added dependency badge for README file;

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Mongoid [![Build Status](https://secure.travis-ci.org/mongoid/mongoid.png?branch=master)](http://travis-ci.org/mongoid/mongoid) [![Code Climate](https://codeclimate.com/github/mongoid/mongoid.png)](https://codeclimate.com/github/mongoid/mongoid) [![Coverage Status](https://coveralls.io/repos/mongoid/mongoid/badge.png?branch=master)](https://coveralls.io/r/mongoid/mongoid?branch=master) [![Gem Version](https://badge.fury.io/rb/mongoid.png)](http://badge.fury.io/rb/mongoid)
+Mongoid [![Build Status](https://secure.travis-ci.org/mongoid/mongoid.png?branch=master)](http://travis-ci.org/mongoid/mongoid) [![Code Climate](https://codeclimate.com/github/mongoid/mongoid.png)](https://codeclimate.com/github/mongoid/mongoid) [![Coverage Status](https://coveralls.io/repos/mongoid/mongoid/badge.png?branch=master)](https://coveralls.io/r/mongoid/mongoid?branch=master) [![Gem Version](https://badge.fury.io/rb/mongoid.png)](http://badge.fury.io/rb/mongoid) [![Dependency Status](https://www.versioneye.com/ruby/mongoid/3.1.6/badge.png)](https://www.versioneye.com/ruby/mongoid/3.1.6)
 ========
 
 Mongoid is an ODM (Object-Document-Mapper) framework for MongoDB in Ruby.


### PR DESCRIPTION
Hi, 

i added dependency badge into README. This badge helps to keep eye on sub-dependencies (specially before the release 4.0) and users can checkout additional metadata about your library. For example, here is [list of libraries](https://www.versioneye.com/ruby/mongoid/references) which are  already using `Mongoid`.

Seems that tzinfo-guys are done huge leap in their versioning - directly from [`0.3` to `1.0`](https://github.com/tzinfo/tzinfo/blob/master/CHANGES.md)  .
