### PR TITLE
MONGOID-4260 Fix regression with blank fields

### DIFF
--- a/lib/mongoid/attributes.rb
+++ b/lib/mongoid/attributes.rb
@@ -350,7 +350,7 @@ module Mongoid
       if localized_fields.has_key?(name)
         value = localized_fields[name].send(:lookup, value)
       end
-      !!value
+      value.present?
     end
   end
 end

--- a/spec/mongoid/attributes_spec.rb
+++ b/spec/mongoid/attributes_spec.rb
@@ -1652,6 +1652,16 @@ describe Mongoid::Attributes do
 
   context 'when calling the attribute check method' do
 
+    context 'when the attribute is blank' do
+      let(:person) do
+        Person.create(title: '')
+      end
+
+      it 'returns false' do
+        expect(person.title?).to be(false)
+      end
+    end
+
     context 'when the attribute is localized' do
       let(:person) do
         Person.create(desc: 'localized')


### PR DESCRIPTION
MONGOID-4260 introduced a regression when checking for presence on blank
fields. This PR switches back to the old lookup method and adds a spec
to prevent this issue in the future.

/cc @estolfo 

Please review my PR