### PR TITLE
Check length to enforce includes better

### DIFF
--- a/spec/mongoid/relations/eager/has_and_belongs_to_many_spec.rb
+++ b/spec/mongoid/relations/eager/has_and_belongs_to_many_spec.rb
@@ -81,6 +81,7 @@ describe Mongoid::Relations::Eager::HasAndBelongsToMany do
 
           Person.all.includes(:houses).each do |person|
             expect(person.houses).to_not be_nil
+            epxect(person.houses.length).to be(3)
           end
         end
       end


### PR DESCRIPTION
In addition to #3383 eager loading is actually completely broken for and has_and_belongs_to_many. The spec has let this slip by because it checks for nil. The eager loader is sending back an empty array which passes.
