### PR TITLE
Mongoid/Moped controller runtime a la ActiveRecord

### DIFF
--- a/lib/mongoid/railtie.rb
+++ b/lib/mongoid/railtie.rb
@@ -95,6 +95,16 @@ module Rails
         end
       end
 
+      # Expose database runtime to controller for logging.
+      initializer "mongoid.log_runtime" do
+        require "mongoid/railties/controller_runtime"
+        ActiveSupport.on_load(:action_controller) do
+          include ::Mongoid::Railties::ControllerRuntime
+        end
+      end
+
+
+
       config.after_initialize do
         # Unicorn clears the START_CTX when a worker is forked, so if we have
         # data in START_CTX then we know we're being preloaded. Unicorn does

--- a/lib/mongoid/railties/controller_runtime.rb
+++ b/lib/mongoid/railties/controller_runtime.rb
@@ -1,0 +1,44 @@
+require 'active_support/core_ext/module/attr_internal'
+require 'mongoid/log_subscriber'
+
+module Mongoid
+  module Railties # :nodoc:
+    module ControllerRuntime #:nodoc:
+      extend ActiveSupport::Concern
+
+    protected
+
+      attr_internal :mongoid_runtime
+
+      def process_action(action, *args)
+        # We also need to reset the runtime before each action
+        # because of queries in middleware or in cases we are streaming
+        # and it won't be cleaned up by the method below.
+        Mongoid::LogSubscriber.reset_runtime
+        super
+      end
+
+      def cleanup_view_runtime
+        db_rt_before_render = Mongoid::LogSubscriber.reset_runtime
+        self.mongoid_runtime = (mongoid_runtime || 0) + db_rt_before_render
+        runtime = super
+        db_rt_after_render = Mongoid::LogSubscriber.reset_runtime
+        self.mongoid_runtime += db_rt_after_render
+        runtime - db_rt_after_render
+      end
+
+      def append_info_to_payload(payload)
+        super
+        payload[:mongoid_runtime] = (mongoid_runtime || 0) + Mongoid::LogSubscriber.reset_runtime
+      end
+
+      module ClassMethods # :nodoc:
+        def log_process_action(payload)
+          messages, mongoid_runtime = super, payload[:mongoid_runtime]
+          messages << ("Mongoid: %.1fms" % mongoid_runtime.to_f) if mongoid_runtime
+          messages
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Shows the amount of time spent in Mongoid/Moped instrumented calls in the ActionController summary after each request:

Completed 200 OK in 1487ms (Views: 504.2ms | ActiveRecord: 36.6ms | Mongoid: 252.6ms | Solr: 599.9ms)
