### PR TITLE
Update Relations::Reflections.reflect_on_all_associations method

### DIFF
--- a/lib/mongoid/relations/reflections.rb
+++ b/lib/mongoid/relations/reflections.rb
@@ -24,7 +24,7 @@ module Mongoid
       # @example Find multiple relation metadata by macro.
       #   person.reflect_on_all_associations(:embeds_many)
       #
-      # @param [ Array<String, Symbol> ] *macros The relation macros.
+      # @param [ Array<Symbol> ] *macros The relation macros.
       #
       # @return [ Array<Metadata> ] The matching relation metadata.
       def reflect_on_all_associations(*macros)
@@ -50,11 +50,13 @@ module Mongoid
         # @example Find multiple relation metadata by macro.
         #   Person.reflect_on_all_associations(:embeds_many)
         #
-        # @param [ Array<String, Symbol> ] *macros The relation macros.
+        # @param [ Array<Symbol> ] *macros The relation macros.
         #
         # @return [ Array<Metadata> ] The matching relation metadata.
         def reflect_on_all_associations(*macros)
-          relations.values.select { |meta| macros.include?(meta.macro) }
+          association_reflections = relations.values
+          association_reflections.select! { |reflection| macros.include?(reflection.macro) } unless macros.empty?
+          association_reflections
         end
       end
     end

--- a/spec/mongoid/relations/reflections_spec.rb
+++ b/spec/mongoid/relations/reflections_spec.rb
@@ -74,23 +74,23 @@ describe Mongoid::Relations::Reflections do
           expect(relations.size).to eq(1)
         end
       end
+
+      context "when no argument supplied" do
+
+        let(:relations) do
+          klass.reflect_on_all_associations
+        end
+
+        it "returns an array of all relations" do
+          expect(relations.size).to eq(3)
+        end
+      end
     end
 
     context "when no relations exist for the macros" do
 
       let(:relations) do
         klass.reflect_on_all_associations(:embeds_one)
-      end
-
-      it "returns an empty array" do
-        expect(relations).to be_empty
-      end
-    end
-
-    context "when no argument supplied" do
-
-      let(:relations) do
-        klass.reflect_on_all_associations
       end
 
       it "returns an empty array" do


### PR DESCRIPTION
Hi guys!

I have noticed that there is something wrong with `Mongoid::Relations::Reflections.reflect_on_all_associations` method.

It said in rdoc that method supports `[ Array<String, Symbol> ]` as argument but it works only with symbols because `meta.macro` is `Symbol`.

Now I just fixed it so the method indeed can accept strings.
But maybe we just should left the method as is and simply update rdoc?

Also I've made the method work even without any arguments (in this case it returns all relations).
I saw that `ActiveRecord` [works](https://github.com/rails/rails/blob/ac027338e4a165273607dccee49a3d38bc836794/activerecord/lib/active_record/reflection.rb#L98) this way and it is useful for a task I'm working on.
But I am not sure if it would be useful for others. 

Thank you.