### PR TITLE
Don't assign empty documents to HasAndBelongsToMany association

### DIFF
--- a/lib/mongoid/relations/eager/has_and_belongs_to_many.rb
+++ b/lib/mongoid/relations/eager/has_and_belongs_to_many.rb
@@ -17,7 +17,7 @@ module Mongoid
 
           @docs.each do |d|
             keys = d.send(group_by_key)
-            docs = entries.values_at(*keys)
+            docs = entries.values_at(*keys).compact
             set_relation(d, docs)
           end
         end

--- a/spec/mongoid/relations/eager/has_and_belongs_to_many_spec.rb
+++ b/spec/mongoid/relations/eager/has_and_belongs_to_many_spec.rb
@@ -113,5 +113,21 @@ describe Mongoid::Relations::Eager::HasAndBelongsToMany do
         end
       end
     end
+
+    context "when some related documents no longer exist" do
+      before do
+        # Deleting the first one to meet Builders::Referenced::ManyToMany#query?
+        House.collection.find(_id: Person.first.house_ids.first).delete_one
+      end
+
+      it "does not accidentally trigger an extra query" do
+        expect_query(2) do
+          Person.asc(:_id).includes(:houses).each do |person|
+            expect(person.houses).to_not be_nil
+            expect(person.houses.length).to be(2)
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Because [`values_at`](http://ruby-doc.org/core-2.1.0/Hash.html#method-i-values_at) will return an `Array` of values corresponding to each key, and it's possible for a document to be removed from the database without updating the inverse document in a `has_and_belongs_to_many` association, using `includes` to eager load the association can assign `nil` in the list of documents.

Since that is not the behaviour when accessing a `has_and_belongs_to_many` association without eager loading (only the existing documents are loaded, no `nil`s), we should be consistent and do the same when eager loading.

I'd be interested in having this fix in _5.1_, let me know and I can make a PR 😃 