### PR TITLE
MONGOID-3535 Allow explicitly loaded attributes to be changed. Take out entire doc readonly enforcement if #only or #without are used.

### DIFF
--- a/lib/mongoid/attributes.rb
+++ b/lib/mongoid/attributes.rb
@@ -139,14 +139,12 @@ module Mongoid
     #
     # @since 1.0.0
     def remove_attribute(name)
-      access = name.to_s
-      unless attribute_writable?(name)
-        raise Errors::ReadonlyAttribute.new(name, :nil)
-      end
-      _assigning do
-        attribute_will_change!(access)
-        delayed_atomic_unsets[atomic_attribute_name(access)] = [] unless new_record?
-        attributes.delete(access)
+      as_writable_attribute!(name) do |access|
+        _assigning do
+          attribute_will_change!(access)
+          delayed_atomic_unsets[atomic_attribute_name(access)] = [] unless new_record?
+          attributes.delete(access)
+        end
       end
     end
 
@@ -165,8 +163,7 @@ module Mongoid
     #
     # @since 1.0.0
     def write_attribute(name, value)
-      access = database_field_name(name.to_s)
-      if attribute_writable?(access)
+      as_writable_attribute!(name) do |access|
         _assigning do
           validate_attribute_value(access, value)
           localized = fields[access].try(:localized?)

--- a/lib/mongoid/attributes/readonly.rb
+++ b/lib/mongoid/attributes/readonly.rb
@@ -25,7 +25,7 @@ module Mongoid
       #
       # @deprecated Use #as_writable_attribute! instead.
       def attribute_writable?(name)
-          new_record? || !readonly_attributes.include?(database_field_name(name))
+        new_record? || !readonly_attributes.include?(database_field_name(name))
       end
 
       private

--- a/lib/mongoid/attributes/readonly.rb
+++ b/lib/mongoid/attributes/readonly.rb
@@ -22,8 +22,24 @@ module Mongoid
       #   readonly.
       #
       # @since 3.0.0
+      #
+      # @deprecated Use #as_writable_attribute! instead.
       def attribute_writable?(name)
-        new_record? || !readonly_attributes.include?(database_field_name(name))
+          new_record? || !readonly_attributes.include?(database_field_name(name))
+      end
+
+      private
+
+      def as_writable_attribute!(name, value = :nil)
+        normalized_name = database_field_name(name)
+        if !new_record? && (readonly_attributes.include?(normalized_name) || not_loaded?(normalized_name))
+          raise Errors::ReadonlyAttribute.new(name, value)
+        end
+        yield(normalized_name)
+      end
+
+      def not_loaded?(name)
+        __selected_fields && !__selected_fields.include?(name)
       end
 
       module ClassMethods

--- a/lib/mongoid/persistable.rb
+++ b/lib/mongoid/persistable.rb
@@ -165,12 +165,10 @@ module Mongoid
     # @since 4.0.0
     def process_atomic_operations(operations)
       operations.each do |field, value|
-        unless attribute_writable?(field)
-          raise Errors::ReadonlyAttribute.new(field, value)
+        as_writable_attribute!(field, value) do |access|
+          yield(access, value)
+          remove_change(access)
         end
-        normalized = database_field_name(field)
-        yield(normalized, value)
-        remove_change(normalized)
       end
     end
 

--- a/spec/app/models/person.rb
+++ b/spec/app/models/person.rb
@@ -36,6 +36,7 @@ class Person
   field :overridden_setter, type: String
   field :arrays, type: Array
   field :range, type: Range
+  field :species, type: Symbol
 
   index age: 1
   index addresses: 1

--- a/spec/mongoid/attributes/readonly_spec.rb
+++ b/spec/mongoid/attributes/readonly_spec.rb
@@ -2,49 +2,56 @@ require "spec_helper"
 
 describe Mongoid::Attributes::Readonly do
 
-  describe ".attr_readonly" do
+  before do
+    Person.attr_readonly(*attributes)
+  end
 
