### PR TITLE
Support ids array input in Selectable#in

### DIFF
--- a/lib/mongoid/criteria/queryable/selectable.rb
+++ b/lib/mongoid/criteria/queryable/selectable.rb
@@ -629,13 +629,14 @@ module Mongoid
         # @example Convert all the values to arrays.
         #   selectable.with_array_values({ key: 1...4 })
         #
-        # @param [ Hash ] criterion The criterion.
+        # @param [ Hash, Array ] criterion The criterion or array of ids.
         #
         # @return [ Hash ] The $in friendly criterion (array values).
         #
         # @since 1.0.0
         def with_array_values(criterion)
           return nil unless criterion
+          criterion = { _id: criterion } if criterion.is_a?(Array)
           criterion.each_pair do |key, value|
             criterion[key] = value.__array__
           end

--- a/spec/mongoid/criteria/queryable/selectable_spec.rb
+++ b/spec/mongoid/criteria/queryable/selectable_spec.rb
@@ -1371,6 +1371,23 @@ describe Mongoid::Criteria::Queryable::Selectable do
         end
       end
 
+      context "when providing an array without a field" do
+
+        let(:selection) do
+          query.in([ 1, 2 ])
+        end
+
+        it "adds the $in selector" do
+          expect(selection.selector).to eq({
+            "_id" =>  { "$in" => [ 1, 2 ] }
+          })
+        end
+
+        it "returns a cloned query" do
+          expect(selection).to_not equal(query)
+        end
+      end
+
       context "when providing a range" do
 
         let(:selection) do


### PR DESCRIPTION
Support ids array inputs for `in` method.

Example:

`User.in(['fake_id', 'fake_id_2'])` will now return an array of users with these ids instead of `undefined method 'each_pair' for []:Array`