### PR TITLE
Fix created_at being set to nil during a non-timeless call

### DIFF
--- a/lib/mongoid/timestamps/created.rb
+++ b/lib/mongoid/timestamps/created.rb
@@ -27,7 +27,7 @@ module Mongoid
           self.created_at = time
         end
 
-        self.class.clear_timeless_option
+        clear_timeless_option
       end
     end
   end

--- a/lib/mongoid/timestamps/updated.rb
+++ b/lib/mongoid/timestamps/updated.rb
@@ -26,7 +26,7 @@ module Mongoid
           self.updated_at = Time.now.utc unless updated_at_changed?
         end
 
-        self.class.clear_timeless_option
+        clear_timeless_option
       end
 
       # Is the updated timestamp able to be set?

--- a/spec/mongoid/timestamps/timeless_spec.rb
+++ b/spec/mongoid/timestamps/timeless_spec.rb
@@ -27,6 +27,22 @@ describe Mongoid::Timestamps::Timeless do
       Object.send(:remove_const, :Egg)
     end
 
+    context "when timeless is used on one instance and then not used on another instance" do
+      let!(:first_instance) do
+        egg = Egg.create!
+        egg.timeless.save!
+        egg
+      end
+
+      let!(:second_instance) do
+        Egg.create!
+      end
+
+      it "second instance's created_at is not nil" do
+        expect(second_instance.created_at).to_not be_nil
+      end
+    end
+
     context "when others persist in the scope of the chain" do
 
       context "when the root executes normally" do


### PR DESCRIPTION
If an existing document has `timeless.save` called on it and then a document in that collection is created with `Collection.create`, the second document will not get a `created_at` timestamp.

The original implementation assumed that `clear_timeless_option` would be called once for each timestamp module it included. However, it is only called once during an update since the create callback does not get called.

This implementation adds an alternate `clear_timeless_option` that will get called if the document is already persisted and decrements the counter for each timestamp module that is included since it will only be called once (by the update callback).