### PR TITLE
MONGOID-4425 #as_document continues to return BSON::Document, but use internal api method #as_attributes otherwise

### DIFF
--- a/lib/mongoid/atomic.rb
+++ b/lib/mongoid/atomic.rb
@@ -222,7 +222,7 @@ module Mongoid
     #
     # @since 2.1.0
     def atomic_pushes
-      pushable? ? { atomic_position => as_document } : {}
+      pushable? ? { atomic_position => as_attributes } : {}
     end
 
     # Get all the attributes that need to be set.
@@ -234,7 +234,7 @@ module Mongoid
     #
     # @since 2.1.0
     def atomic_sets
-      updateable? ? setters : settable? ? { atomic_path => as_document } : {}
+      updateable? ? setters : settable? ? { atomic_path => as_attributes } : {}
     end
 
     # Get all the attributes that need to be unset.

--- a/lib/mongoid/contextual/memory.rb
+++ b/lib/mongoid/contextual/memory.rb
@@ -44,7 +44,7 @@ module Mongoid
         deleted = count
         removed = map do |doc|
           prepare_remove(doc)
-          doc.as_document
+          doc.send(:as_attributes)
         end
         unless removed.empty?
           collection.find(selector).update_one(

--- a/lib/mongoid/copyable.rb
+++ b/lib/mongoid/copyable.rb
@@ -51,7 +51,7 @@ module Mongoid
     #
     # @since 3.0.22
     def clone_document
-      attrs = as_document.__deep_copy__
+      attrs = as_attributes.__deep_copy__
       process_localized_attributes(self, attrs)
       attrs
     end

--- a/lib/mongoid/document.rb
+++ b/lib/mongoid/document.rb
@@ -282,7 +282,7 @@ module Mongoid
           relation, stored = send(name), meta.store_as
           if attributes.key?(stored) || !relation.blank?
             if relation
-              attributes[stored] = relation.as_document
+              attributes[stored] = relation.send(:as_attributes)
             else
               attributes.delete(stored)
             end

--- a/lib/mongoid/matchable.rb
+++ b/lib/mongoid/matchable.rb
@@ -146,7 +146,7 @@ module Mongoid
       # @since 2.2.1
       def extract_attribute(document, key)
         if (key_string = key.to_s) =~ /.+\..+/
-          key_string.split('.').inject(document.as_document) do |_attribs, _key|
+          key_string.split('.').inject(document.send(:as_attributes)) do |_attribs, _key|
             if _attribs.is_a?(::Array)
               if _key =~ /\A\d+\z/ && _attribs.none? {|doc| doc.is_a?(Hash)}
                 _attribs.try(:[], _key.to_i)

--- a/lib/mongoid/persistable/creatable.rb
+++ b/lib/mongoid/persistable/creatable.rb
@@ -42,7 +42,7 @@ module Mongoid
       #
       # @since 2.1.0
       def atomic_inserts
-        { atomic_insert_modifier => { atomic_position => as_document }}
+        { atomic_insert_modifier => { atomic_position => as_attributes }}
       end
 
       # Insert the embedded document.
@@ -76,7 +76,7 @@ module Mongoid
       #
       # @since 4.0.0
       def insert_as_root
-        collection.insert_one(as_document)
+        collection.insert_one(as_attributes)
       end
 
       # Post process an insert, which sets the new record attribute to false

--- a/lib/mongoid/persistable/upsertable.rb
+++ b/lib/mongoid/persistable/upsertable.rb
@@ -21,7 +21,7 @@ module Mongoid
       # @since 3.0.0
       def upsert(options = {})
         prepare_upsert(options) do
-          collection.find(atomic_selector).update_one(as_document, upsert: true)
+          collection.find(atomic_selector).update_one(as_attributes, upsert: true)
         end
       end
 

--- a/lib/mongoid/relations/embedded/batchable.rb
+++ b/lib/mongoid/relations/embedded/batchable.rb
@@ -279,7 +279,7 @@ module Mongoid
                 self.inserts_valid = false
               end
             end
-            doc.as_document
+            doc.send(:as_attributes)
           end
         end
 
@@ -308,7 +308,7 @@ module Mongoid
             _unscoped.delete_one(doc)
             unbind_one(doc)
             execute_callback :after_remove, doc
-            doc.as_document
+            doc.send(:as_attributes)
           end
         end
 

--- a/lib/mongoid/relations/embedded/many.rb
+++ b/lib/mongoid/relations/embedded/many.rb
@@ -57,11 +57,7 @@ module Mongoid
         #
         # @since 2.0.0.rc.1
         def as_document
-          attributes = []
-          _unscoped.each do |doc|
-            attributes.push(doc.as_document)
-          end
-          attributes
+          as_attributes.collect { |attrs| BSON::Document.new(attrs) }
         end
 
         # Appends an array of documents to the relation. Performs a batch
@@ -512,6 +508,14 @@ module Mongoid
         # @since 2.4.0
         def _unscoped=(docs)
           @_unscoped = docs
+        end
+
+        def as_attributes
+          attributes = []
+          _unscoped.each do |doc|
+            attributes.push(doc.as_document)
+          end
+          attributes
         end
 
         class << self

--- a/lib/mongoid/relations/referenced/many.rb
+++ b/lib/mongoid/relations/referenced/many.rb
@@ -569,7 +569,7 @@ module Mongoid
           if doc.new_record? && doc.valid?(:create)
             doc.run_before_callbacks(:save, :create)
             docs.push(doc)
-            inserts.push(doc.as_document)
+            inserts.push(doc.send(:as_attributes))
           else
             doc.save
           end

--- a/lib/mongoid/serializable.rb
+++ b/lib/mongoid/serializable.rb
@@ -66,7 +66,7 @@ module Mongoid
     #
     # @since 3.0.0
     def field_names(options)
-      names = (as_document.keys + attribute_names).uniq.sort
+      names = (as_attributes.keys + attribute_names).uniq.sort
 
       only = Array.wrap(options[:only]).map(&:to_s)
       except = Array.wrap(options[:except]).map(&:to_s)

--- a/spec/mongoid/interceptable_spec.rb
+++ b/spec/mongoid/interceptable_spec.rb
@@ -1152,6 +1152,25 @@ describe Mongoid::Interceptable do
               expect(band.reload.records.first.before_validation_called).to be true
             end
           end
+
+          context 'when the parent is updated' do
+
+            let(:band) do
+              Band.create(name: "Moderat")
+            end
+
+            before do
+              band.update(records: [ { name: 'Black on Both Sides' }])
+            end
+
+            it 'executes the callback' do
+              expect(band.records.first.before_validation_called).to be true
+            end
+
+            it 'persists the change' do
+              expect(band.reload.records.first.before_validation_called).to be true
+            end
+          end
         end
 
         context "when the child is persisted" do

--- a/spec/mongoid/validatable/uniqueness_spec.rb
+++ b/spec/mongoid/validatable/uniqueness_spec.rb
@@ -2424,6 +2424,7 @@ describe Mongoid::Validatable::UniquenessValidator do
 
     before do
       Person.validates_uniqueness_of(:username)
+      Person.index({ ssn: 1 }, { unique: true })
       Person.create_indexes
     end
 
@@ -2433,6 +2434,7 @@ describe Mongoid::Validatable::UniquenessValidator do
 
     after do
       Person.reset_callbacks(:validate)
+      Person.collection.drop
     end
 
     it "transfers the options to the cloned client" do


### PR DESCRIPTION
Mongoid's callbacks rely on being able to mutate the ``attributes`` hash of a model object directly, so we replace the use of ``#as_document`` with ``#as_attributes``, and allow the public API method ``#as_document`` to continue returning a ``BSON::Document``.