### PR TITLE
[WIP] MONGOID-4251 Adding lookup to aggregate pipeline

### DIFF
--- a/lib/mongoid/contextual/mongo.rb
+++ b/lib/mongoid/contextual/mongo.rb
@@ -312,8 +312,12 @@ module Mongoid
         @criteria, @klass, @cache = criteria, criteria.klass, criteria.options[:cache]
         @collection = @klass.with(criteria.persistence_options || {}).collection
         criteria.send(:merge_type_selection)
-        @view = collection.find(criteria.selector)
-        apply_options
+        if criteria.aggregating?
+          @view = collection.aggregate(criteria.pipeline)
+        else
+          @view = collection.find(criteria.selector)
+          apply_options
+        end
       end
 
       delegate(:database_field_name, to: :@klass)

--- a/lib/mongoid/criteria/queryable/aggregable.rb
+++ b/lib/mongoid/criteria/queryable/aggregable.rb
@@ -71,6 +71,22 @@ module Mongoid
           end
         end
 
+        # Add a lookup ($lookUp) to the aggregation pipeline.
+        #
+        # @example Add a lookup to the pipeline.
+        #   aggregable.lookup(from: 'rightCollection', localField: 'leftVal', foreignField: 'rightVal', as: 'embeddedData')
+        #
+        # @param [ Hash ] criterion The lookup to make.
+        #
+        # @return [ Aggregable ] The aggregable.
+        #
+        # @since 3.2.0
+        def lookup(operation)
+          aggregation(operation) do |pipeline|
+            pipeline.lookup(operation)
+          end
+        end
+
         # Add an unwind ($unwind) to the aggregation pipeline.
         #
         # @example Add an unwind to the pipeline.

--- a/lib/mongoid/criteria/queryable/pipeline.rb
+++ b/lib/mongoid/criteria/queryable/pipeline.rb
@@ -68,6 +68,20 @@ module Mongoid
           push("$project" => evolve(entry))
         end
 
+        # Add the $lookup entry to the pipeline.
+        #
+        # @example Add the lookup.
+        #   pipeline.lookup(entry)
+        #
+        # @param [ Hash ] entry The left outer join.
+        #
+        # @return [ Pipeline ] The pipeline.
+        #
+        # @since 3.2.0
+        def lookup(entry)
+          push("$lookup" => evolve(entry))
+        end
+
         # Add the $unwind entry to the pipeline.
         #
         # @example Add the unwind.

--- a/lib/mongoid/version.rb
+++ b/lib/mongoid/version.rb
@@ -1,4 +1,4 @@
 # encoding: utf-8
 module Mongoid
-  VERSION = "6.0.0"
+  VERSION = "5.1.2"
 end


### PR DESCRIPTION
I wanted to use the mongo 3.2 lookup pipeline stage in an app and ran into some things that needed to be done. I'm very unfamiliar with mongoid's codebase, so looking for some suggestions on where some of this code would more appropriately go.

This actually manages to pass all of the important tests, but that, I think, is because I don't see the tests ever actually running aggregation queries. Very strange. The `Mongo::View::Aggregation` that is returned by collection.aggregate is not completely compatible with the `Mongo::View` that is returned by collection.find, which is also problematic.

I'd really like to see a `lookup(:relation)` construct that would make things much easier, including instantiating related documents as if they were embedded. I've worked around it in my own app by overriding the relation helpers, instantiating new objects if my keyword is present or manually building the criteria if not.

Ignore the version downgrade, that was something to make this work with an unrelated gem, would be removed before this is ready to actually merge (alternatively someone much more familiar with this codebase could take over implementing this and I can leave it behind)