### PR TITLE
Fix : map_reduce read mode is forced to "primary"

### DIFF
--- a/lib/mongoid/contextual/map_reduce.rb
+++ b/lib/mongoid/contextual/map_reduce.rb
@@ -299,7 +299,7 @@ module Mongoid
       # @since 3.0.0
       def results
         raise Errors::NoMapReduceOutput.new(command) unless command[:out]
-        @results ||= __client__.command(command).first
+        @results ||= __client__.command(command,__client__.options).first
       end
 
       # Get the client with the proper consistency.

--- a/spec/mongoid/contextual/map_reduce_spec.rb
+++ b/spec/mongoid/contextual/map_reduce_spec.rb
@@ -331,6 +331,31 @@ describe Mongoid::Contextual::MapReduce do
     end
   end
 
+  describe "#raw" do
+    let(:criteria) { Band.all }
+    let(:client) { collection.database.client }
+    let(:map_reduce) { described_class.new(collection, criteria, map, reduce) }
+
+    subject { map_reduce.raw }
+
+    it { expect{subject}.to raise_error(Mongoid::Errors::NoMapReduceOutput) }
+
+    context "when providing inline" do
+      let!(:out) { map_reduce.out(inline: 1) }
+
+      before { allow(client).to receive(:command).and_return(['result', 'from', 'client.command']) }
+
+      it "passes the command to the client, using the client options" do
+        expect(client).to receive(:command).with(out.command, client.options)
+        subject
+      end
+
+      it "returns the first element from the result array of client.command" do
+        expect(subject).to eq('result')
+      end
+    end
+  end
+
   describe "#reduced" do
 
     let(:criteria) do


### PR DESCRIPTION
### Context
The read mode is forced to `primary` on a `map_reduce` client, when `inline == 1`, which makes it impossible to apply any other read mode (`secondary`, `secondary_preferred`...) when performing a `map_reduce` operation.

### Confirmation
* MongoDB read replicas remain idle while performing a succession of `map_reduce` operations, even when the read mode is set to `secondary` in Mongoid configuration
* By outputing MongoDB logs in a Rails console, I get confirmation that the requests are sent to the primary node only.

### Proposed Correction
Allow the `map_reduce` operation to use the client's `options` when applying the `command`.
This way, assuming you've configured a client in `secondary` read mode, a query like `criteria.with(client: :secondary).map_reduce(map, reduce).out(inline: 1)` would perform the operation in `secondary` read mode.