### PR TITLE
Added underscore prefix for unused local parameters as per the ruby sty...

### DIFF
--- a/lib/mongoid/atomic.rb
+++ b/lib/mongoid/atomic.rb
@@ -125,7 +125,7 @@ module Mongoid
     # @return [ Hash ] The updates and their modifiers.
     #
     # @since 2.1.0
-    def atomic_updates(use_indexes = false)
+    def atomic_updates(_use_indexes = false)
       process_flagged_destroys
       mods = Modifiers.new
       generate_atomic_updates(mods, self)

--- a/lib/mongoid/relations/builders/embedded/one.rb
+++ b/lib/mongoid/relations/builders/embedded/one.rb
@@ -15,7 +15,7 @@ module Mongoid
           # @param [ String ] type Not used in this context.
           #
           # @return [ Document ] A single document.
-          def build(type = nil)
+          def build(_type = nil)
             return object unless object.is_a?(Hash)
             if _loading? && base.persisted?
               Factory.from_db(klass, object)

--- a/lib/mongoid/validatable/uniqueness.rb
+++ b/lib/mongoid/validatable/uniqueness.rb
@@ -164,7 +164,7 @@ module Mongoid
       # @return [ Criteria ] The scoped criteria.
       #
       # @since 2.3.0
-      def scope(criteria, document, attribute)
+      def scope(criteria, document, _attribute)
         Array.wrap(options[:scope]).each do |item|
           name = document.database_field_name(item)
           criteria = criteria.where(item => document.attributes[name])


### PR DESCRIPTION
...le guide 

https://github.com/bbatsov/ruby-style-guide/blob/master/README.md#underscore-unused-vars
