### PR TITLE
Refactor eager preload to avoid stack overflow

### DIFF
--- a/lib/mongoid/relations/eager.rb
+++ b/lib/mongoid/relations/eager.rb
@@ -22,13 +22,9 @@ module Mongoid
       end
 
       def preload(relations, docs)
-        grouped_relations = relations.group_by do |metadata|
-          metadata.inverse_class_name
-        end
+        grouped_relations = relations.group_by(&:inverse_class_name)
         grouped_relations.keys.each do |klass|
-          grouped_relations[klass] = grouped_relations[klass].group_by do |metadata|
-            metadata.relation
-          end
+          grouped_relations[klass] = grouped_relations[klass].group_by(&:relation)
         end
         grouped_relations.each do |_klass, associations|
           associations.each do |relation, association|

--- a/lib/mongoid/relations/eager.rb
+++ b/lib/mongoid/relations/eager.rb
@@ -31,9 +31,9 @@ module Mongoid
           end
         end
         grouped_relations.each do |_klass, associations|
-          docs = associations.collect do |_relation, association|
+          associations.each do |_relation, association|
             _relation.eager_load_klass.new(association, docs).run
-          end.flatten
+          end
         end
       end
     end

--- a/lib/mongoid/relations/eager.rb
+++ b/lib/mongoid/relations/eager.rb
@@ -25,14 +25,14 @@ module Mongoid
         grouped_relations = relations.group_by do |metadata|
           metadata.inverse_class_name
         end
-        grouped_relations.keys.each do |_klass|
-          grouped_relations[_klass] = grouped_relations[_klass].group_by do |metadata|
+        grouped_relations.keys.each do |klass|
+          grouped_relations[klass] = grouped_relations[klass].group_by do |metadata|
             metadata.relation
           end
         end
         grouped_relations.each do |_klass, associations|
-          associations.each do |_relation, association|
-            _relation.eager_load_klass.new(association, docs).run
+          associations.each do |relation, association|
+            relation.eager_load_klass.new(association, docs).run
           end
         end
       end

--- a/lib/mongoid/relations/eager.rb
+++ b/lib/mongoid/relations/eager.rb
@@ -22,8 +22,9 @@ module Mongoid
       end
 
       def preload(relations, docs)
-        grouped_relations = relations.group_by(&:inverse_class_name)
-        grouped_relations.values.each do |associations|
+        relations.group_by(&:inverse_class_name)
+                 .values
+                 .each do |associations|
           associations.group_by(&:relation)
                       .each do |relation, association|
             relation.eager_load_klass.new(association, docs).run

--- a/lib/mongoid/relations/eager.rb
+++ b/lib/mongoid/relations/eager.rb
@@ -23,11 +23,9 @@ module Mongoid
 
       def preload(relations, docs)
         grouped_relations = relations.group_by(&:inverse_class_name)
-        grouped_relations.keys.each do |klass|
-          grouped_relations[klass] = grouped_relations[klass].group_by(&:relation)
-        end
-        grouped_relations.each do |_klass, associations|
-          associations.each do |relation, association|
+        grouped_relations.values.each do |associations|
+          associations.group_by(&:relation)
+                      .each do |relation, association|
             relation.eager_load_klass.new(association, docs).run
           end
         end


### PR DESCRIPTION
In some case (more than one circular associations included) It is possible to get a `SystemStackError: stack level too deep`.

After some digging I found it localized in `Eager#preload` code. This patch fix it (ec2a1c6), remove a double iteration (3fc2e2b) and make the method body more readable (413613e, 81901fb and 6cefdb5).