### PR TITLE
Add link to 6.1 API docs

### DIFF
--- a/docs/index.txt
+++ b/docs/index.txt
@@ -23,6 +23,7 @@ framework for MongoDB in Ruby.
    /tutorials/mongoid-indexes
    /tutorials/mongoid-rails
    /tutorials/mongoid-upgrade
+   API <https://docs.mongodb.com/mongoid/6.1/api>
 
 
 For documentation on Mongoid 3 and 4, see `<http://mongoid.github.io>`_.


### PR DESCRIPTION
When publishing mongoid docs from 10gen/docs-mongoid, the process will now generate the API docs and publish along with the other docs.