### PR TITLE
Fix for bug with GET_MORE in combination with QueryCache

### DIFF
--- a/lib/mongoid/query_cache.rb
+++ b/lib/mongoid/query_cache.rb
@@ -137,7 +137,9 @@ module Mongoid
         key = cache_key.push(context)
 
         if more
-          QueryCache.cache_table[key].push(*yield)
+          documents = yield
+          QueryCache.cache_table[key].push(*documents)
+          documents
         elsif QueryCache.cache_table.has_key?(key)
           instrument(key) { QueryCache.cache_table[key] }
         else

--- a/spec/mongoid/query_cache_spec.rb
+++ b/spec/mongoid/query_cache_spec.rb
@@ -181,10 +181,16 @@ describe Mongoid::QueryCache do
 
     before do
       123.times { Band.create! }
-      Band.all.to_a
     end
 
+    it "should return the complete result of the query at the first run" do
+      expect(Band.all.to_a.length).to eq(123)
+    end
+
+
     it "should cache the complete result of the query" do
+      Band.all.to_a
+
       expect_no_queries do
         Band.all.to_a
       end


### PR DESCRIPTION
For bigger collections, I came across this minor bug: the first time a query is run which calls GET_MORE, the result is too large - the resulting array contained all documents from the first part twice or more.

This fixes the issue. Without the change in `lib/mongoid/query_cache.rb` the new spec fails. With the change, it passes.
