### PR TITLE
Use ActiveModel::Model

### DIFF
--- a/lib/mongoid/composable.rb
+++ b/lib/mongoid/composable.rb
@@ -26,13 +26,11 @@ module Mongoid
     # All modules that a +Document+ is composed of are defined in this
     # module, to keep the document class from getting too cluttered.
     included do
-      extend ActiveModel::Translation
       extend Findable
     end
 
-    include ActiveModel::Conversion
+    include ActiveModel::Model
     include ActiveModel::ForbiddenAttributesProtection
-    include ActiveModel::Naming
     include ActiveModel::Serializers::JSON
     include ActiveModel::Serializers::Xml
     include Atomic

--- a/lib/mongoid/validatable.rb
+++ b/lib/mongoid/validatable.rb
@@ -14,7 +14,6 @@ module Mongoid
   # provide: validates_associated and validates_uniqueness_of.
   module Validatable
     extend ActiveSupport::Concern
-    include ActiveModel::Validations
 
     included do
       extend Macros


### PR DESCRIPTION
include ActiveModel::Model instead of the 4 modules different AM models.

After @carlosantoniodasilva talk at RailsConf I realized Mongoid should be using AM::Model to try to be as close as possible of AR API.

@durran :shipit: ?
