### PR TITLE
Create the dependent behaviour restrict_with_error

### DIFF
--- a/lib/config/locales/en.yml
+++ b/lib/config/locales/en.yml
@@ -467,3 +467,7 @@ en:
             %{document} when the child '%{relation}' still has documents in it."
           resolution: "Don't attempt to delete the parent %{document} when
             it has children, or change the dependent option on the relation."
+        restrict_dependent_destroy:
+          one: "Cannot delete record because a dependent %{record} exists"
+          many: "Cannot delete record because dependent %{record} exist"
+          many_to_many: "Cannot delete record because dependent %{record} exist"

--- a/lib/mongoid/persistable/deletable.rb
+++ b/lib/mongoid/persistable/deletable.rb
@@ -111,11 +111,36 @@ module Mongoid
       #
       # @since 4.0.0
       def prepare_delete
-        cascade!
-        yield(self)
-        freeze
-        self.destroyed = true
-        true
+        if skip_deletion?
+          return
+        else
+          yield(self)
+          freeze
+          self.destroyed = true
+          true
+        end
+      end
+
+      # Check to skip deletion or not based on the
+      # cascade.
+      #
+      # @api private
+      #
+      # @example Check that delete or skip the deletion
+      #   if document.skip_deletion?
+      #     return false
+      #   else
+      #     # delete the record
+      #   end
+      #
+      # @return [ true, false ] True if skip the deletion, false if not.
+      #
+      # @since 4.0.2
+      def skip_deletion?
+        catch_result = catch(:skip_delete) do
+          cascade!
+        end
+        true if catch_result.nil?
       end
 
       module ClassMethods

--- a/lib/mongoid/relations/cascading.rb
+++ b/lib/mongoid/relations/cascading.rb
@@ -1,8 +1,10 @@
 # encoding: utf-8
+require "mongoid/relations/cascading/base"
 require "mongoid/relations/cascading/delete"
 require "mongoid/relations/cascading/destroy"
 require "mongoid/relations/cascading/nullify"
 require "mongoid/relations/cascading/restrict"
+require "mongoid/relations/cascading/restrict_with_error"
 
 module Mongoid
   module Relations

--- a/lib/mongoid/relations/cascading/base.rb
+++ b/lib/mongoid/relations/cascading/base.rb
@@ -1,0 +1,26 @@
+# encoding: utf-8
+module Mongoid
+  module Relations
+    module Cascading
+      class Base
+
+        attr_accessor :document, :relation, :metadata
+
+        # Initialize the new cascade strategy, which will set up the relation
+        # and the metadata.
+        #
+        # @example Instantiate the strategy
+        #   Strategy.new(document, metadata)
+        #
+        # @param [ Document ] document The document to cascade from.
+        # @param [ Metadata ] metadata The relation's metadata.
+        #
+        # @return [ Strategy ] The new strategy.
+        def initialize(document, metadata)
+          @document, @metadata = document, metadata
+          @relation = document.send(metadata.name)
+        end
+      end
+    end
+  end
+end

--- a/lib/mongoid/relations/cascading/delete.rb
+++ b/lib/mongoid/relations/cascading/delete.rb
@@ -2,24 +2,7 @@
 module Mongoid
   module Relations
     module Cascading
-      class Delete
-
-        attr_accessor :document, :relation, :metadata
-
-        # Initialize the new cascade strategy, which will set up the relation
-        # and the metadata.
-        #
-        # @example Instantiate the strategy
-        #   Strategy.new(document, metadata)
-        #
-        # @param [ Document ] document The document to cascade from.
-        # @param [ Metadata ] metadata The relation's metadata.
-        #
-        # @return [ Strategy ] The new strategy.
-        def initialize(document, metadata)
-          @document, @metadata = document, metadata
-          @relation = document.send(metadata.name)
-        end
+      class Delete < Base
 
         # Execute the cascading deletion for the relation if it already exists.
         # This should be optimized in the future potentially not to load all

--- a/lib/mongoid/relations/cascading/destroy.rb
+++ b/lib/mongoid/relations/cascading/destroy.rb
@@ -2,24 +2,7 @@
 module Mongoid
   module Relations
     module Cascading
