### PR TITLE
Cannot assign ids through accepts_nested_attributes_for #2644

### DIFF
--- a/lib/mongoid/relations/builders/nested_attributes/many.rb
+++ b/lib/mongoid/relations/builders/nested_attributes/many.rb
@@ -99,15 +99,16 @@ module Mongoid
             if id = attrs.extract_id
               first = existing.first
               converted = first ? convert_id(first.class, id) : id
-              doc = existing.find(converted)
-              if destroyable?(attrs)
-                destroy(parent, existing, doc)
-              else
-                update_document(doc, attrs)
+              if (doc = existing.find(converted))
+                if destroyable?(attrs)
+                  destroy(parent, existing, doc)
+                else
+                  update_document(doc, attrs)
+                end
+                return
               end
-            else
-              existing.push(Factory.build(metadata.klass, attrs)) unless destroyable?(attrs)
             end
+            existing.push(Factory.build(metadata.klass, attrs)) unless destroyable?(attrs)
           end
 
           # Destroy the child document, needs to do some checking for embedded


### PR DESCRIPTION
class Question
  include Mongoid::Document
  embeds_many :options
  accepts_nested_attributes_for :options, allow_destroy: true, reject_if: ->(attrs){ !attrs[:description].present? }
end

class Option
  include Mongoid::Document
  embedded_in :question
  field :name, type: String
  field :description, type: String
end

in console , when i execute this code:
question = Question.new({:options_attributes => {"0"=>{"id"=>"542cb0476c696e06b0000000", "name"=>"A", "description"=>"A Description"}, "1"=>{"id"=>"542cb0476c696e06b0010000", "name"=>"B", "description"=>"B Description"}}})

error message is: NoMethodError: undefined method `assign_attributes' for nil:NilClass
