### PR TITLE
Backport #4350 to 5.1.0-stable

### DIFF
--- a/lib/mongoid/query_cache.rb
+++ b/lib/mongoid/query_cache.rb
@@ -70,6 +70,20 @@ module Mongoid
       ensure
         QueryCache.enabled = enabled
       end
+
+      # Execute the block with the query cache disabled.
+      #
+      # @example Execute without the cache.
+      #   QueryCache.uncached { collection.find }
+      #
+      # @return [ Object ] The result of the block.
+      def uncached
+        enabled = QueryCache.enabled?
+        QueryCache.enabled = false
+        yield
+      ensure
+        QueryCache.enabled = enabled
+      end
     end
 
     # The middleware to be added to a rack application in order to activate the
@@ -252,8 +266,16 @@ module Mongoid
         alias_query_cache_clear :insert_one, :insert_many
       end
     end
+
+    # Bypass the query cache when reloading a document.
+    module Document
+      def reload
+        QueryCache.uncached { super }
+      end
+    end
   end
 end
 
 Mongo::Collection.__send__(:include, Mongoid::QueryCache::Collection)
 Mongo::Collection::View.__send__(:include, Mongoid::QueryCache::View)
+Mongoid::Document.__send__(:include, Mongoid::QueryCache::Document)

--- a/spec/mongoid/query_cache_spec.rb
+++ b/spec/mongoid/query_cache_spec.rb
@@ -271,6 +271,37 @@ describe Mongoid::QueryCache do
     end
   end
 
+  context "when reloading a document" do
+
+    let!(:band_id) do
+      Band.create.id
+    end
+
+    context 'when query cache is disabled' do
+
+      before do
+        Mongoid::QueryCache.enabled = false
+      end
+
+      it "queries again" do
+        band = Band.find(band_id)
+        expect_query(1) do
+          band.reload
+        end
+      end
+    end
+
+    context 'when query cache is enabled' do
+
+      it "queries again" do
+        band = Band.find(band_id)
+        expect_query(1) do
+          band.reload
+        end
+      end
+    end
+  end
+
   context "when querying a very large collection" do
 
     before do


### PR DESCRIPTION
One more query cache pull request 😁 

This backports https://github.com/mongodb/mongoid/pull/4350 to the `5.1.0-stable` branch, so that Rails 4.2 apps can get the fix.