### PR TITLE
Demonstrate .first_or_create failure when scope includes special ($) operators

### DIFF
--- a/spec/mongoid/criteria/modifiable_spec.rb
+++ b/spec/mongoid/criteria/modifiable_spec.rb
@@ -623,6 +623,18 @@ describe Mongoid::Criteria::Modifiable do
           expect(document.map).to eq({ foo: :bar })
         end
       end
+
+      context 'when the criteria selector contains special ($) operators' do
+
+        let(:document) do
+          Person.in(aliases: "foobar").first_or_create(username: "foobar")
+        end
+
+        it 'ignore the special operator' do
+          expect(document.aliases).to eq(nil)
+          expect(document.username).to eq("foobar")
+        end
+      end
     end
   end
 


### PR DESCRIPTION
https://jira.mongodb.org/browse/MONGOID-3887 works well for "normal" scopes but fails when the scope includes special operators; i.e. query fragments such as `{ "$in" => … }`. Depending on configuration, this leads to data corruption (i.e. the field ends up containing `{ "$in" => … }`) or exceptions (when the field is configured not to allow `Hash` values).

This PR only demonstrates the problem to get the conversation started. I am unsure what the desired fix would be. See https://jira.mongodb.org/browse/MONGOID-4261 for discussion.