### PR TITLE
Failing spec for embedded many with BSON Object Id

### DIFF
--- a/spec/mongoid/relations/embedded/many_spec.rb
+++ b/spec/mongoid/relations/embedded/many_spec.rb
@@ -720,6 +720,41 @@ describe Mongoid::Relations::Embedded::Many do
           Address.new
         end
 
+        (1..3).each do |address_count|
+          context "when adding #{address_count} addresses with BSON Id" do
+            before do
+              # If you add 1 address it work for all cases
+              # If you add 2 addresses it fail only for destroy each case
+              # IF you add 3 addresses it fail for all cases
+              address_count.times { |i| person.addresses.create!(id: BSON::ObjectId.new, no: i)}
+            end
+
+            it "destroy each correctly" do
+              expect(person.addresses.count).to be address_count
+              person.addresses.each { |a| a.destroy }
+              expect(person.reload.addresses).to be_empty
+            end
+
+            it "destroy_all correctly" do
+              expect(person.addresses.count).to be address_count
+              person.addresses.destroy_all
+              expect(person.reload.addresses).to be_empty
+            end
+
+            it "delete_all correctly" do
+              expect(person.addresses.count).to be address_count
+              person.addresses.delete_all
+              expect(person.reload.addresses).to be_empty
+            end
+
+            it "delete all correctly when setting directly" do
+              expect(person.addresses.count).to be address_count
+              person.addresses = []
+              expect(person.reload.addresses).to be_empty
+            end
+          end
+        end
+
         context "when setting directly" do
 
           before do


### PR DESCRIPTION
Hello,

Here a failing spec for the deletion of embedded documents.
Related to #3025 and #3085. 

Seem like you do not have the issue in your existing specs because the Address Id is the street not a BON::ObjectId.

As commented in the code, with 1 address it work, with 2 addresses the 

```
person.addresses.each { |a| a.destroy }
```

delete 1 out of 2 others are green.

With 3 addresses all fails.

What I found out is with more embedded the .each number of fail is consistent while other varies.

Feel free to comment so I can help

pmlarocque 
