### PR TITLE
Add support for cloning documents that have nil legacy attributes

### DIFF
--- a/lib/mongoid/copyable.rb
+++ b/lib/mongoid/copyable.rb
@@ -24,7 +24,10 @@ module Mongoid
       attrs = clone_document.except("_id", "id")
       dynamic_attrs = {}
       attrs.reject! do |attr_name, value|
-        dynamic_attrs[attr_name] = value unless self.attribute_names.include?(attr_name)
+        unless self.attribute_names.include?(attr_name)
+          dynamic_attrs[attr_name] = value
+          true
+        end
       end
       self.class.new(attrs).tap do |object|
         dynamic_attrs.each do |attr_name, value|

--- a/spec/mongoid/copyable_spec.rb
+++ b/spec/mongoid/copyable_spec.rb
@@ -73,11 +73,11 @@ describe Mongoid::Copyable do
           expect(cloned.attributes['this_is_not_a_field']).to eq(1)
         end
 
-        it "contains legacy attribute that are nil" do
+        it "contains legacy attributes that are nil" do
           expect(cloned.attributes.key?('this_legacy_field_is_nil')).to eq(true)
         end
 
-        it "copies the known attriutes" do
+        it "copies the known attributes" do
           expect(cloned.name).to eq('test')
         end
       end

--- a/spec/mongoid/copyable_spec.rb
+++ b/spec/mongoid/copyable_spec.rb
@@ -61,7 +61,8 @@ describe Mongoid::Copyable do
         end
 
         before do
-          Actor.collection.find(_id: actor.id).update_one("$set" => { "this_is_not_a_field" => 1 })
+          legacy_fields = { "this_is_not_a_field" => 1, "this_legacy_field_is_nil" => nil }
+          Actor.collection.find(_id: actor.id).update_one("$set" => legacy_fields)
         end
 
         let(:cloned) do
@@ -70,6 +71,10 @@ describe Mongoid::Copyable do
 
         it "sets the legacy attribute" do
           expect(cloned.attributes['this_is_not_a_field']).to eq(1)
+        end
+
+        it "contains legacy attribute that are nil" do
+          expect(cloned.attributes.key?('this_legacy_field_is_nil')).to eq(true)
         end
 
         it "copies the known attriutes" do


### PR DESCRIPTION
This fixes cloning documents with legacy schemas in which one of the key is set to `nil`.
Before it would raise an error such as:
```
Mongoid::Errors::UnknownAttribute (
message:
  Attempted to set a value for '...' which is not allowed on the model ...
summary:
  Without including Mongoid::Attributes::Dynamic in your model and the attribute does not already exist in the attributes hash, attempting to call ...= for it is not allowed. This is also triggered by passing the attribute to any method that accepts an attributes hash, and is raised instead of getting a NoMethodError.
resolution:
  You can include Mongoid::Attributes::Dynamic if you expect to be writing values for undefined fields often.):
```