### PR TITLE
Don't wrap a class that behaves as an array inside another array

### DIFF
--- a/lib/mongoid/relations/auto_save.rb
+++ b/lib/mongoid/relations/auto_save.rb
@@ -68,6 +68,8 @@ module Mongoid
                     options = persistence_options || {}
                     if :belongs_to == metadata.macro
                       relation.with(options).save if changed_for_autosave?(relation)
+                    elsif relation.kind_of? Array # we don't need to wrap this relation, it already behaves like an array
+                      relation.each { |d| d.with(options).save if changed_for_autosave?(d) }
                     else
                       Array(relation).each { |d| d.with(options).save if changed_for_autosave?(d) }
                     end


### PR DESCRIPTION
Seeing an issue where attempting an autosave on a has_many fails because relation is a Mongoid::Relations::Targets::Enumerable. When array attempts to wrap this, it results in a nested array rather than a single array as expected. Adding a check for kind_of? Array avoids wrapping a deep class that already behaves as an array.