### PR TITLE
Adapt index option mappings to new driver

### DIFF
--- a/lib/mongoid/indexable/specification.rb
+++ b/lib/mongoid/indexable/specification.rb
@@ -12,9 +12,7 @@ module Mongoid
       #
       # @since 4.0.0
       MAPPINGS = {
-        bucket_size: :bucketSize,
-        drop_dups: :dropDups,
-        expire_after_seconds: :expireAfterSeconds
+        expire_after_seconds: :expire_after
       }
 
       # @!attribute klass

--- a/spec/mongoid/indexable/specification_spec.rb
+++ b/spec/mongoid/indexable/specification_spec.rb
@@ -96,7 +96,7 @@ describe Mongoid::Indexable::Specification do
     end
 
     it "normalizes the options" do
-      expect(spec.options).to eq(background: true, dropDups: true)
+      expect(spec.options).to eq(background: true, drop_dups: true)
     end
   end
 end

--- a/spec/mongoid/indexable_spec.rb
+++ b/spec/mongoid/indexable_spec.rb
@@ -192,8 +192,8 @@ describe Mongoid::Indexable do
         klass.index_specification(name: 1).options
       end
 
-      it "sets the index with dropDups options" do
-        expect(options).to eq(dropDups: true)
+      it "sets the index with drop_dups option" do
+        expect(options).to eq(drop_dups: true)
       end
     end
 
@@ -327,7 +327,7 @@ describe Mongoid::Indexable do
       end
     end
 
-    context "when providing a geo haystack index" do
+    context "when providing a geo haystack index with a bucket_size" do
 
       before do
         klass.index({ location: "geoHaystack" }, { min: -200, max: 200, bucket_size: 0.5 })
@@ -337,8 +337,8 @@ describe Mongoid::Indexable do
         klass.index_specification(location: "geoHaystack").options
       end
 
-      it "sets the geo haystack index" do
-        expect(options).to eq({ min: -200, max: 200, bucketSize: 0.5 })
+      it "sets the geo haystack index with the bucket_size option" do
+        expect(options).to eq({ min: -200, max: 200, bucket_size: 0.5 })
       end
     end
 
@@ -490,8 +490,8 @@ describe Mongoid::Indexable do
         klass.index_specification(name: 1).options
       end
 
-      it "sets the index with sparse options" do
-        expect(options).to eq(expireAfterSeconds: 3600)
+      it "sets the index with expire_after option" do
+        expect(options).to eq(expire_after: 3600)
       end
     end
 


### PR DESCRIPTION
See [Mongo::Index::View::OPTIONS](https://github.com/mongodb/mongo-ruby-driver/blob/master/lib/mongo/index/view.rb#L48), [Mongo::Index::View#create_one](https://github.com/mongodb/mongo-ruby-driver/blob/master/lib/mongo/index/view.rb#L95) and
http://docs.mongodb.org/manual/reference/method/db.collection.createIndex/#ensureindex-options.