### PR TITLE
Do not cascade :touch callback from parent to child

### DIFF
--- a/lib/mongoid/interceptable.rb
+++ b/lib/mongoid/interceptable.rb
@@ -190,7 +190,7 @@ module Mongoid
     #
     # @since 2.3.0
     def cascadable_child?(kind, child, metadata)
-      return false if kind == :initialize || kind == :find
+      return false if kind == :initialize || kind == :find || kind == :touch
       return false if kind == :validate && metadata.validate?
       child.callback_executable?(kind) ? child.in_callback_state?(kind) : false
     end

--- a/lib/mongoid/interceptable.rb
+++ b/lib/mongoid/interceptable.rb
@@ -124,12 +124,9 @@ module Mongoid
     #
     # @since 2.3.0
     def run_callbacks(kind, *args, &block)
-      opts = args.extract_options!
       cascadable_children(kind).each do |child|
-        unless opts[:callers] && opts[:callers].include?(child)
-          if child.run_callbacks(child_callback_type(kind, child), *args) == false
-            return false
-          end
+        if child.run_callbacks(child_callback_type(kind, child), *args) == false
+          return false
         end
       end
       callback_executable?(kind) ? super(kind, *args, &block) : true

--- a/lib/mongoid/relations/touchable.rb
+++ b/lib/mongoid/relations/touchable.rb
@@ -21,7 +21,7 @@ module Mongoid
       # @return [ true/false ] false if record is new_record otherwise true.
       #
       # @since 3.0.0
-      def touch(field = nil, opts = {})
+      def touch(field = nil)
         return false if _root.new_record?
         current = Time.now
         field = database_field_name(field)
@@ -33,7 +33,7 @@ module Mongoid
           selector = atomic_selector
           _root.collection.find(selector).update_one(positionally(selector, touches))
         end
-        run_callbacks(:touch, opts)
+        run_callbacks(:touch)
         true
       end
 
@@ -85,7 +85,7 @@ module Mongoid
             def #{method_name}
               without_autobuild do
                 relation = __send__(:#{name})
-                relation.touch(#{extra_field ? ":#{extra_field}" : 'nil' }, callers: [self]) if relation
+                relation.touch #{":#{extra_field}" if extra_field} if relation
               end
             end
           TOUCH

--- a/spec/mongoid/relations/touchable_spec.rb
+++ b/spec/mongoid/relations/touchable_spec.rb
@@ -245,6 +245,26 @@ describe Mongoid::Relations::Touchable do
         end
       end
 
+      context "when multiple embedded docs with cascade callbacks" do
+
+        let!(:book) do
+          Book.new
+        end
+
+        before do
+          2.times { book.pages.new }
+          book.save
+          book.unset(:updated_at)
+          book.pages.first.content  = "foo"
+          book.pages.second.content = "bar"
+          book.pages.first.touch
+        end
+
+        it "touches the parent document" do
+          expect(book.updated_at).to be_within(5).of(Time.now)
+        end
+      end
+
       context "when the relation is nil" do
 
         let!(:agent) do


### PR DESCRIPTION
While testing #4391 I discovered another infinite loop case is still possible with two embedded child docs:

touch Child A --> calls touch on Parent --> calls touch on Child B --> calls touch on Parent --> calls touch on Child A --> ...

I also discovered that **in most cases** the `touch` callback **does not actually cascade from parent to child docs**, it only cascades when the child has been modified.

```ruby
    def in_callback_state?(kind)   # kind == :touch
      [ :create, :destroy ].include?(kind) || new_record? || flagged_for_destroy? || changed?
    end
```

Therefore, I believe the best solution is to never cascade the touch callback from parent -> child, and instead only do child -> parent, which avoids any possibility of loops.

This PR reverts the changes in #4391