-      class Destroy
-
-        attr_accessor :document, :relation, :metadata
-
-        # Initialize the new cascade strategy, which will set up the relation
-        # and the metadata.
-        #
-        # @example Instantiate the strategy
-        #   Strategy.new(document, metadata)
-        #
-        # @param [ Document ] document The document to cascade from.
-        # @param [ Metadata ] metadata The relation's metadata.
-        #
-        # @return [ Strategy ] The new strategy.
-        def initialize(document, metadata)
-          @document, @metadata = document, metadata
-          @relation = document.send(metadata.name)
-        end
+      class Destroy < Base
 
         # Execute the cascading deletion for the relation if it already exists.
         # This should be optimized in the future potentially not to load all

--- a/lib/mongoid/relations/cascading/nullify.rb
+++ b/lib/mongoid/relations/cascading/nullify.rb
@@ -2,24 +2,7 @@
 module Mongoid
   module Relations
     module Cascading
-      class Nullify
-
-        attr_accessor :document, :relation, :metadata
-
-        # Initialize the new cascade strategy, which will set up the relation
-        # and the metadata.
-        #
-        # @example Instantiate the strategy
-        #   Strategy.new(document, metadata)
-        #
-        # @param [ Document ] document The document to cascade from.
-        # @param [ Metadata ] metadata The relation's metadata.
-        #
-        # @return [ Strategy ] The new strategy.
-        def initialize(document, metadata)
-          @document, @metadata = document, metadata
-          @relation = document.send(metadata.name)
-        end
+      class Nullify < Base
 
         # This cascade does not delete the referenced relations, but instead
         # sets the foreign key values to nil.

--- a/lib/mongoid/relations/cascading/restrict.rb
+++ b/lib/mongoid/relations/cascading/restrict.rb
@@ -2,24 +2,7 @@
 module Mongoid
   module Relations
     module Cascading
-      class Restrict
-
-        attr_accessor :document, :relation, :metadata
-
-        # Initialize the new cascade strategy, which will set up the relation
-        # and the metadata.
-        #
-        # @example Instantiate the strategy
-        #   Strategy.new(document, metadata)
-        #
-        # @param [ Document ] document The document to cascade from.
-        # @param [ Metadata ] metadata The relation's metadata.
-        #
-        # @return [ Strategy ] The new strategy.
-        def initialize(document, metadata)
-          @document, @metadata = document, metadata
-          @relation = document.send(metadata.name)
-        end
+      class Restrict < Base
 
         # Execute the cascading deletion for the relation if it already exists.
         # This should be optimized in the future potentially not to load all

--- a/lib/mongoid/relations/cascading/restrict_with_error.rb
+++ b/lib/mongoid/relations/cascading/restrict_with_error.rb
@@ -1,0 +1,27 @@
+# encoding: utf-8
+module Mongoid
+  module Relations
+    module Cascading
+      class RestrictWithError < Base
+
+        # This cascade does not delete the document if it has children, this will
+        # add a error on the document.
+        #
+        # @example Restrict with error
+        #   strategy.cascade
+        #
+        # @since 4.0.2
+        def cascade
+          unless relation.blank?
+            record = metadata.name
+            relation_name = metadata.relation.to_s.demodulize.underscore
+            document.errors.add(:base, :"restrict_dependent_destroy.#{relation_name}",
+                                record: record)
+            throw :skip_delete
+          end
+        end
+      end
+    end
+  end
+end
+

