### PR TITLE
Allow raw bson regexp query criteria on fields specified as Strings

### DIFF
--- a/lib/mongoid/criteria/queryable/extensions/regexp.rb
+++ b/lib/mongoid/criteria/queryable/extensions/regexp.rb
@@ -35,6 +35,38 @@ module Mongoid
               end
             end
           end
+
+          module Raw
+
+            # Is the object a regexp?
+            #
+            # @example Is the object a regex?
+            #   bson_raw_regexp.regexp?
+            #
+            # @return [ true ] Always true.
+            #
+            # @since 5.2.1
+            def regexp?; true; end
+
+            module ClassMethods
+
+              # Evolve the object into a raw bson regex.
+              #
+              # @example Evolve the object to a regex.
+              #   BSON::Regexp::Raw.evolve("^[123]")
+              #
+              # @param [ BSON::Regexp::Raw, String ] object The object to evolve.
+              #
+              # @return [ BSON::Regexp::Raw ] The evolved raw regex.
+              #
+              # @since 5.2.1
+              def evolve(object)
+                __evolve__(object) do |obj|
+                  obj.is_a?(String) ? BSON::Regexp::Raw.new(obj) : obj
+                end
+              end
+            end
+          end
         end
       end
     end
@@ -43,3 +75,5 @@ end
 
 ::Regexp.__send__(:include,Mongoid::Criteria::Queryable::Extensions::Regexp)
 ::Regexp.__send__(:extend, Mongoid::Criteria::Queryable::Extensions::Regexp::ClassMethods)
+BSON::Regexp::Raw.__send__(:include,Mongoid::Criteria::Queryable::Extensions::Regexp::Raw)
+BSON::Regexp::Raw.__send__(:extend, Mongoid::Criteria::Queryable::Extensions::Regexp::Raw::ClassMethods)

--- a/lib/mongoid/matchable.rb
+++ b/lib/mongoid/matchable.rb
@@ -13,6 +13,7 @@ require "mongoid/matchable/nin"
 require "mongoid/matchable/or"
 require "mongoid/matchable/size"
 require "mongoid/matchable/elem_match"
+require "mongoid/matchable/regexp"
 
 module Mongoid
 
@@ -117,6 +118,8 @@ module Mongoid
           else
             Default.new(extract_attribute(document, key))
           end
+        elsif value.regexp?
+          Regexp.new(extract_attribute(document, key))
         else
           case key.to_s
             when "$or" then Or.new(value, document)

--- a/lib/mongoid/matchable/regexp.rb
+++ b/lib/mongoid/matchable/regexp.rb
@@ -1,0 +1,27 @@
+module Mongoid
+  module Matchable
+
+    # Defines behavior for handling regular expressions in embedded documents.
+    class Regexp < Default
+
+      # Does the supplied query match the attribute?
+      #
+      # @example Does this match?
+      #   matcher.matches?(/^Em/)
+      #   matcher.matches?(BSON::Regex::Raw.new("^Em"))
+      #
+      # @param [ BSON::Regexp::Raw, Regexp ] regexp The regular expression object.
+      #
+      # @return [ true, false ] True if matches, false if not.
+      #
+      # @since 5.2.1
+      def matches?(regexp)
+        if native_regexp = regexp.try(:compile)
+          super(native_regexp)
+        else
+          super
+        end
+      end
+    end
+  end
+end

--- a/spec/mongoid/criteria/queryable/extensions/regexp_raw_spec.rb
+++ b/spec/mongoid/criteria/queryable/extensions/regexp_raw_spec.rb
@@ -1,0 +1,89 @@
+require "spec_helper"
+
+describe Mongoid::Criteria::Queryable::Extensions::Regexp::Raw do
+
+  describe ".evolve" do
+
+    context "when provided a bson raw regexp" do
+
+      let(:regexp) do
+        BSON::Regexp::Raw.new("^[123]")
+      end
+
+      let(:evolved) do
+        BSON::Regexp::Raw.evolve(regexp)
+      end
+
+      it "returns the regexp" do
+        expect(evolved).to be(regexp)
+      end
+    end
+
+    context "when providing a string" do
+
+      let(:regexp_string) do
+        '^[123]'
+      end
+
+      let(:evolved) do
+        BSON::Regexp::Raw.evolve(regexp_string)
+      end
+
+      it "returns the converted raw regexp" do
+        expect(evolved).to eq(BSON::Regexp::Raw.new(regexp_string))
+      end
+    end
+
+    context "when provided an array" do
+
+      context "when the elements are bson raw regexps" do
+
+        let(:regexp) do
+          BSON::Regexp::Raw.new("^[123]")
+        end
+
+        let(:array) do
+          [ regexp ]
+        end
+
+        let(:evolved) do
+          BSON::Regexp::Raw.evolve(array)
+        end
+
+        it "returns the array containing raw regexps" do
+          expect(evolved).to eq([ regexp ])
+        end
+
+        it "does not evolve in place" do
+          expect(evolved).to_not equal(array)
+        end
+      end
+
+      context "when the elements are strings" do
+
+        let(:regexp_string) do
+          "^[123]"
+        end
+
+        let(:evolved) do
+          BSON::Regexp::Raw.evolve([ regexp_string ])
+        end
+
+        it "returns the regexps" do
+          expect(evolved).to eq([ BSON::Regexp::Raw.new(regexp_string) ])
+        end
+      end
+    end
+  end
+
+  describe "#regexp?" do
+
+    let(:regexp) do
+      BSON::Regexp::Raw.new('^[123]')
+    end
+
+    it "returns true" do
+      expect(regexp).to be_regexp
+    end
+  end
+end

