### PR TITLE
Backport #4295 to 5.1.0-stable

### DIFF
--- a/lib/mongoid/query_cache.rb
+++ b/lib/mongoid/query_cache.rb
@@ -222,7 +222,7 @@ module Mongoid
 
       def cached_cursor
         if limit
-          key = [ collection.namespace, selector, nil, skip, projection ]
+          key = [ collection.namespace, selector, nil, skip, sort, projection ]
           cursor = QueryCache.cache_table[key]
           if cursor
             limited_docs = cursor.to_a[0...limit.abs]
@@ -233,7 +233,7 @@ module Mongoid
       end
 
       def cache_key
-        [ collection.namespace, selector, limit, skip, projection ]
+        [ collection.namespace, selector, limit, skip, sort, projection ]
       end
 
       def system_collection?

--- a/spec/mongoid/query_cache_spec.rb
+++ b/spec/mongoid/query_cache_spec.rb
@@ -173,6 +173,27 @@ describe Mongoid::QueryCache do
       end
     end
 
+    context "when sorting documents" do
+      before do
+        Band.asc(:id).to_a
+      end
+
+      context "with different selector" do
+
+        it "queries again" do
+          expect_query(1) do
+            Band.desc(:id).to_a
+          end
+        end
+      end
+
+      it "does not query again" do
+        expect_query(0) do
+          Band.asc(:id).to_a
+        end
+      end
+    end
+
     context "when query caching is enabled and the batch_size is set" do
 
       around(:each) do |example|


### PR DESCRIPTION
This backports https://github.com/mongodb/mongoid/pull/4295 to the `5.1.0-stable` branch.

Rails 4.2 apps can't use Mongoid 6, so they'll be affected by this bug if they enable the query cache.