### PR TITLE
Make Hash.mongoize return a new Hash rather than modifying its argument

### DIFF
--- a/lib/mongoid/extensions/hash.rb
+++ b/lib/mongoid/extensions/hash.rb
@@ -194,7 +194,7 @@ module Mongoid
         # @since 3.0.0
         def mongoize(object)
           return if object.nil?
-          evolve(object).update_values { |value| value.mongoize }
+          evolve(object).each_with_object({}) { |(key, value), new_hash| new_hash[key] = value.mongoize }
         end
 
         # Can the size of this object change?

--- a/spec/mongoid/extensions/hash_spec.rb
+++ b/spec/mongoid/extensions/hash_spec.rb
@@ -281,6 +281,10 @@ describe Mongoid::Extensions::Hash do
       it "converts the elements properly" do
         expect(mongoized[:date]).to eq(Time.utc(2012, 1, 1, 0, 0, 0))
       end
+
+      it "does not modify its argument" do
+        expect(Hash.mongoize(hash.freeze)).to be_a(Hash)
+      end
     end
 
     context "when object is nil" do


### PR DESCRIPTION
This bug was causing confusing behavior that would prevent mongoid setter methods from being able to accept frozen Hashes:

    some_mongoid_model.my_attr = {a: 1}.freeze
    # kablammo! "Can't modify frozen Hash"