### PR TITLE
Embedded field changes should be persisted by set

### DIFF
--- a/lib/mongoid/persistable/settable.rb
+++ b/lib/mongoid/persistable/settable.rb
@@ -23,7 +23,7 @@ module Mongoid
         prepare_atomic_operation do |ops|
           process_atomic_operations(setters) do |field, value|
             process_attribute(field.to_s, value)
-            ops[atomic_attribute_name(field)] = attributes[field]
+            ops[atomic_attribute_name(field)] = value
           end
           { "$set" => ops }
         end

--- a/spec/mongoid/persistable/settable_spec.rb
+++ b/spec/mongoid/persistable/settable_spec.rb
@@ -137,6 +137,34 @@ describe Mongoid::Persistable::Settable do
     end
   end
 
+  context "when the document has embedded fields" do
+    let(:person) do
+      Person.create
+    end
+
+    let(:pet) do
+      Animal.new(name: "somepet")
+    end
+
+    let(:home_phone) do
+      Phone.new(number: "555-555-5555")
+    end
+
+    let(:office_phone) do
+      Phone.new(number: "666-666-6666")
+    end
+
+    it "should persist changes of embeds_one field" do
+      person.set({pet: pet.as_document})
+      expect(person.reload.pet).to eq(pet)
+    end
+
+    it "should persist changes of embeds_many fields" do
+      person.set({ phone_numbers: [home_phone, office_phone].map { |p| p.as_document} })
+      expect(person.reload.phone_numbers).to eq([home_phone, office_phone])
+    end
+  end
+
   context "when dynamic attributes are not enabled" do
     let(:account) do
       Account.create


### PR DESCRIPTION
Related ticket: https://jira.mongodb.org/browse/MONGOID-4300

Not sure this is a valid fix. This PR is for discussion for now.

When using mongoid in our project, we use `set` to persist certain embedded fields that are of one-to-one relationship. I found that in `settable.rb`, changes to these fields are ignored since `attributes[field]` won't have the updated value for embedded fields, instead `nil` is assigned to these fields.

This PR might have some hidden issues that I am not aware of, please take a look and let me know what you think. Thanks @estolfo 