### PR TITLE
Fix for query cache with large queries

### DIFF
--- a/spec/mongoid/query_cache_spec.rb
+++ b/spec/mongoid/query_cache_spec.rb
@@ -177,6 +177,23 @@ describe Mongoid::QueryCache do
     end
   end
 
+  context "when querying a very large collection" do
+
+    before do
+      123.times { Band.create! }
+      Band.all.to_a
+    end
+
+    it "should cache the complete result of the query" do
+      expect_no_queries do
+        Band.all.to_a
+      end
+
+      expect(Band.all.to_a.length).to eq(123)
+    end
+
+  end
+
   context "when inserting an index" do
 
     it "does not cache the query" do


### PR DESCRIPTION
When using the QueryCache in combination with larger collections, a query calling `get_more` to fetch all documents from the database, would only cache the first results, not the complete query result. Upon the next time the same query is done, the QueryCache would return an incomplete set of documents as results for the query.

I added a spec to describe the behaviour: it is failing for the current master. Adding the `get_more` results to the QueryCache fixes the issue.
