### PR TITLE
#only and #without methods should not be scoped to specific locales, unless user explicitly does so.

### DIFF
--- a/lib/mongoid/attributes.rb
+++ b/lib/mongoid/attributes.rb
@@ -245,19 +245,11 @@ module Mongoid
     private
 
     def selection_excluded?(name, selection, field)
-      if field && field.localized?
-        selection["#{name}.#{::I18n.locale}"] == 0
-      else
-        selection[name] == 0
-      end
+      selection[name] == 0
     end
 
     def selection_included?(name, selection, field)
-      if field && field.localized?
-        selection.key?("#{name}.#{::I18n.locale}")
-      else
-        selection.key?(name) || selection.keys.collect { |k| k.partition('.').first }.include?(name)
-      end
+      selection.key?(name) || selection.keys.collect { |k| k.partition('.').first }.include?(name)
     end
 
     # Does the string contain dot syntax for accessing hashes?

--- a/lib/mongoid/criteria/queryable/optional.rb
+++ b/lib/mongoid/criteria/queryable/optional.rb
@@ -147,7 +147,9 @@ module Mongoid
           args = args.flatten
           option(*args) do |options|
             options.store(
-              :fields, args.inject(options[:fields] || {}){ |sub, field| sub.tap { sub[field] = 1 }}
+              :fields,
+              args.inject(options[:fields] || {}){ |sub, field| sub.tap { sub[field] = 1 }},
+              false
             )
           end
         end
@@ -279,7 +281,9 @@ module Mongoid
           args = args.flatten
           option(*args) do |options|
             options.store(
-              :fields, args.inject(options[:fields] || {}){ |sub, field| sub.tap { sub[field] = 0 }}
+              :fields,
+              args.inject(options[:fields] || {}){ |sub, field| sub.tap { sub[field] = 0 }},
+              false
             )
           end
         end

--- a/lib/mongoid/criteria/queryable/options.rb
+++ b/lib/mongoid/criteria/queryable/options.rb
@@ -67,8 +67,8 @@ module Mongoid
         # @return [ Object ] The stored object.
         #
         # @since 1.0.0
-        def store(key, value)
-          super(key, evolve(value))
+        def store(key, value, localize = true)
+          super(key, evolve(value, localize))
         end
         alias :[]= :store
 
@@ -102,10 +102,10 @@ module Mongoid
         # @return [ Object ] The serialized object.
         #
         # @since 1.0.0
-        def evolve(value)
+        def evolve(value, localize = true)
           case value
           when Hash
-            evolve_hash(value)
+            evolve_hash(value, localize)
           else
             value
           end
@@ -123,10 +123,11 @@ module Mongoid
         # @return [ Object ] The serialized hash.
         #
         # @since 1.0.0
-        def evolve_hash(value)
+        def evolve_hash(value, localize = true)
           value.inject({}) do |hash, (field, _value)|
             name, serializer = storage_pair(field)
-            hash[normalized_key(name, serializer)] = _value
+            name = localized_key(name, serializer) if localize
+            hash[name] = _value
             hash
           end
         end

--- a/lib/mongoid/criteria/queryable/selector.rb
+++ b/lib/mongoid/criteria/queryable/selector.rb
@@ -48,7 +48,7 @@ module Mongoid
           if multi_selection?(name)
             super(name, evolve_multi(value))
           else
-            super(normalized_key(name, serializer), evolve(serializer, value))
+            super(localized_key(name, serializer), evolve(serializer, value))
           end
         end
         alias :[]= :store
@@ -87,7 +87,7 @@ module Mongoid
             Hash[val.map do |key, _value|
               _value = evolve_multi(_value) if multi_selection?(key)
               name, serializer = storage_pair(key)
-              [ normalized_key(name, serializer), evolve(serializer, _value) ]
+              [ localized_key(name, serializer), evolve(serializer, _value) ]
             end]
           end.uniq
         end

--- a/lib/mongoid/criteria/queryable/smash.rb
+++ b/lib/mongoid/criteria/queryable/smash.rb
@@ -60,13 +60,14 @@ module Mongoid
 
         private
 
-        # Get the normalized value for the key. If localization is in play the
-        # current locale will be appended to the key in MongoDB dot notation.
+        # Get the localized value for the key if needed. If the field uses
+        # localization the current locale will be appended to the key in
+        # MongoDB dot notation.
         #
         # @api private
         #
         # @example Get the normalized key name.
-        #   smash.normalized_key("field", serializer)
+        #   smash.localized_key("field", serializer)
         #
         # @param [ String ] name The name of the field.
         # @param [ Object ] serializer The optional field serializer.
@@ -74,7 +75,7 @@ module Mongoid
         # @return [ String ] The normalized key.
         #
         # @since 1.0.0
-        def normalized_key(name, serializer)
+        def localized_key(name, serializer)
           serializer && serializer.localized? ? "#{name}.#{::I18n.locale}" : name
         end
 

