### PR TITLE
MONGOID-4175 has_many first and last supporting legacy functionality

### DIFF
--- a/lib/mongoid/contextual/mongo.rb
+++ b/lib/mongoid/contextual/mongo.rb
@@ -265,7 +265,7 @@ module Mongoid
       #   context.geo_near([ 10, 10 ]).spherical
       #
       # @example Find with a max distance.
-      #   context.geo_near([ 10, 10 ]).max_distance(0.5n)
+      #   context.geo_near([ 10, 10 ]).max_distance(0.5)
       #
       # @example Provide a distance multiplier.
       #   context.geo_near([ 10, 10 ]).distance_multiplier(1133)
@@ -564,7 +564,6 @@ module Mongoid
       #
       # @since 3.1.0
       def apply_option(name)
-        #binding.pry
         if spec = criteria.options[name]
           @view = view.send(name, spec)
         end

--- a/spec/mongoid/contextual/mongo_spec.rb
+++ b/spec/mongoid/contextual/mongo_spec.rb
@@ -764,6 +764,92 @@ describe Mongoid::Contextual::Mongo do
         end
       end
 
+      context "with no criteria" do
+
+        let(:criteria) do
+          Band.all
+        end
+
+        let(:context) do
+          described_class.new(criteria)
+        end
+
+        context "when there is not criteria the context" do
+
+          it "returns the first object" do
+            expect(context.send(method)).to eq(depeche_mode)
+          end
+        end
+
+        context "when subsequently calling #last" do
+
+          it "returns the correct document" do
+            expect(context.send(method)).to eq(depeche_mode)
+            expect(context.last).to eq(new_order)
+          end
+        end
+      end
+
+      context 'with flag :none' do
+        context 'and no criteria' do
+          let(:criteria) do
+            Band.all
+          end
+
+          let(:context) do
+            described_class.new(criteria)
+          end
+
+          let(:flag) do
+            {sort: :none}
+          end
+
+          context "when there is not criteria the context" do
+
+            it "returns the first object" do
+              expect(context.send(method, flag)).to eq(depeche_mode)
+            end
+          end
+
+          context "when subsequently calling #last" do
+
+            it "returns the correct document" do
+              expect(context.send(method, flag)).to eq(depeche_mode)
+              expect(context.last(flag)).to eq(depeche_mode)
+            end
+          end
+        end
+
+        context 'and .sort criteria' do
+          let(:criteria) do
+            Band.desc(:name)
+          end
+
+          let(:context) do
+            described_class.new(criteria)
+          end
+
+          let(:flag) do
+            {sort: :none}
+          end
+
+          context "when there is not criteria the context" do
+
+            it "returns the first object" do
+              expect(context.send(method, flag)).to eq(new_order)
+            end
+          end
+
+          context "when subsequently calling #last" do
+
+            it "returns the correct document" do
+              expect(context.send(method, flag)).to eq(new_order)
+              expect(context.last(flag)).to eq(depeche_mode)
+            end
+          end
+        end
+      end
+
       context "when using .sort" do
 
         let(:criteria) do


### PR DESCRIPTION
Following the idea of thomas morgan in this ticket: https://jira.mongodb.org/browse/MONGOID-4175 
@pedroescudero and I have developed this fix for maintaining the legacy of #first and #last in has_many relationships with the new functionality removing the default sort criteria ({id_ 1}) with a flag called sort: :none.

We have plenty of applications with mongoid 4 and other SQL servers so to keep the same standard/behaviour if we want to upgrade the gem to v5 we think this solution allow to maintain the previous code without breaking all #last calls.

ex:
Band.all.first #legacy functionality, returns the first document with sort: {id: 1}
Band.all.last #legacy functionality, returns the last document with sort: {id: 1}

Band.all.first(sort: :none) #default functionality, returns the first document.
Band.all.last(sort: :none) #default functionality, returns the first document.