### PR TITLE
Fixed template for Mongoid configuration

### DIFF
--- a/lib/rails/generators/mongoid/config/templates/mongoid.yml
+++ b/lib/rails/generators/mongoid/config/templates/mongoid.yml
@@ -131,5 +131,5 @@ test:
         - localhost:27017
       options:
         read:
-          mode: primary
+          mode: :primary
         max_pool_size: 1


### PR DESCRIPTION
Hey there,

first of all, many thanks for Mongoid.

This is a small pull request which fixes the generated Mongoid configuration. I think, with Mongoid 5.0.0, the mode must be a symbol.