### PR TITLE
Fix compatibility of Mongoid::Contextual::None with other contexts by adding distinct

### DIFF
--- a/lib/mongoid/contextual/none.rb
+++ b/lib/mongoid/contextual/none.rb
@@ -21,6 +21,18 @@ module Mongoid
         other.is_a?(None)
       end
 
+      # Allow distinct for null context.
+      #
+      # @example Get the distinct values.
+      #   context.distinct(:name)
+      #
+      # @param [ String, Symbol ] field the name of the field.
+      #
+      # @return [ Array ] Empty Array
+      def distinct(field)
+        []
+      end
+
       # Iterate over the null context. There are no documents to iterate over
       # in this case.
       #

--- a/spec/mongoid/contextual/none_spec.rb
+++ b/spec/mongoid/contextual/none_spec.rb
@@ -65,6 +65,21 @@ describe Mongoid::Contextual::None do
     end
   end
 
+  describe "#distinct" do
+
+    let!(:band) do
+      Band.create(name: "Depeche Mode")
+    end
+
+    let(:context) do
+      described_class.new(Band.where(name: "Depeche Mode"))
+    end
+
+    it "returns an empty array" do
+      expect(context.distinct(:id)).to eq([])
+    end
+  end
+
   describe "#pluck" do
 
     let!(:band) do


### PR DESCRIPTION
Currently `Mongoid::Contextual::None` does not implement the `distinct` method.

Since `Mongoid::Contextual::None` is intended to provide a compatible API with the other contexts (to be used when no documents should be returned), it should implement `distinct` as well.

Added a test case that fails before the change, and passes after implementing the method.

#### Example:
```ruby
users = if admin?
  User.where(email: /@mongodb.com/)
else
  User.none
end

ids = users.distinct(:id)
```
