### PR TITLE
fix rails 4.2 deprecation warning in uniqueness validator

### DIFF
--- a/lib/mongoid/validatable/uniqueness.rb
+++ b/lib/mongoid/validatable/uniqueness.rb
@@ -26,20 +26,6 @@ module Mongoid
     class UniquenessValidator < ActiveModel::EachValidator
       include Queryable
 
-      attr_reader :klass
-
-      # Unfortunately, we have to tie Uniqueness validators to a class.
-      #
-      # @example Setup the validator.
-      # UniquenessValidator.new.setup(Person)
-      #
-      # @param [ Class ] klass The class getting validated.
-      #
-      # @since 1.0.0
-      def setup(klass)
-        @klass = klass
-      end
-
       # Validate the document for uniqueness violations.
       #
       # @example Validate the document.
@@ -280,7 +266,9 @@ module Mongoid
       #
       # @since 2.4.10
       def validate_root(document, attribute, value)
-        criteria = create_criteria(klass || document.class, document, attribute, value)
+        klass = document.class
+        klass = klass.superclass while !klass.validators.include?(self)
+        criteria = create_criteria(klass, document, attribute, value)
         criteria = criteria.merge(options[:conditions].call) if options[:conditions]
 
         if criteria.with(persistence_options(criteria)).exists?


### PR DESCRIPTION
Running mongoid/master against rails/master generates deprecation warnings on the uniqueness validator, as per:

https://github.com/rails/rails/blob/master/activemodel/lib/active_model/validator.rb#L129

I've removed the setup, and used document.class.superclass to locate the appropriate scope for the uniqueness query to be run from. Specs are all still green. What have I missed?
