### PR TITLE
Remove obsolete config from mongoid.yml

### DIFF
--- a/lib/rails/generators/mongoid/config/templates/mongoid.yml
+++ b/lib/rails/generators/mongoid/config/templates/mongoid.yml
@@ -29,9 +29,6 @@ development:
         # retry_interval: 1
   # Configure Mongoid specific options. (optional)
   options:
-    # Enable the identity map, needed for eager loading. (default: false)
-    # identity_map_enabled: false
-
     # Includes the root model name in json serialization. (default: false)
     # include_root_in_json: false
 


### PR DESCRIPTION
`identity_map_enabled` is removed in 718017394.
So this config option is invalid.
