### PR TITLE
add support for matching index of an array

### DIFF
--- a/lib/mongoid/matchable.rb
+++ b/lib/mongoid/matchable.rb
@@ -145,7 +145,11 @@ module Mongoid
         if (key_string = key.to_s) =~ /.+\..+/
           key_string.split('.').inject(document.as_document) do |_attribs, _key|
             if _attribs.is_a?(::Array)
-              _attribs.map { |doc| doc.try(:[], _key) }
+              if _key =~ /\A\d+\z/ && _attribs.none? {|doc| doc.is_a?(Hash)}
+                _attribs.try(:[], _key.to_i)
+              else
+                _attribs.map { |doc| doc.try(:[], _key) }
+              end
             else
               _attribs.try(:[], _key)
             end

--- a/spec/mongoid/matchable_spec.rb
+++ b/spec/mongoid/matchable_spec.rb
@@ -9,12 +9,13 @@ describe Mongoid::Matchable do
       let(:document) do
         Address.new(street: "Clarkenwell Road")
       end
+      let(:occupants){[{'name' => 'Tim'}]}
 
       before do
         document.locations << Location.new(
           name: 'No.1',
           info: { 'door' => 'Red'},
-          occupants: [{'name' => 'Tim'}]
+          occupants: occupants
         )
       end
 
@@ -68,6 +69,33 @@ describe Mongoid::Matchable do
 
           let(:selector) do
             { "info.something_else" => "Red" }
+          end
+
+          it "returns false" do
+            expect(document.locations.first.matches?(selector)).to be false
+          end
+        end
+      end
+
+      context "when matching index of an array" do
+
+        let(:occupants){["Tim","Logan"]}
+
+        context "when the contents match" do
+
+          let(:selector) do
+            { "occupants.0" => "Tim" }
+          end
+          
+          it "returns true" do
+            expect(document.locations.first.matches?(selector)).to be true
+          end
+        end
+
+        context "when the contents do not match" do
+
+          let(:selector) do
+            { "occupants.0" => "Logan" }
           end
 
           it "returns false" do


### PR DESCRIPTION
This allows selecting an item in an array by index.

Ex:
document: `{"occupants" => ["Tim","Logan"]}`
selector: `{ "occupants.0" => "Tim" }`

`document.matches?(selector)` will be true.