### PR TITLE
[WIP] MONGOID-4173 Nested eager loading issue

### DIFF
--- a/spec/mongoid/criteria_spec.rb
+++ b/spec/mongoid/criteria_spec.rb
@@ -3749,4 +3749,53 @@ describe Mongoid::Criteria do
       end
     end
   end
+
+  describe "#nested eager loading" do
+    before do
+      class User 
+        include Mongoid::Document
+
+        field :name
+      end
+
+      class Unit
+        include Mongoid::Document
+
+        field :number
+      end
+
+      class Booking
+        include Mongoid::Document
+
+        field :number
+
+        belongs_to :unit
+        has_many :vouchers
+      end
+
+      class Voucher
+        include Mongoid::Document
+
+        field :number
+
+        belongs_to :booking
+        belongs_to :created_by, class_name: 'User'
+      end
+    end
+
+    it 'should load all nested models' do
+      user = User.create(name: 'John')
+      unit = Unit.create(number: 1)
+      booking = Booking.create(number: 1, unit: unit)
+      voucher = Voucher.create(number: 123, booking: booking, created_by: user)
+
+      vouchers = Voucher.includes(:created_by, booking: [:unit])
+
+      vouchers.each do |voucher|
+        expect(voucher.created_by).to eql(user)
+        expect(voucher.booking).to eql(booking)
+        expect(voucher.booking.unit).to eql(unit)
+      end
+    end
+  end
 end


### PR DESCRIPTION
```
1) Mongoid::Criteria#nested eager loading should load all nested models
     Failure/Error: doc.send(group_by_key)
     
     NoMethodError:
       undefined method `unit_id' for #<User:0x00000002ea7bb0>
     # ./lib/mongoid/relations/eager/base.rb:107:in `block in grouped_docs'
     # ./lib/mongoid/relations/eager/base.rb:106:in `each'
     # ./lib/mongoid/relations/eager/base.rb:106:in `group_by'
     # ./lib/mongoid/relations/eager/base.rb:106:in `grouped_docs'
     # ./lib/mongoid/relations/eager/base.rb:120:in `keys_from_docs'
     # ./lib/mongoid/relations/eager/base.rb:75:in `each_loaded_document'
     # ./lib/mongoid/relations/eager/belongs_to.rb:15:in `preload'
     # ./lib/mongoid/relations/eager/base.rb:50:in `run'
     # ./lib/mongoid/relations/eager.rb:47:in `block (2 levels) in preload'
     # ./lib/mongoid/relations/eager.rb:46:in `each'
     # ./lib/mongoid/relations/eager.rb:46:in `collect'
     # ./lib/mongoid/relations/eager.rb:46:in `block in preload'
     # ./lib/mongoid/relations/eager.rb:45:in `each'
     # ./lib/mongoid/relations/eager.rb:45:in `preload'
     # ./lib/mongoid/relations/eager.rb:32:in `eager_load'
     # ./lib/mongoid/contextual/mongo.rb:664:in `documents_for_iteration'
     # ./lib/mongoid/contextual/mongo.rb:123:in `each'
     # ./lib/mongoid/contextual.rb:20:in `each'
     # ./spec/mongoid/criteria_spec.rb:3794:in `block (3 levels) in <top (required)>'
```