### PR TITLE
Explicitly set enforce_available_locales to false.

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -93,6 +93,8 @@ ActiveSupport::Inflector.inflections do |inflect|
   inflect.singular("address_components", "address_component")
 end
 
+I18n.config.enforce_available_locales = false
+
 RSpec.configure do |config|
   config.include Mongoid::SpecHelpers
   config.raise_errors_for_deprecations!


### PR DESCRIPTION
This fixes spec failures when running with i18n 0.7.0.
