### PR TITLE
Mongoid exception messages should not be localized

### DIFF
--- a/lib/mongoid/errors/mongoid_error.rb
+++ b/lib/mongoid/errors/mongoid_error.rb
@@ -40,7 +40,7 @@ module Mongoid
       #
       # @return [ String ] A localized error message string.
       def translate(key, options)
-        ::I18n.translate("#{BASE_KEY}.#{key}", options)
+        ::I18n.translate("#{BASE_KEY}.#{key}", { locale: :en }.merge(options))
       end
 
       # Create the problem.

--- a/spec/mongoid/errors/mongoid_error_spec.rb
+++ b/spec/mongoid/errors/mongoid_error_spec.rb
@@ -9,7 +9,7 @@ describe Mongoid::Errors::MongoidError do
   before do
     ["message", "summary", "resolution"].each do |name|
       expect(::I18n).to receive(:translate).
-        with("mongoid.errors.messages.#{key}.#{name}", {}).
+        with("mongoid.errors.messages.#{key}.#{name}", { locale: :en }).
       and_return(name)
     end
 


### PR DESCRIPTION
I understand some developers want localized exception messages, but, I think, most of us don't.
This PR is simply reverting #3169.

Because
- We don't have any official locale files other than English ( https://github.com/mongoid/mongoid/commit/99b04782e086c62e5cf63b09dd627cac134364c1 ).
- It seems @durran intentionally set locale :en. ( #2205 ).
- As a matter of course, this commit does not affect ActiveModel's localized error messages (such as validation error messages).
