### PR TITLE
Mongo/Criteria map should use pluck, not only

### DIFF
--- a/lib/mongoid/contextual/mongo.rb
+++ b/lib/mongoid/contextual/mongo.rb
@@ -305,8 +305,7 @@ module Mongoid
         if block_given?
           super(&block)
         else
-          field = field.to_sym
-          criteria.only(field).map(&field.to_proc)
+          criteria.pluck(field)
         end
       end
 

--- a/spec/mongoid/contextual/mongo_spec.rb
+++ b/spec/mongoid/contextual/mongo_spec.rb
@@ -1089,11 +1089,6 @@ describe Mongoid::Contextual::Mongo do
 
     context "when passed the symbol field name" do
 
-      it "limits query to that field" do
-        expect(criteria).to receive(:only).with(:name).and_call_original
-        context.map(:name)
-      end
-
       it "performs mapping" do
         expect(context.map(:name)).to eq ["Depeche Mode", "New Order"]
       end


### PR DESCRIPTION
It's not safe to use `only` in a __lot__ (most?) cases. Back in the good ol' days (Mongoid 3) lazy-loading attributes worked as expected, so this would have been fine. However, `only` has essentially been producing invalid ORM objects since Mongoid 4. `map`'s behaviour needs to be changed to accomodate this.

Example crash caused by the existing `map` implementation:
```
> criteria.map :position
ActiveModel::MissingAttributeError: Missing attribute: 'type'.
	from /app/vendor/bundle/ruby/2.3.0/gems/mongoid-5.1.3/lib/mongoid/attributes.rb:97:in `read_attribute'
	from /app/vendor/bundle/ruby/2.3.0/gems/mongoid-5.1.3/lib/mongoid/fields.rb:414:in `block (2 levels) in create_field_getter'
	from /app/vendor/bundle/ruby/2.3.0/gems/enumerize-1.1.1/lib/enumerize/attribute.rb:86:in `type'
	from /app/vendor/bundle/ruby/2.3.0/gems/enumerize-1.1.1/lib/enumerize/base.rb:97:in `public_send'
	from /app/vendor/bundle/ruby/2.3.0/gems/enumerize-1.1.1/lib/enumerize/base.rb:97:in `block in _set_default_value_for_enumerized_attributes'
	from /app/vendor/bundle/ruby/2.3.0/gems/enumerize-1.1.1/lib/enumerize/attribute_map.rb:23:in `block in each'
	from /app/vendor/bundle/ruby/2.3.0/gems/enumerize-1.1.1/lib/enumerize/attribute_map.rb:22:in `each_pair'
	from /app/vendor/bundle/ruby/2.3.0/gems/enumerize-1.1.1/lib/enumerize/attribute_map.rb:22:in `each'
	from /app/vendor/bundle/ruby/2.3.0/gems/enumerize-1.1.1/lib/enumerize/base.rb:95:in `_set_default_value_for_enumerized_attributes'
	from /app/vendor/bundle/ruby/2.3.0/gems/activesupport-4.2.6/lib/active_support/callbacks.rb:432:in `block in make_lambda'
	from /app/vendor/bundle/ruby/2.3.0/gems/activesupport-4.2.6/lib/active_support/callbacks.rb:228:in `block in halting_and_conditional'
	from /app/vendor/bundle/ruby/2.3.0/gems/activesupport-4.2.6/lib/active_support/callbacks.rb:506:in `block in call'
	from /app/vendor/bundle/ruby/2.3.0/gems/activesupport-4.2.6/lib/active_support/callbacks.rb:506:in `each'
	from /app/vendor/bundle/ruby/2.3.0/gems/activesupport-4.2.6/lib/active_support/callbacks.rb:506:in `call'
	from /app/vendor/bundle/ruby/2.3.0/gems/activesupport-4.2.6/lib/active_support/callbacks.rb:92:in `__run_callbacks__'
	from /app/vendor/bundle/ruby/2.3.0/gems/activesupport-4.2.6/lib/active_support/callbacks.rb:778:in `_run_initialize_callbacks'
... 4 levels...
	from /app/vendor/bundle/ruby/2.3.0/gems/mongoid-5.1.3/lib/mongoid/contextual/mongo.rb:672:in `yield_document'
	from /app/vendor/bundle/ruby/2.3.0/gems/mongoid-5.1.3/lib/mongoid/contextual/mongo.rb:122:in `block in each'
	from /app/vendor/bundle/ruby/2.3.0/gems/mongo-2.2.5/lib/mongo/collection/view/iterable.rb:45:in `block in each'
	from /app/vendor/bundle/ruby/2.3.0/gems/mongo-2.2.5/lib/mongo/cursor.rb:85:in `block in each'
	from /app/vendor/bundle/ruby/2.3.0/gems/mongo-2.2.5/lib/mongo/cursor.rb:85:in `each'
	from /app/vendor/bundle/ruby/2.3.0/gems/mongo-2.2.5/lib/mongo/cursor.rb:85:in `each'
	from /app/vendor/bundle/ruby/2.3.0/gems/mongo-2.2.5/lib/mongo/collection/view/iterable.rb:44:in `each'
	from /app/vendor/bundle/ruby/2.3.0/gems/mongoid-5.1.3/lib/mongoid/query_cache.rb:207:in `each'
	from /app/vendor/bundle/ruby/2.3.0/gems/mongoid-5.1.3/lib/mongoid/contextual/mongo.rb:121:in `each'
	from /app/vendor/bundle/ruby/2.3.0/gems/mongoid-5.1.3/lib/mongoid/contextual/mongo.rb:295:in `map'
	from /app/vendor/bundle/ruby/2.3.0/gems/mongoid-5.1.3/lib/mongoid/contextual/mongo.rb:295:in `map'
	from /app/vendor/bundle/ruby/2.3.0/gems/mongoid-5.1.3/lib/mongoid/contextual.rb:20:in `map'
	from /app/vendor/bundle/ruby/2.3.0/gems/mongoid-5.1.3/lib/mongoid/contextual/mongo.rb:298:in `map'
	from /app/vendor/bundle/ruby/2.3.0/gems/mongoid-5.1.3/lib/mongoid/contextual.rb:20:in `map'
	from (irb):8
	from /app/bin/irb:15:in `<main>'
```

vs. the expected behaviour:

```
irb(main):009:0> criteria.map { |t| t.position }
=> [0]
```

This pull request utilises `pluck`, which is a safe work-around for `only`'s short-comings in this use case. 