### PR TITLE
Localized attribute presence lookup which has a nil value should not fail

### DIFF
--- a/lib/mongoid/attributes.rb
+++ b/lib/mongoid/attributes.rb
@@ -336,7 +336,7 @@ module Mongoid
     end
 
     def lookup_attribute_presence(name, value)
-      if localized_fields.has_key?(name)
+      if localized_fields.has_key?(name) && value
         value = localized_fields[name].send(:lookup, value)
       end
       value.present?

--- a/spec/mongoid/attributes_spec.rb
+++ b/spec/mongoid/attributes_spec.rb
@@ -1772,15 +1772,22 @@ describe Mongoid::Attributes do
 
     context 'when the attribute is localized' do
       let(:person) do
-        Person.create(desc: 'localized')
+        Person.create
       end
 
-      before do
-        person.desc = nil
+      context 'after initialization when the field is nil' do
+
+        it 'returns false' do
+          expect(person.desc?).to be(false)
+        end
       end
 
-      it 'applies the localization when checking the attribute' do
-        expect(person.desc?).to be(false)
+      context 'when setting the field to nil' do
+
+        it 'applies the localization when checking the attribute' do
+          person.desc = nil
+          expect(person.desc?).to be(false)
+        end
       end
 
       context 'when the field is a boolean' do


### PR DESCRIPTION
From the model Person in the specs...

```ruby
class Person
  # ...
  field :desc, localize: true
  # ...
end
```

```ruby
  p = Person.new
  p.desc = nil
  p.desc? #=> false

  p = Person.new
  p.desc? #=>
  NoMethodError: undefined method `[]' for nil:NilClass
  from /Users/nicolasblanco/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/mongoid-6.0.0/lib/mongoid/fields/localized.rb:80:in `lookup'
```

After patch:
```ruby
  p = Person.new
  p.desc = nil
  p.desc? #=> false

  p = Person.new
  p.desc? #=> false
```

This patch fixes the exception by doing the localized lookup only if there is an actual value and also adds one more test to the tests suite.
