### PR TITLE
Ignore extra attributes on clone when not using Dynamic Attributes

### DIFF
--- a/lib/mongoid/copyable.rb
+++ b/lib/mongoid/copyable.rb
@@ -18,15 +18,40 @@ module Mongoid
     #
     # @return [ Document ] The new document.
     def clone
-      # @note This next line is here to address #2704, even though having an
-      # _id and id field in the document would cause problems with Mongoid
-      # elsewhere.
-      attrs = clone_document.except("_id", "id")
+      attrs = clone_attr
       self.class.new(attrs)
     end
     alias :dup :clone
 
     private
+
+    # Build a hash of attributes used for cloning
+    # Includes embedded document attributes
+    # Ignores dynamic attribtues
+    #
+    # @api private
+    #
+    # @example clone attr
+    #   model.clone_attr
+    #
+    # @return [ Hash ] A hash with key/values used for cloning the document
+    def clone_attr
+      # @note This next line is here to address #2704, even though having an
+      # _id and id field in the document would cause problems with Mongoid
+      # elsewhere.
+      attrs = clone_document.except("_id", "id")
+      unless kind_of?(Mongoid::Attributes::Dynamic)      
+        embedded_attrs = {}
+        self.embedded_relations.keys.each do |relation_key|
+          embedded_attrs[relation_key] = self.send(self.embedded_relations[relation_key][:name]).map do |relation|
+            relation.send(:clone_attr)
+          end
+        end
+        attrs.merge!(embedded_attrs)
+        attrs = attrs.slice(*self.fields.keys, *self.embedded_relations.keys, *embedded_attrs.keys) 
+      end
+      attrs
+    end
 
     # Clone the document attributes
     #

--- a/lib/mongoid/copyable.rb
+++ b/lib/mongoid/copyable.rb
@@ -43,7 +43,8 @@ module Mongoid
       unless kind_of?(Mongoid::Attributes::Dynamic)      
         embedded_attrs = {}
         self.embedded_relations.keys.each do |relation_key|
-          embedded_attrs[relation_key] = self.send(self.embedded_relations[relation_key][:name]).map do |relation|
+          embedded_relation = [*self.send(self.embedded_relations[relation_key][:name])]
+          embedded_attrs[relation_key] = embedded_relation.map do |relation|
             relation.send(:clone_attr)
           end
         end


### PR DESCRIPTION
When changing fields in either parent and/or children, and no dynamic fields
are included, the clone will still be possible.

Fixes #3710 - thanks to @riencroonenborghs for fixes around embedded document
cloning