### PR TITLE
Improve BigDecimal mongoize behavior

### DIFF
--- a/lib/mongoid/extensions/big_decimal.rb
+++ b/lib/mongoid/extensions/big_decimal.rb
@@ -28,6 +28,18 @@ module Mongoid
         to_s
       end
 
+      # Is the BigDecimal a number?
+      #
+      # @example Is the object a number?.
+      #   object.numeric?
+      #
+      # @return [ true ] Always true.
+      #
+      # @since 6.0.0
+      def numeric?
+        true
+      end
+
       module ClassMethods
 
         # Convert the object from its mongo friendly ruby type to this type.
@@ -37,28 +49,25 @@ module Mongoid
         #
         # @param [ Object ] object The object to demongoize.
         #
-        # @return [ Object ] The object.
+        # @return [ BigDecimal, nil ] A BigDecimal derived from the object or nil.
         #
         # @since 3.0.0
         def demongoize(object)
-          if object
-            object.numeric? ? ::BigDecimal.new(object.to_s) : object
-          end
+          object && object.numeric? ? ::BigDecimal.new(object.to_s) : nil
         end
 
-        # Mongoize an object of any type to how it's stored in the db as a big
-        # decimal.
+        # Mongoize an object of any type to how it's stored in the db as a String.
         #
         # @example Mongoize the object.
         #   BigDecimal.mongoize(123)
         #
         # @param [ Object ] object The object to Mongoize
         #
-        # @return [ String ] The mongoized object.
+        # @return [ String, nil ] A String representing the object or nil.
         #
         # @since 3.0.7
         def mongoize(object)
-          object ? object.to_s : object
+          object && object.numeric? ? object.to_s : nil
         end
       end
     end

--- a/lib/mongoid/extensions/string.rb
+++ b/lib/mongoid/extensions/string.rb
@@ -72,7 +72,8 @@ module Mongoid
         self =~ /\A(|_)id$/
       end
 
-      # Is the string a number?
+      # Is the string a number? The literals "NaN", "Infinity", and "-Infinity"
+      # are counted as numbers.
       #
       # @example Is the string a number.
       #   "1234.23".numeric?
@@ -81,7 +82,7 @@ module Mongoid
       #
       # @since 3.0.0
       def numeric?
-        true if Float(self) rescue (self == "NaN")
+        true if Float(self) rescue (self =~ /^NaN|\-?Infinity$/)
       end
 
       # Get the string as a getter string.

--- a/lib/mongoid/findable.rb
+++ b/lib/mongoid/findable.rb
@@ -11,7 +11,7 @@ module Mongoid
     select_with :with_default_scope
 
     # These are methods defined on the criteria that should also be accessible
-    # directly from the the class level.
+    # directly from the class level.
     delegate \
       :aggregates,
       :avg,

--- a/spec/mongoid/attributes/nested_spec.rb
+++ b/spec/mongoid/attributes/nested_spec.rb
@@ -1970,7 +1970,7 @@ describe Mongoid::Attributes::Nested do
                       }
                   end
 
-                  it "ignores the the marked document" do
+                  it "ignores the marked document" do
                     expect(person.addresses.size).to eq(1)
                   end
 
@@ -2031,7 +2031,7 @@ describe Mongoid::Attributes::Nested do
                       }
                   end
 
-                  it "adds the the marked document" do
+                  it "adds the marked document" do
                     expect(person.addresses.first.street).to eq("Maybachufer")
                   end
 
@@ -2091,7 +2091,7 @@ describe Mongoid::Attributes::Nested do
                       }
                   end
 
-                  it "adds the the marked document" do
+                  it "adds the marked document" do
                     expect(person.addresses.first.street).to eq("Maybachufer")
                   end
 
@@ -3431,7 +3431,7 @@ describe Mongoid::Attributes::Nested do
                       }
                   end
 
-                  it "ignores the the marked document" do
+                  it "ignores the marked document" do
                     expect(person.posts.size).to eq(1)
                   end
 
@@ -3492,7 +3492,7 @@ describe Mongoid::Attributes::Nested do
                       }
                   end
 
-                  it "adds the the marked document" do
+                  it "adds the marked document" do
                     expect(person.posts.first.title).to eq("New Blog")
                   end
 
@@ -3552,7 +3552,7 @@ describe Mongoid::Attributes::Nested do
                       }
                   end
 
