### PR TITLE
MONGOID-4160 Don't save the foreign key of a parent if it fails validation

### DIFF
--- a/lib/mongoid/relations/auto_save.rb
+++ b/lib/mongoid/relations/auto_save.rb
@@ -67,7 +67,11 @@ module Mongoid
                     if :belongs_to == metadata.macro
                       if changed_for_autosave?(relation)
                         relation.with(persistence_context) do |_relation|
-                          _relation.save
+                          unless _relation.save
+                            self.remove_attribute(metadata.foreign_key)
+                            self.send("#{metadata.name}=", nil)
+                            save(validate: false)
+                          end
                         end
                       end
                     else
@@ -87,7 +91,6 @@ module Mongoid
             after_save save_method, unless: :autosaved?
           end
         end
-
       end
     end
   end

--- a/spec/mongoid/relations/referenced/one_spec.rb
+++ b/spec/mongoid/relations/referenced/one_spec.rb
@@ -1237,4 +1237,37 @@ describe Mongoid::Relations::Referenced::One do
       end
     end
   end
+
+  context 'when the relation fails validations' do
+
+    let(:petal) do
+      petal = Petal.new
+      petal.flower = Flower.new
+      petal.save
+      petal
+    end
+
+    before do
+      class Flower
+        include Mongoid::Document
+
+        has_one :petal
+        field :type
+        validates :type, presence: true
+      end
+      class Petal
+        include Mongoid::Document
+        belongs_to :flower
+      end
+    end
+
+    after do
+      Object.send(:remove_const, :Flower)
+      Object.send(:remove_const, :Petal)
+    end
+
+    it 'does not save the foreign key of the unsaved object' do
+      expect(petal.reload.flower).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
This is not a good solution. Relations need to be refactored so that related objects are attempted to be saved first (as AR does)
This should not be merged, it just serves as an example of what you could do to make this work...