### PR TITLE
Support partial indexes.

### DIFF
--- a/lib/mongoid/indexable/validators/options.rb
+++ b/lib/mongoid/indexable/validators/options.rb
@@ -26,7 +26,8 @@ module Mongoid
           :key,
           :sphere_version,
           :text_version,
-          :version
+          :version,
+          :partial_filter_expression
         ]
 
         VALID_TYPES = [


### PR DESCRIPTION
Partial indexes were added in MongoDB 3.2 and ruby driver 2.2.