-                  it "adds the the marked document" do
+                  it "adds the marked document" do
                     expect(person.posts.first.title).to eq("New Blog")
                   end
 
@@ -4097,7 +4097,7 @@ describe Mongoid::Attributes::Nested do
                       }
                   end
 
-                  it "ignores the the marked document" do
+                  it "ignores the marked document" do
                     expect(person.preferences.size).to eq(1)
                   end
 
@@ -4158,7 +4158,7 @@ describe Mongoid::Attributes::Nested do
                       }
                   end
 
-                  it "adds the the marked document" do
+                  it "adds the marked document" do
                     expect(person.preferences.first.name).to eq("New Blog")
                   end
 
@@ -4218,7 +4218,7 @@ describe Mongoid::Attributes::Nested do
                       }
                   end
 
-                  it "adds the the marked document" do
+                  it "adds the marked document" do
                     expect(person.preferences.first.name).to eq("New Blog")
                   end
 

--- a/spec/mongoid/extensions/big_decimal_spec.rb
+++ b/spec/mongoid/extensions/big_decimal_spec.rb
@@ -2,16 +2,64 @@ require "spec_helper"
 
 describe Mongoid::Extensions::BigDecimal do
 
-  let(:number) do
+  let(:big_decimal) do
     BigDecimal.new("123456.789")
   end
 
   describe ".demongoize" do
 
-    context "when the the value is a string" do
+    context "when the value is an empty String" do
 
-      it "returns a big decimal" do
-        expect(BigDecimal.demongoize(number.to_s)).to eq(number)
+      let(:string) do
+        ""
+      end
+
+      it "returns nil" do
+        expect(BigDecimal.demongoize(string)).to be_nil
+      end
+    end
+
+    context "when the value is a numeric String" do
+
+      let(:string) do
+        "123456.789"
+      end
+
+      it "returns a BigDecimal" do
+        expect(BigDecimal.demongoize(string)).to eq(BigDecimal.new(string))
+      end
+    end
+
+    context "when the value is the numeric String zero" do
+
+      let(:string) do
+        "0.0"
+      end
+
+      it "returns a BigDecimal" do
+        expect(BigDecimal.demongoize(string)).to eq(BigDecimal.new(string))
+      end
+    end
+
+    context "when the value is the numeric String negative zero" do
+
+      let(:string) do
+        "-0.0"
+      end
+
+      it "returns a BigDecimal" do
+        expect(BigDecimal.demongoize(string)).to eq(BigDecimal.new(string))
+      end
+    end
+
+    context "when the value is a non-numeric String" do
+
+      let(:string) do
+        "1a2"
+      end
+
+      it "returns nil" do
+        expect(BigDecimal.demongoize(string)).to be_nil
       end
     end
 
@@ -22,18 +70,29 @@ describe Mongoid::Extensions::BigDecimal do
       end
     end
 
-    context "when the value is a float" do
+    context "when the value is true" do
 
-      let(:float) do
-        123456.789
+      let(:value) do
+        true
       end
 
-      it "returns a float" do
-        expect(BigDecimal.demongoize(float)).to eq(float)
+      it "returns nil" do
+        expect(BigDecimal.demongoize(value)).to be_nil
       end
     end
 
-    context "when the value is an integer" do
+    context "when the value is false" do
+
+      let(:value) do
+        false
+      end
+
+      it "returns nil" do
+        expect(BigDecimal.demongoize(value)).to be_nil
+      end
+    end
+
+    context "when the value is an Integer" do
 
       let(:integer) do
         123456
@@ -44,7 +103,18 @@ describe Mongoid::Extensions::BigDecimal do
       end
     end
 
-    context "when the value is NaN" do
+    context "when the value is a Float" do
+
+      let(:float) do
+        123456.789
+      end
+
+      it "returns a float" do
+        expect(BigDecimal.demongoize(float)).to eq(float)
+      end
+    end
+
+    context "when the value is the String 'NaN'" do
 
       let(:nan) do
         "NaN"
@@ -54,22 +124,126 @@ describe Mongoid::Extensions::BigDecimal do
         BigDecimal.demongoize(nan)
       end
 
-      it "returns a big decimal" do
+      it "returns a BigDecimal" do
         expect(demongoized).to be_a(BigDecimal)
       end
 
