### PR TITLE
checks added for :update_attribute for dynamic attributes refs #3875

### DIFF
--- a/lib/mongoid/persistable/updatable.rb
+++ b/lib/mongoid/persistable/updatable.rb
@@ -29,11 +29,7 @@ module Mongoid
           raise Errors::ReadonlyAttribute.new(normalized, value)
         end
         setter = "#{normalized}="
-        if respond_to?(setter)
-          send(setter, value)
-        else
-          write_attribute(database_field_name(normalized), value)
-        end
+        process_attribute(normalized, value)
         save(validate: false)
       end
 

--- a/spec/app/models/dokument.rb
+++ b/spec/app/models/dokument.rb
@@ -1,5 +1,6 @@
 class Dokument
   include Mongoid::Document
   include Mongoid::Timestamps
+  include Mongoid::Attributes::Dynamic
   embeds_many :addresses, as: :addressable, validate: false
 end

--- a/spec/app/models/subscription.rb
+++ b/spec/app/models/subscription.rb
@@ -1,4 +1,5 @@
 class Subscription
   include Mongoid::Document
+  include Mongoid::Attributes::Dynamic
   has_many :packs, class_name: "ShippingPack"
 end

--- a/spec/mongoid/persistable/updatable_spec.rb
+++ b/spec/mongoid/persistable/updatable_spec.rb
@@ -112,6 +112,18 @@ describe Mongoid::Persistable::Updatable do
       end
     end
 
+    context "when dynamic attributes are not enabled" do
+      let(:account) do
+        Account.create
+      end
+
+      it "raises exception for an unknown attribute " do
+        expect {
+          account.update_attribute(:somethingnew, "somethingnew")
+        }.to raise_error(Mongoid::Errors::UnknownAttribute)
+      end
+    end
+
     context "when provided a symbol attribute name" do
 
       let(:post) do


### PR DESCRIPTION
When we call process_attribute, it does all the checks for ensuring that
dynamic attributes are allowed.

**Note** This impacts the `:counter_cache` option as it requires dynamic fields.
When using the counter_cache, the model must include
`Mongoid::Attributes::Dynamic`

refs #3875 