### PR TITLE
Fix metadata classify

### DIFF
--- a/lib/mongoid/relations/metadata.rb
+++ b/lib/mongoid/relations/metadata.rb
@@ -123,7 +123,7 @@ module Mongoid
       #
       # @since 2.0.0.rc.1
       def class_name
-        @class_name ||= (self[:class_name] || classify).sub(/\A::/,"")
+        @class_name ||= (self[:class_name] || classify).to_s.sub(/\A::/,"")
       end
 
       # Get the foreign key contraint for the metadata.


### PR DESCRIPTION
Could be some problems with classify
Example:

```ruby
class Project::Interview < ::Article::Abstract

end
```

```ruby
class Article::Abstract
   include Mongoid::Document
end
```