### PR TITLE
UnknownAttribute Exception when cloning documents containing deprecated attributes

### DIFF
--- a/lib/mongoid/copyable.rb
+++ b/lib/mongoid/copyable.rb
@@ -22,7 +22,7 @@ module Mongoid
       # _id and id field in the document would cause problems with Mongoid
       # elsewhere.
       attrs = clone_document.except("_id", "id")
-      self.class.new(attrs)
+      self.class.new(attrs, allow_dynamic_attrs: true)
     end
     alias :dup :clone
 

--- a/lib/mongoid/document.rb
+++ b/lib/mongoid/document.rb
@@ -100,14 +100,15 @@ module Mongoid
     # @return [ Document ] A new document.
     #
     # @since 1.0.0
-    def initialize(attrs = nil)
+    def initialize(attrs = nil, opts = {})
       _building do
+        @opts = opts
         @new_record = true
         @attributes ||= {}
         with(self.class.persistence_options)
         apply_pre_processed_defaults
         apply_default_scoping
-        process_attributes(attrs) do
+        process_attributes(attrs, opts[:allow_dynamic_attrs]) do
           yield(self) if block_given?
         end
         apply_post_processed_defaults

--- a/lib/mongoid/factory.rb
+++ b/lib/mongoid/factory.rb
@@ -15,12 +15,12 @@ module Mongoid
     # @param [ Hash ] options The mass assignment scoping options.
     #
     # @return [ Document ] The instantiated document.
-    def build(klass, attributes = nil)
+    def build(klass, attributes = nil, opts = {})
       type = (attributes || {})["_type"]
       if type && klass._types.include?(type)
-        type.constantize.new(attributes)
+        type.constantize.new(attributes, opts)
       else
-        klass.new(attributes)
+        klass.new(attributes, opts)
       end
     end
 

--- a/lib/mongoid/relations/builders/nested_attributes/one.rb
+++ b/lib/mongoid/relations/builders/nested_attributes/one.rb
@@ -22,14 +22,14 @@ module Mongoid
           # @return [ Document ] The built document.
           #
           # @since 2.0.0
-          def build(parent)
+          def build(parent, opts = {})
             return if reject?(parent, attributes)
             @existing = parent.send(metadata.name)
             if update?
               attributes.delete_id
               existing.assign_attributes(attributes)
             elsif replace?
-              parent.send(metadata.setter, Factory.build(metadata.klass, attributes))
+              parent.send(metadata.setter, Factory.build(metadata.klass, attributes, opts))
             elsif delete?
               parent.send(metadata.setter, nil)
             end


### PR DESCRIPTION
I'm not certain if this is newly intended behaviour, but now an UnknownAttribute exception is thrown whenever you call `.clone` on a document that contains deprecated data (that is, it was assigned data under an old schema containing that attribute, but the attribute has since been removed from the model).

I find one of the major advantages of Mongo is the flexible data model that allows for easy changes to the schema while retaining deprecated data, so hopefully this isn't the intended behaviour!  Explicitly including Dynamic::Attributes would solve the issue, but this would undesirably throw-away enforcement of the schema on new documents.  IMO, when cloning old documents, the deprecated attributes should be copied or possibly silently ignored.

This PR fixes the issue by copying them, but let me know if a different approach would be favourable...