-      it "is a NaN big decimal" do
+      it "is a NaN BigDecimal" do
         expect(demongoized).to be_nan
+      end
+    end
+
+    context "when the value is the String 'Infinity'" do
+
+      let(:infinity) do
+        "Infinity"
+      end
+
+      let(:demongoized) do
+        BigDecimal.demongoize(infinity)
+      end
+
+      it "returns a BigDecimal" do
+        expect(demongoized).to be_a(BigDecimal)
+      end
+
+      it "is a infinity BigDecimal" do
+        expect(demongoized.infinite?).to eq 1
+      end
+    end
+
+    context "when the value is the String '-Infinity'" do
+
+      let(:neg_infinity) do
+        "-Infinity"
+      end
+
+      let(:demongoized) do
+        BigDecimal.demongoize(neg_infinity)
+      end
+
+      it "returns a BigDecimal" do
+        expect(demongoized).to be_a(BigDecimal)
+      end
+
+      it "is a negative infinity BigDecimal" do
+        expect(demongoized.infinite?).to eq -1
       end
     end
   end
 
   describe ".mongoize" do
 
-    context "when the value is a big decimal" do
+    context "when the value is a BigDecimal" do
 
       it "returns a string" do
-        expect(BigDecimal.mongoize(number)).to eq(number.to_s)
+        expect(BigDecimal.mongoize(big_decimal)).to eq(big_decimal.to_s)
+      end
+    end
+
+    context "when the value is the BigDecimal zero" do
+
+      let(:big_decimal) do
+        BigDecimal.new("0.0")
+      end
+
+      it "returns a BigDecimal" do
+        expect(BigDecimal.mongoize(big_decimal)).to eq(big_decimal.to_s)
+      end
+    end
+
+    context "when the value is the BigDecimal negative zero" do
+
+      let(:big_decimal) do
+        BigDecimal.new("-0.0")
+      end
+
+      it "returns a BigDecimal" do
+        expect(BigDecimal.mongoize(big_decimal)).to eq(big_decimal.to_s)
+      end
+    end
+
+    context "when the value is an empty String" do
+
+      let(:string) do
+        ""
+      end
+
+      it "returns nil" do
+        expect(BigDecimal.mongoize(string)).to be_nil
+      end
+    end
+
+    context "when the value is an integer numeric String" do
+
+      let(:string) do
+        "123456"
+      end
+
+      it "returns the String" do
+        expect(BigDecimal.mongoize(string)).to eq string
+      end
+    end
+
+    context "when the value is a float numeric String" do
+
+      let(:string) do
+        "123456.789"
+      end
+
+      it "returns the String" do
+        expect(BigDecimal.mongoize(string)).to eq string
+      end
+    end
+
+    context "when the value is a non-numeric String" do
+
+      let(:string) do
+        "1a2"
+      end
+
+      it "returns nil" do
+        expect(BigDecimal.mongoize(string)).to be_nil
       end
     end
 
@@ -80,17 +254,138 @@ describe Mongoid::Extensions::BigDecimal do
       end
     end
 
-    context "when the value is an integer" do
+    context "when the value is true" do
+
+      let(:value) do
+        true
+      end
+
+      it "returns nil" do
+        expect(BigDecimal.mongoize(value)).to be_nil
+      end
+    end
+
+    context "when the value is false" do
+
+      let(:value) do
+        false
+      end
+
+      it "returns nil" do
+        expect(BigDecimal.mongoize(value)).to be_nil
+      end
+    end
+
+    context "when the value is an Integer" do
 
       it "returns a string" do
         expect(BigDecimal.mongoize(123456)).to eq("123456")
       end
     end
 
-    context "when the value is a float" do
+    context "when the value is a Float" do
 
       it "returns a string" do
         expect(BigDecimal.mongoize(123456.789)).to eq("123456.789")
