### PR TITLE
MONGOID-4448 Use "background_indexing" option by default to create new indexes

### DIFF
--- a/lib/mongoid/config.rb
+++ b/lib/mongoid/config.rb
@@ -27,6 +27,7 @@ module Mongoid
     option :log_level, default: :info
     option :belongs_to_required_by_default, default: true
     option :app_name, default: nil
+    option :background_indexing, default: false
 
     # Has Mongoid been configured? This is checking that at least a valid
     # client config exists.

--- a/lib/mongoid/indexable.rb
+++ b/lib/mongoid/indexable.rb
@@ -28,8 +28,11 @@ module Mongoid
       # @since 1.0.0
       def create_indexes
         return unless index_specifications
+
+        default_options = {background: Config.background_indexing}
+
         index_specifications.each do |spec|
-          key, options = spec.key, spec.options
+          key, options = spec.key, default_options.merge(spec.options)
           if database = options[:database]
             with(database: database) do |klass|
               klass.collection.indexes.create_one(key, options.except(:database))

--- a/lib/rails/generators/mongoid/config/templates/mongoid.yml
+++ b/lib/rails/generators/mongoid/config/templates/mongoid.yml
@@ -145,6 +145,9 @@ development:
     # Application name that is printed to the mongodb logs upon establishing a
     # connection in server versions >= 3.4. Note that the name cannot exceed 128 bytes.
     # app_name: MyApplicationName
+
+    # Use background indexes by default if `background` option not specified. (default: false)
+    # background_indexing: false
 test:
   clients:
     default:

--- a/spec/config/mongoid.yml
+++ b/spec/config/mongoid.yml
@@ -32,6 +32,7 @@ test:
     log_level: :warn
     belongs_to_required_by_default: false
     app_name: 'testing'
+    background_indexing: false
 test_with_max_staleness:
   clients:
     default:

--- a/spec/mongoid/config_spec.rb
+++ b/spec/mongoid/config_spec.rb
@@ -88,6 +88,30 @@ describe Mongoid::Config do
     end
   end
 
+  context 'when background_indexing option' do
+    context 'is not set in the config' do
+      it 'sets the value to false by default' do
+        Mongoid::Config.reset
+        configuration = CONFIG.merge(options: {})
+
+        Mongoid.configure { |config| config.load_configuration(configuration) }
+
+        expect(Mongoid::Config.background_indexing).to be(false)
+      end
+    end
+
+    context 'is set in the config' do
+      it 'sets the value' do
+        Mongoid::Config.reset
+        configuration = CONFIG.merge(options: {background_indexing: true})
+
+        Mongoid.configure { |config| config.load_configuration(configuration) }
+
+        expect(Mongoid::Config.background_indexing).to be(true)
+      end
+    end
+  end
+
   context 'when the belongs_to_required_by_default option is not set in the config' do
 
     before do

--- a/spec/mongoid/indexable_spec.rb
+++ b/spec/mongoid/indexable_spec.rb
@@ -89,8 +89,9 @@ describe Mongoid::Indexable do
         klass.create_indexes
       end
 
-      it "creates the indexes" do
-        expect(klass.collection.indexes.get(_type: 1)).to_not be_nil
+      it "creates the indexes by using specified background option" do
+        index = klass.collection.indexes.get(_type: 1)
+        expect(index[:background]).to eq(true)
       end
     end
 
@@ -104,12 +105,9 @@ describe Mongoid::Indexable do
         end
       end
 
-      before do
-        klass.create_indexes
-      end
-
       after do
         klass.remove_indexes
+        Mongoid::Config.background_indexing = false
       end
 
       let(:indexes) do
@@ -118,8 +116,20 @@ describe Mongoid::Indexable do
         end
       end
 
-      it "creates the indexes" do
-        expect(indexes.get(_type: 1)).to_not be_nil
+      it "creates the indexes by using default background_indexing option" do
+        klass.create_indexes
+
+        index = indexes.get(_type: 1)
+        expect(index[:background]).to eq(Mongoid::Config.background_indexing)
+      end
+
+      it "creates the indexes by using specified background_indexing option" do
+        Mongoid::Config.background_indexing = true
+
+        klass.create_indexes
+
+        index = indexes.get(_type: 1)
+        expect(index[:background]).to eq(true)
       end
     end
 


### PR DESCRIPTION
Hey,

I wonder if we can add an additional option to create DB indexes in the background by default. 

I think it might be useful in case if somebody added an index on a huge collection and forgot to specify `background: true`. By setting something like:

```yaml
# config/mongoid.yml
production:
  options:
    background_indexing: true
```

And after adding a new index:

```ruby
# app/models/person.rb
class Person
  include Mongoid::Document
  field :ssn
  index ssn: 1 # <=== NEW INDEX
end
```

And running:

```sh
bundle exec rails runner "Person.create_indexes"
# or
bundle exec rake db:mongoid:create_indexes
```

We can avoid human mistakes, which may lead to catastrophic DB blocking:
> By default, creating an index blocks all other operations on a database.
> https://docs.mongodb.com/manual/core/index-creation/

These changes don't break backward compatibility 😉 