### PR TITLE
Use right database when override_database + options.

### DIFF
--- a/lib/mongoid/clients/options.rb
+++ b/lib/mongoid/clients/options.rb
@@ -44,12 +44,12 @@ module Mongoid
 
       def mongo_client
         tmp = persistence_options
-        if opts = tmp && tmp.dup
+        if (opts = tmp && !tmp.empty? && tmp.dup)
           if opts[:client]
             client = Clients.with_name(opts[:client])
           else
             client = Clients.with_name(self.class.client_name)
-            client.use(self.class.database_name)
+            client = client.use(self.class.database_name)
           end
           client.with(opts.reject{ |k, v| k == :collection || k == :client })
         end


### PR DESCRIPTION
Mongoid would not always use the right database to persist data when persistence options (even an empty hash) are given, while at the same time using the `Mongoid.override_database` feature.

Our application is using `Mongoid.override_database` and although we are not using persistence options explicitly, empty hashes would end up in `Options#mongo_client`, and the method would return a `mongo` client that would use the default database, and not the one given to `override_database`.

We experienced very weird behaviour where one document would be saved in one database, and others in another one.

Here is the code sample that I used to figure out the problem, for your entertainment:

```
class Foo
  include Mongoid::Document
  has_many :bars
  accepts_nested_attributes_for :bars
end

class Bar
  include Mongoid::Document
  field :name
  belongs_to :foo
end

# 'first_database' in mongoid.yml
Mongoid.override_database(:second_database)

foo = Foo.create!
attributes = { '0' => { 'name' => 'name' } }
foo.update_attributes!(bars_attributes: attributes)
```

With the code above, the `Foo` document would be persisted in `second_database` and the new `Bar` document would be create in `first_database`. (Because an empty hash is given to `mongo_client` while persisting the `Bar` document.)

If empty hashes are filtered, the same outcome can be achieved by using something like:

```
foo.with(connect_timeout: 10).update_attributes!(bars_attributes: attributes)
```

### TLDR

Mongoid would not always persist to the right database. This is bad.

See additional comments in the code.

Questions, comments, and merge are welcome! Thank you! :-)