--- a/spec/mongoid/relations/cascading/restrict_with_error_spec.rb
+++ b/spec/mongoid/relations/cascading/restrict_with_error_spec.rb
@@ -1,0 +1,78 @@
+require 'spec_helper'
+
+describe Mongoid::Relations::Cascading::RestrictWithError do
+
+  before :each do
+    Person.has_many :drugs, validate: false, dependent: :restrict_with_error
+  end
+
+  after :each do
+    Person.cascades.delete("drugs")
+    Person.has_many :drugs, validate: false
+  end
+
+  let(:person) do
+    Person.new
+  end
+
+  let(:metadata) do
+    double(name: :drugs, relation: Mongoid::Relations::Referenced::Many)
+  end
+
+  let(:strategy) do
+    described_class.new(person, metadata)
+  end
+
+  describe "#cascade" do
+
+    let(:drug) do
+      double
+    end
+
+    context "when the document exists" do
+
+      context "when person has no drugs" do
+
+        before do
+          expect(person).to receive(:drugs).and_return([ ])
+        end
+
+        it "deletes the person" do
+          expect { strategy.cascade }.to_not raise_error
+        end
+      end
+
+      context "when person has drugs" do
+
+        before do
+          expect(person).to receive(:drugs).and_return([ drug ])
+        end
+
+        it "it throw an symbol" do
+          expect { strategy.cascade }.to throw_symbol(:skip_delete)
+        end
+
+        it "add the error message" do
+          catch(:skip_delete) { strategy.cascade }
+          expect(person.errors[:base]).to include('Cannot delete record because dependent drugs exist')
+        end
+
+        it "does not deletes the parent" do
+          catch(:skip_delete) { strategy.cascade }
+          expect(person).to_not be_destroyed
+        end
+      end
+    end
+
+    context "when no document exists" do
+      before do
+        expect(person).to receive(:drugs).and_return([])
+      end
+
+      it "doesn't delete anything" do
+        expect(drug).to receive(:delete).never
+        strategy.cascade
+      end
+    end
+  end
+end

--- a/spec/mongoid/relations/cascading_spec.rb
+++ b/spec/mongoid/relations/cascading_spec.rb
@@ -349,6 +349,132 @@ describe Mongoid::Relations::Cascading do
             end
           end
         end
+
+        context "when dependent is restrict_with_error" do
+
+          context "when restricting a references many" do
+
+            before do
+              Person.has_many :drugs, dependent: :restrict_with_error
+            end
+
+            after do
+              Person.cascades.delete("drugs")
+              Person.has_many :drugs, validate: false
+            end
+
+            context "when the relation is empty" do
+
+              let(:person) do
+                Person.new drugs: []
+              end
+
+              it "deletes the parent" do
+                person.send(method)
+                expect(person).to be_destroyed
+              end
+            end
+
+            context "when the relation is not empty" do
+
+              let(:person) do
+                Person.new drugs: [ Drug.new ]
+              end
+
+              it "add the error message" do
+                person.send(method)
+                expect(person.errors[:base]).to include('Cannot delete record because dependent drugs exist')
+              end
+
+              it "does not deletes the parent" do
+                person.send(method)
+                expect(person).to_not be_destroyed
+              end
+            end
+          end
+
+          context "when restricting a references one" do
+
+            before do
+              Person.has_one :account, dependent: :restrict_with_error
+            end
+
+            after do
+              Person.cascades.delete("account")
+              Person.has_one :account, validate: false
+            end
+
+            context "when the relation is empty" do
+
+              let(:person) do
+                Person.new account: nil
+              end
+
+              it "deletes the parent" do
+                person.send(method)
+                expect(person).to be_destroyed
+              end
+            end
+
+            context "when the relation is not empty" do
+
+              let(:person) do
+                Person.new account: Account.new(name: 'test')
+              end
+
+              it "add the error message" do
+                person.send(method)
+                expect(person.errors[:base]).to include('Cannot delete record because a dependent account exists')
+              end
+
+              it "does not deletes the parent" do
+                person.send(method)
+                expect(person).to_not be_destroyed
+              end
+            end
+          end
+
+          context "when restricting a many to many" do
+
+            before do
+              Person.has_and_belongs_to_many :houses, dependent: :restrict_with_error
+            end
+
+            after do
+              Person.cascades.delete("houses")
+              Person.has_and_belongs_to_many :houses, validate: false
+            end
+
+            context "when the relation is empty" do
+
+              let(:person) do
+                Person.new houses: []
+              end
+
+              it "deletes the parent" do
+                person.send(method)
+                expect(person).to be_destroyed
+              end
+            end
+
+            context "when the relation is not empty" do
+
+              let(:person) do
+                Person.new houses: [House.new]
+              end
+
+              it "add the error message" do
+                person.send(method)
+                expect(person.errors[:base]).to include('Cannot delete record because dependent houses exist')
+              end
+
+              it "does not deletes the parent" do
+                person.send(method)
+                expect(person).to_not be_destroyed
+              end
+            end
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Causes an error to be added to the owner if there are any associated
objects.

It is the same behaviour we have on [AR](http://api.rubyonrails.org/classes/ActiveRecord/Associations/ClassMethods.html#method-i-has_many).
