### PR TITLE
Add test for persisting inverse keys for HABTM substitution

### DIFF
--- a/spec/mongoid/relations/referenced/many_to_many_spec.rb
+++ b/spec/mongoid/relations/referenced/many_to_many_spec.rb
@@ -609,6 +609,11 @@ describe Mongoid::Relations::Referenced::ManyToMany do
             person.preferences = [ from_db ]
             expect(from_db.person_ids).to eq([ person.id ])
           end
+
+          it "persists the inverse keys" do
+            person.preferences = [ from_db ]
+            expect(from_db.reload.person_ids).to eq([ person.id ])
+          end
         end
       end
     end


### PR DESCRIPTION
## Setup

``` ruby
class Post
  include Mongoid::Document

  has_and_belongs_to_many :tags
end

class Tag
  include Mongoid::Document

  has_and_belongs_to_many :posts
end

tag = Tag.create
post = Post.create(tags: [tag])
post.tags = [Tag.last]
```
## Expected Behavior

``` ruby
post.reload.tag_ids #=> [tag.id]
tags.reload.post_ids #=> [post.id]
```
## Actual Behavior

``` ruby
post.reload.tag_ids #=> [tag.id]
tag.reload.post_ids #=> []
```

Commit has a failing test in the `many_to_many_spec.rb`, but we aren't sure how to fix with out breaking other functionality.
