### PR TITLE
Fix Findable#last behavior

### DIFF
--- a/lib/mongoid/findable.rb
+++ b/lib/mongoid/findable.rb
@@ -156,7 +156,7 @@ module Mongoid
     #
     # @return [ Document ] The last matching document.
     def last
-      with_default_scope.last
+      with_default_scope.order([[:_id, 1]]).last
     end
   end
 end

--- a/spec/mongoid/findable_spec.rb
+++ b/spec/mongoid/findable_spec.rb
@@ -476,6 +476,42 @@ describe Mongoid::Findable do
     end
   end
 
+  describe ".first" do
+
+    before do
+      Band.create(name: "Tool")
+      Band.create(name: "Photek")
+    end
+
+    it "returns first record" do
+      expect(Band.first.name).to eq("Tool")
+    end
+
+    it "returns first record if an order is specified" do
+      expect(Band.order([[:name, 1]]).first.name).to eq("Photek")
+    end
+  end
+
+  describe ".last" do
+
+    before do
+      Band.create(name: "Tool")
+      Band.create(name: "Photek")
+    end
+
+    it "returns last record" do
+      expect(Band.last.name).to eq("Photek")
+    end
+
+    it "returns last record if an order is specified" do
+      expect(Band.order([[:name, 1]]).last.name).to eq("Tool")
+    end
+
+    it "returns last record if an id order is specified" do
+      expect(Band.order([[:_id, -1]]).last.name).to eq("Tool")
+    end
+  end
+
   Mongoid::Criteria::Queryable::Selectable.forwardables.each do |method|
 
     describe "##{method}" do


### PR DESCRIPTION
* Fix `Findable#last` behavior by specifying an `:_id` sort order.
* Added tests for `Findable#first` and `Findable#last`