### PR TITLE
[MONGOID-4169] Test case for distinct query crash

### DIFF
--- a/spec/mongoid/findable_spec.rb
+++ b/spec/mongoid/findable_spec.rb
@@ -485,4 +485,15 @@ describe Mongoid::Findable do
       end
     end
   end
+
+  it "able to apply distinct query on string fields" do
+    class Person
+      include Mongoid::Document 
+
+      field :name, type: String
+    end
+
+    Person.create(name: 'Siva')
+    expect(Person.distinct(:name)).to match_array(['Siva'])
+  end
 end


### PR DESCRIPTION
If you run this test case you would get this crash:

```
  undefined method `__metadata' for "Siva":String
     # ./lib/mongoid/relations/proxy.rb:141:in `characterize_one'
     # ./lib/mongoid/relations/embedded/one.rb:20:in `block in initialize'
     # ./lib/mongoid/relations/proxy.rb:42:in `init'
     # ./lib/mongoid/relations/embedded/one.rb:19:in `initialize'
     # ./lib/mongoid/relations/accessors.rb:44:in `new'
     # ./lib/mongoid/relations/accessors.rb:44:in `create_relation'
     # ./lib/mongoid/relations/accessors.rb:26:in `__build__'
     # ./lib/mongoid/relations/accessors.rb:233:in `block (2 levels) in setter'
     # ./lib/mongoid/relations/accessors.rb:140:in `without_autobuild'
     # ./lib/mongoid/relations/accessors.rb:229:in `block in setter'
     # ./lib/mongoid/attributes/processing.rb:144:in `block in process_relations'
     # ./lib/mongoid/attributes/processing.rb:139:in `each_pair'
     # ./lib/mongoid/attributes/processing.rb:139:in `process_relations'
     # ./lib/mongoid/attributes/processing.rb:125:in `process_pending'
     # ./lib/mongoid/attributes/processing.rb:29:in `process_attributes'
     # ./lib/mongoid/document.rb:109:in `block in initialize'
     # ./lib/mongoid/threaded/lifecycle.rb:89:in `_building'
     # ./lib/mongoid/document.rb:103:in `initialize'
     # ./lib/mongoid/persistable/creatable.rb:148:in `new'
     # ./lib/mongoid/persistable/creatable.rb:148:in `block in create'
     # ./lib/mongoid/threaded/lifecycle.rb:161:in `_creating'
     # ./lib/mongoid/persistable/creatable.rb:144:in `create'
     # ./spec/mongoid/findable_spec.rb:496:in `block (2 levels) in <top (required)>'

```