### PR TITLE
Fix YARD doc for Criteria#merge method

### DIFF
--- a/lib/mongoid/criteria.rb
+++ b/lib/mongoid/criteria.rb
@@ -211,7 +211,7 @@ module Mongoid
     #
     # @example Merge the criteria with a hash. The hash must contain a klass
     #   key and the key/value pairs correspond to method names/args.
-
+    #
     #   criteria.merge({
     #     klass: Band,
     #     where: { name: "Depeche Mode" },


### PR DESCRIPTION
Hi.

This uncommented new line breaks documentation for `Criteria#merge` method.
Now it looks like:
![image](https://cloud.githubusercontent.com/assets/11523473/22501793/5aea9a74-e87b-11e6-83bf-d2d5d6ee8b25.png)

While it should look like:
![image](https://cloud.githubusercontent.com/assets/11523473/22501757/3f962108-e87b-11e6-9ce9-3a72318841f8.png)
 