-    after do
-      Person.readonly_attributes.clear
+  after do
+    Person.readonly_attributes.reject! do |a|
+      [ attributes ].flatten.include?(a.to_sym) ||
+        [ attributes ].flatten.include?(Person.aliased_fields.key(a).to_sym)
     end
+  end
+
+  describe ".attr_readonly" do
 
     context "when providing a single field" do
 
-      before do
-        Person.attr_readonly :title
+      let(:attributes) do
+        :title
       end
 
       it "adds the field to readonly attributes" do
-        expect(Person.readonly_attributes.to_a).to eq([ "title" ])
+        expect(Person.readonly_attributes.to_a).to include("title")
       end
     end
 
     context "when providing a field alias" do
 
-      before do
-        Person.attr_readonly :aliased_timestamp
+      let(:attributes) do
+        :aliased_timestamp
       end
 
       it "adds the database field name to readonly attributes" do
-        expect(Person.readonly_attributes.to_a).to eq([ "at" ])
+        expect(Person.readonly_attributes.to_a).to include("at")
       end
     end
 
     context "when providing multiple fields" do
 
-      before do
-        Person.attr_readonly :title, :terms
+      let(:attributes) do
+        [ :title, :terms ]
       end
 
       it "adds the fields to readonly attributes" do
-        expect(Person.readonly_attributes.to_a).to eq([ "title", "terms" ])
+        expect(Person.readonly_attributes.to_a).to include("title", "terms")
       end
     end
 
     context "when creating a new document with a readonly field" do
 
-      before do
-        Person.attr_readonly :title, :terms, :aliased_timestamp
+      let(:attributes) do
+        [ :title, :terms, :aliased_timestamp ]
       end
 
       let(:person) do
@@ -78,8 +85,8 @@ describe Mongoid::Attributes::Readonly do
 
     context "when updating an existing readonly field" do
 
-      before do
-        Person.attr_readonly :title, :terms, :score, :aliased_timestamp
+      let(:attributes) do
+        [ :title, :terms, :score, :aliased_timestamp ]
       end
 
       let(:person) do
@@ -88,25 +95,31 @@ describe Mongoid::Attributes::Readonly do
 
       context "when updating via the setter" do
 
-        before do
-          person.title = "mr"
-          person.aliased_timestamp = Time.at(43)
-          person.save
-        end
-
         it "does not update the first field" do
+          expect {
+            person.title = 'mr'
+          }.to raise_exception(Mongoid::Errors::ReadonlyAttribute)
           expect(person.title).to eq("sir")
         end
 
         it "does not update the second field" do
+          expect {
+            person.aliased_timestamp = Time.at(43)
+          }.to raise_exception(Mongoid::Errors::ReadonlyAttribute)
           expect(person.aliased_timestamp).to eq(Time.at(42))
         end
 
         it "does not persist the first field" do
+          expect {
+            person.title = 'mr'
+          }.to raise_exception(Mongoid::Errors::ReadonlyAttribute)
           expect(person.reload.title).to eq("sir")
         end
 
         it "does not persist the second field" do
+          expect {
+            person.aliased_timestamp = Time.at(43)
+          }.to raise_exception(Mongoid::Errors::ReadonlyAttribute)
           expect(person.reload.aliased_timestamp).to eq(Time.at(42))
         end
       end
@@ -114,6 +127,7 @@ describe Mongoid::Attributes::Readonly do
       context "when updating via inc" do
 
         context 'with single field operation' do
