### PR TITLE
MONGOID-4264 Require a belongs_to association by default and accept :required and :optional relation options

### DIFF
--- a/lib/mongoid/config.rb
+++ b/lib/mongoid/config.rb
@@ -25,6 +25,7 @@ module Mongoid
     option :use_activesupport_time_zone, default: true
     option :use_utc, default: false
     option :log_level, default: :info
+    option :belongs_to_required_by_default, default: true
 
     # Has Mongoid been configured? This is checking that at least a valid
     # client config exists.

--- a/lib/mongoid/relations/embedded/in.rb
+++ b/lib/mongoid/relations/embedded/in.rb
@@ -8,6 +8,11 @@ module Mongoid
       # multiple documents.
       class In < Relations::One
 
+        # The allowed options when defining this relation.
+        #
+        # @return [ Array<Symbol> ] The allowed options when defining this relation.
+        #
+        # @since 6.0.0
         VALID_OPTIONS = [
           :autobuild,
           :cyclic,

--- a/lib/mongoid/relations/embedded/in.rb
+++ b/lib/mongoid/relations/embedded/in.rb
@@ -8,6 +8,13 @@ module Mongoid
       # multiple documents.
       class In < Relations::One
 
+        VALID_OPTIONS = [
+          :autobuild,
+          :cyclic,
+          :polymorphic,
+          :touch
+         ].freeze
+
         # Instantiate a new embedded_in relation.
         #
         # @example Create the new relation.
@@ -209,7 +216,7 @@ module Mongoid
           #
           # @since 2.1.0
           def valid_options
-            [ :autobuild, :cyclic, :polymorphic, :touch ]
+            VALID_OPTIONS
           end
 
           # Get the default validation setting for the relation. Determines if

--- a/lib/mongoid/relations/embedded/many.rb
+++ b/lib/mongoid/relations/embedded/many.rb
@@ -10,6 +10,18 @@ module Mongoid
       class Many < Relations::Many
         include Batchable
 
+        VALID_OPTIONS = [
+          :as,
+          :cascade_callbacks,
+          :cyclic,
+          :order,
+          :store_as,
+          :before_add,
+          :after_add,
+          :before_remove,
+          :after_remove
+         ].freeze
+
         # Appends a document or array of documents to the relation. Will set
         # the parent and update the index in the process.
         #
@@ -618,10 +630,7 @@ module Mongoid
           #
           # @since 2.1.0
           def valid_options
-            [
-              :as, :cascade_callbacks, :cyclic, :order, :store_as,
-              :before_add, :after_add, :before_remove, :after_remove
-            ]
+            VALID_OPTIONS
           end
 
           # Get the default validation setting for the relation. Determines if

--- a/lib/mongoid/relations/embedded/many.rb
+++ b/lib/mongoid/relations/embedded/many.rb
@@ -10,6 +10,11 @@ module Mongoid
       class Many < Relations::Many
         include Batchable
 
+        # The allowed options when defining this relation.
+        #
+        # @return [ Array<Symbol> ] The allowed options when defining this relation.
+        #
+        # @since 6.0.0
         VALID_OPTIONS = [
           :as,
           :cascade_callbacks,

--- a/lib/mongoid/relations/embedded/one.rb
+++ b/lib/mongoid/relations/embedded/one.rb
@@ -7,6 +7,14 @@ module Mongoid
       # relations.
       class One < Relations::One
 
+        VALID_OPTIONS = [
+          :autobuild,
+          :as,
+          :cascade_callbacks,
+          :cyclic,
+          :store_as
+        ].freeze
+
         # Instantiate a new embeds_one relation.
         #
         # @example Create the new proxy.
@@ -202,7 +210,7 @@ module Mongoid
           #
           # @since 2.1.0
           def valid_options
-            [ :autobuild, :as, :cascade_callbacks, :cyclic, :store_as ]
+            VALID_OPTIONS
           end
 
           # Get the default validation setting for the relation. Determines if

--- a/lib/mongoid/relations/embedded/one.rb
+++ b/lib/mongoid/relations/embedded/one.rb
@@ -7,6 +7,11 @@ module Mongoid
       # relations.
       class One < Relations::One
 
+        # The allowed options when defining this relation.
+        #
+        # @return [ Array<Symbol> ] The allowed options when defining this relation.
+        #
+        # @since 6.0.0
         VALID_OPTIONS = [
           :autobuild,
           :as,

--- a/lib/mongoid/relations/macros.rb
+++ b/lib/mongoid/relations/macros.rb
@@ -140,6 +140,7 @@ module Mongoid
           aliased_fields[name.to_s] = meta.foreign_key
           touchable(meta)
           add_counter_cache_callbacks(meta) if meta.counter_cached?
+          validates(name, presence: true) if require_association?(options)
           meta
         end
 
@@ -352,6 +353,12 @@ module Mongoid
           Fields::Validators::Macro.validate_relation(self, name)
           self.relations = relations.merge(name.to_s => metadata)
           getter(name, metadata).setter(name, metadata).existence_check(name)
+        end
+
+        def require_association?(options = {})
+          required = options[:required] if options.key?(:required)
+          required = !options[:optional] if required.nil?
+          required.nil? ? Mongoid.belongs_to_required_by_default : required
         end
       end
     end

--- a/lib/mongoid/relations/macros.rb
+++ b/lib/mongoid/relations/macros.rb
@@ -357,7 +357,7 @@ module Mongoid
 
         def require_association?(options = {})
           required = options[:required] if options.key?(:required)
-          required = !options[:optional] if required.nil?
+          required = !options[:optional] if options.key?(:optional) && required.nil?
           required.nil? ? Mongoid.belongs_to_required_by_default : required
         end
       end

--- a/lib/mongoid/relations/options.rb
+++ b/lib/mongoid/relations/options.rb
@@ -17,7 +17,7 @@ module Mongoid
         :name,
         :relation,
         :validate
-      ]
+      ].freeze
 
       # Determine if the provided options are valid for the relation.
       #
@@ -32,7 +32,7 @@ module Mongoid
       #
       # @since 2.1.0
       def validate!(options)
-        valid_options = options[:relation].valid_options.concat(COMMON)
+        valid_options = options[:relation]::VALID_OPTIONS + COMMON
         options.keys.each do |key|
           if !valid_options.include?(key)
             raise Errors::InvalidOptions.new(

--- a/lib/mongoid/relations/referenced/in.rb
+++ b/lib/mongoid/relations/referenced/in.rb
@@ -10,6 +10,11 @@ module Mongoid
       class In < Relations::One
         include Evolvable
 
+        # The allowed options when defining this relation.
+        #
+        # @return [ Array<Symbol> ] The allowed options when defining this relation.
+        #
+        # @since 6.0.0
         VALID_OPTIONS = [
           :autobuild,
           :autosave,

--- a/lib/mongoid/relations/referenced/in.rb
+++ b/lib/mongoid/relations/referenced/in.rb
@@ -10,6 +10,19 @@ module Mongoid
       class In < Relations::One
         include Evolvable
 
+        VALID_OPTIONS = [
+          :autobuild,
+          :autosave,
+          :dependent,
+          :foreign_key,
+          :index,
+          :polymorphic,
+          :primary_key,
+          :touch,
+          :optional,
+          :required
+        ].freeze
+
         # Instantiate a new referenced_in relation.
         #
         # @example Create the new relation.
@@ -267,16 +280,7 @@ module Mongoid
           #
           # @since 2.1.0
           def valid_options
-            [
-              :autobuild,
-              :autosave,
-              :dependent,
-              :foreign_key,
-              :index,
-              :polymorphic,
-              :primary_key,
-              :touch
-            ]
+            VALID_OPTIONS
           end
 
           # Get the default validation setting for the relation. Determines if

--- a/lib/mongoid/relations/referenced/many.rb
+++ b/lib/mongoid/relations/referenced/many.rb
@@ -10,7 +10,11 @@ module Mongoid
         delegate :count, to: :criteria
         delegate :first, :in_memory, :last, :reset, :uniq, to: :target
 
-
+        # The allowed options when defining this relation.
+        #
+        # @return [ Array<Symbol> ] The allowed options when defining this relation.
+        #
+        # @since 6.0.0
         VALID_OPTIONS = [
           :after_add,
           :after_remove,

--- a/lib/mongoid/relations/referenced/many.rb
+++ b/lib/mongoid/relations/referenced/many.rb
@@ -10,6 +10,20 @@ module Mongoid
         delegate :count, to: :criteria
         delegate :first, :in_memory, :last, :reset, :uniq, to: :target
 
+
+        VALID_OPTIONS = [
+          :after_add,
+          :after_remove,
+          :as,
+          :autosave,
+          :before_add,
+          :before_remove,
+          :dependent,
+          :foreign_key,
+          :order,
+          :primary_key
+        ].freeze
+
         # Appends a document or array of documents to the relation. Will set
         # the parent and update the index in the process.
         #
@@ -730,18 +744,7 @@ module Mongoid
           #
           # @since 2.1.0
           def valid_options
-            [
-              :after_add,
-              :after_remove,
-              :as,
-              :autosave,
-              :before_add,
-              :before_remove,
-              :dependent,
-              :foreign_key,
-              :order,
-              :primary_key
-            ]
+            VALID_OPTIONS
           end
 
           # Get the default validation setting for the relation. Determines if

--- a/lib/mongoid/relations/referenced/many_to_many.rb
+++ b/lib/mongoid/relations/referenced/many_to_many.rb
@@ -7,6 +7,19 @@ module Mongoid
       # many-to-many between documents in different collections.
       class ManyToMany < Many
 
+        VALID_OPTIONS = [
+          :after_add,
+          :after_remove,
+          :autosave,
+          :before_add,
+          :before_remove,
+          :dependent,
+          :foreign_key,
+          :index,
+          :order,
+          :primary_key
+        ].freeze
+
         # Appends a document or array of documents to the relation. Will set
         # the parent and update the index in the process.
         #
@@ -439,18 +452,7 @@ module Mongoid
           #
           # @since 2.1.0
           def valid_options
-            [
-              :after_add,
-              :after_remove,
-              :autosave,
-              :before_add,
-              :before_remove,
-              :dependent,
-              :foreign_key,
-              :index,
-              :order,
-              :primary_key
-            ]
+            VALID_OPTIONS
           end
 
           # Get the default validation setting for the relation. Determines if

--- a/lib/mongoid/relations/referenced/many_to_many.rb
+++ b/lib/mongoid/relations/referenced/many_to_many.rb
@@ -7,6 +7,11 @@ module Mongoid
       # many-to-many between documents in different collections.
       class ManyToMany < Many
 
+        # The allowed options when defining this relation.
+        #
+        # @return [ Array<Symbol> ] The allowed options when defining this relation.
+        #
+        # @since 6.0.0
         VALID_OPTIONS = [
           :after_add,
           :after_remove,

--- a/lib/mongoid/relations/referenced/one.rb
+++ b/lib/mongoid/relations/referenced/one.rb
@@ -7,6 +7,11 @@ module Mongoid
       # one-to-one between documents in different collections.
       class One < Relations::One
 
+        # The allowed options when defining this relation.
+        #
+        # @return [ Array<Symbol> ] The allowed options when defining this relation.
+        #
+        # @since 6.0.0
         VALID_OPTIONS = [
           :as,
           :autobuild,

--- a/lib/mongoid/relations/referenced/one.rb
+++ b/lib/mongoid/relations/referenced/one.rb
@@ -7,6 +7,15 @@ module Mongoid
       # one-to-one between documents in different collections.
       class One < Relations::One
 
+        VALID_OPTIONS = [
+          :as,
+          :autobuild,
+          :autosave,
+          :dependent,
+          :foreign_key,
+          :primary_key
+        ].freeze
+
         # Instantiate a new references_one relation. Will set the foreign key
         # and the base on the inverse object.
         #
@@ -256,7 +265,7 @@ module Mongoid
           #
           # @since 2.1.0
           def valid_options
-            [ :as, :autobuild, :autosave, :dependent, :foreign_key, :primary_key ]
+            VALID_OPTIONS
           end
 
           # Get the default validation setting for the relation. Determines if

--- a/spec/config/mongoid.yml
+++ b/spec/config/mongoid.yml
@@ -22,3 +22,4 @@ test:
     use_activesupport_time_zone: true
     use_utc: false
     log_level: :warn
+    belongs_to_required_by_default: false

--- a/spec/mongoid/config_spec.rb
+++ b/spec/mongoid/config_spec.rb
@@ -91,7 +91,7 @@ describe Mongoid::Config do
     end
 
     it 'sets the Mongoid.belongs_to_required_by_default value to true' do
-      expect(Mongoid.belongs_to_required_by_default).to be(true)
+      expect(Mongoid.belongs_to_required_by_default).to be(false)
     end
   end
 

--- a/spec/mongoid/config_spec.rb
+++ b/spec/mongoid/config_spec.rb
@@ -115,7 +115,7 @@ describe Mongoid::Config do
       end
 
       let(:conf) do
-        CONFIG.merge( options: { belongs_to_required_by_default: true })
+        CONFIG.merge(options: { belongs_to_required_by_default: true })
       end
 
       it 'sets the Mongoid.belongs_to_required_by_default value to true' do
@@ -130,7 +130,7 @@ describe Mongoid::Config do
       end
 
       let(:conf) do
-        CONFIG.merge( options: { belongs_to_required_by_default: false })
+        CONFIG.merge(options: { belongs_to_required_by_default: false })
       end
 
       before do

--- a/spec/mongoid/config_spec.rb
+++ b/spec/mongoid/config_spec.rb
@@ -89,13 +89,14 @@ describe Mongoid::Config do
   context 'when the belongs_to_required_by_default option is not set in the config' do
 
     before do
+      Mongoid::Config.reset
       Mongoid.configure do |config|
-        config.load_configuration(CONFIG)
+        config.load_configuration(clients: CONFIG[:clients])
       end
     end
 
     it 'sets the Mongoid.belongs_to_required_by_default value to true' do
-      expect(Mongoid.belongs_to_required_by_default).to be(false)
+      expect(Mongoid.belongs_to_required_by_default).to be(true)
     end
   end
 
@@ -118,7 +119,7 @@ describe Mongoid::Config do
       end
 
       it 'sets the Mongoid.belongs_to_required_by_default value to true' do
-        expect(Mongoid.belongs_to_required_by_default).to be(conf[:options][:belongs_to_required_by_default])
+        expect(Mongoid.belongs_to_required_by_default).to be(true)
       end
     end
 
@@ -139,7 +140,7 @@ describe Mongoid::Config do
       end
 
       it 'sets the Mongoid.belongs_to_required_by_default value to false' do
-        expect(Mongoid.belongs_to_required_by_default).to be(conf[:options][:belongs_to_required_by_default])
+        expect(Mongoid.belongs_to_required_by_default).to be(false)
       end
     end
   end

--- a/spec/mongoid/config_spec.rb
+++ b/spec/mongoid/config_spec.rb
@@ -7,7 +7,9 @@ describe Mongoid::Config do
     if defined?(RailsTemp)
       Rails = RailsTemp
     end
+  end
 
+  after do
     Mongoid.configure do |config|
       config.load_configuration(CONFIG)
     end
@@ -110,10 +112,6 @@ describe Mongoid::Config do
 
     context 'when the value is set to true' do
 
-      let(:opts) do
-        { belongs_to_required_by_default: true }
-      end
-
       let(:conf) do
         CONFIG.merge(options: { belongs_to_required_by_default: true })
       end
@@ -124,10 +122,6 @@ describe Mongoid::Config do
     end
 
     context 'when the value is set to false' do
-
-      let(:opts) do
-        { belongs_to_required_by_default: true }
-      end
 
       let(:conf) do
         CONFIG.merge(options: { belongs_to_required_by_default: false })

--- a/spec/mongoid/config_spec.rb
+++ b/spec/mongoid/config_spec.rb
@@ -82,6 +82,64 @@ describe Mongoid::Config do
     end
   end
 
+  context 'when the belongs_to_required_by_default option is not set in the config' do
+
+    before do
+      Mongoid.configure do |config|
+        config.load_configuration(CONFIG)
+      end
+    end
+
+    it 'sets the Mongoid.belongs_to_required_by_default value to true' do
+      expect(Mongoid.belongs_to_required_by_default).to be(true)
+    end
+  end
+
+  context 'when the belongs_to_required_by_default option is set in the config' do
+
+    context 'when the value is set to true' do
+
+      let(:opts) do
+        { belongs_to_required_by_default: true }
+      end
+
+      let(:conf) do
+        CONFIG.merge( options: { belongs_to_required_by_default: true })
+      end
+
+      before do
+        Mongoid.configure do |config|
+          config.load_configuration(conf)
+        end
+      end
+
+      it 'sets the Mongoid.belongs_to_required_by_default value to true' do
+        expect(Mongoid.belongs_to_required_by_default).to be(conf[:options][:belongs_to_required_by_default])
+      end
+    end
+
+    context 'when the value is set to false' do
+
+      let(:opts) do
+        { belongs_to_required_by_default: true }
+      end
+
+      let(:conf) do
+        CONFIG.merge( options: { belongs_to_required_by_default: false })
+      end
+
+      before do
+        Mongoid.configure do |config|
+          config.load_configuration(conf)
+        end
+      end
+
+      it 'sets the Mongoid.belongs_to_required_by_default value to false' do
+        expect(Mongoid.belongs_to_required_by_default).to be(conf[:options][:belongs_to_required_by_default])
+      end
+    end
+  end
+
   describe "#load!" do
 
     before(:all) do

--- a/spec/mongoid/config_spec.rb
+++ b/spec/mongoid/config_spec.rb
@@ -7,6 +7,10 @@ describe Mongoid::Config do
     if defined?(RailsTemp)
       Rails = RailsTemp
     end
+
+    Mongoid.configure do |config|
+      config.load_configuration(CONFIG)
+    end
   end
 
   describe "#configured?" do
@@ -97,6 +101,12 @@ describe Mongoid::Config do
 
   context 'when the belongs_to_required_by_default option is set in the config' do
 
+    before do
+      Mongoid.configure do |config|
+        config.load_configuration(conf)
+      end
+    end
+
     context 'when the value is set to true' do
 
       let(:opts) do
@@ -105,12 +115,6 @@ describe Mongoid::Config do
 
       let(:conf) do
         CONFIG.merge( options: { belongs_to_required_by_default: true })
-      end
-
-      before do
-        Mongoid.configure do |config|
-          config.load_configuration(conf)
-        end
       end
 
       it 'sets the Mongoid.belongs_to_required_by_default value to true' do
@@ -173,12 +177,6 @@ describe Mongoid::Config do
 
       before do
         described_class.load!(file, :test)
-      end
-
-      after do
-        Mongoid.configure do |config|
-          config.load_configuration(CONFIG)
-        end
       end
 
       it "sets the Mongoid logger level" do

--- a/spec/mongoid/relations/macros_spec.rb
+++ b/spec/mongoid/relations/macros_spec.rb
@@ -16,6 +16,7 @@ describe Mongoid::Relations::Macros do
   end
 
   after do
+    klass.relations.clear
     klass.validators.clear
   end
 
@@ -333,7 +334,6 @@ describe Mongoid::Relations::Macros do
               let(:default_require) { true }
 
               it 'does not require the association' do
-                binding.pry
                 expect(relation.save).to be(true)
               end
             end

--- a/spec/mongoid/relations/macros_spec.rb
+++ b/spec/mongoid/relations/macros_spec.rb
@@ -508,7 +508,7 @@ describe Mongoid::Relations::Macros do
 
               let(:default_require) { false }
 
-              it 'does not require' do
+              it 'does not require the association' do
                 expect(relation.save).to be(true)
               end
             end
@@ -544,24 +544,21 @@ describe Mongoid::Relations::Macros do
 
     context 'when the relation does not have options' do
 
-      context 'when the relation does not have the option :optional' do
+      context 'when the default config is to require the association' do
 
-        context 'when the default config is to require the association' do
+        let(:default_require) { true }
 
-          let(:default_require) { true }
-
-          it 'requires the association' do
-            expect(relation.save).to be(false)
-          end
+        it 'requires the association' do
+          expect(relation.save).to be(false)
         end
+      end
 
-        context 'when the default config is to not require the association' do
+      context 'when the default config is to not require the association' do
 
-          let(:default_require) { false }
+        let(:default_require) { false }
 
-          it 'does not require the association' do
-            expect(relation.save).to be(true)
-          end
+        it 'does not require the association' do
+          expect(relation.save).to be(true)
         end
       end
     end

--- a/spec/mongoid/relations/macros_spec.rb
+++ b/spec/mongoid/relations/macros_spec.rb
@@ -281,7 +281,7 @@ describe Mongoid::Relations::Macros do
       _class.new
     end
 
-    let(:options) { {} }
+    let(:relation_options) { {} }
 
     let(:default_require) { Mongoid.belongs_to_required_by_default }
 
@@ -289,7 +289,7 @@ describe Mongoid::Relations::Macros do
       Mongoid.configure do |config|
         config.load_configuration(conf)
       end
-      _class.belongs_to(:person, options)
+      _class.belongs_to(:person, relation_options)
     end
 
     after do
@@ -314,7 +314,7 @@ describe Mongoid::Relations::Macros do
 
           context 'when :required is true' do
 
-            let(:options) do
+            let(:relation_options) do
               { required: true }
             end
 
@@ -339,7 +339,7 @@ describe Mongoid::Relations::Macros do
 
           context 'when :required is false' do
 
-            let(:options) do
+            let(:relation_options) do
               { required: false }
             end
 
@@ -369,7 +369,7 @@ describe Mongoid::Relations::Macros do
 
             context 'when :optional is true' do
 
-              let(:options) do
+              let(:relation_options) do
                 {
                   required: true,
                   optional: true
@@ -397,7 +397,7 @@ describe Mongoid::Relations::Macros do
 
             context 'when :optional is false' do
 
-              let(:options) do
+              let(:relation_options) do
                 {
                   required: true,
                   optional: false
@@ -428,7 +428,7 @@ describe Mongoid::Relations::Macros do
 
             context 'when :optional is true' do
 
-              let(:options) do
+              let(:relation_options) do
                 {
                   required: false,
                   optional: true
@@ -456,7 +456,7 @@ describe Mongoid::Relations::Macros do
 
             context 'when :optional is false' do
 
-              let(:options) do
+              let(:relation_options) do
                 {
                   required: false,
                   optional: false
@@ -491,7 +491,7 @@ describe Mongoid::Relations::Macros do
 
           context 'when :optional is true' do
 
-            let(:options) do
+            let(:relation_options) do
               { optional: true }
             end
 
@@ -516,7 +516,7 @@ describe Mongoid::Relations::Macros do
 
           context 'when :optional is false' do
 
-            let(:options) do
+            let(:relation_options) do
               { optional: false }
             end
 

--- a/spec/mongoid/relations/macros_spec.rb
+++ b/spec/mongoid/relations/macros_spec.rb
@@ -15,6 +15,10 @@ describe Mongoid::Relations::Macros do
     klass._validators.clear
   end
 
+  after do
+    klass.validators.clear
+  end
+
   describe ".embedded_in" do
 
     it "defines the macro" do
@@ -264,6 +268,310 @@ describe Mongoid::Relations::Macros do
 
     it "defines the macro" do
       expect(klass).to respond_to(:belongs_to)
+    end
+
+    context 'when the relation has options' do
+
+      before do
+        Mongoid.configure do |config|
+          config.load_configuration(conf)
+        end
+        klass.belongs_to(:person, options)
+      end
+
+      after(:all) do
+        Mongoid.configure do |config|
+          config.load_configuration(CONFIG)
+        end
+      end
+
+      let(:conf) do
+        CONFIG.merge( options: { belongs_to_required_by_default: default_require })
+      end
+
+      let(:relation) do
+        klass.new
+      end
+
+      context 'when the relation has the option :required' do
+
+        context 'when the relation does not have the :optional option' do
+
+          context 'when :required is true' do
+
+            let(:options) do
+              { required: true }
+            end
+
+            context 'when the default config is to require the association' do
+
+              let(:default_require) { true }
+
+              it 'requires the association' do
+                expect(relation.save).to be(false)
+              end
+            end
+
+            context 'when the default config is to not require the association' do
+
+              let(:default_require) { false }
+
+              it 'requires the association' do
+                expect(relation.save).to be(false)
+              end
+            end
+          end
+
+          context 'when :required is false' do
+
+            let(:options) do
+              { required: false }
+            end
+
+            context 'when the default config is to require the association' do
+
+              let(:default_require) { true }
+
+              it 'does not require the association' do
+                binding.pry
+                expect(relation.save).to be(true)
+              end
+            end
+
+            context 'when the default config is to not require the association' do
+
+              let(:default_require) { false }
+
+              it 'does not require the association' do
+                expect(relation.save).to be(true)
+              end
+            end
+          end
+        end
+
+        context 'when the relation has the option :optional' do
+
+          context 'when :required is true' do
+
+            context 'when :optional is true' do
+
+              let(:options) do
+                {
+                  required: true,
+                  optional: true
+                }
+              end
+
+              context 'when the default config is to require the association' do
+
+                let(:default_require) { true }
+
+                it 'requires the association' do
+                  expect(relation.save).to be(false)
+                end
+              end
+
+              context 'when the default config is to not require the association' do
+
+                let(:default_require) { false }
+
+                it 'requires the association' do
+                  expect(relation.save).to be(false)
+                end
+              end
+            end
+
+            context 'when :optional is false' do
+
+              let(:options) do
+                {
+                  required: true,
+                  optional: false
+                }
+              end
+
+              context 'when the default config is to require the association' do
+
+                let(:default_require) { true }
+
+                it 'requires the association' do
+                  expect(relation.save).to be(false)
+                end
+              end
+
+              context 'when the default config is to not require the association' do
+
+                let(:default_require) { false }
+
+                it 'requires the association' do
+                  expect(relation.save).to be(false)
+                end
+              end
+            end
+          end
+
+          context 'when :required is false' do
+
+            context 'when :optional is true' do
+
+              let(:options) do
+                {
+                  required: false,
+                  optional: true
+                }
+              end
+
+              context 'when the default config is to require the association' do
+
+                let(:default_require) { true }
+
+                it 'requires the association' do
+                  expect(relation.save).to be(false)
+                end
+              end
+
+              context 'when the default config is to not require the association' do
+
+                let(:default_require) { true }
+
+                it 'does not require the association' do
+                  expect(relation.save).to be(true)
+                end
+              end
+            end
+
+            context 'when :optional is false' do
+
+              let(:options) do
+                {
+                  required: false,
+                  optional: false
+                }
+              end
+
+              context 'when the default config is to require the association' do
+
+                let(:default_require) { true }
+
+                it 'does not require the association' do
+                  expect(relation.save).to be(true)
+                end
+              end
+
+              context 'when the default config is to not require the association' do
+
+                let(:default_require) { false }
+
+                it 'does not require the association' do
+                  expect(relation.save).to be(true)
+                end
+              end
+            end
+          end
+        end
+      end
+
+      context 'when the relation does not have the option :required' do
+
+        context 'when the relation has the option :optional' do
+
+          context 'when :optional is true' do
+
+            let(:options) do
+              { optional: true }
+            end
+
+            context 'when the default config is to require the association' do
+
+              let(:default_require) { true }
+
+              it 'requires the association' do
+                expect(relation.save).to be(true)
+              end
+            end
+
+            context 'when the default config is to not require the association' do
+
+              let(:default_require) { false }
+
+              it 'requires the association' do
+                expect(relation.save).to be(true)
+              end
+            end
+          end
+
+          context 'when :optional is false' do
+
+            let(:options) do
+              { optional: false }
+            end
+
+            context 'when the default config is to require the association' do
+
+              let(:default_require) { true }
+
+              it 'requires the association' do
+                expect(relation.save).to be(false)
+              end
+            end
+
+            context 'when the default config is to not require the association' do
+
+              let(:default_require) { false }
+
+              it 'requires the association' do
+                expect(relation.save).to be(false)
+              end
+            end
+          end
+        end
+      end
+    end
+
+
+    context 'when the relation does not have options' do
+
+      before do
+        Mongoid.configure do |config|
+          config.load_configuration(conf)
+        end
+        klass.belongs_to(:person)
+      end
+
+      after(:all) do
+        Mongoid.configure do |config|
+          config.load_configuration(CONFIG)
+        end
+      end
+
+      let(:conf) do
+        CONFIG.merge( options: { belongs_to_required_by_default: default_require })
+      end
+
+      let(:relation) do
+        klass.new
+      end
+
+      context 'when the relation does not have the option :optional' do
+
+        context 'when the default config is to require the association' do
+
+          let(:default_require) { true }
+
+          it 'requires the association' do
+            expect(relation.save).to be(false)
+          end
+        end
+
+        context 'when the default config is to not require the association' do
+
+          let(:default_require) { false }
+
+          it 'does not require the association' do
+            expect(relation.save).to be(true)
+          end
+        end
+      end
     end
 
     context "when the relation is polymorphic" do

--- a/spec/mongoid/relations/macros_spec.rb
+++ b/spec/mongoid/relations/macros_spec.rb
@@ -267,32 +267,46 @@ describe Mongoid::Relations::Macros do
 
   describe ".belongs_to" do
 
+    let(:_class) do
+      class RelationsTestClass
+        include Mongoid::Document
+      end
+    end
+
+    let(:conf) do
+      CONFIG.merge( options: { belongs_to_required_by_default: default_require })
+    end
+
+    let(:relation) do
+      _class.new
+    end
+
+    let(:options) { {} }
+
+    let(:default_require) { Mongoid.belongs_to_required_by_default }
+
+    before do
+      Mongoid.configure do |config|
+        config.load_configuration(conf)
+      end
+      _class.belongs_to(:person, options)
+    end
+
+    after do
+      Object.send(:remove_const, _class.name)
+    end
+
+    after(:all) do
+      Mongoid.configure do |config|
+        config.load_configuration(CONFIG)
+      end
+    end
+
     it "defines the macro" do
-      expect(klass).to respond_to(:belongs_to)
+      expect(_class).to respond_to(:belongs_to)
     end
 
     context 'when the relation has options' do
-
-      before do
-        Mongoid.configure do |config|
-          config.load_configuration(conf)
-        end
-        klass.belongs_to(:person, options)
-      end
-
-      after(:all) do
-        Mongoid.configure do |config|
-          config.load_configuration(CONFIG)
-        end
-      end
-
-      let(:conf) do
-        CONFIG.merge( options: { belongs_to_required_by_default: default_require })
-      end
-
-      let(:relation) do
-        klass.new
-      end
 
       context 'when the relation has the option :required' do
 
@@ -334,7 +348,7 @@ describe Mongoid::Relations::Macros do
               let(:default_require) { true }
 
               it 'does not require the association' do
-                expect(relation.save).to be(true)
+                expect(relation.save!).to be(true)
               end
             end
 
@@ -425,8 +439,8 @@ describe Mongoid::Relations::Macros do
 
                 let(:default_require) { true }
 
-                it 'requires the association' do
-                  expect(relation.save).to be(false)
+                it 'does not require the association' do
+                  expect(relation.save).to be(true)
                 end
               end
 
@@ -485,7 +499,7 @@ describe Mongoid::Relations::Macros do
 
               let(:default_require) { true }
 
-              it 'requires the association' do
+              it 'does not require the association' do
                 expect(relation.save).to be(true)
               end
             end
@@ -494,7 +508,7 @@ describe Mongoid::Relations::Macros do
 
               let(:default_require) { false }
 
-              it 'requires the association' do
+              it 'does not require' do
                 expect(relation.save).to be(true)
               end
             end
@@ -528,29 +542,7 @@ describe Mongoid::Relations::Macros do
       end
     end
 
-
     context 'when the relation does not have options' do
-
-      before do
-        Mongoid.configure do |config|
-          config.load_configuration(conf)
-        end
-        klass.belongs_to(:person)
-      end
-
-      after(:all) do
-        Mongoid.configure do |config|
-          config.load_configuration(CONFIG)
-        end
-      end
-
-      let(:conf) do
-        CONFIG.merge( options: { belongs_to_required_by_default: default_require })
-      end
-
-      let(:relation) do
-        klass.new
-      end
 
       context 'when the relation does not have the option :optional' do
 

--- a/spec/mongoid/relations/macros_spec.rb
+++ b/spec/mongoid/relations/macros_spec.rb
@@ -274,7 +274,7 @@ describe Mongoid::Relations::Macros do
     end
 
     let(:conf) do
-      CONFIG.merge( options: { belongs_to_required_by_default: default_require })
+      CONFIG.merge(options: { belongs_to_required_by_default: default_require })
     end
 
     let(:relation) do
@@ -348,7 +348,7 @@ describe Mongoid::Relations::Macros do
               let(:default_require) { true }
 
               it 'does not require the association' do
-                expect(relation.save!).to be(true)
+                expect(relation.save).to be(true)
               end
             end
 

--- a/spec/mongoid/relations/referenced/in_spec.rb
+++ b/spec/mongoid/relations/referenced/in_spec.rb
@@ -1066,7 +1066,9 @@ describe Mongoid::Relations::Referenced::In do
           :index,
           :polymorphic,
           :primary_key,
-          :touch
+          :touch,
+          :optional,
+          :required
         ]
       )
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -64,6 +64,9 @@ CONFIG = {
         auth_source: Mongo::Database::ADMIN,
       }
     }
+  },
+  options: {
+    belongs_to_required_by_default: false
   }
 }
 


### PR DESCRIPTION
ActiveRecord by default requires an association for belongs_to relations. This pull request implements that behavior in Mongoid as well.

Commit in Rails: https://github.com/rails/rails/pull/18937/files