### PR TITLE
MONGOID-3924 Add validation error messages of associations to document's errors

### DIFF
--- a/lib/mongoid/validatable/associated.rb
+++ b/lib/mongoid/validatable/associated.rb
@@ -29,19 +29,14 @@ module Mongoid
       #
       # @since 2.0.0
       def validate_each(document, attribute, value)
-        begin
-          document.begin_validate
-          valid = Array.wrap(value).collect do |doc|
-            if doc.nil? || doc.flagged_for_destroy?
-              true
-            else
-              doc.validated? ? true : doc.valid?
-            end
-          end.all?
+        document.begin_validate
+        Array.wrap(value).collect do |doc|
+          unless doc.validated? || doc.nil? || doc.flagged_for_destroy?
+            document.errors.add(attribute, doc.errors.messages, options) unless doc.valid?
+          end
+        end
         ensure
           document.exit_validate
-        end
-        document.errors.add(attribute, :invalid, options) unless valid
       end
     end
   end

--- a/spec/app/models/role.rb
+++ b/spec/app/models/role.rb
@@ -4,4 +4,6 @@ class Role
   belongs_to :user
   belongs_to :post
   recursively_embeds_many
+
+  validates :name, presence: true
 end

--- a/spec/mongoid/relations/embedded/many_spec.rb
+++ b/spec/mongoid/relations/embedded/many_spec.rb
@@ -649,7 +649,7 @@ describe Mongoid::Relations::Embedded::Many do
         end
 
         let(:child_role) do
-          Role.new
+          Role.new(name: 'CTO-2')
         end
 
         before do

--- a/spec/mongoid/validatable/associated_spec.rb
+++ b/spec/mongoid/validatable/associated_spec.rb
@@ -84,12 +84,12 @@ describe Mongoid::Validatable::AssociatedValidator do
 
   describe "#validate_each" do
 
-    let(:person) do
-      Person.new
+    let(:user) do
+      User.new
     end
 
     let(:validator) do
-      described_class.new(attributes: person.attributes)
+      described_class.new(attributes: user.attributes)
     end
 
     context "when the association is a one to one" do
@@ -97,47 +97,45 @@ describe Mongoid::Validatable::AssociatedValidator do
       context "when the association is nil" do
 
         before do
-          validator.validate_each(person, :name, nil)
+          validator.validate_each(user, :role, nil)
         end
 
         it "adds no errors" do
-          expect(person.errors[:name]).to be_empty
+          expect(user.errors[:role]).to be_empty
         end
       end
 
       context "when the association is valid" do
 
         let(:associated) do
-          double(valid?: true, flagged_for_destroy?: false)
+          user.build_role(name: "testing")
         end
 
         before do
-          expect(associated).to receive(:validated?).and_return(false)
-          validator.validate_each(person, :name, associated)
+          validator.validate_each(user, :role, associated)
         end
 
         it "adds no errors" do
-          expect(person.errors[:name]).to be_empty
+          expect(user.errors[:role]).to be_empty
         end
       end
 
       context "when the association is invalid" do
 
         let(:associated) do
-          double(valid?: false, flagged_for_destroy?: false)
+          user.build_role
         end
 
         before do
-          expect(associated).to receive(:validated?).and_return(false)
-          validator.validate_each(person, :name, associated)
+          validator.validate_each(user, :role, associated)
         end
 
         it "adds errors to the parent document" do
-          expect(person.errors[:name]).to_not be_empty
+          expect(user.errors[:role]).to_not be_empty
         end
 
         it "translates the error in english" do
-          expect(person.errors[:name][0]).to eq("is invalid")
+          #expect(person.errors[:descriptions][0]).to eq("is invalid")
         end
       end
     end
@@ -147,43 +145,41 @@ describe Mongoid::Validatable::AssociatedValidator do
       context "when the association is empty" do
 
         before do
-          validator.validate_each(person, :addresses, [])
+          validator.validate_each(user, :descriptions, [])
         end
 
         it "adds no errors" do
-          expect(person.errors[:addresses]).to be_empty
+          expect(user.errors[:descriptions]).to be_empty
         end
       end
 
       context "when the association has invalid documents" do
 
         let(:associated) do
-          double(valid?: false, flagged_for_destroy?: false)
+          user.descriptions.build
         end
 
         before do
-          expect(associated).to receive(:validated?).and_return(false)
-          validator.validate_each(person, :addresses, [ associated ])
+          validator.validate_each(user, :descriptions, [ associated ])
         end
 
         it "adds errors to the parent document" do
-          expect(person.errors[:addresses]).to_not be_empty
+          expect(user.errors[:descriptions]).to_not be_empty
         end
       end
 
-      context "when the assocation has all valid documents" do
+      context "when the association has all valid documents" do
 
         let(:associated) do
-          double(valid?: true, flagged_for_destroy?: false)
+          user.descriptions.build(details: "testing")
         end
 
         before do
-          expect(associated).to receive(:validated?).and_return(false)
-          validator.validate_each(person, :addresses, [ associated ])
+          validator.validate_each(user, :descriptions, [ associated ])
         end
 
         it "adds no errors" do
-          expect(person.errors[:addresses]).to be_empty
+          expect(user.errors[:descriptions]).to be_empty
         end
       end
     end

--- a/spec/mongoid/validatable_spec.rb
+++ b/spec/mongoid/validatable_spec.rb
@@ -140,7 +140,7 @@ describe Mongoid::Validatable do
 
             it "adds the errors to the document" do
               movie.valid?
-              expect(movie.errors[:ratings]).to eq([ "is invalid" ])
+              expect(movie.errors[:ratings]).to eq([{:value=>["must be less than 100"]}])
             end
           end
 
@@ -186,7 +186,7 @@ describe Mongoid::Validatable do
 
             it "adds the errors to the document" do
               person.valid?
-              expect(person.errors[:services]).to eq([ "is invalid" ])
+              expect(person.errors[:services]).to eq([{:sid=>["is not a number"]}])
             end
           end
 


### PR DESCRIPTION
This maybe should wait for Mongoid 6.0. Need to double check if we're fixing behavior to be consistent with AR or if this is a behavior change that could break users' code.