### PR TITLE
Fix random error loading active_support/core_ext

### DIFF
--- a/lib/mongoid.rb
+++ b/lib/mongoid.rb
@@ -5,6 +5,7 @@ require "delegate"
 require "time"
 require "set"
 
+require "active_support"
 require "active_support/core_ext"
 require "active_support/json"
 require "active_support/inflector"


### PR DESCRIPTION
You should require 'active_support' before 'active_support/core_ext' or it'll randomly give an error with ActiveSupport::NumberHelper if core_ext/numeric.rb is included before core_ext/object.rb.

ref: https://github.com/rails/rails/issues/14664
