### PR TITLE
Fix assigning a localized field when attributes is a BSON::Document

### DIFF
--- a/lib/mongoid/attributes.rb
+++ b/lib/mongoid/attributes.rb
@@ -176,7 +176,8 @@ module Mongoid
             attribute_will_change!(access)
           end
           if localized
-            (attributes[access] ||= {}).merge!(typed_value)
+            attributes[access] ||= {}
+            attributes[access].merge!(typed_value)
           else
             attributes[access] = typed_value
           end

--- a/spec/mongoid/attributes_spec.rb
+++ b/spec/mongoid/attributes_spec.rb
@@ -1207,6 +1207,19 @@ describe Mongoid::Attributes do
         }.to raise_error(Mongoid::Errors::InvalidValue)
       end
     end
+
+    context "when attribute is localized and #attributes is a BSON::Document" do
+      let(:dictionary) { Dictionary.new }
+
+      before do
+        allow(dictionary).to receive(:attributes).and_return(BSON::Document.new)
+      end
+
+      it "sets the value for the current locale" do
+        dictionary.write_attribute(:description, 'foo')
+        expect(dictionary.description).to eq('foo')
+      end
+    end
   end
 
   describe "#typed_value_for" do


### PR DESCRIPTION
This is to fix issue https://github.com/mongoid/mongoid/issues/4055