### PR TITLE
Method names containing hyphens are not valid

### DIFF
--- a/lib/mongoid/extensions/string.rb
+++ b/lib/mongoid/extensions/string.rb
@@ -117,7 +117,7 @@ module Mongoid
       #
       # @since 3.0.15
       def valid_method_name?
-        /[@$"]/ !~ self
+        /[@$"-]/ !~ self
       end
 
       # Does the string end with _before_type_cast?


### PR DESCRIPTION
Dynamic attributes relies on this regex to filter method name candidates that are valid to def: https://github.com/mongodb/mongoid/blob/master/lib/mongoid/attributes/dynamic.rb#L39