--- a/spec/mongoid/criteria_spec.rb
+++ b/spec/mongoid/criteria_spec.rb
@@ -2809,7 +2809,7 @@ describe Mongoid::Criteria do
         I18n.locale = :en
         d = Dictionary.create(description: 'english-text')
         I18n.locale = :de
-        d.reload.description = 'deutsch-text'
+        d.description = 'deutsch-text'
         d.save
       end
 
@@ -3128,7 +3128,7 @@ describe Mongoid::Criteria do
         I18n.locale = :en
         d = Dictionary.create(description: 'english-text')
         I18n.locale = :de
-        d.reload.description = 'deutsch-text'
+        d.description = 'deutsch-text'
         d.save
       end
 

--- a/spec/mongoid/criteria_spec.rb
+++ b/spec/mongoid/criteria_spec.rb
@@ -2802,6 +2802,93 @@ describe Mongoid::Criteria do
         end
       end
     end
+
+    context 'when the field is localized' do
+
+      before do
+        I18n.locale = :en
+        d = Dictionary.create(description: 'english-text')
+        I18n.locale = :de
+        d.reload.description = 'deutsch-text'
+        d.save
+      end
+
+      after do
+        I18n.locale = :en
+      end
+
+      context 'when entire field is included' do
+
+        let(:dictionary) do
+          Dictionary.only(:description).first
+
+        end
+
+        it 'loads all translations' do
+          expect(dictionary.description_translations.keys).to include('de', 'en')
+        end
+
+        it 'returns the field value for the current locale' do
+          I18n.locale = :en
+          expect(dictionary.description).to eq('english-text')
+          I18n.locale = :de
+          expect(dictionary.description).to eq('deutsch-text')
+        end
+      end
+
+      context 'when a specific locale is included' do
+
+        let(:dictionary) do
+          Dictionary.only(:'description.de').first
+        end
+
+        it 'loads translations only for the included locale' do
+          expect(dictionary.description_translations.keys).to include('de')
+          expect(dictionary.description_translations.keys).to_not include('en')
+        end
+
+        it 'returns the field value for the included locale' do
+          I18n.locale = :en
+          expect(dictionary.description).to be_nil
+          I18n.locale = :de
+          expect(dictionary.description).to eq('deutsch-text')
+        end
+      end
+
+      context 'when entire field is excluded' do
+
+        let(:dictionary) do
+          Dictionary.without(:description).first
+        end
+
+        it 'does not load all translations' do
+          expect(dictionary.description_translations.keys).to_not include('de', 'en')
+        end
+
+        it 'raises an ActiveModel::MissingAttributeError when attempting to access the field' do
+          expect{dictionary.description}.to raise_error ActiveModel::MissingAttributeError
+        end
+      end
+
+      context 'when a specific locale is excluded' do
+
+        let(:dictionary) do
+          Dictionary.without(:'description.de').first
+        end
+
+        it 'does not load excluded translations' do
+          expect(dictionary.description_translations.keys).to_not include('de')
+          expect(dictionary.description_translations.keys).to include('en')
+        end
+
+        it 'returns nil for excluded translations' do
+          I18n.locale = :en
+          expect(dictionary.description).to eq('english-text')
+          I18n.locale = :de
+          expect(dictionary.description).to be_nil
+        end
+      end
+    end
   end
 
   [ :or, :any_of ].each do |method|
@@ -2954,7 +3041,7 @@ describe Mongoid::Criteria do
         end
       end
 
-      context "when plucking mult-fields" do
+      context "when plucking multi-fields" do
 
         let(:plucked) do
           Band.where(:name.exists => true).pluck(:name, :likes)
@@ -3031,6 +3118,43 @@ describe Mongoid::Criteria do
 
         it "returns a nil arrays" do
           expect(plucked).to eq([[nil, nil], [nil, nil], [nil, nil]])
+        end
+      end
+    end
+
+    context 'when plucking a localized field' do
+
+      before do
+        I18n.locale = :en
+        d = Dictionary.create(description: 'english-text')
+        I18n.locale = :de
+        d.reload.description = 'deutsch-text'
+        d.save
+      end
+
+      after do
+        I18n.locale = :en
+      end
+
+      context 'when plucking the entire field' do
+
+        let(:plucked) do
+          Dictionary.all.pluck(:description)
+        end
+
+        it 'returns all translations' do
+          expect(plucked.first).to eq({'en' => 'english-text', 'de' => 'deutsch-text'})
+        end
+      end
+
+      context 'when plucking a specific locale' do
+
+        let(:plucked) do
+          Dictionary.all.pluck(:'description.de')
+        end
+
+        it 'returns the specific translations' do
+          expect(plucked.first).to eq({'de' => 'deutsch-text'})
         end
       end
     end


### PR DESCRIPTION
I have renamed `#normalized_key` to `#localized_key` for clarity.

The behavior should be clear by reading the added specs.

Fixes MONGOID-4052

Replaces #4277 

@estolfo @simi please review