### PR TITLE
Make Proxy objects #equal? to themselves

### DIFF
--- a/lib/mongoid/relations/proxy.rb
+++ b/lib/mongoid/relations/proxy.rb
@@ -12,7 +12,7 @@ module Mongoid
       # We undefine most methods to get them sent through to the target.
       instance_methods.each do |method|
         undef_method(method) unless
-          method =~ /(^__|^send|^object_id|^respond_to|^tap|^public_send|extend_proxy|extend_proxies)/
+          method =~ /^(__.*|send|object_id|respond_to\?|tap|public_send|extend_proxy|extend_proxies)$/
       end
 
       include Threaded::Lifecycle

--- a/lib/mongoid/relations/proxy.rb
+++ b/lib/mongoid/relations/proxy.rb
@@ -12,7 +12,7 @@ module Mongoid
       # We undefine most methods to get them sent through to the target.
       instance_methods.each do |method|
         undef_method(method) unless
-          method =~ /^(__.*|send|object_id|respond_to\?|tap|public_send|extend_proxy|extend_proxies)$/
+          method =~ /^(__.*|send|object_id|equal\?|respond_to\?|tap|public_send|extend_proxy|extend_proxies)$/
       end
 
       include Threaded::Lifecycle

--- a/spec/mongoid/relations/proxy_spec.rb
+++ b/spec/mongoid/relations/proxy_spec.rb
@@ -97,4 +97,28 @@ describe Mongoid::Relations::Proxy do
       end
     end
   end
+
+  describe "equality" do
+    let(:messages) do
+      Person.create.messages
+    end
+
+    it "is #equal? to itself" do
+      expect(messages.equal?(messages)).to eq(true)
+    end
+
+    it "is == to itself" do
+      expect(messages == messages).to eq(true)
+    end
+
+    it "is not #equal? to its target" do
+      expect(messages.equal?(messages.target)).to eq(false)
+      expect(messages.target.equal?(messages)).to eq(false)
+    end
+
+    it "is == to its target" do
+      expect(messages == messages.target).to eq(true)
+      expect(messages.target == messages).to eq(true)
+    end
+  end
 end


### PR DESCRIPTION
This makes #object_id and #equals? consistent with each other so they are both always called against the Proxy.

Another possibility would be to pass through #object_id and #equals? to the target so that the Proxy and its target would look like the exact same object. This seems more likely to cause confusion/problems since they aren't actually the exact same object, and the code has being calling #object_id on the Proxy for a long time. 

The first commit rewrites the regex slightly. It now always does an exact match except for '__' prefixes. I'm happy to undo that refactoring if there is a reason the old way was better or more correct.