### PR TITLE
Mongoid::Changeable#changes returns a hash with indifferent access.

### DIFF
--- a/lib/mongoid/changeable.rb
+++ b/lib/mongoid/changeable.rb
@@ -64,12 +64,12 @@ module Mongoid
     #
     # @since 2.4.0
     def changes
-      _changes = ActiveSupport::HashWithIndifferentAccess.new
+      _changes = {}
       changed.each do |attr|
         change = attribute_change(attr)
         _changes[attr] = change if change
       end
-      _changes
+      _changes.with_indifferent_access
     end
 
     # Call this method after save, so the changes can be properly switched.

--- a/lib/mongoid/changeable.rb
+++ b/lib/mongoid/changeable.rb
@@ -64,7 +64,7 @@ module Mongoid
     #
     # @since 2.4.0
     def changes
-      _changes = {}
+      _changes = ActiveSupport::HashWithIndifferentAccess.new
       changed.each do |attr|
         change = attribute_change(attr)
         _changes[attr] = change if change

--- a/spec/mongoid/changeable_spec.rb
+++ b/spec/mongoid/changeable_spec.rb
@@ -940,7 +940,7 @@ describe Mongoid::Changeable do
       end
 
       it "returns a hash with indifferent access" do
-        expect(person.changes["title"]).to eq(
+        expect(person.changes[:title]).to eq(
           [ nil, "Captain Obvious" ]
         )
       end


### PR DESCRIPTION
Mongoid::Changeable#changes should return a HashWithIndifferentAccess.
Or whether there is a reason to return the Hash it 's not HashWithIndifferentAccess?