+
           it "raises an error " do
             expect {
               person.inc(score: 1)
@@ -122,6 +136,7 @@ describe Mongoid::Attributes::Readonly do
         end
 
         context 'with multiple fields operation' do
+
           it "raises an error " do
             expect {
               person.inc(score: 1, age: 1)
@@ -133,6 +148,7 @@ describe Mongoid::Attributes::Readonly do
       context "when updating via bit" do
 
         context 'with single field operation' do
+
           it "raises an error " do
             expect {
               person.bit(score: { or: 13 })
@@ -141,6 +157,7 @@ describe Mongoid::Attributes::Readonly do
         end
 
         context 'with multiple fields operation' do
+
           it "raises an error " do
             expect {
               person.bit(
@@ -153,98 +170,124 @@ describe Mongoid::Attributes::Readonly do
 
       context "when updating via []=" do
 
-        before do
-          person[:title] = "mr"
-          person[:aliased_timestamp] = Time.at(43)
-          person.save
-        end
-
         it "does not update the first field" do
+          expect {
+            person[:title] = "mr"
+          }.to raise_exception(Mongoid::Errors::ReadonlyAttribute)
           expect(person.title).to eq("sir")
         end
 
         it "does not update the second field" do
+          expect {
+            person[:aliased_timestamp] = Time.at(43)
+          }.to raise_exception(Mongoid::Errors::ReadonlyAttribute)
           expect(person.aliased_timestamp).to eq(Time.at(42))
         end
 
         it "does not persist the first field" do
+          expect {
+            person[:title] = "mr"
+          }.to raise_exception(Mongoid::Errors::ReadonlyAttribute)
           expect(person.reload.title).to eq("sir")
         end
 
         it "does not persist the second field" do
+          expect {
+            person[:aliased_timestamp] = Time.at(43)
+          }.to raise_exception(Mongoid::Errors::ReadonlyAttribute)
           expect(person.reload.aliased_timestamp).to eq(Time.at(42))
         end
       end
 
       context "when updating via write_attribute" do
 
-        before do
-          person.write_attribute(:title, "mr")
-          person.write_attribute(:aliased_timestamp, Time.at(43))
-          person.save
-        end
-
         it "does not update the first field" do
+          expect {
+            person.write_attribute(:title, "mr")
+          }.to raise_exception(Mongoid::Errors::ReadonlyAttribute)
           expect(person.title).to eq("sir")
         end
 
         it "does not update the second field" do
+          expect {
+            person.write_attribute(:aliased_timestamp, Time.at(43))
+          }.to raise_exception(Mongoid::Errors::ReadonlyAttribute)
           expect(person.aliased_timestamp).to eq(Time.at(42))
         end
 
         it "does not persist the first field" do
+          expect {
+            person.write_attribute(:title, "mr")
+          }.to raise_exception(Mongoid::Errors::ReadonlyAttribute)
           expect(person.reload.title).to eq("sir")
         end
 
         it "does not persist the second field" do
+          expect {
+            person.write_attribute(:aliased_timestamp, Time.at(43))
+          }.to raise_exception(Mongoid::Errors::ReadonlyAttribute)
           expect(person.reload.aliased_timestamp).to eq(Time.at(42))
         end
       end
 
       context "when updating via update_attributes" do
 
-        before do
-          person.update_attributes(title: "mr", aliased_timestamp: Time.at(43))
-          person.save
-        end
-
         it "does not update the first field" do
+          expect {
+            person.update_attributes(title: "mr", aliased_timestamp: Time.at(43))
+          }.to raise_exception(Mongoid::Errors::ReadonlyAttribute)
           expect(person.title).to eq("sir")
         end
 
         it "does not update the second field" do
+          expect {
+            person.update_attributes(title: "mr", aliased_timestamp: Time.at(43))
+          }.to raise_exception(Mongoid::Errors::ReadonlyAttribute)
           expect(person.aliased_timestamp).to eq(Time.at(42))
         end
 
         it "does not persist the first field" do
+          expect {
+            person.update_attributes(title: "mr", aliased_timestamp: Time.at(43))
+          }.to raise_exception(Mongoid::Errors::ReadonlyAttribute)
           expect(person.reload.title).to eq("sir")
         end
 
         it "does not persist the second field" do
+          expect {
+            person.update_attributes(title: "mr", aliased_timestamp: Time.at(43))
+          }.to raise_exception(Mongoid::Errors::ReadonlyAttribute)
           expect(person.reload.aliased_timestamp).to eq(Time.at(42))
         end
       end
 
       context "when updating via update_attributes!" do
 
-        before do
-          person.update_attributes!(title: "mr", aliased_timestamp: Time.at(43))
-          person.save
-        end
-
         it "does not update the first field" do
+          expect {
+            person.update_attributes!(title: "mr", aliased_timestamp: Time.at(43))
+          }.to raise_exception(Mongoid::Errors::ReadonlyAttribute)
           expect(person.title).to eq("sir")
         end
 
         it "does not update the second field" do
+          expect {
+            person.update_attributes!(title: "mr", aliased_timestamp: Time.at(43))
+          }.to raise_exception(Mongoid::Errors::ReadonlyAttribute)
           expect(person.aliased_timestamp).to eq(Time.at(42))
         end
 
         it "does not persist the first field" do
+          expect {
+            person.update_attributes!(title: "mr", aliased_timestamp: Time.at(43))
+          }.to raise_exception(Mongoid::Errors::ReadonlyAttribute)
           expect(person.reload.title).to eq("sir")
         end
 
         it "does not persist the second field" do
+          expect {
+            person.update_attributes!(title: "mr", aliased_timestamp: Time.at(43))
+          }.to raise_exception(Mongoid::Errors::ReadonlyAttribute)
           expect(person.reload.aliased_timestamp).to eq(Time.at(42))
         end
       end

--- a/spec/mongoid/attributes_spec.rb
+++ b/spec/mongoid/attributes_spec.rb
@@ -1060,6 +1060,69 @@ describe Mongoid::Attributes do
         expect(person.delayed_atomic_unsets).to be_empty
       end
     end
+
+    context "when the attribute is aliased" do
+
+      context 'when the database name is used' do
+
+        let(:person) do
+          Person.create(at: Time.now)
+        end
+
+        before do
+          person.remove_attribute(:at)
+        end
+
+        it "removes the attribute" do
+          expect(person.at).to be_nil
+        end
+
+        it "removes the key from the attributes hash" do
+          expect(person.has_attribute?(:at)).to be false
+        end
+
+        context "when saving after the removal" do
+
+          before do
+            person.save
+          end
+
+          it "persists the removal" do
+            expect(person.reload.has_attribute?(:at)).to be false
+          end
+        end
+      end
+
+      context 'when the alias is used' do
+
+        let(:person) do
+          Person.create(aliased_timestamp: Time.now)
+        end
+
+        before do
+          person.remove_attribute(:aliased_timestamp)
+        end
+
+        it "removes the attribute" do
+          expect(person.aliased_timestamp).to be_nil
+        end
+
+        it "removes the key from the attributes hash" do
+          expect(person.has_attribute?(:aliased_timestamp)).to be false
+        end
+
+        context "when saving after the removal" do
+
+          before do
+            person.save
+          end
+
+          it "persists the removal" do
+            expect(person.reload.has_attribute?(:aliased_timestamp)).to be false
+          end
+        end
+      end
+    end
   end
 
   describe "#respond_to?" do

--- a/spec/mongoid/persistable/savable_spec.rb
+++ b/spec/mongoid/persistable/savable_spec.rb
@@ -295,20 +295,37 @@ describe Mongoid::Persistable::Savable do
       end
     end
 
-    context "when the document is readonly" do
-
-      let(:person) do
-        Person.only(:title).first
-      end
+    context "when the changed attribute is not writable" do
 
       before do
         Person.create(title: "sir")
       end
 
+      let(:person) do
+        Person.only(:title).first
+      end
+
       it "raises an error" do
         expect {
+          person.username = 'unloaded-attribute'
           person.save
-        }.to raise_error(Mongoid::Errors::ReadonlyDocument)
+        }.to raise_error(Mongoid::Errors::ReadonlyAttribute)
+      end
+
+      context 'when the changed attribute is aliased' do
+
+        before do
+          Person.create(at: Time.now)
+        end
+
+        let(:person) do
+          Person.only(:at).first
+        end
+
+        it "saves the document" do
+          person.aliased_timestamp = Time.now
+          expect(person.save).to be true
+        end
       end
     end
 
@@ -493,23 +510,6 @@ describe Mongoid::Persistable::Savable do
 
       it "properly sets up the entire hierarchy" do
         expect(from_db.shapes.first.canvas).to eq(firefox)
-      end
-    end
-
-    context "when the document is readonly" do
-
-      let(:person) do
-        Person.only(:title).first
-      end
-
-      before do
-        Person.create(title: "sir")
-      end
-
-      it "raises an error" do
-        expect {
-          person.save!
-        }.to raise_error(Mongoid::Errors::ReadonlyDocument)
       end
     end
   end

--- a/spec/mongoid/persistable/savable_spec.rb
+++ b/spec/mongoid/persistable/savable_spec.rb
@@ -324,7 +324,7 @@ describe Mongoid::Persistable::Savable do
 
         it "saves the document" do
           person.aliased_timestamp = Time.now
-          expect(person.save).to be true
+          expect(person.save(validate: false)).to be true
         end
       end
     end

--- a/spec/mongoid/persistable/updatable_spec.rb
+++ b/spec/mongoid/persistable/updatable_spec.rb
@@ -368,6 +368,52 @@ describe Mongoid::Persistable::Updatable do
         end
       end
     end
+
+    context 'when fields are explicitly not loaded' do
+
+      before do
+        Person.create(title: 'Captain')
+      end
+
+      context 'when the loaded attribute is updated' do
+
+        let(:person) do
+          Person.without(:age).first.tap do |_person|
+            _person.update_attribute(:title, 'Esteemed')
+          end
+        end
+
+        it 'allows the field to be updated' do
+          expect(person.title).to eq('Esteemed')
+        end
+
+        it 'persists the updated field' do
+          expect(person.reload.title).to eq('Esteemed')
+        end
+      end
+
+      context 'when the non-loaded attribute is updated' do
+
+        let(:person) do
+          Person.without(:title).first
+        end
+
+        it 'does not allow the field to be updated' do
+          expect {
+            person.update_attribute(:title, 20)
+          }.to raise_exception(ActiveModel::MissingAttributeError)
+        end
+
+        context 'when referring to the attribute with a string' do
+
+          it 'does not allow the field to be updated' do
+            expect {
+              person.update_attribute('title', 20)
+            }.to raise_exception(ActiveModel::MissingAttributeError)
+          end
+        end
+      end
+    end
   end
 
   [:update_attributes, :update].each do |method|

--- a/spec/mongoid/persistable/updatable_spec.rb
+++ b/spec/mongoid/persistable/updatable_spec.rb
@@ -269,6 +269,105 @@ describe Mongoid::Persistable::Updatable do
         expect(from_db.reload.name).to eq("home")
       end
     end
+
+    context 'when the field is read-only' do
+
+      before do
+        Person.attr_readonly :species
+      end
+
+      after do
+        Person.readonly_attributes.reject! { |a| a == 'species' }
+      end
+
+      let(:person) do
+        Person.create(species: :human)
+      end
+
+      it 'raises an error when trying to set the attribute' do
+        expect {
+          person.update_attribute(:species, :reptile)
+        }.to raise_exception(Mongoid::Errors::ReadonlyAttribute)
+      end
+
+      context 'when referring to the attribute with a string' do
+
+        it 'raises an error when trying to set the attribute' do
+          expect {
+            person.update_attribute('species', :reptile)
+          }.to raise_exception(Mongoid::Errors::ReadonlyAttribute)
+        end
+      end
+
+      context 'when the field is aliased' do
+
+        before do
+          Person.attr_readonly :at
+        end
+
+        after do
+          Person.readonly_attributes.reject! { |a| a == 'at' }
+        end
+
+        it 'raises an error when trying to set the attribute using the db name' do
+          expect {
+            person.update_attribute(:at, Time.now)
+          }.to raise_exception(Mongoid::Errors::ReadonlyAttribute)
+        end
+
+        it 'raises an error when trying to set the attribute using the aliased name' do
+          expect {
+            person.update_attribute(:aliased_timestamp, Time.now)
+          }.to raise_exception(Mongoid::Errors::ReadonlyAttribute)
+        end
+      end
+    end
+
+    context 'when the field is loaded explicitly' do
+
+      before do
+        Person.create(title: 'Captain')
+      end
+
+      context 'when the loaded attribute is updated' do
+
+        let(:person) do
+          Person.only(:title).first.tap do |_person|
+            _person.update_attribute(:title, 'Esteemed')
+          end
+        end
+
+        it 'allows the field to be updated' do
+          expect(person.title).to eq('Esteemed')
+        end
+
+        it 'persists the updated field' do
+          expect(person.reload.title).to eq('Esteemed')
+        end
+      end
+
+      context 'when the an attribute other than the loaded one is updated' do
+
+        let(:person) do
+          Person.only(:title).first
+        end
+
+        it 'does not allow the field to be updated' do
+          expect {
+            person.update_attribute(:age, 20)
+          }.to raise_exception(Mongoid::Errors::ReadonlyAttribute)
+        end
+
+        context 'when referring to the attribute with a string' do
+
+          it 'does not allow the field to be updated' do
+            expect {
+              person.update_attribute('age', 20)
+            }.to raise_exception(Mongoid::Errors::ReadonlyAttribute)
+          end
+        end
+      end
+    end
   end
 
   [:update_attributes, :update].each do |method|

--- a/spec/mongoid/persistable/updatable_spec.rb
+++ b/spec/mongoid/persistable/updatable_spec.rb
@@ -277,7 +277,7 @@ describe Mongoid::Persistable::Updatable do
       end
 
       after do
-        Person.readonly_attributes.reject! { |a| a == 'species' }
+        Person.readonly_attributes.reject! { |a| a.to_s == 'species' }
       end
 
       let(:person) do
@@ -306,7 +306,7 @@ describe Mongoid::Persistable::Updatable do
         end
 
         after do
-          Person.readonly_attributes.reject! { |a| a == 'at' }
+          Person.readonly_attributes.reject! { |a| a.to_s == 'at' }
         end
 
         it 'raises an error when trying to set the attribute using the db name' do
@@ -358,12 +358,20 @@ describe Mongoid::Persistable::Updatable do
           }.to raise_exception(Mongoid::Errors::ReadonlyAttribute)
         end
 
+        it 'does not persist the change' do
+          expect(person.reload.age).to eq(100)
+        end
+
         context 'when referring to the attribute with a string' do
 
           it 'does not allow the field to be updated' do
             expect {
               person.update_attribute('age', 20)
             }.to raise_exception(Mongoid::Errors::ReadonlyAttribute)
+          end
+
+          it 'does not persist the change' do
+            expect(person.reload.age).to eq(100)
           end
         end
       end
@@ -400,16 +408,24 @@ describe Mongoid::Persistable::Updatable do
 
         it 'does not allow the field to be updated' do
           expect {
-            person.update_attribute(:title, 20)
+            person.update_attribute(:title, 'Esteemed')
           }.to raise_exception(ActiveModel::MissingAttributeError)
+        end
+
+        it 'does not persist the change' do
+          expect(person.reload.title).to eq('Captain')
         end
 
         context 'when referring to the attribute with a string' do
 
           it 'does not allow the field to be updated' do
             expect {
-              person.update_attribute('title', 20)
+              person.update_attribute('title', 'Esteemed')
             }.to raise_exception(ActiveModel::MissingAttributeError)
+          end
+
+          it 'does not persist the change' do
+            expect(person.reload.title).to eq('Captain')
           end
         end
       end


### PR DESCRIPTION
This pull request adds the ability to change attributes that have been explicitly loaded using #only or #without. It takes out the behavior that such documents are entirely readonly.