### PR TITLE
MONGOID-4444 Don't include PersistenceContext methods in prohibted field names, include Clients::Options

### DIFF
--- a/lib/mongoid/composable.rb
+++ b/lib/mongoid/composable.rb
@@ -75,6 +75,7 @@ module Mongoid
       Scopable,
       Serializable,
       Clients,
+      Clients::Options,
       Shardable,
       Stateful,
       Cacheable,
@@ -84,8 +85,7 @@ module Mongoid
       Equality,
       Relations::Synchronization,
       ActiveModel::Model,
-      ActiveModel::Validations,
-      PersistenceContext
+      ActiveModel::Validations
     ]
 
     # These are methods names defined in included blocks that may conflict


### PR DESCRIPTION
MONGOID-4418 included PersistenceContext method names in the list of prohibited field names, but Clients::Options should have been included instead.