### PR TITLE
Add typed attributes

### DIFF
--- a/lib/mongoid/attributes.rb
+++ b/lib/mongoid/attributes.rb
@@ -242,6 +242,16 @@ module Mongoid
         (selection.values.first == 1 && !selection_included?(name, selection, field))
     end
 
+    # Return type casted attributes.
+    #
+    # @example Type casted attributes.
+    #   document.typed_attributes
+    #
+    # @return [ Object ] The hash with keys and values of the type casted attributes.
+    def typed_attributes
+      attribute_names.map { |name| [name, send(name)] }.to_h
+    end
+
     private
 
     def selection_excluded?(name, selection, field)

--- a/spec/mongoid/attributes_spec.rb
+++ b/spec/mongoid/attributes_spec.rb
@@ -1385,6 +1385,21 @@ describe Mongoid::Attributes do
     end
   end
 
+  describe "#typed_attributes"  do
+    
+    let(:date_time) do
+      DateTime.current
+    end
+
+    let(:user) do
+      User.new(last_login: date_time)
+    end
+
+    it 'returns typecasted attributes' do
+      expect(user.typed_attributes).to include("last_login" => date_time)
+    end
+  end
+
   [:attributes=, :write_attributes].each do |method|
 
     describe "##{method}" do


### PR DESCRIPTION
I've read many issues about typed attributes absence in Mongoid (particularly, the latest is ["Custom types typecasting problem"](https://jira.mongodb.org/browse/MONGOID-2533), I guess). Despite of `#attributes` mongonized nature, I'd like to add method which allows to retrieve type casted (demongoized ) attributes.
This is my first PR to Mongoid project, so don't hesitate to abandon it or give some advices for the improvements.
