### PR TITLE
MONGOID-4190 Disconnect new clusters to avoid leaving monitor threads running in calls to Model#with

### DIFF
--- a/lib/mongoid/clients.rb
+++ b/lib/mongoid/clients.rb
@@ -111,6 +111,7 @@ module Mongoid
       #
       # @since 3.0.0
       def mongo_client
+        return client_with_options if client_with_options
         client = Clients.with_name(client_name)
         opts = self.persistence_options ? self.persistence_options.dup : {}
         if defined?(Mongo::Client::VALID_OPTIONS)

--- a/lib/mongoid/clients/options.rb
+++ b/lib/mongoid/clients/options.rb
@@ -176,10 +176,10 @@ module Mongoid
         #
         # @since 5.1.0
         def unset_client_with_options(klass)
-          if Thread.current["[mongoid][#{klass}]:mongo-client"]
-            Thread.current["[mongoid][#{klass}]:mongo-client"].close
+          if client = Thread.current["[mongoid][#{klass}]:mongo-client"]
+            client.close
+            Thread.current["[mongoid][#{klass}]:mongo-client"] = nil
           end
-          Thread.current["[mongoid][#{klass}]:mongo-client"] = nil
         end
 
         # Unset the persistence options and client with special options on the current thread.

--- a/spec/mongoid/clients/options_spec.rb
+++ b/spec/mongoid/clients/options_spec.rb
@@ -28,7 +28,7 @@ describe Mongoid::Clients::Options do
         expect(Band.new.persistence_options).to be_nil
       end
 
-      context 'when passed a block' do
+      context 'when passed a block', if: testing_locally? do
 
         let!(:connections_before) do
           Band.mongo_client.database.command(serverStatus: 1).first['connections']['current']

--- a/spec/mongoid/clients/options_spec.rb
+++ b/spec/mongoid/clients/options_spec.rb
@@ -28,6 +28,41 @@ describe Mongoid::Clients::Options do
         expect(Band.new.persistence_options).to be_nil
       end
 
+      context 'when passed a block' do
+
+        let!(:connections_before) do
+          Band.mongo_client.database.command(serverStatus: 1).first['connections']['current']
+        end
+
+        before do
+          Band.with(options) do |klass|
+            klass.where(name: 'emily').to_a
+          end
+        end
+
+        let(:connections_after) do
+          Band.mongo_client.database.command(serverStatus: 1).first['connections']['current']
+        end
+
+        context 'when a new cluster is created by the driver' do
+
+          let(:options) { { connect_timeout: 2 } }
+
+          it 'disconnects the new cluster' do
+            expect(connections_after).to eq(connections_before)
+          end
+        end
+
+        context 'when the same cluster is used by the new client' do
+
+          let(:options) { { database: 'same-cluster' } }
+
+          it 'does not disconnect the original cluster' do
+            expect(connections_after).to eq(connections_before)
+          end
+        end
+      end
+
       context "when calling .collection method" do
 
         before do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -71,6 +71,10 @@ def non_legacy_server?
   Mongoid::Clients.default.cluster.servers.first.features.write_command_enabled?
 end
 
+def testing_locally?
+  !(ENV['CI'] == 'travis')
+end
+
 # Set the database that the spec suite connects to.
 Mongoid.configure do |config|
   config.load_configuration(CONFIG)

--- a/spec/support/authorization.rb
+++ b/spec/support/authorization.rb
@@ -7,6 +7,7 @@ MONGOID_ROOT_USER = Mongo::Auth::User.new(
     Mongo::Auth::Roles::USER_ADMIN_ANY_DATABASE,
     Mongo::Auth::Roles::DATABASE_ADMIN_ANY_DATABASE,
     Mongo::Auth::Roles::READ_WRITE_ANY_DATABASE,
-    Mongo::Auth::Roles::HOST_MANAGER
+    Mongo::Auth::Roles::HOST_MANAGER,
+    Mongo::Auth::Roles::CLUSTER_MONITOR
   ]
 )


### PR DESCRIPTION
This goes in 5.1.0 so don't merge until later.