### PR TITLE
Callbacks are fired multipled times for nested embedded_many relationships

### DIFF
--- a/lib/mongoid/relations/constraint.rb
+++ b/lib/mongoid/relations/constraint.rb
@@ -34,8 +34,12 @@ module Mongoid
       #
       # @since 2.0.0.rc.7
       def convert(object)
-        return object if metadata.polymorphic?
-        klass, field = metadata.klass, metadata.klass.fields["_id"]
+        klass = if metadata.polymorphic?
+          metadata.inverse_class_name.constantize
+        else
+          metadata.klass
+        end
+        field = klass.fields["_id"]
         if klass.using_object_ids?
           Moped::BSON::ObjectId.mongoize(object)
         elsif object.is_a?(::Array)

--- a/spec/mongoid/relations/constraint_spec.rb
+++ b/spec/mongoid/relations/constraint_spec.rb
@@ -20,6 +20,7 @@ describe Mongoid::Relations::Constraint do
           class_name: "Person",
           name: :person,
           inverse_class_name: "Post",
+          polymorphic: polymorphic,
           relation: Mongoid::Relations::Referenced::In
         )
       end
@@ -28,25 +29,55 @@ describe Mongoid::Relations::Constraint do
         described_class.new(metadata)
       end
 
-      context "when provided an object id" do
+      context "when the relation is not polymorphic" do
+        let (:polymorphic) { false }
 
-        let(:object) do
-          Moped::BSON::ObjectId.new
+        context "when provided an object id" do
+
+          let(:object) do
+            Moped::BSON::ObjectId.new
+          end
+
+          it "returns the object id" do
+            constraint.convert(object).should eq(object)
+          end
         end
 
-        it "returns the object id" do
-          constraint.convert(object).should eq(object)
+        context "when provided a string" do
+
+          let(:object) do
+            Moped::BSON::ObjectId.new
+          end
+
+          it "returns an object id from the string" do
+            constraint.convert(object.to_s).should eq(object)
+          end
         end
       end
 
-      context "when provided a string" do
+      context "when the relation is polymorphic" do
+        let (:polymorphic) { true }
 
-        let(:object) do
-          Moped::BSON::ObjectId.new
+        context "when provided an object id" do
+
+          let(:object) do
+            Moped::BSON::ObjectId.new
+          end
+
+          it "returns the object id" do
+            constraint.convert(object).should eq(object)
+          end
         end
 
-        it "returns an object id from the string" do
-          constraint.convert(object.to_s).should eq(object)
+        context "when provided a string" do
+
+          let(:object) do
+            Moped::BSON::ObjectId.new
+          end
+
+          it "returns an object id from the string" do
+            constraint.convert(object.to_s).should eq(object)
+          end
         end
       end
     end


### PR DESCRIPTION
I tried to fix this but hit a wall. The closest I got was: 

``` ruby
--- a/lib/mongoid/callbacks.rb
+++ b/lib/mongoid/callbacks.rb
@@ -169,7 +169,6 @@ module Mongoid
           Array.wrap(relation).each do |child|
             next if children.include?(child)
             children.add(child) if cascadable_child?(kind, child)
-            child.send(:cascadable_children, kind, children)
           end
         end
       end
```

but this causes `spec/mongoid/nested_attributes_spec.rb:709` to fail
