### PR TITLE
prevent NoMethodError when using __nested__

### DIFF
--- a/lib/mongoid/extensions/hash.rb
+++ b/lib/mongoid/extensions/hash.rb
@@ -105,6 +105,7 @@ module Mongoid
         keys = string.split(".")
         value = self
         keys.each do |key|
+          return nil if value.nil?
           nested = value[key] || value[key.to_i]
           value = nested
         end

--- a/spec/mongoid/extensions/hash_spec.rb
+++ b/spec/mongoid/extensions/hash_spec.rb
@@ -247,6 +247,21 @@ describe Mongoid::Extensions::Hash do
     end
   end
 
+  context "when the parent key is not present" do
+
+    let(:hash) do
+      { "101" => { "name" => "hundred and one" } }
+    end
+
+    let(:nested) do
+      hash.__nested__("100.name")
+    end
+
+    it "should return nil" do
+      expect(nested).to eq(nil)
+    end
+  end
+
   describe ".demongoize" do
 
     let(:hash) do


### PR DESCRIPTION
fixes e.g:

`{ "name" => { "en" => "test" }}.__nested__("email.en")`