### PR TITLE
Provide read-access to problem, summary and resolution fields for Mongoid::Errors::MongoidError

### DIFF
--- a/lib/mongoid/errors/mongoid_error.rb
+++ b/lib/mongoid/errors/mongoid_error.rb
@@ -7,6 +7,8 @@ module Mongoid
     # translating the messages.
     class MongoidError < StandardError
 
+      attr_reader :problem, :summary, :resolution
+
       BASE_KEY = "mongoid.errors.messages"
 
       # Compose the message.
@@ -18,9 +20,9 @@ module Mongoid
       #
       # @since 3.0.0
       def compose_message(key, attributes)
-        @problem = problem(key, attributes)
-        @summary = summary(key, attributes)
-        @resolution = resolution(key, attributes)
+        @problem = translate_problem(key, attributes)
+        @summary = translate_summary(key, attributes)
+        @resolution = translate_resolution(key, attributes)
         @problem_title = translate("message_title", {})
         @summary_title = translate("summary_title", {})
         @resolution_title = translate("resolution_title", {})
@@ -58,7 +60,7 @@ module Mongoid
       # @return [ String ] The problem.
       #
       # @since 3.0.0
-      def problem(key, attributes)
+      def translate_problem(key, attributes)
         translate("#{key}.message", attributes)
       end
 
@@ -73,7 +75,7 @@ module Mongoid
       # @return [ String ] The summary.
       #
       # @since 3.0.0
-      def summary(key, attributes)
+      def translate_summary(key, attributes)
         translate("#{key}.summary", attributes)
       end
 
@@ -88,7 +90,7 @@ module Mongoid
       # @return [ String ] The resolution.
       #
       # @since 3.0.0
-      def resolution(key, attributes)
+      def translate_resolution(key, attributes)
         translate("#{key}.resolution", attributes)
       end
     end

--- a/spec/mongoid/errors/mongoid_error_spec.rb
+++ b/spec/mongoid/errors/mongoid_error_spec.rb
@@ -23,15 +23,15 @@ describe Mongoid::Errors::MongoidError do
   describe "#compose_message" do
 
     it "sets ivar problem" do
-      expect(error.instance_variable_get(:@problem)).to be
+      expect(error.problem).to be
     end
 
     it "sets ivar summary" do
-      expect(error.instance_variable_get(:@summary)).to be
+      expect(error.summary).to be
     end
 
     it "sets ivar resolution" do
-      expect(error.instance_variable_get(:@resolution)).to be
+      expect(error.resolution).to be
     end
 
     it "sets ivar problem_title" do


### PR DESCRIPTION
In some cases, I want to catch Mongoid::Errors::MongoidError and include the **problem** field in my own exception, without the **summary** or **exception** fields.  Currently i'm using `problem = exception.instance_variable_get(:@problem)` and I can't think of a reason why these fields shouldn't be readable from outside the class.