### PR TITLE
Remove all references to 'persist_in_safe_mode'.

### DIFF
--- a/lib/mongoid/config/options.rb
+++ b/lib/mongoid/config/options.rb
@@ -20,7 +20,7 @@ module Mongoid
       # Define a configuration option with a default.
       #
       # @example Define the option.
-      #   Options.option(:persist_in_safe_mode, :default => true)
+      #   Options.option(:logger, :default => Logger.new($stdout, :warn))
       #
       # @param [ Symbol ] name The name of the configuration option.
       # @param [ Hash ] options Extras for the option.

--- a/lib/mongoid/railtie.rb
+++ b/lib/mongoid/railtie.rb
@@ -42,7 +42,6 @@ module Rails
       #   module MyApplication
       #     class Application < Rails::Application
       #       config.mongoid.logger = Logger.new($stdout, :warn)
-      #       config.mongoid.persist_in_safe_mode = true
       #     end
       #   end
       #


### PR DESCRIPTION
`persist_in_safe_mode` was removed in version 3.