### PR TITLE
[6.1.0] add string “on” to list of true boolean values

### DIFF
--- a/lib/mongoid/criteria/queryable/extensions/boolean.rb
+++ b/lib/mongoid/criteria/queryable/extensions/boolean.rb
@@ -21,7 +21,7 @@ module Mongoid
             # @since 1.0.0
             def evolve(object)
               __evolve__(object) do |obj|
-                obj.to_s =~ (/(true|t|yes|y|1|1.0)$/i) ? true : false
+                obj.to_s =~ (/(true|t|yes|y|on|1|1.0)$/i) ? true : false
               end
             end
           end

--- a/lib/mongoid/criteria/queryable/extensions/boolean.rb
+++ b/lib/mongoid/criteria/queryable/extensions/boolean.rb
@@ -21,7 +21,7 @@ module Mongoid
             # @since 1.0.0
             def evolve(object)
               __evolve__(object) do |obj|
-                obj.to_s =~ (/(true|t|yes|y|on|1|1.0)$/i) ? true : false
+                obj.to_s =~ (/\A(true|t|yes|y|on|1|1.0)\z/i) ? true : false
               end
             end
           end

--- a/spec/mongoid/extensions/boolean_spec.rb
+++ b/spec/mongoid/extensions/boolean_spec.rb
@@ -82,6 +82,13 @@ describe Mongoid::Boolean do
         end
       end
 
+      context "when provided on" do
+
+        it "returns true" do
+          expect(described_class.mongoize("on")).to eq(true)
+        end
+      end
+
       context "when provided false" do
 
         it "returns false" do
@@ -121,6 +128,13 @@ describe Mongoid::Boolean do
 
         it "returns false" do
           expect(described_class.mongoize("n")).to eq(false)
+        end
+      end
+
+      context "when provided off" do
+
+        it "returns true" do
+          expect(described_class.mongoize("off")).to eq(false)
         end
       end
     end


### PR DESCRIPTION
HTML forms use "on" to indicate a checked checkbox value. This would provide seamless transition from an html form to a boolean value on a model.
