### PR TITLE
Prefix Readonly#_loaded? method to avoid namespace pollution

### DIFF
--- a/lib/mongoid/attributes/readonly.rb
+++ b/lib/mongoid/attributes/readonly.rb
@@ -32,14 +32,14 @@ module Mongoid
 
       def as_writable_attribute!(name, value = :nil)
         normalized_name = database_field_name(name)
-        if new_record? || (!readonly_attributes.include?(normalized_name) && loaded?(normalized_name))
+        if new_record? || (!readonly_attributes.include?(normalized_name) && _loaded?(normalized_name))
           yield(normalized_name)
         else
           raise Errors::ReadonlyAttribute.new(name, value)
         end
       end
 
-      def loaded?(name)
+      def _loaded?(name)
         __selected_fields.nil? || projected_field?(name)
       end
 


### PR DESCRIPTION
In order to avoid namespace pollution, we could prefix the `loaded?` method as discussed in 
https://jira.mongodb.org/browse/MONGOID-4393