### PR TITLE
Fixed bug in relationships with `inverse_of` field

### DIFF
--- a/lib/mongoid/relations/referenced/many.rb
+++ b/lib/mongoid/relations/referenced/many.rb
@@ -803,8 +803,8 @@ module Mongoid
           # @since 3.0.0
           def with_inverse_field_criterion(criteria, metadata)
             inverse_metadata = metadata.inverse_metadata(metadata.klass)
-            if inverse_metadata.try(:inverse_of_field)
-              criteria.any_in(inverse_metadata.inverse_of_field => [ metadata.name, nil ])
+            if inverse_metadata.try(:inverse_of)
+              criteria.any_in(inverse_metadata.inverse_of => [ metadata.name, nil ])
             else
               criteria
             end

--- a/spec/mongoid/relations/metadata_spec.rb
+++ b/spec/mongoid/relations/metadata_spec.rb
@@ -1236,6 +1236,14 @@ describe Mongoid::Relations::Metadata do
           it "returns the name of the inverse_of property" do
             expect(metadata.inverse).to eq(:crazy_name)
           end
+
+          it "will have have an inverse_of key" do
+            expect(metadata.key?(:inverse_of)).to be true
+          end
+
+          it "will NOT have an inverse_of_field key" do
+            expect(metadata.key?(:inverse_of_field)).to be false
+          end
         end
       end
 


### PR DESCRIPTION
This fixes a bug in `Mongoid::Relations::Referenced::Many` when it goes
to find the inverse of a relationship within the
`#with_inverse_field_criterion` method. The method was trying to use
`:inverse_of_field` which doesn't exist on the metadata and is, instead,
`:inverse_of', resulting in a method-not-found error.