### PR TITLE
fix deleting document data when using atomically without any operations

### DIFF
--- a/lib/mongoid/persistable.rb
+++ b/lib/mongoid/persistable.rb
@@ -207,7 +207,7 @@ module Mongoid
     #
     # @since 4.0.0
     def persist_atomic_operations(operations)
-      if persisted?
+      if persisted? && operations.any?
         selector = atomic_selector
         _root.collection.find(selector).update(positionally(selector, operations))
       end


### PR DESCRIPTION
see example from my code. There is no one "record.set" some times. In these cases record's data is completely destroyed with "update( {} )"

```
atomically do |record|
  fields_to_update.each do |field, value|
    next unless value_should_be_changed?(value)
    record.set(field, value)
  end
end
```