### PR TITLE
Allocate far fewer strings from threaded.rb

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,5 @@ group :test do
     gem "guard"
     gem "guard-rspec"
     gem "rb-fsevent"
-    gem "allocation_stats"
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,7 +15,6 @@ require "action_controller"
 require "mongoid"
 require "rspec"
 require "helpers"
-require "allocation_stats"
 
 # These environment variables can be set if wanting to test against a database
 # that is not on the local machine.
@@ -107,18 +106,4 @@ RSpec.configure do |config|
   config.filter_run_excluding(config: ->(value){
     return true if value == :mongohq && !mongohq_connectable?
   })
-
-  config.before(:suite) do
-    $count = 0
-  end
-
-  config.around do |example|
-    stats = AllocationStats.trace { example.run }
-    count = stats.allocations.from("threaded.rb").where(class: String).to_a.count
-    $count += count
-  end
-
-  config.after(:suite) do
-    puts "String allocations in threaded.rb: #{$count}"
-  end
 end


### PR DESCRIPTION
In the process of memory profiling an application that uses Mongoid, @ersatzryan and I discovered that Mongoid's `threaded.rb` is responsible for generating hundreds of thousands of new strings during our test case. In fact, Mongoid's own test suite generates 1,075,171 new strings just from `threaded.rb`.

Defining constant thread variable keys and memoizing stack keys drastically reduces the number of new strings allocated during typical usage, bringing the test suite total from 1,075,171 to 102.

We're also experiencing a ~4% increase in the speed of the test suite locally.
