### PR TITLE
(uninitialized constant for polymorphic) Mongoid does not specify the target class when using nested attributes

### DIFF
--- a/lib/mongoid/attributes/nested.rb
+++ b/lib/mongoid/attributes/nested.rb
@@ -53,7 +53,7 @@ module Mongoid
             autosave_nested_attributes(metadata)
             re_define_method(meth) do |attrs|
               _assigning do
-                if metadata.polymorphic?
+                if metadata.polymorphic? and metadata.inverse_type
                   metadata.class_name = self.send(metadata.inverse_type)
                 end
                 metadata.nested_builder(attrs, options).build(self)

--- a/lib/mongoid/attributes/nested.rb
+++ b/lib/mongoid/attributes/nested.rb
@@ -53,6 +53,9 @@ module Mongoid
             autosave_nested_attributes(metadata)
             re_define_method(meth) do |attrs|
               _assigning do
+                if metadata.polymorphic?
+                  metadata.class_name = self.send(metadata.inverse_type)
+                end
                 metadata.nested_builder(attrs, options).build(self)
               end
             end

--- a/lib/mongoid/relations/metadata.rb
+++ b/lib/mongoid/relations/metadata.rb
@@ -126,6 +126,10 @@ module Mongoid
         @class_name ||= (self[:class_name] || classify).sub(/\A::/,"")
       end
 
+      def class_name=(name)
+        self[:class_name], @class_name = name
+      end
+
       # Get the foreign key contraint for the metadata.
       #
       # @example Get the constaint.
@@ -572,7 +576,7 @@ module Mongoid
       #
       # @since 2.0.0.rc.1
       def klass
-        @klass ||= class_name.constantize
+        @klass = class_name.constantize
       end
 
       # Is this metadata representing a one to many or many to many relation?

--- a/spec/mongoid/attributes/nested_spec.rb
+++ b/spec/mongoid/attributes/nested_spec.rb
@@ -179,6 +179,34 @@ describe Mongoid::Attributes::Nested do
         expect(post.person.title).to eq("Sir")
       end
     end
+
+    context "when the association is referenced in and polymorphic: true" do
+      before(:all) do
+        class Post
+          belongs_to :posteable, polymorphic: true
+          accepts_nested_attributes_for :posteable, autosave: true
+        end
+
+        class Website
+          include Mongoid::Document
+          has_one :post, as: :posteable
+          field :name, type: String
+        end
+      end
+
+      context "when the association is referenced in and polymorphic: true" do
+        it 'infers the class name of the polymorphic with the inverse type' do
+          expect {
+            Post.create!(
+              title: "My awesome title",
+              content: "My awesome content of 500 words",
+              posteable_type: "Website",
+              posteable_attributes: { name: 'My awesome website' }
+            )
+          }.not_to raise_error
+        end
+      end
+    end
   end
 
   describe "##{name}_attributes=" do

--- a/spec/mongoid/relations/metadata_spec.rb
+++ b/spec/mongoid/relations/metadata_spec.rb
@@ -584,6 +584,22 @@ describe Mongoid::Relations::Metadata do
         end
       end
     end
+
+    context "when the association is polymorphic" do
+
+      let(:metadata) do
+        described_class.new(
+          name: :ratable,
+          relation: Mongoid::Relations::Referenced::In,
+          polymorphic: true,
+          inverse_class_name: "Rating"
+        )
+      end
+
+      it "returns the polymorphic class name" do
+        expect(metadata.class_name).to eq("Ratable")
+      end
+    end
   end
 
   describe "#destructive?" do


### PR DESCRIPTION
Hi guys!

I've been experiencing this issue when using nested attributes and polymorphic associations, the issue is described as follows:

``` ruby
class Product
  include Mongoid::Document
  belongs_to :shop, polymorphic: true
  accepts_nested_attributes_for :shop, autosave: true
end

class ShopOne
  include Mongoid::Document

  field :something, type: String

  has_one :product, as: :shop
end

class ShopTwo
  include Mongoid::Document

  field :another_thing, type: Integer

  has_one :product, as: :shop
end
```

And when I do this
``` ruby
Product.new(shop_type: "ShopOne", shop_attributes: { something: 'Foo' })
```

It gives me this
```ruby
uninitialized constant Shop
{... path}/mongoid/relations/builders/nested_attributes/one.rb:32
```

The solution I'm proposing is to override the class_name attribute inside of the metadata class only if the association you're trying to store is polymorphic (See code in the pull request).