### PR TITLE
Infinite loop case with embeds + cascade_callbacks + touch

### DIFF
--- a/spec/app/models/band.rb
+++ b/spec/app/models/band.rb
@@ -1,5 +1,6 @@
 class Band
   include Mongoid::Document
+  include Mongoid::Timestamps
   include Mongoid::Attributes::Dynamic
   field :name, type: String
   field :active, type: Mongoid::Boolean, default: true

--- a/spec/app/models/record.rb
+++ b/spec/app/models/record.rb
@@ -9,7 +9,7 @@ class Record
   field :before_validation_called, type: Mongoid::Boolean, default: false
   field :before_destroy_called, type: Mongoid::Boolean, default: false
 
-  embedded_in :band
+  embedded_in :band, touch: true
   embeds_many :tracks, cascade_callbacks: true
   embeds_many :notes, as: :noteable, cascade_callbacks: true, validate: false
 

--- a/spec/mongoid/relations/touchable_spec.rb
+++ b/spec/mongoid/relations/touchable_spec.rb
@@ -227,6 +227,26 @@ describe Mongoid::Relations::Touchable do
         end
       end
 
+      context "when the parent of embedded doc has cascade callbacks" do
+
+        let(:band) do
+          Band.create(name: "The Rutles")
+        end
+
+        let!(:record) do
+          band.records.create(name: "All you need is cash")
+        end
+
+        before do
+          band.unset(:updated_at)
+          record.touch
+        end
+
+        it "touches the parent document" do
+          expect(band.updated_at).to be_within(5).of(Time.now)
+        end
+      end
+
       context "when the relation is nil" do
 
         let!(:agent) do


### PR DESCRIPTION
This PR adds a failing test case and a naive fix for an infinite loop issue. The issue occurs when you have:

```
class Parent
   embeds_many :kids, cascade_callbacks: true
end

class Kid
  embedded_in :parent, touch: true
end
```

When you call `kid.touch` the touch callback is triggered on the `parent`, then it cascades to the kids, and again back to the parent in a loop and triggers a `StackOverflow` error.

**Do no merge my fix, please investigate and do a proper fix for the issue**