### PR TITLE
Add db:mongoid:list_indexes Rake task

### DIFF
--- a/lib/mongoid/tasks/database.rake
+++ b/lib/mongoid/tasks/database.rake
@@ -5,6 +5,11 @@ namespace :db do
     task :load_models do
     end
 
+    desc "Lists the indexes defined on your mongoid models and in the database (does not make changes)"
+    task :list_indexes => [:environment, :load_models] do
+      ::Mongoid::Tasks::Database.list_indexes
+    end
+
     desc "Create the indexes defined on your mongoid models"
     task :create_indexes => [:environment, :load_models] do
       ::Mongoid::Tasks::Database.create_indexes

--- a/lib/mongoid/tasks/database.rb
+++ b/lib/mongoid/tasks/database.rb
@@ -65,6 +65,48 @@ module Mongoid
         undefined_by_model
       end
 
+      # Prints a list of indexes to the logger, including missing and undefined indexes.
+      #
+      # @example Print list of indexes.
+      #   Mongoid::Tasks::Database.list_indexes
+      #
+      # @return [ Array(Class, Array(Hash)) ] The models and categorized indexes that were listed.
+      #
+      # @since 6.0.0
+      def list_indexes(models = ::Mongoid.models)
+        indexes = diffed_indexes(models).to_a
+        indexes.sort_by! { |index| "#{diff_sort(index[1])}#{index[0]}" }
+        indexes.each do |model, diff|
+          logger.info "#{model.to_s.ljust(50)} #{diff_status(diff)}"
+
+          if diff[:ok]
+            if (diff.keys - [:ok]).present?
+              logger.info "  OK"
+              log_index_specifications(diff[:ok])
+            else
+              log_index_specifications(diff[:ok], 2)
+            end
+          end
+
+          if diff[:conflict]
+            logger.info "  CONFLICT"
+            log_index_specifications(diff[:conflict])
+          end
+
+          if diff[:missing]
+            logger.info "  MISSING"
+            log_index_specifications(diff[:missing])
+          end
+
+          if diff[:undefined]
+            logger.info "  UNDEFINED"
+            log_indexes(diff[:undefined])
+          end
+
+          logger.info ''
+        end
+      end
+
       # Remove indexes that exist in the database but aren't specified on the
       # models.
       #
@@ -112,6 +154,91 @@ module Mongoid
 
       def logger
         Mongoid.logger
+      end
+
+      def log_indexes(indexes, indent=4)
+        indexes.each{ |index| logger.info("#{' '*indent}#{index['name']}") }
+      end
+
+      def log_index_specifications(indexes, indent=4)
+        indexes.each{ |index| logger.info("#{' '*indent}#{index.key}#{', ' + index.options.to_s unless index.options.empty?}".gsub(/:(.*?)=>/, '\1: ')) }
+      end
+
+      # Return a nested Hash of indexes by model then by status:
+      # - ok: Defined in model and exists in database.
+      # - conflict: The options of the model-defined index are different than the database index.
+      # - missing: Defined in model but does not exist in database.
+      # - undefined: Exists in database but not defined in model.
+      #
+      # @example Return the list of nonexistent indexes.
+      #   Mongoid::Tasks::Database.diffed_indexes
+      #
+      # @return Hash{Class => Hash{Symbol => Array()}} The list of indexes by model then by status.
+      #
+      # @since 6.0.0
+      def diffed_indexes(models = ::Mongoid.models)
+        indexes_by_model = {}
+        valid_options = ::Mongoid::Indexable::Validators::Options::VALID_OPTIONS - [:key, :name]
+
+        models.each do |model|
+          next if model.embedded?
+          indexes_by_model[model] ||= {}
+          indexes_by_model[model][:missing] = model.index_specifications.dup
+          begin
+            model.collection.indexes.each do |index|
+              next if index['name'] == '_id_'
+              key = index['key'].symbolize_keys
+              spec = model.index_specification(key, index['name'])
+              if spec
+                indexes_by_model[model][:missing] -= [spec]
+                spec_options  = spec.options.symbolize_keys.slice(*valid_options).sort
+                index_options = index.symbolize_keys.slice(*valid_options).sort
+                if spec_options == index_options
+                  indexes_by_model[model][:ok] ||= []
+                  indexes_by_model[model][:ok] << spec
+                else
+                  indexes_by_model[model][:conflict] ||= []
+                  indexes_by_model[model][:conflict] << spec
+                end
+              else
+                indexes_by_model[model][:undefined] ||= []
+                indexes_by_model[model][:undefined] << index
+              end
+            end
+          rescue Mongo::Error::OperationFailure; end
+
+          indexes_by_model[model].delete(:missing) if indexes_by_model[model][:missing].empty?
+        end
+
+        indexes_by_model
+      end
+
+      # Returns a human-readable status of an index diff
+      #
+      # @return String The status.
+      #
+      # @since 6.0.0
+      def diff_status(diff)
+        if diff.blank?
+          'NONE'
+        elsif (diff.keys - [:ok]).present?
+          'BAD'
+        else
+          'OK'
+        end
+      end
+
+      # Returns sort order of an index diff
+      #
+      # @return Integer The sort order.
+      #
+      # @since 6.0.0
+      def diff_sort(diff)
+        case diff_status(diff)
+          when 'OK'   then 0
+          when 'NONE' then 1
+          when 'BAD'  then 2
+        end
       end
     end
   end

--- a/spec/mongoid/tasks/database_rake_spec.rb
+++ b/spec/mongoid/tasks/database_rake_spec.rb
@@ -201,6 +201,32 @@ describe "db:mongoid:create_indexes", if: non_legacy_server? do
   end
 end
 
+describe "db:mongoid:list_indexes", if: non_legacy_server? do
+  include_context "rake task"
+
+  it "receives list_indexes" do
+    expect(Mongoid::Tasks::Database).to receive(:list_indexes)
+    task.invoke
+  end
+
+  it "calls environment" do
+    expect(task.prerequisites).to include("environment")
+  end
+
+  context "when using rails task" do
+    include_context "rails rake task"
+
+    before do
+      expect(Rails).to receive(:application).and_return(application)
+    end
+
+    it "receives list_indexes" do
+      expect(Mongoid::Tasks::Database).to receive(:list_indexes)
+      task.invoke
+    end
+  end
+end
+
 describe "db:mongoid:remove_undefined_indexes", if: non_legacy_server? do
   include_context "rake task"
 


### PR DESCRIPTION
Outputs:

```
User                                               OK
  {name: 1}

Account                                            NONE

Person                                             BAD
  OK
    {addresses: 1}
  CONFLICT
    {age: 1}
  MISSING
    {dob: 1}
    {name: 1}
    {title: 1}
    {preference_ids: 1}, {background: true}
  UNDEFINED
    dob_1_title_1
```

- ok: Defined in model and exists in database.
- conflict: The options of the model-defined index are different than the database index.
- missing: Defined in model but does not exist in database.
- undefined: Exists in database but not defined in model.