### PR TITLE
Another case where infinite loop can occur with touch callback

### DIFF
--- a/spec/mongoid/relations/touchable_spec.rb
+++ b/spec/mongoid/relations/touchable_spec.rb
@@ -245,6 +245,26 @@ describe Mongoid::Relations::Touchable do
         end
       end
 
+      context "when multiple embedded docs with cascade callbacks" do
+
+        let!(:book) do
+          Book.new
+        end
+
+        before do
+          2.times { book.pages.new }
+          book.save
+          book.unset(:updated_at)
+          book.pages.first.content  = "foo"
+          book.pages.second.content = "bar"
+          book.pages.first.touch
+        end
+
+        it "touches the parent document" do
+          expect(book.updated_at).to be_within(5).of(Time.now)
+        end
+      end
+
       context "when the relation is nil" do
 
         let!(:agent) do


### PR DESCRIPTION
While testing the fix in #4388 I've determined that a stack overflow can still can occur when there are multiple embedded children. If both children are in a state where they can get the touch callback (e.g. `changed?` is `true`), then they will cause an infinite loop like:

touch Child A --> calls touch on Parent --> calls touch on Child B --> calls touch on Parent --> calls touch on Child A --> ...

The only way I can think to solve this is to track an array of already called children on each object and not call the same child twice. I've made a proof of concept implementation of this. If we go with this approach  we should also rollback the changes from #4388