### PR TITLE
remove Railtie.generator

### DIFF
--- a/lib/mongoid/railtie.rb
+++ b/lib/mongoid/railtie.rb
@@ -13,19 +13,6 @@ module Rails
     # @since 2.0.0
     class Railtie < Rails::Railtie
 
-      # Determine which generator to use. app_generators was introduced after
-      # 3.0.0.
-      #
-      # @example Get the generators method.
-      #   railtie.generators
-      #
-      # @return [ Symbol ] The method name to use.
-      #
-      # @since 2.0.0.rc.4
-      def self.generator
-        config.respond_to?(:app_generators) ? :app_generators : :generators
-      end
-
       # Mapping of rescued exceptions to HTTP responses
       #
       # @example
@@ -41,7 +28,7 @@ module Rails
         }
       end
 
-      config.send(generator).orm :mongoid, migration: false
+      config.app_generators.orm :mongoid, migration: false
 
       if config.action_dispatch.rescue_responses
         config.action_dispatch.rescue_responses.merge!(rescue_responses)


### PR DESCRIPTION
This method is no longer needed, he detects the generator method wich has changed from Rails 2.x to 3.0.0. Mongoid has a dependency to activemodel > 4.0, which related in a dependency to Rails > 4.0. Which means that this check is no longer needed, there can't be a Rails < 4.0

NOTE: The failed travis build is seams not related to this PR
