### PR TITLE
Fix serialize models with subset of attributes

### DIFF
--- a/lib/mongoid/serializable.rb
+++ b/lib/mongoid/serializable.rb
@@ -102,7 +102,7 @@ module Mongoid
         attrs[name] = value ? value.serializable_hash(options) : nil
       elsif names.include?(name) && !fields.has_key?(name)
         attrs[name] = read_attribute(name)
-      else
+      elsif !attribute_missing?(name)
         attrs[name] = send(name)
       end
     end

--- a/spec/mongoid/serializable_spec.rb
+++ b/spec/mongoid/serializable_spec.rb
@@ -231,6 +231,24 @@ describe Mongoid::Serializable do
           )
         end
       end
+
+      context "when only two attributes are loaded" do
+        before do
+          person.save
+        end
+
+        let(:from_db) do
+          Person.only("_id", "username").first
+        end
+
+        let(:hash) do
+          from_db.serializable_hash
+        end
+
+        it "returns those two attributes only" do
+          expect(hash.keys).to eq(["_id", "username"])
+        end
+      end
     end
 
     context "when a model has dynamic fields" do


### PR DESCRIPTION
The following code raises an `ActiveModel::MissingAttributeError`:

```
Person.only("_id", "username").first.as_json
```

This PR fixes it.
