### PR TITLE
MONGOID-4157 Ensure that new clusters are not created when new client options are set

### DIFF
--- a/lib/mongoid/clients.rb
+++ b/lib/mongoid/clients.rb
@@ -13,11 +13,6 @@ module Mongoid
     include ThreadOptions
     include Options
 
-    # Options that a new client should be created with.
-    #
-    # @since 5.0.1
-    NEW_CLIENT_OPTS = [ :read, :write ]
-
     class << self
 
       # Clear all clients from the current thread.

--- a/lib/mongoid/clients.rb
+++ b/lib/mongoid/clients.rb
@@ -121,13 +121,8 @@ module Mongoid
       # @since 3.0.0
       def mongo_client
         client = Clients.with_name(client_name)
-        opts = {}
+        opts = self.persistence_options ? self.persistence_options.dup : {}
         opts.merge!(database: database_name) unless client.database.name.to_sym == database_name.to_sym
-        if self.persistence_options
-          self.persistence_options.each do |opt, value|
-            opts.merge!(opt => value) if NEW_CLIENT_OPTS.include?(opt)
-          end
-        end
         client.with(opts)
       end
       alias :mongo_session :mongo_client

--- a/lib/mongoid/clients.rb
+++ b/lib/mongoid/clients.rb
@@ -13,6 +13,11 @@ module Mongoid
     include ThreadOptions
     include Options
 
+    # Options that a new client should be created with.
+    #
+    # @since 5.0.1
+    NEW_CLIENT_OPTS = [ :read, :write ]
+
     class << self
 
       # Clear all clients from the current thread.
@@ -115,13 +120,15 @@ module Mongoid
       #
       # @since 3.0.0
       def mongo_client
-        name = client_name
-        client = Clients.with_name(name)
+        client = Clients.with_name(client_name)
+        opts = {}
+        opts.merge!(database: database_name) unless client.database.name.to_sym == database_name.to_sym
         if self.persistence_options
-          client.with(self.persistence_options.merge(database: database_name))
-        else
-          client.with(database: database_name)
+          self.persistence_options.each do |opt, value|
+            opts.merge!(opt => value) if NEW_CLIENT_OPTS.include?(opt)
+          end
         end
+        client.with(opts)
       end
       alias :mongo_session :mongo_client
       deprecate :mongo_session, :mongo_client, 2015, 12

--- a/spec/mongoid/clients/options_spec.rb
+++ b/spec/mongoid/clients/options_spec.rb
@@ -47,10 +47,6 @@ describe Mongoid::Clients::Options do
           it 'uses that collection' do
             expect(klass.collection.name).to eq(options[:collection])
           end
-
-          it 'does not create a new cluster' do
-            expect(klass.mongo_client.cluster).to be(cluster)
-          end
         end
       end
 

--- a/spec/mongoid/clients/options_spec.rb
+++ b/spec/mongoid/clients/options_spec.rb
@@ -8,6 +8,10 @@ describe Mongoid::Clients::Options do
 
       let(:options) { { database: 'test' } }
 
+      let!(:cluster) do
+        Band.mongo_client.cluster
+      end
+
       let!(:klass) do
         Band.with(options)
       end
@@ -32,6 +36,21 @@ describe Mongoid::Clients::Options do
 
         it "keeps the options" do
           expect(klass.persistence_options).to eq(options)
+        end
+
+        context 'when changing the collection' do
+
+          let(:options) do
+            { collection: 'other' }
+          end
+
+          it 'uses that collection' do
+            expect(klass.collection.name).to eq(options[:collection])
+          end
+
+          it 'does not create a new cluster' do
+            expect(klass.mongo_client.cluster).to be(cluster)
+          end
         end
       end
 
@@ -59,6 +78,7 @@ describe Mongoid::Clients::Options do
     let(:instance) do
       Band.new.with(options)
     end
+
 
     it "sets the options into" do
       expect(instance.persistence_options).to eq(options)

--- a/spec/mongoid/clients/options_spec.rb
+++ b/spec/mongoid/clients/options_spec.rb
@@ -79,7 +79,6 @@ describe Mongoid::Clients::Options do
       Band.new.with(options)
     end
 
-
     it "sets the options into" do
       expect(instance.persistence_options).to eq(options)
     end


### PR DESCRIPTION
This pull request solves a few problems:

- If #with is called on a Model, the database name is passed as an option to the new client as a Symbol. In the driver, the database name is a string, so [this line](https://github.com/mongodb/mongo-ruby-driver/blob/master/lib/mongo/client.rb#L324) will return false and a new cluster will be created. A new cluster means more monitoring threads.

- Arbitrary options passed to Mongo::Client#with, creating new clusters (and monitoring threads); if an option is passed to Mongo::Client#with that isn't even a valid option, a new cluster will be created because the option won't be a member of [this list](https://github.com/mongodb/mongo-ruby-driver/blob/master/lib/mongo/client.rb#L28).

- Mongoid now never calls #with on Mongo::Client with options that would create a new cluster. If Mongoid were to create clusters, it would have to keep track of them and stop their monitoring threads from Mongoid#disconnect_clients.

Update: with [this change](https://github.com/mongodb/mongo-ruby-driver/pull/701) to the driver, Mongoid won't have to whitelist the options it send to #with on the client.