### PR TITLE
The app_name function in config geneartion fails if there are no Rails::...

### DIFF
--- a/lib/rails/generators/mongoid/config/config_generator.rb
+++ b/lib/rails/generators/mongoid/config/config_generator.rb
@@ -13,7 +13,9 @@ module Mongoid
       end
 
       def app_name
-        Rails::Application.subclasses.first.parent.to_s.underscore
+        subclasses = Rails::Application.subclasses
+        subclasses = Rails::Engine.subclasses if subclasses.empty?
+        subclasses.first.parent.to_s.underscore
       end
 
       def create_config_file


### PR DESCRIPTION
...Application subclasses as might be the case with engines. Without this you'll get an error like this:
```
rails g mongoid:config
/Users/timo/.rvm/gems/ruby-2.1.4@nappi_frontend/gems/mongoid-4.0.0/lib/rails/generators/mongoid/config/config_generator.rb:18:in `app_name': undefined method `parent' for nil:NilClass (NoMethodError)
	from /Users/timo/.rvm/gems/ruby-2.1.4@nappi_frontend/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
	from /Users/timo/.rvm/gems/ruby-2.1.4@nappi_frontend/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
	from /Users/timo/.rvm/gems/ruby-2.1.4@nappi_frontend/gems/thor-0.19.1/lib/thor/invocation.rb:133:in `block in invoke_all'
	from /Users/timo/.rvm/gems/ruby-2.1.4@nappi_frontend/gems/thor-0.19.1/lib/thor/invocation.rb:133:in `each'
	from /Users/timo/.rvm/gems/ruby-2.1.4@nappi_frontend/gems/thor-0.19.1/lib/thor/invocation.rb:133:in `map'
	from /Users/timo/.rvm/gems/ruby-2.1.4@nappi_frontend/gems/thor-0.19.1/lib/thor/invocation.rb:133:in `invoke_all'
	from /Users/timo/.rvm/gems/ruby-2.1.4@nappi_frontend/gems/thor-0.19.1/lib/thor/group.rb:232:in `dispatch'
	from /Users/timo/.rvm/gems/ruby-2.1.4@nappi_frontend/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
	from /Users/timo/.rvm/gems/ruby-2.1.4@nappi_frontend/gems/railties-4.1.7/lib/rails/generators.rb:157:in `invoke'
	from /Users/timo/.rvm/gems/ruby-2.1.4@nappi_frontend/gems/railties-4.1.7/lib/rails/commands/generate.rb:11:in `<top (required)>'
	from /Users/timo/.rvm/gems/ruby-2.1.4@nappi_frontend/gems/railties-4.1.7/lib/rails/engine/commands.rb:19:in `require'
	from /Users/timo/.rvm/gems/ruby-2.1.4@nappi_frontend/gems/railties-4.1.7/lib/rails/engine/commands.rb:19:in `<top (required)>'
	from bin/rails:12:in `require'
	from bin/rails:12:in `<main>'
```