### PR TITLE
Don't throw exception on empty localized fields when calling valid?

### DIFF
--- a/lib/mongoid/validatable/uniqueness.rb
+++ b/lib/mongoid/validatable/uniqueness.rb
@@ -123,7 +123,7 @@ module Mongoid
         field = document.database_field_name(attribute)
 
         if localized?(document, field)
-          conditions = value.inject([]) { |acc, (k,v)| acc << { "#{field}.#{k}" => filter(v) } }
+          conditions = (value || {}).inject([]) { |acc, (k,v)| acc << { "#{field}.#{k}" => filter(v) } }
           selector = { "$or" => conditions }
         else
           selector = { field => filter(value) }

--- a/spec/mongoid/validatable/uniqueness_spec.rb
+++ b/spec/mongoid/validatable/uniqueness_spec.rb
@@ -147,6 +147,17 @@ describe Mongoid::Validatable::UniquenessValidator do
                 Dictionary.reset_callbacks(:validate)
               end
 
+              context "when the value is not set" do
+
+                let(:dictionary) do
+                  Dictionary.new
+                end
+
+                it "returns false" do
+                  expect(dictionary.valid?).to be false
+                end
+              end
+
               context "when the attribute is unique" do
 
                 context "when single localization" do


### PR DESCRIPTION
I have came across an issue when trying to persists localized documents:

I have a model with: 

 `field :name, type: String, localize: true`
 `validates_uniqueness_of :name`

And when I run Model.new.valid?

I get: 

```NoMethodError: undefined method `inject' for nil:NilClass` in `lib/mongoid/validatable/uniqueness.rb:126:in `criterion'````

I have wrote a small test for it and changed the behaviour of the method so that `valid?` would return false in this case. Feel free to merge if it's any useful. 
Thanks for the library.
cheers