+      end
+    end
+
+    context "when the value is String NaN" do
+
+      let(:nan) do
+        "NaN"
+      end
+
+      it "returns a String" do
+        expect(BigDecimal.mongoize(nan)).to eq("NaN")
+      end
+    end
+
+    context "when the value is String Infinity" do
+
+      let(:infinity) do
+        "Infinity"
+      end
+
+      it "returns a String" do
+        expect(BigDecimal.mongoize(infinity)).to eq("Infinity")
+      end
+    end
+
+    context "when the value is String negative Infinity" do
+
+      let(:neg_infinity) do
+        "-Infinity"
+      end
+
+      it "returns a String" do
+        expect(BigDecimal.mongoize(neg_infinity)).to eq("-Infinity")
+      end
+    end
+
+    context "when the value is BigDecimal NaN" do
+
+      let(:nan) do
+        BigDecimal.new("NaN")
+      end
+
+      it "returns a String" do
+        expect(BigDecimal.mongoize(nan)).to eq("NaN")
+      end
+    end
+
+    context "when the value is BigDecimal Infinity" do
+
+      let(:infinity) do
+        BigDecimal.new("Infinity")
+      end
+
+      it "returns a String" do
+        expect(BigDecimal.mongoize(infinity)).to eq("Infinity")
+      end
+    end
+
+    context "when the value is BigDecimal negative Infinity" do
+
+      let(:neg_infinity) do
+        BigDecimal.new("-Infinity")
+      end
+
+      it "returns a String" do
+        expect(BigDecimal.mongoize(neg_infinity)).to eq("-Infinity")
+      end
+    end
+
+    context "when the value is the constant Float::NAN" do
+
+      let(:nan) do
+        Float::NAN
+      end
+
+      it "returns a String" do
+        expect(BigDecimal.mongoize(nan)).to eq("NaN")
+      end
+    end
+
+    context "when the value is constant Float::INFINITY" do
+
+      let(:infinity) do
+        Float::INFINITY
+      end
+
+      it "returns a String" do
+        expect(BigDecimal.mongoize(infinity)).to eq("Infinity")
+      end
+    end
+
+    context "when the value is constant Float::INFINITY * -1" do
+
+      let(:neg_infinity) do
+        Float::INFINITY * -1
+      end
+
+      it "returns a String" do
+        expect(BigDecimal.mongoize(neg_infinity)).to eq("-Infinity")
       end
     end
   end
@@ -98,7 +393,14 @@ describe Mongoid::Extensions::BigDecimal do
   describe "#mongoize" do
 
     it "returns a string" do
-      expect(number.mongoize).to eq(number.to_s)
+      expect(big_decimal.mongoize).to eq(big_decimal.to_s)
+    end
+  end
+
+  describe "#numeric?" do
+
+    it "returns true" do
+      expect(big_decimal.numeric?).to eq(true)
     end
   end
 end

--- a/spec/mongoid/extensions/float_spec.rb
+++ b/spec/mongoid/extensions/float_spec.rb
@@ -23,7 +23,7 @@ describe Mongoid::Extensions::Float do
 
   describe ".demongoize" do
 
-    context "when the the value is a float" do
+    context "when the value is a float" do
 
       it "returns a float" do
         expect(Float.demongoize(number)).to eq(number)
@@ -142,6 +142,13 @@ describe Mongoid::Extensions::Float do
 
     it "returns self" do
       expect(number.mongoize).to eq(number)
+    end
+  end
+
+  describe "#numeric?" do
+
+    it "returns true" do
+      expect(number.numeric?).to eq(true)
     end
   end
 end

--- a/spec/mongoid/extensions/integer_spec.rb
+++ b/spec/mongoid/extensions/integer_spec.rb
@@ -23,7 +23,7 @@ describe Mongoid::Extensions::Integer do
 
   describe ".demongoize" do
 
-    context "when the the value is an integer" do
+    context "when the value is an integer" do
 
       it "returns a integer" do
         expect(Integer.demongoize(number)).to eq(number)
@@ -131,6 +131,13 @@ describe Mongoid::Extensions::Integer do
 
     it "returns self" do
       expect(number.mongoize).to eq(number)
+    end
+  end
+
+  describe "#numeric?" do
+
+    it "returns true" do
+      expect(number.numeric?).to eq(true)
     end
   end
 end

--- a/spec/mongoid/extensions/object_spec.rb
+++ b/spec/mongoid/extensions/object_spec.rb
@@ -289,4 +289,15 @@ describe Mongoid::Extensions::Object do
       end
     end
   end
+
+  describe "#numeric?" do
+
+    let(:object) do
+      Object.new
+    end
+
+    it "returns false" do
+      expect(object.numeric?).to eq(false)
+    end
+  end
 end

