### PR TITLE
Require `active_support` before cherry-picking any modules

### DIFF
--- a/lib/mongoid.rb
+++ b/lib/mongoid.rb
@@ -5,6 +5,7 @@ require "delegate"
 require "time"
 require "set"
 
+require "active_support"
 require "active_support/core_ext"
 require "active_support/json"
 require "active_support/inflector"


### PR DESCRIPTION
We should follow the rule in case the loading order of modules is irregular, 
http://guides.rubyonrails.org/active_support_core_extensions.html#how-to-load-core-extensions

Actually, I got the following error on Heroku.

```
2014-05-18T13:03:56.478977+00:00 app[scheduler.6847]: /app/vendor/bundle/ruby/2.1.0/gems/activesupport-4.1.1/lib/active_support/number_helper.rb:3:in `<module:NumberHelper>': uninitialized constant ActiveSupport::Autoload (NameError)
2014-05-18T13:03:56.479023+00:00 app[scheduler.6847]:   from /app/vendor/bundle/ruby/2.1.0/gems/activesupport-4.1.1/lib/active_support/number_helper.rb:2:in `<module:ActiveSupport>'
2014-05-18T13:03:56.479025+00:00 app[scheduler.6847]:   from /app/vendor/bundle/ruby/2.1.0/gems/activesupport-4.1.1/lib/active_support/number_helper.rb:1:in `<top (required)>'
2014-05-18T13:03:56.479027+00:00 app[scheduler.6847]:   from /app/vendor/bundle/ruby/2.1.0/gems/activesupport-4.1.1/lib/active_support/core_ext/numeric/conversions.rb:2:in `require'
2014-05-18T13:03:56.479029+00:00 app[scheduler.6847]:   from /app/vendor/bundle/ruby/2.1.0/gems/activesupport-4.1.1/lib/active_support/core_ext/numeric/conversions.rb:2:in `<top (required)>'
2014-05-18T13:03:56.479030+00:00 app[scheduler.6847]:   from /app/vendor/bundle/ruby/2.1.0/gems/activesupport-4.1.1/lib/active_support/core_ext/numeric.rb:3:in `require'
2014-05-18T13:03:56.479032+00:00 app[scheduler.6847]:   from /app/vendor/bundle/ruby/2.1.0/gems/activesupport-4.1.1/lib/active_support/core_ext/numeric.rb:3:in `<top (required)>'
2014-05-18T13:03:56.479033+00:00 app[scheduler.6847]:   from /app/vendor/bundle/ruby/2.1.0/gems/activesupport-4.1.1/lib/active_support/core_ext.rb:2:in `require'
2014-05-18T13:03:56.479035+00:00 app[scheduler.6847]:   from /app/vendor/bundle/ruby/2.1.0/gems/activesupport-4.1.1/lib/active_support/core_ext.rb:2:in `block in <top (required)>'
2014-05-18T13:03:56.479037+00:00 app[scheduler.6847]:   from /app/vendor/bundle/ruby/2.1.0/gems/activesupport-4.1.1/lib/active_support/core_ext.rb:1:in `each'
2014-05-18T13:03:56.479038+00:00 app[scheduler.6847]:   from /app/vendor/bundle/ruby/2.1.0/gems/activesupport-4.1.1/lib/active_support/core_ext.rb:1:in `<top (required)>'
2014-05-18T13:03:56.479039+00:00 app[scheduler.6847]:   from /app/vendor/bundle/ruby/2.1.0/bundler/gems/mongoid-9be37a9266d8/lib/mongoid.rb:8:in `require'
```
