### PR TITLE
Add option to localized fields to disable fallbacks. #3937

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ For instructions on upgrading to newer versions, visit
 
 * \#3985 Return nil when using `{upsert: true}` in `find_and_modify` (Adrien Siami)
 
+* \#3937 Add fallbacks boolean option for localized fields, to allow
+  disabling them. (Braulio Martinez)
+
 ## 4.0.2
 
 ### New Features

--- a/lib/mongoid/fields/localized.rb
+++ b/lib/mongoid/fields/localized.rb
@@ -48,6 +48,18 @@ module Mongoid
 
       private
 
+      # Are fallbacks enabled for the field?
+      #
+      # @example Are fallbacks enabled for the field?
+      #   field.fallbacks?
+      #
+      # @return [ true, false ]
+      def fallbacks?
+        return true if options[:fallbacks].nil?
+
+        !!options[:fallbacks]
+      end
+
       # Lookup the value from the provided object.
       #
       # @api private
@@ -62,7 +74,7 @@ module Mongoid
       # @since 3.0.0
       def lookup(object)
         locale = ::I18n.locale
-        if ::I18n.respond_to?(:fallbacks)
+        if fallbacks? && ::I18n.respond_to?(:fallbacks)
           object[::I18n.fallbacks[locale].map(&:to_s).find{ |loc| object.has_key?(loc) }]
         else
           object[locale.to_s]

--- a/lib/mongoid/fields/validators/macro.rb
+++ b/lib/mongoid/fields/validators/macro.rb
@@ -13,6 +13,7 @@ module Mongoid
           :identity,
           :label,
           :localize,
+          :fallbacks,
           :metadata,
           :pre_processed,
           :subtype,

--- a/spec/mongoid/fields/localized_spec.rb
+++ b/spec/mongoid/fields/localized_spec.rb
@@ -274,8 +274,23 @@ describe Mongoid::Fields::Localized do
                   field.demongoize({ "en" => 1 })
                 end
 
-                it "returns the fallback translation" do
-                  expect(value).to eq(1)
+                context "and fallbacks are enabled" do
+
+                  it "returns the fallback translation" do
+                    expect(value).to eq(1)
+                  end
+                end
+
+
+                context "and fallbacks are disabled" do
+
+                  let(:field) do
+                    described_class.new(:description, localize: true, type: Integer, fallbacks: false)
+                  end
+
+                  it "returns nil" do
+                    expect(value).to be_nil
+                  end
                 end
               end
 


### PR DESCRIPTION
This PR addresses #3937 by adding the fallbacks options to localized fields.

The default behavior will stay the same, so if fallbacks is not specified, I18n.fallbacks will be used as usual.