### PR TITLE
Failing spec: changes in callbacks of an embedded document not persisted.

### DIFF
--- a/spec/app/models/page.rb
+++ b/spec/app/models/page.rb
@@ -6,11 +6,16 @@ class Page
   embedded_in :book, touch: true
   embeds_many :notes
   field :content, :type => String
+  field :page_number, :type => Integer
 
   after_initialize do
     if self[:content]
       self[:text] = self[:content]
       self.remove_attribute(:content)
     end
+  end
+
+  before_validation do
+    self.page_number = 1 unless self.page_number
   end
 end

--- a/spec/mongoid/persistable/updatable_spec.rb
+++ b/spec/mongoid/persistable/updatable_spec.rb
@@ -611,6 +611,27 @@ describe Mongoid::Persistable::Updatable do
           end
         end
 
+        context "when providing an embedded child with before validation" do
+
+          let!(:book) do
+            Book.create
+          end
+
+          before do
+            book.send(method, pages: [{content: "text"}])
+          end
+
+          # passed
+          it "updates the embedded document with changes from before validation callback" do
+            expect(book.pages.first.page_number).to eq(1)
+          end
+
+          # failed. expected 1, got nil
+          it "persistes the changes from before validation callback" do
+            expect(book.reload.pages.first.page_number).to eq(1)
+          end
+        end
+
         context "when providing a parent to a referenced in" do
 
           let!(:person) do


### PR DESCRIPTION
hi guys.

I just upgraded our project from mongoid `5.1.4` to `6.0.3`. And we got a bunch of tests failing. It looks like if you have an embedded document with `before_validation` callbacks, changes in the `before_validation` callbacks are not persisted anymore if you run a `update_attributes` on the parent model object.

The changes are persisted alright with mongoid `5.1.4`. So I guess this is a new change in version 6.x?

Is this an expected behaviour? or we are doing something wrong here?

In this PR, I added a before_validation on the book page model, and two specs for it. The one with database reloading is failing.

(I know for this test, you could use a default value to replace the before_validation. But this spec is not talking about the business logic. It's just an example.)

Jira ticket: https://jira.mongodb.org/browse/MONGOID-4425

Thanks a lot in advanced.