### PR TITLE
[bug][tweak] replace session to client

### DIFF
--- a/lib/mongoid/railtie.rb
+++ b/lib/mongoid/railtie.rb
@@ -60,7 +60,7 @@ module Rails
             ::Mongoid.load!(config_file)
           rescue ::Mongoid::Errors::NoClientsConfig => e
             handle_configuration_error(e)
-          rescue ::Mongoid::Errors::NoDefaultSession => e
+          rescue ::Mongoid::Errors::NoDefaultClient => e
             handle_configuration_error(e)
           rescue ::Mongoid::Errors::NoSessionDatabase => e
             handle_configuration_error(e)


### PR DESCRIPTION
this is error
```
NameError: uninitialized constant Mongoid::Errors::NoDefaultSession
/home/ubuntu/GyazoRails/vendor/bundle/ruby/2.1.0/gems/mongoid-5.0.0.beta/lib/mongoid/railtie.rb:63:in `rescue in block in <class:Railtie>'
```

so I replace `NoDefaultSession` to `NoDefaultClient`