### PR TITLE
Update @since attributes for Mongoid client methods

### DIFF
--- a/lib/mongoid.rb
+++ b/lib/mongoid.rb
@@ -60,7 +60,7 @@ module Mongoid
   #
   # @return [ Mongo::Client ] The default client.
   #
-  # @since 3.0.0
+  # @since 5.0.0
   def default_client
     Clients.default
   end
@@ -72,7 +72,7 @@ module Mongoid
   #
   # @return [ true ] True.
   #
-  # @since 3.1.0
+  # @since 5.0.0
   def disconnect_clients
     Clients.disconnect
   end
@@ -84,7 +84,7 @@ module Mongoid
   #
   # @return [ Mongo::Client ] The named client.
   #
-  # @since 3.0.0
+  # @since 5.0.0
   def client(name)
     Clients.with_name(name)
   end


### PR DESCRIPTION
Those methods had the word session instead of client in versions prior mongoid 5.0.0.
Thus it is irritating to say that the method default_client is available since version 3.0.0, since I can't call it in versions 3.0.0 or 4.0.0.