### PR TITLE
Backports #3397 to 3.1.0-stable branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 For instructions on upgrading to newer versions, visit
 [mongoid.org](http://mongoid.org/en/mongoid/docs/upgrading.html).
 
+## Unreleased
+
+* \#3397 Fixed $ne matcher for embedded documents to match server behaviour.
+
 ## 3.1.7
 
 ### Resolved Issues

--- a/lib/mongoid/matchers/ne.rb
+++ b/lib/mongoid/matchers/ne.rb
@@ -14,7 +14,7 @@ module Mongoid
       #
       # @return [ true, false ] If a value exists.
       def matches?(value)
-        @attribute != value.values.first
+        !super(value.values.first)
       end
     end
   end

--- a/spec/mongoid/matchers/ne_spec.rb
+++ b/spec/mongoid/matchers/ne_spec.rb
@@ -21,5 +21,26 @@ describe Mongoid::Matchers::Ne do
         matcher.matches?("$ne" => "first").should be_false
       end
     end
+
+    context "when the value is an array" do
+
+      let(:array_matcher) do
+        described_class.new([ "first" ])
+      end
+
+      context "when the value is in the array" do
+
+        it "returns false" do
+          expect(array_matcher.matches?("$ne" => "first")).to be false
+        end
+      end
+
+      context "when the value is not in the array" do
+
+        it "returns true" do
+          expect(array_matcher.matches?("$ne" => "second")).to be true
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
We got bit by this as well in an embedded document `where`.
