### PR TITLE
 Where, in criteria didn't match

### DIFF
--- a/lib/mongoid/criteria/queryable/selector.rb
+++ b/lib/mongoid/criteria/queryable/selector.rb
@@ -21,7 +21,11 @@ module Mongoid
           other.each_pair do |key, value|
             if value.is_a?(Hash) && self[key.to_s].is_a?(Hash)
               value = self[key.to_s].merge(value) do |_key, old_val, new_val|
-                multi_value?(_key) ? (old_val + new_val).uniq : new_val
+                if multi_value?(_key)
+                  _key == '$in' ? new_val & old_val : old_val + new_val
+                else
+                  new_val
+                end
               end
             end
             if multi_selection?(key)

--- a/spec/mongoid/criteria/queryable/selectable_spec.rb
+++ b/spec/mongoid/criteria/queryable/selectable_spec.rb
@@ -4156,4 +4156,28 @@ describe Mongoid::Criteria::Queryable::Selectable do
       end
     end
   end
+
+  context "'where' strategy, 'in' strategy should match" do
+    before do
+      class Project
+        include Mongoid::Document
+      end
+
+      class Booking
+        include Mongoid::Document
+
+        belongs_to :project
+      end
+    end
+  
+    it "on querying 'where', 'in' strageries should generate same criteria" do
+      bookings = Booking.where(:project_id.in => [1, 2])
+      bookings = bookings.where(:project_id.in => [1])
+
+      in_bookings = Booking.in(project_id: [1, 2])
+      in_bookings = in_bookings.in(project_id: [1])
+
+      expect(bookings.criteria.selector).to eql(in_bookings.criteria.selector)
+    end
+  end
 end

--- a/spec/mongoid/criteria/queryable/selector_spec.rb
+++ b/spec/mongoid/criteria/queryable/selector_spec.rb
@@ -63,7 +63,7 @@ describe Mongoid::Criteria::Queryable::Selector do
         end
 
         it "combines the two $nin queries into one" do
-          expect(selector).to eq({
+          expect(selector).to include({
             "field" => { "$nin" => ["foo", "bar"] }
           })
         end


### PR DESCRIPTION
Upon this case execution

```
 1) Mongoid::Criteria::Queryable::Selectable 'where' strategy, 'in' strategy should match on querying 'where', 'in' strageries should generate same criteria
     Failure/Error: expect(bookings.criteria.selector).to eql(in_bookings.criteria.selector)
     
       expected: {"project_id"=>{"$in"=>[1]}}
            got: {"project_id"=>{"$in"=>[1, 2]}}
     
       (compared using eql?)
     
       Diff:
       @@ -1,2 +1,2 @@
       -"project_id" => {"$in"=>[1]},
       +"project_id" => {"$in"=>[1, 2]},
       
     # ./spec/mongoid/criteria/queryable/selectable_spec.rb:4180:in `block (3 levels) in <top (required)>'
```