### PR TITLE
Small improvement to spec for Touchable

### DIFF
--- a/spec/mongoid/relations/touchable_spec.rb
+++ b/spec/mongoid/relations/touchable_spec.rb
@@ -343,6 +343,7 @@ describe Mongoid::Relations::Touchable do
         end
 
         it "does not persist other attribute changes" do
+          expect(band.name).to eq('Nocebo')
           expect(band.reload.name).not_to eq('Nocebo')
         end
       end
@@ -354,6 +355,7 @@ describe Mongoid::Relations::Touchable do
         end
 
         it "does not persist other attribute changes" do
+          expect(band.name).to eq('Nocebo')
           expect(band.reload.name).not_to eq('Nocebo')
         end
       end


### PR DESCRIPTION
In specs, when touching a model, assert that changes are not rolled back authomatically.