### PR TITLE
Check MONGOID_ENV first to get the env_name

### DIFF
--- a/lib/config/locales/en.yml
+++ b/lib/config/locales/en.yml
@@ -292,8 +292,8 @@ en:
           message: "Could not load the configuration since no environment
             was defined."
           summary: "Mongoid attempted to find the appropriate environment
-            but no Rails.env, Sinatra::Base.environment, RACK_ENV, or
-            MONGOID_ENV could be found."
+            but no MONGOID_ENV, Rails.env, Sinatra::Base.environment or RACK_ENV
+             could be found."
           resolution: "Make sure some environment is set from the mentioned
             options. Mongoid cannot load configuration from the yaml without
             knowing which environment it is in, and we have considered

--- a/lib/mongoid/config/environment.rb
+++ b/lib/mongoid/config/environment.rb
@@ -7,7 +7,7 @@ module Mongoid
       extend self
 
       # Get the name of the environment that we are running under. This first
-      # looks for Rails, then Sinatra, then a RACK_ENV environment variable,
+      # looks for MONGOID_ENV, then Rails, then Sinatra, then a RACK_ENV environment variable,
       # and if none of those are found raises an error.
       #
       # @example Get the env name.
@@ -19,9 +19,10 @@ module Mongoid
       #
       # @since 2.3.0
       def env_name
+        return ENV["MONGOID_ENV"] if ENV["MONGOID_ENV"]
         return Rails.env if defined?(Rails)
         return Sinatra::Base.environment.to_s if defined?(Sinatra)
-        ENV["RACK_ENV"] || ENV["MONGOID_ENV"] || raise(Errors::NoEnvironment.new)
+        ENV["RACK_ENV"] || raise(Errors::NoEnvironment.new)
       end
 
       # Load the yaml from the provided path and return the settings for the

--- a/spec/mongoid/config/environment_spec.rb
+++ b/spec/mongoid/config/environment_spec.rb
@@ -51,6 +51,22 @@ describe Mongoid::Config::Environment do
       end
     end
 
+    context "when the MONGOID_ENV variable is defined" do
+
+      before do
+        Object.send(:remove_const, :Rails) if defined?(Rails)
+        ENV["MONGOID_ENV"] = "acceptance"
+      end
+
+      after do
+        ENV["MONGOID_ENV"] = nil
+      end
+
+      it "returns the MONGOID_ENV" do
+        expect(described_class.env_name).to eq("acceptance")
+      end
+    end
+
     context "when the rack env variable is defined" do
 
       before do

--- a/spec/mongoid/errors/no_environment_spec.rb
+++ b/spec/mongoid/errors/no_environment_spec.rb
@@ -16,7 +16,7 @@ describe Mongoid::Errors::NoEnvironment do
 
     it "contains the summary in the message" do
       expect(error.message).to include(
-        "Mongoid attempted to find the appropriate environment but no Rails.env"
+        "Mongoid attempted to find the appropriate environment but no MONGOID_ENV"
       )
     end
 


### PR DESCRIPTION
When the environment is not supplied in the `load!` method:

```ruby
Mongoid.load!('config/mongoid.yml')
```

Mongoid tries to find the environment looking for Rails, then Sinatra, then RACK_ENV, then MONGOID_ENV (last option).

Which makes Mongoid a little bit more coupled with these frameworks.

I'm using Mongoid in a standalone Ruby application and I was loading Mongoid without supplying the environment, because I was setting `ENV['MONGOID_ENV'] = ENV['MY_APPLICATION_ENV']` before the `.load!`, but then I added a gem that includes railties, by including railties it was making Rails to be defined + `Rails.env => 'development` by default

```shell
    21: def env_name
 => 22:   binding.pry
    23:   return Rails.env if defined?(Rails)
    24:   return Sinatra::Base.environment.to_s if defined?(Sinatra)
    25:   ENV["RACK_ENV"] || ENV["MONGOID_ENV"] || raise(Errors::NoEnvironment.new)
    26: end
4.1.1@2.0.0 (Mongoid::Config::Environment)> Rails.env
=> "development"
```

So after adding the gem, my tests (test environment) started to delete (DatabaseCleaner) my development database. Luckily the production hosts had RAILS_ENV defined, otherwise they would try to load the development settings.

Changing the load order would make Mongoid less coupled.