### PR TITLE
Fix tested Ruby versions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Project Tracking
 Compatibility
 -------------
 
-Mongoid is tested against MRI 1.9.3, 2.0.0, 2.1.0. 2.2.0 and JRuby (1.9).
+Mongoid is tested against MRI 2.2, 2.3 and JRuby (9.1).
 
 Documentation
 -------------


### PR DESCRIPTION
It seems current tested Ruby versions are described in [`.travis.yml`](https://github.com/mongodb/mongoid/blob/71c29a80599087008ecfbd057d3d049c2153c7ce/.travis.yml#L8-L10).