### PR TITLE
Add link to v5.2 API docs

### DIFF
--- a/docs/index.txt
+++ b/docs/index.txt
@@ -1,6 +1,6 @@
-=======
-Mongoid
-=======
+=============
+Mongoid (5.2)
+=============
 
 .. default-domain:: mongodb
 
@@ -20,6 +20,7 @@ The Mongoid documentation has the following tutorials:
    /tutorials/mongoid-indexes
    /tutorials/mongoid-rails
    /tutorials/mongoid-upgrade
+   API <https://docs.mongodb.com/mongoid/5.2/api/>
 
 For documentation on Mongoid 3 and 4, see `<http://mongoid.github.io>`_.
 


### PR DESCRIPTION
When publishing mongoid docs from 10gen/docs-mongoid, the process will now generate the API docs and publish along with the other docs.