### PR TITLE
Move MONGODB_VERSION to version.rb

### DIFF
--- a/lib/mongoid.rb
+++ b/lib/mongoid.rb
@@ -37,8 +37,6 @@ module Mongoid
   extend Loggable
   extend self
 
-  MONGODB_VERSION = "2.2.0"
-
   # Sets the Mongoid configuration options. Best used by passing a block.
   #
   # @example Set up configuration options.

--- a/lib/mongoid/version.rb
+++ b/lib/mongoid/version.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
 module Mongoid
   VERSION = "4.0.0"
+  MONGODB_VERSION = "2.2.0"
 end


### PR DESCRIPTION
Why do we even have this constant ? Should i remove it ?