### PR TITLE
Update config template

### DIFF
--- a/lib/rails/generators/mongoid/config/templates/mongoid.yml
+++ b/lib/rails/generators/mongoid/config/templates/mongoid.yml
@@ -121,6 +121,10 @@ development:
     # existing method. (default: false)
     # scope_overwrite_exception: false
 
+    # Raise an error when defining a field with the same name as an
+    # existing method. (default: false)
+    # duplicate_fields_exception: false
+
     # Use Active Support's time zone in conversions. (default: true)
     # use_activesupport_time_zone: true
 
@@ -131,6 +135,11 @@ development:
     # environment. The Mongoid logger will be set to the Rails logger
     # otherwise.(default: :info)
     # log_level: :info
+
+    # Control whether `belongs_to` association is required. By default
+    # `belongs_to` will trigger a validation error if the association
+    # is not present. (default: true)
+    # belongs_to_required_by_default: true
 
     # Application name that is printed to the mongodb logs upon establishing a
     # connection in server versions >= 3.4. Note that the name cannot exceed 128 bytes.


### PR DESCRIPTION
Hi.

I have noticed that config [template](https://github.com/mongodb/mongoid/blob/master/lib/rails/generators/mongoid/config/templates/mongoid.yml) doesn't contain information about some options such as `duplicate_fields_exception` and `belongs_to_required_by_default`.

I added these options but I am not sure about descriptions.
I took description for `duplicate_fields_exception` option from CHANGELOG:
> #2938 A configuration option duplicate_fields_exception has been added that when set to true will raise an exception when defining a field that will override an existing method. (Arthur Neves)

And I wrote description for `belongs_to_required_by_default` by myself.

So maybe I should reword it somehow?

Thanks.