### PR TITLE
Fix Fields::Localized#lookup to work with boolean and empty keys

### DIFF
--- a/lib/mongoid/fields/localized.rb
+++ b/lib/mongoid/fields/localized.rb
@@ -63,7 +63,13 @@ module Mongoid
       def lookup(object)
         locale = ::I18n.locale
         if ::I18n.respond_to?(:fallbacks)
-          object[::I18n.fallbacks[locale].map(&:to_s).find{ |loc| object[loc] }]
+          object[::I18n.fallbacks[locale].map(&:to_s).find{ |loc|
+            if object.has_key?(loc)
+              unless object[loc].empty?
+                loc
+              end
+            end
+          }]
         else
           object[locale.to_s]
         end


### PR DESCRIPTION
When the translated has a key, but with empty value, mongo will return it empty, brooking the fallback.

Eg.
p = Post.find 'some_id'
p.title_translations
=> {"de"=>"", "en"=>"Bibliography", "es"=>"", "fr"=>"", "it"=>"", "pt-BR"=>""}

If set I18n.locale = :de will return p.title_translations['de'] = blank