### PR TITLE
Removed everything related to making entire documents readonly...

### DIFF
--- a/lib/mongoid/persistable/deletable.rb
+++ b/lib/mongoid/persistable/deletable.rb
@@ -19,7 +19,6 @@ module Mongoid
       #
       # @since 1.0.0
       def delete(options = {})
-        raise Errors::ReadonlyDocument.new(self.class) if readonly?
         prepare_delete do
           if embedded?
             delete_as_embedded(options)

--- a/lib/mongoid/persistable/destroyable.rb
+++ b/lib/mongoid/persistable/destroyable.rb
@@ -19,7 +19,6 @@ module Mongoid
       #
       # @since 1.0.0
       def destroy(options = nil)
-        raise Errors::ReadonlyDocument.new(self.class) if readonly?
         self.flagged_for_destroy = true
         result = run_callbacks(:destroy) { delete(options || {}) }
         self.flagged_for_destroy = false

--- a/lib/mongoid/persistable/updatable.rb
+++ b/lib/mongoid/persistable/updatable.rb
@@ -134,7 +134,6 @@ module Mongoid
       #
       # @since 1.0.0
       def update_document(options = {})
-        raise Errors::ReadonlyDocument.new(self.class) if readonly?
         prepare_update(options) do
           updates, conflicts = init_atomic_updates
           unless updates.empty?

--- a/lib/mongoid/stateful.rb
+++ b/lib/mongoid/stateful.rb
@@ -70,18 +70,6 @@ module Mongoid
         !_parent.delayed_atomic_sets[atomic_path]
     end
 
-    # Is the document readonly?
-    #
-    # @example Is the document readonly?
-    #   document.readonly?
-    #
-    # @return [ true, false ] If the document is readonly.
-    #
-    # @since 4.0.0
-    def readonly?
-      __selected_fields != nil
-    end
-
     # Determine if the document can be set.
     #
     # @example Is this settable?

--- a/spec/mongoid/persistable/deletable_spec.rb
+++ b/spec/mongoid/persistable/deletable_spec.rb
@@ -8,19 +8,6 @@ describe Mongoid::Persistable::Deletable do
       Person.create
     end
 
-    context "when deleting a readonly document" do
-
-      let(:from_db) do
-        Person.only(:_id).first
-      end
-
-      it "raises an error" do
-        expect {
-          from_db.delete
-        }.to raise_error(Mongoid::Errors::ReadonlyDocument)
-      end
-    end
-
     context "when removing a root document" do
 
       let!(:deleted) do

--- a/spec/mongoid/persistable/destroyable_spec.rb
+++ b/spec/mongoid/persistable/destroyable_spec.rb
@@ -8,19 +8,6 @@ describe Mongoid::Persistable::Destroyable do
       Person.create
     end
 
-    context "when destroying a readonly document" do
-
-      let(:from_db) do
-        Person.only(:_id).first
-      end
-
-      it "raises an error" do
-        expect {
-          from_db.destroy
-        }.to raise_error(Mongoid::Errors::ReadonlyDocument)
-      end
-    end
-
     context "when removing a root document" do
 
       let!(:destroyd) do

--- a/spec/mongoid/persistable/savable_spec.rb
+++ b/spec/mongoid/persistable/savable_spec.rb
@@ -268,23 +268,6 @@ describe Mongoid::Persistable::Savable do
         end
       end
     end
-
-    context "when the document is readonly" do
-
-      let(:person) do
-        Person.only(:title).first
-      end
-
-      before do
-        Person.create(title: "sir")
-      end
-
-      it "raises an error" do
-        expect {
-          person.save
-        }.to raise_error(Mongoid::Errors::ReadonlyDocument)
-      end
-    end
   end
 
   describe "save!" do
@@ -438,23 +421,6 @@ describe Mongoid::Persistable::Savable do
 
       it "properly sets up the entire hierarchy" do
         expect(from_db.shapes.first.canvas).to eq(firefox)
-      end
-    end
-
-    context "when the document is readonly" do
-
-      let(:person) do
-        Person.only(:title).first
-      end
-
-      before do
-        Person.create(title: "sir")
-      end
-
-      it "raises an error" do
-        expect {
-          person.save!
-        }.to raise_error(Mongoid::Errors::ReadonlyDocument)
       end
     end
   end

--- a/spec/mongoid/stateful_spec.rb
+++ b/spec/mongoid/stateful_spec.rb
@@ -99,29 +99,4 @@ describe Mongoid::Stateful do
       end
     end
   end
-
-  describe "#readonly?" do
-
-    let(:document) do
-      Band.new
-    end
-
-    context "when the document is readonly" do
-
-      before do
-        document.__selected_fields = { test: 1 }
-      end
-
-      it "returns true" do
-        expect(document).to be_readonly
-      end
-    end
-
-    context "when no readonly has been set" do
-
-      it "returns false" do
-        expect(document).to_not be_readonly
-      end
-    end
-  end
 end


### PR DESCRIPTION
 ...based on selected fields. Perhaps I'm missing something here but the ReadonlyAttribute error already prevents us from making mistakes with partially loaded documents?