### PR TITLE
Add option to turn off raising missing attribute error

### DIFF
--- a/lib/mongoid/attributes.rb
+++ b/lib/mongoid/attributes.rb
@@ -91,7 +91,7 @@ module Mongoid
     # @since 1.0.0
     def read_attribute(name)
       normalized = database_field_name(name.to_s)
-      if attribute_missing?(normalized)
+      if attribute_missing?(normalized) && Mongoid.raise_missing_attribute_error
         raise ActiveModel::MissingAttributeError, "Missing attribute: '#{name}'."
       end
       if hash_dot_syntax?(normalized)

--- a/lib/mongoid/config.rb
+++ b/lib/mongoid/config.rb
@@ -20,6 +20,7 @@ module Mongoid
     option :include_type_for_serialization, default: false
     option :preload_models, default: false
     option :raise_not_found_error, default: true
+    option :raise_missing_attribute_error, default: true
     option :scope_overwrite_exception, default: false
     option :duplicate_fields_exception, default: false
     option :use_activesupport_time_zone, default: true

--- a/lib/rails/generators/mongoid/config/templates/mongoid.yml
+++ b/lib/rails/generators/mongoid/config/templates/mongoid.yml
@@ -46,6 +46,10 @@ development:
     # (default: true)
     # raise_not_found_error: true
 
+    # Raise an error when performing a #read_attribute and the attribute is not found.
+    # (default: true)
+    # raise_missing_attribute_error: true
+
     # Raise an error when defining a scope with the same name as an
     # existing method. (default: false)
     # scope_overwrite_exception: false

--- a/spec/config/mongoid.yml
+++ b/spec/config/mongoid.yml
@@ -35,5 +35,6 @@ test:
     preload_models: false
     scope_overwrite_exception: false
     raise_not_found_error: true
+    raise_missing_attribute_error: true
     use_activesupport_time_zone: true
     use_utc: false

--- a/spec/mongoid/attributes_spec.rb
+++ b/spec/mongoid/attributes_spec.rb
@@ -56,7 +56,9 @@ describe Mongoid::Attributes do
         end
       end
 
-      context "when excluding with only" do
+      context "when excluding with only and raising missing attribute error" do
+
+        before { Mongoid.raise_missing_attribute_error = true }
 
         let(:from_db) do
           Person.only(:_id).first
@@ -69,7 +71,22 @@ describe Mongoid::Attributes do
         end
       end
 
-      context "when excluding with without" do
+      context "when excluding with only and not raising missing attribute error" do
+
+        before { Mongoid.raise_missing_attribute_error = false }
+
+        let(:from_db) do
+          Person.only(:_id).first
+        end
+
+        it "does not raise an error" do
+          expect(from_db.desc).to eq(nil)
+        end
+      end
+
+      context "when excluding with without and raising missing attribute error" do
+
+        before { Mongoid.raise_missing_attribute_error = true }
 
         let(:from_db) do
           Person.without(:title).first
@@ -79,6 +96,19 @@ describe Mongoid::Attributes do
           expect {
             from_db.title
           }.to raise_error(ActiveModel::MissingAttributeError)
+        end
+      end
+
+      context "when excluding with without and not raising missing attribute error" do
+
+        before { Mongoid.raise_missing_attribute_error = false }
+
+        let(:from_db) do
+          Person.without(:title).first
+        end
+
+        it "does not raise an error" do
+          expect(from_db.desc).to eq(nil)
         end
       end
     end
@@ -140,7 +170,9 @@ describe Mongoid::Attributes do
 
       context "when the attribute was excluded in a criteria" do
 
-        context "when excluding with only" do
+        context "when excluding with only and raising missing attribute error" do
+
+          before { Mongoid.raise_missing_attribute_error = true }
 
           let(:from_db) do
             Person.only(:_id).first
@@ -153,7 +185,22 @@ describe Mongoid::Attributes do
           end
         end
 
-        context "when excluding with without" do
+        context "when excluding with only and not raising missing attribute error" do
+
+          before { Mongoid.raise_missing_attribute_error = false }
+
+          let(:from_db) do
+            Person.only(:_id).first
+          end
+
+          it "does not raise an error" do
+            expect(from_db.desc).to eq(nil)
+          end
+        end
+
+        context "when excluding with without and raise missing attribute error" do
+
+          before { Mongoid.raise_missing_attribute_error = true }
 
           let(:from_db) do
             Person.without(:title).first
@@ -163,6 +210,19 @@ describe Mongoid::Attributes do
             expect {
               from_db[:title]
             }.to raise_error(ActiveModel::MissingAttributeError)
+          end
+        end
+
+        context "when excluding with without and not raise missing attribute error" do
+
+          before { Mongoid.raise_missing_attribute_error = false }
+
+          let(:from_db) do
+            Person.without(:title).first
+          end
+
+          it "does not raises an error" do
+            expect(from_db.desc).to eq(nil)
           end
         end
       end

--- a/spec/mongoid/config_spec.rb
+++ b/spec/mongoid/config_spec.rb
@@ -119,6 +119,10 @@ describe Mongoid::Config do
         expect(described_class.raise_not_found_error).to be true
       end
 
+      it "sets the raise missing attribute error option" do
+        expect(described_class.raise_missing_attribute_error).to be true
+      end
+
       it "sets the use activesupport time zone option" do
         expect(described_class.use_activesupport_time_zone).to be true
       end


### PR DESCRIPTION
Sometimes it no needs to raise MissingAttributeError. For example, when you have old documents with missing some special attributes and you would not want to update them. To avoid this you can just set to 'false' option 'raise_missing_attribute_error' in config/mongoid.yml.
