### PR TITLE
Prevent proxy's method_missing from running intentionally hidden methods by calling public_send

### DIFF
--- a/lib/mongoid/relations/proxy.rb
+++ b/lib/mongoid/relations/proxy.rb
@@ -147,7 +147,7 @@ module Mongoid
       # @param [ String, Symbol ] name The name of the method.
       # @param [ Array ] *args The arguments passed to the method.
       def method_missing(name, *args, &block)
-        target.send(name, *args, &block)
+        target.public_send(name, *args, &block)
       end
 
       # When the base document illegally references an embedded document this


### PR DESCRIPTION
Calling send directly allows for protected/private methods to be invoked, breaking encapsulation. Most other method_missing methods in mongoid either use respond_to? to prevent calling send or use public_send. I think public_send here is more appropriate. mongoid/relations/targets/enumerable's method_missing might also need this change as well.