### PR TITLE
Update the config template to reflect that ssl_verify is on by default

### DIFF
--- a/lib/rails/generators/mongoid/config/templates/mongoid.yml
+++ b/lib/rails/generators/mongoid/config/templates/mongoid.yml
@@ -92,7 +92,7 @@ development:
         # A passphrase for the private key.
         # ssl_key_pass_phrase: password
 
-        # Whether or not to do peer certification validation. (default: false)
+        # Whether or not to do peer certification validation. (default: true)
         # ssl_verify: true
 
         # The file containing a set of concatenated certification authority certifications


### PR DESCRIPTION
I had a problem recently where I couldn't connect to an SSL instance that used self-signed certificates. I found out that if I manually specify `ssl_verify: false`, it will connect, and if I specify `ssl_verify: true`, I get the same error as I did while using the default. Therefore I've determined that the default for this is actually true, not false, as it currently says in the config file. Changing the config file to reflect this will likely help others avoid headaches in the future.