### PR TITLE
MONGOID-4261 MONGOID-3887 Assign hash attributes in first_or_* methods on Criteria

### DIFF
--- a/lib/mongoid/criteria/modifiable.rb
+++ b/lib/mongoid/criteria/modifiable.rb
@@ -220,12 +220,16 @@ module Mongoid
       private
 
       def invalid_key?(hash, key)
-        key.to_s =~ BSON::String::ILLEGAL_KEY || hash.key?(key.to_sym) || hash.key?(key)
+        # @todo Change this to BSON::String::ILLEGAL_KEY when ruby driver 2.3.0 is
+        # released and mongoid is updated to depend on driver >= 2.3.0
+        key.to_s =~ Mongoid::Document::ILLEGAL_KEY || hash.key?(key.to_sym) || hash.key?(key)
       end
 
       def invalid_embedded_doc?(value)
+        # @todo Change this to BSON::String::ILLEGAL_KEY when ruby driver 2.3.0 is
+        # released and mongoid is updated to depend on driver >= 2.3.0
         value.is_a?(Hash) && value.any? do |key, v|
-          key.to_s =~ BSON::String::ILLEGAL_KEY || invalid_embedded_doc?(v)
+          key.to_s =~ Mongoid::Document::ILLEGAL_KEY || invalid_embedded_doc?(v)
         end
       end
     end

--- a/lib/mongoid/document.rb
+++ b/lib/mongoid/document.rb
@@ -31,6 +31,15 @@ module Mongoid
       Mongoid.register_model(self)
     end
 
+    # Regex for matching illegal BSON keys.
+    # Note that bson 4.1 has the constant BSON::String::ILLEGAL_KEY
+    # that should be used instead.
+    # When ruby driver 2.3.0 is released and Mongoid can be updated
+    # to require >= 2.3.0, the BSON constant can be used.
+    #
+    # @since 6.0.0
+    ILLEGAL_KEY = /(\A[$])|(\.)/.freeze
+
     # Freezes the internal attributes of the document.
     #
     # @example Freeze the document

--- a/spec/app/models/record.rb
+++ b/spec/app/models/record.rb
@@ -1,6 +1,7 @@
 class Record
   include Mongoid::Document
   field :name, type: String
+  field :producers, type: Array
 
   field :before_create_called, type: Mongoid::Boolean, default: false
   field :before_save_called, type: Mongoid::Boolean, default: false


### PR DESCRIPTION
depends on mongo >= 2.3, which depends on bson 4.1.1, so BSON::String::ILLEGAL_KEY can be referenced.

UPDATE: removed use of BSON::String::ILLEGAL_KEY and put in Mongoid's own constant so there's no dependency on driver 2.3