### PR TITLE
Update the template and readme: local_threshold's default from 5 to 0.015

### DIFF
--- a/docs/tutorials/mongoid-installation.txt
+++ b/docs/tutorials/mongoid-installation.txt
@@ -9,7 +9,7 @@ Installation
    :backlinks: none
    :depth: 1
    :class: singlecol
-   
+
 Install the Gem
 ---------------
 
@@ -198,8 +198,8 @@ comments above each key.
           # via ismaster commands. (default: 10)
           heartbeat_frequency: 10
 
-          # The time in seconds for selecting servers for a near read preference. (default: 5)
-          local_threshold: 5
+          # The time in seconds for selecting servers for a near read preference. (default: 0.015)
+          local_threshold: 0.015
 
           # The timeout in seconds for selecting a server for an operation. (default: 30)
           server_selection_timeout: 30

--- a/lib/rails/generators/mongoid/config/templates/mongoid.yml
+++ b/lib/rails/generators/mongoid/config/templates/mongoid.yml
@@ -51,8 +51,8 @@ development:
         # via ismaster commands. (default: 10)
         # heartbeat_frequency: 10
 
-        # The time in seconds for selecting servers for a near read preference. (default: 5)
-        # local_threshold: 5
+        # The time in seconds for selecting servers for a near read preference. (default: 0.015)
+        # local_threshold: 0.015
 
         # The timeout in seconds for selecting a server for an operation. (default: 30)
         # server_selection_timeout: 30


### PR DESCRIPTION
The default value of local_threshold configuration has been changed from 5 to 0.015 since [mongo-ruby-driver](https://github.com/mongodb/mongo-ruby-driver) ver 2.0.

[See source code and comments here](https://github.com/mongodb/mongo-ruby-driver/blob/8b442d8ff30083ef8dca3bc8dac78d4b924d9ff8/lib/mongo/server_selector.rb#L34)

So we'd better to update the document in the code.
There are no changes to the implementation.
