### PR TITLE
Mongo/Criteria map should use pluck, not only

### DIFF
--- a/lib/mongoid/contextual/mongo.rb
+++ b/lib/mongoid/contextual/mongo.rb
@@ -294,8 +294,7 @@ module Mongoid
         if block_given?
           super(&block)
         else
-          field = field.to_sym
-          criteria.only(field).map(&field.to_proc)
+          criteria.pluck(field)
         end
       end
 

--- a/spec/mongoid/contextual/mongo_spec.rb
+++ b/spec/mongoid/contextual/mongo_spec.rb
@@ -1003,11 +1003,6 @@ describe Mongoid::Contextual::Mongo do
 
     context "when passed the symbol field name" do
 
-      it "limits query to that field" do
-        expect(criteria).to receive(:only).with(:name).and_call_original
-        context.map(:name)
-      end
-
       it "performs mapping" do
         expect(context.map(:name)).to eq ["Depeche Mode", "New Order"]
       end


### PR DESCRIPTION
Back-ported https://github.com/mongodb/mongoid/pull/4290 to 5.1.x.