### PR TITLE
Add sorting options to the cache key

### DIFF
--- a/lib/mongoid/query_cache.rb
+++ b/lib/mongoid/query_cache.rb
@@ -223,7 +223,7 @@ module Mongoid
 
       def cached_cursor
         if limit
-          key = [ collection.namespace, selector, nil, skip, projection ]
+          key = [ collection.namespace, selector, nil, skip, sort, projection ]
           cursor = QueryCache.cache_table[key]
           if cursor
             limited_docs = cursor.to_a[0...limit.abs]
@@ -234,7 +234,7 @@ module Mongoid
       end
 
       def cache_key
-        [ collection.namespace, selector, limit, skip, projection ]
+        [ collection.namespace, selector, limit, skip, sort, projection ]
       end
 
       def system_collection?

--- a/spec/mongoid/query_cache_spec.rb
+++ b/spec/mongoid/query_cache_spec.rb
@@ -262,6 +262,27 @@ describe Mongoid::QueryCache do
       end
     end
 
+    context "when sorting documents" do
+      before do
+        Band.asc(:id).to_a
+      end
+
+      context "with different selector" do
+
+        it "queries again" do
+          expect_query(1) do
+            Band.desc(:id).to_a
+          end
+        end
+      end
+
+      it "does not query again" do
+        expect_query(0) do
+          Band.asc(:id).to_a
+        end
+      end
+    end
+
     context "when query caching is enabled and the batch_size is set" do
 
       around(:each) do |example|


### PR DESCRIPTION
The `sort` option is not added to the cache key, leading to wrong results when querying a collection:

```ruby
Mongoid::QueryCache.enabled = true

Band.asc(:name).pluck(:name)
=> ["AC DC", "ZZ Top"]
Band.desc(:name).pluck(:name)
=> ["AC DC", "ZZ Top"]
```

This PR adds the hash returned by the `Mongoid::Criteria::Queryable::Options#sort` method to the cache key.