### PR TITLE
Add docs for create/remove indexes called on models

### DIFF
--- a/docs/tutorials/mongoid-indexes.txt
+++ b/docs/tutorials/mongoid-indexes.txt
@@ -114,3 +114,14 @@ Mongoid also provides a rake task to delete all secondary indexes.
 
    $ rake db:mongoid:remove_indexes
 
+These create/remove indexes commands also works for just one model by running
+
+.. code-block:: ruby
+
+   Model.create_indexes
+   
+or 
+
+.. code-block:: ruby
+
+   Model.remove_indexes


### PR DESCRIPTION
Sometimes creating/removing indexes for the entire database can be very expensive, when searching for the same behavior for just one collection I found out that it can be used directly on models, I thought that could be interesting to have mentioned on the docs :smile: 
