### PR TITLE
Fix habtm self reference

### DIFF
--- a/lib/mongoid/relations/accessors.rb
+++ b/lib/mongoid/relations/accessors.rb
@@ -229,7 +229,7 @@ module Mongoid
             without_autobuild do
               if value = get_relation(name, metadata, object)
                 value = __build__(name, value, metadata) unless value.respond_to?(:substitute)
-                set_relation(name, value.substitute(object.substitutable)) unless value == object.substitutable
+                set_relation(name, value.substitute(object.substitutable))
               else
                 __build__(name, object.substitutable, metadata)
               end

--- a/lib/mongoid/relations/accessors.rb
+++ b/lib/mongoid/relations/accessors.rb
@@ -228,12 +228,8 @@ module Mongoid
           re_define_method("#{name}=") do |object|
             without_autobuild do
               if value = get_relation(name, metadata, object)
-                if value.respond_to?(:substitute)
-                  set_relation(name, value.substitute(object.substitutable))
-                else
-                  value = __build__(name, value, metadata)
-                  set_relation(name, value.substitute(object.substitutable))
-                end
+                value = __build__(name, value, metadata) unless value.respond_to?(:substitute)
+                set_relation(name, value.substitute(object.substitutable)) unless value == object.substitutable
               else
                 __build__(name, object.substitutable, metadata)
               end

--- a/lib/mongoid/relations/referenced/many_to_many.rb
+++ b/lib/mongoid/relations/referenced/many_to_many.rb
@@ -189,11 +189,13 @@ module Mongoid
         #
         # @since 2.0.0.rc.1
         def substitute(replacement)
-          purge
-          unless replacement.blank?
-            push(replacement.compact.uniq)
-          else
-            reset_unloaded
+          unless replacement == self
+            purge
+            if replacement.present?
+              push(replacement.compact.uniq)
+            else
+              reset_unloaded
+            end
           end
           self
         end

--- a/spec/app/models/vertex.rb
+++ b/spec/app/models/vertex.rb
@@ -1,0 +1,6 @@
+class Vertex
+  include Mongoid::Document
+
+  has_and_belongs_to_many :parents, inverse_of: :children, class_name: 'Vertex'
+  has_and_belongs_to_many :children, inverse_of: :parents, class_name: 'Vertex'
+end

--- a/spec/mongoid/relations/referenced/many_to_many_spec.rb
+++ b/spec/mongoid/relations/referenced/many_to_many_spec.rb
@@ -814,6 +814,86 @@ describe Mongoid::Relations::Referenced::ManyToMany do
     end
   end
 
+  describe "when self-referencing" do
+    let!(:parent) do
+      Vertex.create
+    end
+
+    let!(:child) do
+      Vertex.create(parents: [parent])
+    end
+
+    describe "#create" do
+      before do
+        parent.reload
+        child.reload
+      end
+
+      it "sets the parent" do
+        expect(child.parents).to include(parent)
+      end
+
+      it "sets the parent id" do
+        expect(child.parent_ids).to include(parent.id)
+      end
+
+      it "sets the child" do
+        expect(parent.children).to include(child)
+      end
+
+      it "sets the child id" do
+        expect(parent.child_ids).to include(child.id)
+      end
+    end
+
+    describe "#update" do
+      before do
+        parent.reload
+        child.reload
+        child.update(parents: [parent])
+      end
+
+      it "sets the parent" do
+        expect(child.parents).to include(parent)
+      end
+
+      it "sets the parent id" do
+        expect(child.parent_ids).to include(parent.id)
+      end
+
+      it "sets the child" do
+        expect(parent.children).to include(child)
+      end
+
+      it "sets the child id" do
+        expect(parent.child_ids).to include(child.id)
+      end
+
+      describe "when reloading" do
+        before do
+          parent.reload
+          child.reload
+        end
+
+        it "sets the parent" do
+          expect(child.parents).to include(parent)
+        end
+
+        it "sets the parent id" do
+          expect(child.parent_ids).to include(parent.id)
+        end
+
+        it "sets the child" do
+          expect(parent.children).to include(child)
+        end
+
+        it "sets the child id" do
+          expect(parent.child_ids).to include(child.id)
+        end
+      end
+    end
+  end
+
   [ nil, [] ].each do |value|
 
     describe "#= #{value}" do


### PR DESCRIPTION
Attempted fix for #4286

The issue is that:
- `#substitute` method of the many-to-many relation is calling `purge` which removes the inverse relationship value
- `#substitute` method then calls `push` to add value to the current doc relation WITHOUT updating the inverse.
- Normally this is not a problem because the `Synchornization` callbacks will detect that the value has changed and update the inverse, EXCEPT if the value is the same (i.e. NOT changed)

Solution is to skip `substitute` logic if no change.