### PR TITLE
Fix uniqueness validation for inherited models.

### DIFF
--- a/lib/mongoid/validatable/uniqueness.rb
+++ b/lib/mongoid/validatable/uniqueness.rb
@@ -267,7 +267,10 @@ module Mongoid
       # @since 2.4.10
       def validate_root(document, attribute, value)
         klass = document.class
-        klass = klass.superclass while !klass.validators.include?(self)
+
+        while klass.superclass.respond_to?(:validators) && klass.superclass.validators.include?(self)
+          klass = klass.superclass
+        end
         criteria = create_criteria(klass, document, attribute, value)
         criteria = criteria.merge(options[:conditions].call) if options[:conditions]
 

--- a/spec/mongoid/validatable/uniqueness_spec.rb
+++ b/spec/mongoid/validatable/uniqueness_spec.rb
@@ -2344,18 +2344,19 @@ describe Mongoid::Validatable::UniquenessValidator do
   end
 
   context "when validation works with inheritance" do
-
-    before do
-      Actor.validates_uniqueness_of :name
-      Actor.create!(name: "Johnny Depp")
+    class EuropeanActor < Actor
+      validates_uniqueness_of :name
     end
 
-    after do
-      Actor.reset_callbacks(:validate)
+    class SpanishActor < EuropeanActor
+    end
+
+    before do
+      EuropeanActor.create!(name: "Antonio Banderas")
     end
 
     let!(:subclass_document_with_duplicated_name) do
-      Actress.new(name: "Johnny Depp")
+      SpanishActor.new(name: "Antonio Banderas")
     end
 
     it "should be invalid" do


### PR DESCRIPTION
The uniqueness validation for inherited models is currently broken. The spec example doesn't represent real-world situation, when subclasses contain all superclass validators - it dynamically defines validation on superclass when subclasses were already loaded and it's why it was passing.