--- a/spec/mongoid/criteria/queryable/selectable_spec.rb
+++ b/spec/mongoid/criteria/queryable/selectable_spec.rb
@@ -3469,6 +3469,21 @@ describe Mongoid::Criteria::Queryable::Selectable do
             expect(selection.selector).to eq({ "user_id" => document.id })
           end
         end
+
+        context 'when the field is a String and the value is a BSON::Regexp::Raw' do
+
+          let(:raw_regexp) do
+            BSON::Regexp::Raw.new('^Em')
+          end
+
+          let(:selection) do
+            Login.where(_id: raw_regexp)
+          end
+
+          it 'does not convert the bson raw regexp object to a String' do
+            expect(selection.selector).to eq({ "_id" => raw_regexp })
+          end
+        end
       end
     end
 

--- a/spec/mongoid/matchable/regexp_spec.rb
+++ b/spec/mongoid/matchable/regexp_spec.rb
@@ -1,0 +1,59 @@
+require "spec_helper"
+
+describe Mongoid::Matchable::Regexp do
+
+  let(:matcher) do
+    described_class.new(attribute)
+  end
+
+  let(:attribute) do
+    'Emily'
+  end
+
+  describe '#matches?' do
+
+    context 'when a BSON::Regexp::Raw object is passed' do
+
+      let(:regexp) do
+        BSON::Regexp::Raw.new('^Em')
+      end
+
+      it 'compiles the regexp object to a native regexp for the matching' do
+        expect(matcher.matches?(regexp)).to be(true)
+      end
+
+      context 'when the value does not match the attribute' do
+
+        let(:attribute) do
+          'ily'
+        end
+
+        it 'compiles the regexp object to a native regexp for the matching' do
+          expect(matcher.matches?(regexp)).to be(false)
+        end
+      end
+    end
+
+    context 'when a native Regexp object is passed' do
+
+      let(:regexp) do
+        /^Em/
+      end
+
+      it 'calls super with the native regexp' do
+        expect(matcher.matches?(regexp)).to be(true)
+      end
+
+      context 'when the value does not match the attribute' do
+
+        let(:attribute) do
+          'ily'
+        end
+
+        it 'compiles the regexp object to a native regexp for the matching' do
+          expect(matcher.matches?(regexp)).to be(false)
+        end
+      end
+    end
+  end
+end

--- a/spec/mongoid/matchable_spec.rb
+++ b/spec/mongoid/matchable_spec.rb
@@ -289,6 +289,28 @@ describe Mongoid::Matchable do
           expect(document.matches?(selector)).to be false
         end
       end
+
+      context 'when a BSON::Regexp::Raw object is used' do
+
+        let(:selector) do
+          { street: BSON::Regexp::Raw.new("^Clarkenwell") }
+        end
+
+        it "returns true" do
+          expect(document.matches?(selector)).to be true
+        end
+      end
+
+      context 'when a native Regexp object is used' do
+
+        let(:selector) do
+          { street: /^Clarkenwell/ }
+        end
+
+        it "returns true" do
+          expect(document.matches?(selector)).to be true
+        end
+      end
     end
 
     context "when performing complex matching" do


### PR DESCRIPTION
When a field is specified as a String, Mongoid previously assumed anything other than a native ruby regex should be converted to a String when defining the query selector. This pull request allows a BSON::Regexp::Raw type to be part of the query selector, without being converted to a String.

Also allow a BSON::Regexp::Raw object to be used in an in-memory query.