### PR TITLE
Document Ruby 2.1.0 support in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Project Tracking
 Compatibility
 -------------
 
-Mongoid is tested against MRI 1.9.3, 2.0.0, and JRuby (1.9).
+Mongoid is tested against MRI 1.9.3, 2.0.0, 2.1.0 and JRuby (1.9).
 
 Documentation
 -------------


### PR DESCRIPTION
It seems tested with Ruby 2.1.0: https://github.com/mongoid/mongoid/blob/master/.travis.yml#L6
