### PR TITLE
More complete enumerable marshaling

### DIFF
--- a/lib/mongoid/relations/targets/enumerable.rb
+++ b/lib/mongoid/relations/targets/enumerable.rb
@@ -340,7 +340,7 @@ module Mongoid
         #
         # @since 3.0.15
         def marshal_dump
-          [ _added, _loaded, _unloaded ]
+          [ _added, _loaded, _unloaded, @executed]
         end
 
         # Loads the data needed to Marshal.load an enumerable proxy.
@@ -352,7 +352,7 @@ module Mongoid
         #
         # @since 3.0.15
         def marshal_load(data)
-          @_added, @_loaded, @_unloaded = data
+          @_added, @_loaded, @_unloaded, @executed = data
         end
 
         # Reset the enumerable back to its persisted state.


### PR DESCRIPTION
Marshal state of @executed to allow for complete state saving. Without this, caching a query with .includes in it will raise error "undefined method `selector' for nil:NilClass" when trying to enumerate over the included part. Example:

```
def cached_users
  Rails.cache.fetch('users') do
    users.includes(:friends).entries
  end
end

# then elsewhere after the cache is populated

friends_group = cached_users.select { |u| u.friends.include? best_friend }
```