### PR TITLE
Update mongoid-queries.txt with valid ruby

### DIFF
--- a/docs/tutorials/mongoid-queries.txt
+++ b/docs/tutorials/mongoid-queries.txt
@@ -488,7 +488,7 @@ extending functionality.
     scope :active, ->{
       where(active: true) do
         def deutsch
-          tap |scope| do
+          tap do |scope|
             scope.selector.store("origin" => "Deutschland")
           end
         end


### PR DESCRIPTION
`|scope|` is on the wrong side of the `do` keyword