### PR TITLE
Use nanoseconds for cache_key timestamp instead of plain seconds

### DIFF
--- a/lib/mongoid/document.rb
+++ b/lib/mongoid/document.rb
@@ -225,7 +225,7 @@ module Mongoid
     # plural model name.
     #
     # If new_record?     - will append /new
-    # If not             - will append /id-updated_at.to_s(:number)
+    # If not             - will append /id-updated_at.to_s(:nsec)
     # Without updated_at - will append /id
     #
     # This is usually called insode a cache() block
@@ -238,7 +238,7 @@ module Mongoid
     # @since 2.4.0
     def cache_key
       return "#{model_key}/new" if new_record?
-      return "#{model_key}/#{id}-#{updated_at.utc.to_s(:number)}" if do_or_do_not(:updated_at)
+      return "#{model_key}/#{id}-#{updated_at.utc.to_s(:nsec)}" if do_or_do_not(:updated_at)
       "#{model_key}/#{id}"
     end
 

--- a/spec/mongoid/document_spec.rb
+++ b/spec/mongoid/document_spec.rb
@@ -144,7 +144,7 @@ describe Mongoid::Document do
       context "with updated_at" do
 
         let!(:updated_at) do
-          document.updated_at.utc.to_s(:number)
+          document.updated_at.utc.to_s(:nsec)
         end
 
         it "has the id and updated_at key name" do
@@ -182,7 +182,7 @@ describe Mongoid::Document do
       end
 
       let!(:updated_at) do
-        agent.updated_at.utc.to_s(:number)
+        agent.updated_at.utc.to_s(:nsec)
       end
 
       it "has the id and updated_at key name" do


### PR DESCRIPTION
This has caused several issues for our app because of its inaccuracy, specially in the test environment.
It would be better to define the cache key using nanoseconds, as in:

``` ruby
def cache_key
  ...
  return "#{model_key}/#{id}-#{updated_at.utc.to_s(:nsec)}" if do_or_do_not(:updated_at)
  ...
end
```

Fixes #3772.
