### PR TITLE
MONGOID-4119 Ensure that criteria selector becomes pipeline operator value

### DIFF
--- a/lib/mongoid/contextual/aggregable/mongo.rb
+++ b/lib/mongoid/contextual/aggregable/mongo.rb
@@ -124,8 +124,8 @@ module Mongoid
         def pipeline(field)
           db_field = "$#{database_field_name(field)}"
           pipeline = []
-          pipeline << { "$match" => { field => { :$exists => true }  } }
-          pipeline << { "$match" => { field => criteria.selector[field.to_s] } }
+          pipeline << { "$match" => criteria.selector }
+          pipeline << { "$match" => { field => { :$exists => true } } }
           pipeline << { "$sort" => criteria.options[:sort] } if criteria.options[:sort]
           pipeline << { "$skip" => criteria.options[:skip] } if criteria.options[:skip]
           pipeline << { "$limit" => criteria.options[:limit] } if criteria.options[:limit]

--- a/lib/mongoid/contextual/aggregable/mongo.rb
+++ b/lib/mongoid/contextual/aggregable/mongo.rb
@@ -125,7 +125,7 @@ module Mongoid
           db_field = "$#{database_field_name(field)}"
           pipeline = []
           pipeline << { "$match" => criteria.selector }
-          pipeline << { "$match" => { field => { :$exists => true } } }
+          pipeline << { "$match" =>  criteria.exists(field => true).selector }
           pipeline << { "$sort" => criteria.options[:sort] } if criteria.options[:sort]
           pipeline << { "$skip" => criteria.options[:skip] } if criteria.options[:skip]
           pipeline << { "$limit" => criteria.options[:limit] } if criteria.options[:limit]

--- a/lib/mongoid/contextual/aggregable/mongo.rb
+++ b/lib/mongoid/contextual/aggregable/mongo.rb
@@ -124,6 +124,7 @@ module Mongoid
         def pipeline(field)
           db_field = "$#{database_field_name(field)}"
           pipeline = []
+          pipeline << { "$match" => { field => { :$exists => true }  } }
           pipeline << { "$match" => { field => criteria.selector[field.to_s] } }
           pipeline << { "$sort" => criteria.options[:sort] } if criteria.options[:sort]
           pipeline << { "$skip" => criteria.options[:skip] } if criteria.options[:skip]

--- a/lib/mongoid/contextual/aggregable/mongo.rb
+++ b/lib/mongoid/contextual/aggregable/mongo.rb
@@ -124,7 +124,7 @@ module Mongoid
         def pipeline(field)
           db_field = "$#{database_field_name(field)}"
           pipeline = []
-          pipeline << { "$match" => criteria.nin(field => nil).selector }
+          pipeline << { "$match" => { field => criteria.selector[field.to_s] } }
           pipeline << { "$sort" => criteria.options[:sort] } if criteria.options[:sort]
           pipeline << { "$skip" => criteria.options[:skip] } if criteria.options[:skip]
           pipeline << { "$limit" => criteria.options[:limit] } if criteria.options[:limit]

--- a/spec/mongoid/contextual/aggregable/mongo_spec.rb
+++ b/spec/mongoid/contextual/aggregable/mongo_spec.rb
@@ -302,6 +302,29 @@ describe Mongoid::Contextual::Aggregable::Mongo do
 
   describe "#max" do
 
+    context 'when the field does not exist in any document' do
+
+      let!(:depeche) do
+        Band.create(name: "Depeche Mode", likes: 1000)
+      end
+
+      let(:criteria) do
+        Band.all
+      end
+
+      let(:context) do
+        Mongoid::Contextual::Mongo.new(criteria)
+      end
+
+      let(:max) do
+        context.max(:non_existent)
+      end
+
+      it 'returns nil' do
+        expect(max).to be(nil)
+      end
+    end
+
     context "when provided a single field" do
 
       let!(:depeche) do

--- a/spec/mongoid/contextual/mongo_spec.rb
+++ b/spec/mongoid/contextual/mongo_spec.rb
@@ -1818,16 +1818,16 @@ describe Mongoid::Contextual::Mongo do
         described_class.new(criteria)
       end
 
-      let(:matches) do
+      let(:matches_operators) do
         context.send(:pipeline, 'name').select { |o| o['$match'] }
       end
 
-      it 'creates a pipeline with the selector as one $match criteria' do
-        expect(matches).to include('$match' => criteria.selector)
+      it 'creates a pipeline with the selector as one of the $match criteria' do
+        expect(matches_operators).to include('$match' => criteria.selector)
       end
 
-      it 'creates a pipeline with the selector as one $match criteria' do
-        expect(matches).to include('$match' => { 'name' => { :$exists => true } })
+      it 'creates a pipeline with the $exists operator as one of the $match criteria' do
+        expect(matches_operators).to include('$match' => { 'name' => { '$exists' => true } })
       end
     end
   end

--- a/spec/mongoid/contextual/mongo_spec.rb
+++ b/spec/mongoid/contextual/mongo_spec.rb
@@ -1818,8 +1818,16 @@ describe Mongoid::Contextual::Mongo do
         described_class.new(criteria)
       end
 
-      it 'creates a pipeline with the selector as the $match criteria' do
-        expect(context.send(:pipeline, 'name').first['$match']).to eq(criteria.selector)
+      let(:matches) do
+        context.send(:pipeline, 'name').select { |o| o['$match'] }
+      end
+
+      it 'creates a pipeline with the selector as one $match criteria' do
+        expect(matches).to include('$match' => criteria.selector)
+      end
+
+      it 'creates a pipeline with the selector as one $match criteria' do
+        expect(matches).to include('$match' => { 'name' => { :$exists => true } })
       end
     end
   end

--- a/spec/mongoid/contextual/mongo_spec.rb
+++ b/spec/mongoid/contextual/mongo_spec.rb
@@ -1805,4 +1805,22 @@ describe Mongoid::Contextual::Mongo do
       end
     end
   end
+
+  describe '#pipeline' do
+
+    context 'when the criteria has a selector' do
+
+      let(:criteria) do
+        Band.where(name: "New Order")
+      end
+
+      let(:context) do
+        described_class.new(criteria)
+      end
+
+      it 'creates a pipeline with the selector as the $match criteria' do
+        expect(context.send(:pipeline, 'name').first['$match']).to eq(criteria.selector)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Need to figure out a better way to test, i.e. not test a private method specifically.

Change code to apply two $match operators, first will apply the $exists selector, the second will apply the user-defined selector.

Test the situation in which the selector refers to a field that is not present to make sure calculations don't fail.