### PR TITLE
MONGOID-4326 Update MapReduce implementation to use driver object to lay groundwork for supporting collation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,9 @@ gem 'rake'
 gem 'actionpack', '~> 5.0.0'
 gem 'activemodel', '~> 5.0.0'
 
+# @todo: remove this when driver 2.4.1 is released
+gem 'mongo', github: "mongodb/mongo-ruby-driver"
+
 group :test do
   gem 'rspec', '~> 3.4.0'
 end

--- a/spec/mongoid/contextual/map_reduce_spec.rb
+++ b/spec/mongoid/contextual/map_reduce_spec.rb
@@ -308,7 +308,7 @@ describe Mongoid::Contextual::MapReduce do
           Band.all.read(mode: :secondary)
         end
 
-        it "passes the command to the client, using the client options", if: testing_replica_set? do
+        it "uses the read preference", if: testing_replica_set? do
 
           expect {
             replace_map_reduce.raw

--- a/spec/mongoid/contextual/map_reduce_spec.rb
+++ b/spec/mongoid/contextual/map_reduce_spec.rb
@@ -32,15 +32,15 @@ describe Mongoid::Contextual::MapReduce do
     Band.collection
   end
 
+  let(:criteria) do
+    Band.all
+  end
+
+  let(:map_reduce) do
+    described_class.new(collection, criteria, map, reduce)
+  end
+
   describe "#command" do
-
-    let(:criteria) do
-      Band.all
-    end
-
-    let(:map_reduce) do
-      described_class.new(collection, criteria, map, reduce)
-    end
 
     let(:base_command) do
       {
@@ -51,27 +51,25 @@ describe Mongoid::Contextual::MapReduce do
       }
     end
 
-    it "returns the db command" do
-      expect(map_reduce.command).to eq(base_command)
-    end
-
     context "with sort" do
+
       let(:criteria) do
         Band.order_by(name: -1)
       end
 
-      it "returns the db command with a sort option" do
-        expect(map_reduce.command).to eq(base_command.merge(sort: {'name' => -1}))
+      it "includes a sort option in the map reduce command" do
+        expect(map_reduce.command[:sort]).to eq('name' => -1)
       end
     end
 
     context "with limit" do
+
       let(:criteria) do
         Band.limit(10)
       end
 
       it "returns the db command with a limit option" do
-        expect(map_reduce.command).to eq(base_command.merge(limit: 10))
+        expect(map_reduce.command[:limit]).to eq(10)
       end
     end
   end
@@ -80,10 +78,6 @@ describe Mongoid::Contextual::MapReduce do
 
     let(:criteria) do
       Band.all
-    end
-
-    let(:map_reduce) do
-      described_class.new(collection, criteria, map, reduce)
     end
 
     let(:counts) do
@@ -101,14 +95,6 @@ describe Mongoid::Contextual::MapReduce do
   end
 
   describe "#each" do
-
-    let(:criteria) do
-      Band.all
-    end
-
-    let(:map_reduce) do
-      described_class.new(collection, criteria, map, reduce)
-    end
 
     context "when the map/reduce is inline" do
 
@@ -130,20 +116,40 @@ describe Mongoid::Contextual::MapReduce do
         map_reduce.out(replace: "mr-output")
       end
 
-      it "iterates over the results" do
-        expect(results.entries).to eq([
+      let(:expected_results) do
+        [
           { "_id" => "Depeche Mode", "value" => { "likes" => 200 }},
           { "_id" => "Tool", "value" => { "likes" => 100 }}
-        ])
+        ]
+      end
+
+      it "iterates over the results" do
+        expect(results.entries).to eq(expected_results)
+      end
+
+      it 'outputs to the collection' do
+        expect(results.entries).to eq(map_reduce.criteria.view.database["mr-output"].find.to_a)
       end
     end
 
     context "when no output is provided" do
 
-      it "raises an error" do
-        expect {
-          map_reduce.entries
-        }.to raise_error(Mongoid::Errors::NoMapReduceOutput)
+      context "when the results are iterated" do
+
+        it "raises an error" do
+          expect {
+            map_reduce.entries
+          }.to raise_error(Mongoid::Errors::NoMapReduceOutput)
+        end
+      end
+
+      context "when the statstics are requested" do
+
+        it "raises an error" do
+          expect {
+            map_reduce.counts
+          }.to raise_error(Mongoid::Errors::NoMapReduceOutput)
+        end
       end
     end
 
@@ -165,14 +171,6 @@ describe Mongoid::Contextual::MapReduce do
 
   describe "#emitted" do
 
-    let(:criteria) do
-      Band.all
-    end
-
-    let(:map_reduce) do
-      described_class.new(collection, criteria, map, reduce)
-    end
-
     let(:emitted) do
       map_reduce.out(inline: 1).emitted
     end
@@ -184,15 +182,7 @@ describe Mongoid::Contextual::MapReduce do
 
   describe "#empty?" do
 
-    let(:map_reduce) do
-      described_class.new(collection, criteria, map, reduce)
-    end
-
     context "when the map/reduce has results" do
-
-      let(:criteria) do
-        Band.all
-      end
 
       let(:results) do
         map_reduce.out(inline: 1)
@@ -221,14 +211,6 @@ describe Mongoid::Contextual::MapReduce do
 
   describe "#finalize" do
 
-    let(:criteria) do
-      Band.all
-    end
-
-    let(:map_reduce) do
-      described_class.new(collection, criteria, map, reduce)
-    end
-
     let(:finalized) do
       map_reduce.finalize("testing")
     end
@@ -239,14 +221,6 @@ describe Mongoid::Contextual::MapReduce do
   end
 
   describe "#input" do
-
-    let(:criteria) do
-      Band.all
-    end
-
-    let(:map_reduce) do
-      described_class.new(collection, criteria, map, reduce)
-    end
 
     let(:input) do
       map_reduce.out(inline: 1).input
@@ -259,14 +233,6 @@ describe Mongoid::Contextual::MapReduce do
 
   describe "#js_mode" do
 
-    let(:criteria) do
-      Band.all
-    end
-
-    let(:map_reduce) do
-      described_class.new(collection, criteria, map, reduce)
-    end
-
     let(:results) do
       map_reduce.out(inline: 1).js_mode
     end
@@ -278,14 +244,6 @@ describe Mongoid::Contextual::MapReduce do
 
   describe "#out" do
 
-    let(:criteria) do
-      Band.all
-    end
-
-    let(:map_reduce) do
-      described_class.new(collection, criteria, map, reduce)
-    end
-
     context "when providing inline" do
 
       let(:out) do
@@ -293,7 +251,7 @@ describe Mongoid::Contextual::MapReduce do
       end
 
       it "sets the out command" do
-        expect(out.command[:out]).to eq(inline: 1)
+        expect(out.command[:out][:inline]).to eq(1)
       end
     end
 
@@ -306,21 +264,13 @@ describe Mongoid::Contextual::MapReduce do
         end
 
         it "sets the out command value to a string" do
-          expect(out.command[:out]).to eq(replace: "test")
+          expect(out.command[:out][:replace]).to eq('test')
         end
       end
     end
   end
 
   describe "#output" do
-
-    let(:criteria) do
-      Band.all
-    end
-
-    let(:map_reduce) do
-      described_class.new(collection, criteria, map, reduce)
-    end
 
     let(:output) do
       map_reduce.out(inline: 1).output
@@ -332,39 +282,43 @@ describe Mongoid::Contextual::MapReduce do
   end
 
   describe "#raw" do
-    let(:criteria) { Band.all }
-    let(:client) { collection.database.client }
-    let(:map_reduce) { described_class.new(collection, criteria, map, reduce) }
 
-    subject { map_reduce.raw }
+    let(:client) do
+      collection.database.client
+    end
 
-    it { expect{subject}.to raise_error(Mongoid::Errors::NoMapReduceOutput) }
+    context "when not specifying an out" do
 
-    context "when providing inline" do
-      let!(:out) { map_reduce.out(inline: 1) }
+      it "raises a NoMapReduceOutput error" do
+        expect {
+          map_reduce.raw
+        }.to raise_error(Mongoid::Errors::NoMapReduceOutput)
+      end
+    end
 
-      before { allow(client).to receive(:command).and_return(['result', 'from', 'client.command']) }
+    context "when providing replace" do
 
-      it "passes the command to the client, using the client options" do
-        expect(client).to receive(:command).with(out.command, client.options)
-        subject
+      let(:replace_map_reduce) do
+        map_reduce.out(replace: 'output-collection')
       end
 
-      it "returns the first element from the result array of client.command" do
-        expect(subject).to eq('result')
+      context 'when a read preference is defined' do
+
+        let(:criteria) do
+          Band.all.read(mode: :secondary)
+        end
+
+        it "passes the command to the client, using the client options", if: testing_replica_set? do
+
+          expect {
+            replace_map_reduce.raw
+          }.to raise_exception(Mongo::Error::OperationFailure)
+        end
       end
     end
   end
 
   describe "#reduced" do
-
-    let(:criteria) do
-      Band.all
-    end
-
-    let(:map_reduce) do
-      described_class.new(collection, criteria, map, reduce)
-    end
 
     let(:reduced) do
       map_reduce.out(inline: 1).reduced
@@ -376,14 +330,6 @@ describe Mongoid::Contextual::MapReduce do
   end
 
   describe "#scope" do
-
-    let(:criteria) do
-      Band.all
-    end
-
-    let(:map_reduce) do
-      described_class.new(collection, criteria, map, reduce)
-    end
 
     let(:finalize) do
       %Q{
@@ -404,14 +350,6 @@ describe Mongoid::Contextual::MapReduce do
 
   describe "#time" do
 
-    let(:criteria) do
-      Band.all
-    end
-
-    let(:map_reduce) do
-      described_class.new(collection, criteria, map, reduce)
-    end
-
     let(:time) do
       map_reduce.out(inline: 1).time
     end
@@ -422,14 +360,6 @@ describe Mongoid::Contextual::MapReduce do
   end
 
   describe "#execute" do
-
-    let(:criteria) do
-      Band.all
-    end
-
-    let(:map_reduce) do
-      described_class.new(collection, criteria, map, reduce)
-    end
 
     let(:execution_results) do
       map_reduce.out(inline: 1).execute

--- a/spec/mongoid/contextual/mongo_spec.rb
+++ b/spec/mongoid/contextual/mongo_spec.rb
@@ -1417,7 +1417,7 @@ describe Mongoid::Contextual::Mongo do
       context 'when db is a string' do
 
         let(:results) do
-          context.map_reduce(map, reduce).out(merge: :mr_output, db: 'another-db').to_a
+          context.map_reduce(map, reduce).out(merge: :mr_output, db: 'another-db')
         end
 
         it "returns the correct number of documents" do

--- a/spec/mongoid/contextual/mongo_spec.rb
+++ b/spec/mongoid/contextual/mongo_spec.rb
@@ -1417,7 +1417,7 @@ describe Mongoid::Contextual::Mongo do
       context 'when db is a string' do
 
         let(:results) do
-          context.map_reduce(map, reduce).out(merge: :mr_output, db: 'another-db')
+          context.map_reduce(map, reduce).out(merge: :mr_output, db: 'another-db').to_a
         end
 
         it "returns the correct number of documents" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -74,6 +74,10 @@ def non_legacy_server?
   Mongoid::Clients.default.cluster.servers.first.features.write_command_enabled?
 end
 
+def testing_replica_set?
+  Mongoid::Clients.default.cluster.replica_set?
+end
+
 def testing_locally?
   !(ENV['CI'] == 'travis')
 end


### PR DESCRIPTION
This prepares Mongoid's MapReduce implementation to be able to support collation.
I'm using the driver's Collection::View::MapReduce object in the Mongoid MapReduce object instead of manipulating and keeping track of its own command spec.
Collation can now be automatically applied.

Bugs in the ruby driver were discovered as a result of this. See https://github.com/mongodb/mongo-ruby-driver/pull/842