### PR TITLE
MONGOID-4196 Temporarily fix concurrency issues with persistence options. Redesign is needed.

### DIFF
--- a/lib/mongoid/clients/options.rb
+++ b/lib/mongoid/clients/options.rb
@@ -43,7 +43,8 @@ module Mongoid
       end
 
       def mongo_client
-        if opts = persistence_options && persistence_options.dup
+        tmp = persistence_options
+        if opts = tmp && tmp.dup
           if opts[:client]
             client = Clients.with_name(opts[:client])
           else

--- a/lib/mongoid/clients/options.rb
+++ b/lib/mongoid/clients/options.rb
@@ -43,14 +43,14 @@ module Mongoid
       end
 
       def mongo_client
-        if persistence_options
-          if persistence_options[:client]
-            client = Clients.with_name(persistence_options[:client])
+        if opts = persistence_options && persistence_options.dup
+          if opts[:client]
+            client = Clients.with_name(opts[:client])
           else
             client = Clients.with_name(self.class.client_name)
             client.use(self.class.database_name)
           end
-          client.with(persistence_options.reject{ |k, v| k == :collection || k == :client })
+          client.with(opts.reject{ |k, v| k == :collection || k == :client })
         end
       end
 


### PR DESCRIPTION
Redesign using a context object instead of class/instance variables is needed. We need to get rid of the use of Thread local variables. 