### PR TITLE
add missing index options

### DIFF
--- a/lib/mongoid/indexable/validators/options.rb
+++ b/lib/mongoid/indexable/validators/options.rb
@@ -11,6 +11,7 @@ module Mongoid
           :background,
           :database,
           :default_language,
+          :language_override,
           :drop_dups,
           :name,
           :sparse,
@@ -20,7 +21,8 @@ module Mongoid
           :bits,
           :bucket_size,
           :expire_after_seconds,
-          :weights
+          :weights,
+          :storage_engine
         ]
 
         VALID_TYPES = [


### PR DESCRIPTION
specifically I was missing 'language_override' in my project and had to create the index manually
I've also add 'storage_engine' although I'm not sure what it does

based on
http://docs.mongodb.org/manual/reference/method/db.collection.createIndex/