--- a/spec/mongoid/extensions/string_spec.rb
+++ b/spec/mongoid/extensions/string_spec.rb
@@ -301,6 +301,27 @@ describe Mongoid::Extensions::String do
         expect("blah").to_not be_numeric
       end
     end
+
+    context "when the string is NaN" do
+
+      it "returns true" do
+        expect("NaN").to be_numeric
+      end
+    end
+
+    context "when the string is Infinity" do
+
+      it "returns true" do
+        expect("Infinity").to be_numeric
+      end
+    end
+
+    context "when the string is -Infinity" do
+
+      it "returns true" do
+        expect("-Infinity").to be_numeric
+      end
+    end
   end
 
   describe "#singularize" do

--- a/spec/mongoid/relations/accessors_spec.rb
+++ b/spec/mongoid/relations/accessors_spec.rb
@@ -728,7 +728,7 @@ describe Mongoid::Relations::Accessors do
         game.save
       end
 
-      it "keeps the the foreign key as ObjectID" do
+      it "keeps the foreign key as ObjectID" do
         expect(game.reload.person_id).to eq(person.id)
       end
     end


### PR DESCRIPTION
Recently I attempted to migrate a number of `Float` fields to `BigDecimal`, and I found that the behavior is inconsistent between the two. This PR rectifies that situation. Note that `BigDecimal` is stored in MongoDB as a string, as there is no native BSON type for it.

- `demongoize` should always return a BigDecimal or else nil, never an empty string (this mirrors how Floats and Integers behave).
- `mongoize` should always return a String which can be demongoized to a BigDecimal, otherwise nil
- Support storing BigDecimal values `"Infinity"` and `"-Infinity"` in the database.
- The strings `"Infinity"` and `"-Infinity"` now evaluate as numeric? true.
- `BigDecimal`s now evaluate as numeric? true.
- Additional tests for BigDecimal covering all edge cases.


### Demongoize

| Value to Demongoize | Current            | New | Behavior Changed? |
| ---         | ---                | --- | --- |
| "0"         | BigDecimal 0.0     | BigDecimal 0.0 |   |
| "-0"        | BigDecimal -0.0    | BigDecimal -0.0 |   |
| "1"         | BigDecimal 1       | BigDecimal 1 |   |
| "1.1"       | BigDecimal 1.1     | BigDecimal 1.1 |   |
| nil         | String ""          | nil | **Y** |
| false       | nil                | nil |   |
| true        | true (TrueClass) | nil | **Y** |
| ""          | String ""          | nil | **Y** |
| "other1"    | String "other"     | nil | **Y** |
| "NaN"       | BigDecimal NaN     | BigDecimal NaN |   |
| "Infinity"  | String "Infinity"  | BigDecimal Infinity  | **Y** |
| "-Infinity" | String "-Infinity" | BigDecimal -Infinity | **Y** |

### Mongoize

| Value to Mongoize | Current        | New | Behavior Changed? |
| ---            | ---            | --- | --- |
| BigDecimal 0   | String "0.0"   | String "0.0"  |   |
| BigDecimal -0  | String "-0.0"  | String "-0.0" |   |
| BigDecimal 1   | String "1"     | String "1"    |   |
| BigDecimal 1.1 | String "1.1"   | String "1.1"  |   |
| nil            | String ""      | nil | **Y** |
| false          | false (FalseClass) | nil | **Y** |
| true           | String "true"  | nil | **Y** |
| ""             | String ""      | nil | **Y** |
| "1"            | String "1"     | String "1"   |   |
| "1.1"          | String "1.1"   | String "1.1" |   |
| "other1"       | String "other" | nil | **Y** |
| String "NaN"         | String "NaN"       | String "NaN"       |   |
| String "Infinity"    | String "Infinity"  | String "Infinity"  |   |
| String "-Infinity"   | String "-Infinity" | String "-Infinity" |   |
| BigDecimal NaN       | String "NaN"       | String "NaN"       |   |
| BigDecimal Infinity  | String "Infinity"  | String "Infinity"  |   |
| BigDecimal -Infinity | String "-Infinity" | String "-Infinity" |   |
| Float::NAN           | String "NaN"       | String "NaN"       |   |
| Float::INFINITY      | String "Infinity"  | String "Infinity"  |   |
| Float::INFINITY * -1 | String "-Infinity" | String "-Infinity" |   |