### PR TITLE
MONGOID-4455 Make readonly attributes behavior consistent with ActiveRecord

### DIFF
--- a/lib/mongoid/attributes.rb
+++ b/lib/mongoid/attributes.rb
@@ -163,7 +163,8 @@ module Mongoid
     #
     # @since 1.0.0
     def write_attribute(name, value)
-      as_writable_attribute!(name) do |access|
+      access = database_field_name(name)
+      if attribute_writable?(access)
         _assigning do
           validate_attribute_value(access, value)
           localized = fields[access].try(:localized?)

--- a/lib/mongoid/attributes/readonly.rb
+++ b/lib/mongoid/attributes/readonly.rb
@@ -22,17 +22,15 @@ module Mongoid
       #   readonly.
       #
       # @since 3.0.0
-      #
-      # @deprecated Use #as_writable_attribute! instead.
       def attribute_writable?(name)
-        new_record? || !readonly_attributes.include?(database_field_name(name))
+        new_record? || (!readonly_attributes.include?(name) && _loaded?(name))
       end
 
       private
 
       def as_writable_attribute!(name, value = :nil)
         normalized_name = database_field_name(name)
-        if new_record? || (!readonly_attributes.include?(normalized_name) && _loaded?(normalized_name))
+        if attribute_writable?(normalized_name)
           yield(normalized_name)
         else
           raise Errors::ReadonlyAttribute.new(name, value)

--- a/lib/mongoid/persistable.rb
+++ b/lib/mongoid/persistable.rb
@@ -162,10 +162,9 @@ module Mongoid
     # @since 4.0.0
     def process_atomic_operations(operations)
       operations.each do |field, value|
-        as_writable_attribute!(field, value) do |access|
-          yield(access, value)
-          remove_change(access)
-        end
+        access = database_field_name(field)
+        yield(access, value)
+        remove_change(access)
       end
     end
 

--- a/lib/mongoid/persistable/incrementable.rb
+++ b/lib/mongoid/persistable/incrementable.rb
@@ -28,7 +28,7 @@ module Mongoid
             attributes[field] = (current || 0) + increment
             ops[atomic_attribute_name(field)] = increment
           end
-          { "$inc" => ops }
+          { "$inc" => ops } unless ops.empty?
         end
       end
     end

--- a/lib/mongoid/persistable/logical.rb
+++ b/lib/mongoid/persistable/logical.rb
@@ -30,7 +30,7 @@ module Mongoid
             attributes[field] = value
             ops[atomic_attribute_name(field)] = values
           end
-          { "$bit" => ops }
+          { "$bit" => ops } unless ops.empty?
         end
       end
     end

--- a/spec/app/models/person.rb
+++ b/spec/app/models/person.rb
@@ -114,6 +114,9 @@ class Person
     dependent:  :nullify,
     validate: false
 
+  belongs_to :mother, class_name: 'Person'
+  has_many :children, class_name: 'Person'
+
   accepts_nested_attributes_for :addresses
   accepts_nested_attributes_for :name, update_only: true
   accepts_nested_attributes_for :pet, allow_destroy: true

--- a/spec/mongoid/attributes/readonly_spec.rb
+++ b/spec/mongoid/attributes/readonly_spec.rb
@@ -144,9 +144,7 @@ describe Mongoid::Attributes::Readonly do
         context 'with multiple fields operation' do
 
           it "udpates the attribute" do
-            person.bit(
-              age: {and: 13}, score: {or: 13}, inte: {and: 13, or: 10}
-            )
+            person.bit(age: {and: 13}, score: {or: 13})
             person.save
             expect(person.reload.score).to eq(13)
             expect(person.reload.age).to eq(4)

--- a/spec/mongoid/attributes/readonly_spec.rb
+++ b/spec/mongoid/attributes/readonly_spec.rb
@@ -232,5 +232,40 @@ describe Mongoid::Attributes::Readonly do
         end
       end
     end
+
+    context 'when a foreign_key is defined as readonly' do
+
+      let(:attributes) do
+        :mother_id
+      end
+
+      context 'when the relation exists' do
+
+        let(:mother) do
+          Person.create
+        end
+
+        let(:child) do
+          Person.create(mother: mother)
+          Person.find_by(mother: mother)
+        end
+
+        it 'the relation can still be accessed' do
+          expect(child.mother).to eq(mother)
+        end
+      end
+
+      context 'when the relation does not exist' do
+
+        let(:child) do
+          Person.create
+        end
+
+        it 'the relation is nil' do
+          expect(child.mother).to be_nil
+        end
+      end
+
+    end
   end
 end

--- a/spec/mongoid/attributes/readonly_spec.rb
+++ b/spec/mongoid/attributes/readonly_spec.rb
@@ -96,30 +96,14 @@ describe Mongoid::Attributes::Readonly do
       context "when updating via the setter" do
 
         it "does not update the first field" do
-          expect {
-            person.title = 'mr'
-          }.to raise_exception(Mongoid::Errors::ReadonlyAttribute)
-          expect(person.title).to eq("sir")
-        end
-
-        it "does not update the second field" do
-          expect {
-            person.aliased_timestamp = Time.at(43)
-          }.to raise_exception(Mongoid::Errors::ReadonlyAttribute)
-          expect(person.aliased_timestamp).to eq(Time.at(42))
-        end
-
-        it "does not persist the first field" do
-          expect {
-            person.title = 'mr'
-          }.to raise_exception(Mongoid::Errors::ReadonlyAttribute)
+          person.title = 'mr'
+          person.save
           expect(person.reload.title).to eq("sir")
         end
 
-        it "does not persist the second field" do
-          expect {
-            person.aliased_timestamp = Time.at(43)
-          }.to raise_exception(Mongoid::Errors::ReadonlyAttribute)
+        it "does not update the second field" do
+          person.aliased_timestamp = Time.at(43)
+          person.save
           expect(person.reload.aliased_timestamp).to eq(Time.at(42))
         end
       end
@@ -128,19 +112,20 @@ describe Mongoid::Attributes::Readonly do
 
         context 'with single field operation' do
 
-          it "raises an error " do
-            expect {
-              person.inc(score: 1)
-            }.to raise_error(Mongoid::Errors::ReadonlyAttribute)
+          it "updates the field" do
+            person.inc(score: 1)
+            person.save
+            expect(person.reload.score).to eq(2)
           end
         end
 
         context 'with multiple fields operation' do
 
-          it "raises an error " do
-            expect {
-              person.inc(score: 1, age: 1)
-            }.to raise_error(Mongoid::Errors::ReadonlyAttribute)
+          it "updates the fields" do
+            person.inc(score: 1, age: 1)
+            person.save
+            expect(person.reload.score).to eq(2)
+            expect(person.reload.age).to eq(101)
           end
         end
       end
@@ -149,21 +134,22 @@ describe Mongoid::Attributes::Readonly do
 
         context 'with single field operation' do
 
-          it "raises an error " do
-            expect {
-              person.bit(score: { or: 13 })
-            }.to raise_error(Mongoid::Errors::ReadonlyAttribute)
+          it "does the update" do
+            person.bit(score: { or: 13 })
+            person.save
+            expect(person.reload.score).to eq(13)
           end
         end
 
         context 'with multiple fields operation' do
 
-          it "raises an error " do
-            expect {
-              person.bit(
-                age: { and: 13 }, score: { or: 13 }, inte: { and: 13, or: 10 }
-              )
-            }.to raise_error(Mongoid::Errors::ReadonlyAttribute)
+          it "udpates the attribute" do
+            person.bit(
+              age: {and: 13}, score: {or: 13}, inte: {and: 13, or: 10}
+            )
+            person.save
+            expect(person.reload.score).to eq(13)
+            expect(person.reload.age).to eq(4)
           end
         end
       end
@@ -171,30 +157,14 @@ describe Mongoid::Attributes::Readonly do
       context "when updating via []=" do
 
         it "does not update the first field" do
-          expect {
-            person[:title] = "mr"
-          }.to raise_exception(Mongoid::Errors::ReadonlyAttribute)
-          expect(person.title).to eq("sir")
-        end
-
-        it "does not update the second field" do
-          expect {
-            person[:aliased_timestamp] = Time.at(43)
-          }.to raise_exception(Mongoid::Errors::ReadonlyAttribute)
-          expect(person.aliased_timestamp).to eq(Time.at(42))
-        end
-
-        it "does not persist the first field" do
-          expect {
-            person[:title] = "mr"
-          }.to raise_exception(Mongoid::Errors::ReadonlyAttribute)
+          person[:title] = "mr"
+          person.save
           expect(person.reload.title).to eq("sir")
         end
 
-        it "does not persist the second field" do
-          expect {
-            person[:aliased_timestamp] = Time.at(43)
-          }.to raise_exception(Mongoid::Errors::ReadonlyAttribute)
+        it "does not update the second field" do
+          person[:aliased_timestamp] = Time.at(43)
+          person.save
           expect(person.reload.aliased_timestamp).to eq(Time.at(42))
         end
       end
@@ -202,30 +172,14 @@ describe Mongoid::Attributes::Readonly do
       context "when updating via write_attribute" do
 
         it "does not update the first field" do
-          expect {
-            person.write_attribute(:title, "mr")
-          }.to raise_exception(Mongoid::Errors::ReadonlyAttribute)
-          expect(person.title).to eq("sir")
-        end
-
-        it "does not update the second field" do
-          expect {
-            person.write_attribute(:aliased_timestamp, Time.at(43))
-          }.to raise_exception(Mongoid::Errors::ReadonlyAttribute)
-          expect(person.aliased_timestamp).to eq(Time.at(42))
-        end
-
-        it "does not persist the first field" do
-          expect {
-            person.write_attribute(:title, "mr")
-          }.to raise_exception(Mongoid::Errors::ReadonlyAttribute)
+          person.write_attribute(:title, "mr")
+          person.save
           expect(person.reload.title).to eq("sir")
         end
 
-        it "does not persist the second field" do
-          expect {
-            person.write_attribute(:aliased_timestamp, Time.at(43))
-          }.to raise_exception(Mongoid::Errors::ReadonlyAttribute)
+        it "does not update the second field" do
+          person.write_attribute(:aliased_timestamp, Time.at(43))
+          person.save
           expect(person.reload.aliased_timestamp).to eq(Time.at(42))
         end
       end
@@ -233,30 +187,14 @@ describe Mongoid::Attributes::Readonly do
       context "when updating via update_attributes" do
 
         it "does not update the first field" do
-          expect {
-            person.update_attributes(title: "mr", aliased_timestamp: Time.at(43))
-          }.to raise_exception(Mongoid::Errors::ReadonlyAttribute)
-          expect(person.title).to eq("sir")
-        end
-
-        it "does not update the second field" do
-          expect {
-            person.update_attributes(title: "mr", aliased_timestamp: Time.at(43))
-          }.to raise_exception(Mongoid::Errors::ReadonlyAttribute)
-          expect(person.aliased_timestamp).to eq(Time.at(42))
-        end
-
-        it "does not persist the first field" do
-          expect {
-            person.update_attributes(title: "mr", aliased_timestamp: Time.at(43))
-          }.to raise_exception(Mongoid::Errors::ReadonlyAttribute)
+          person.update_attributes(title: "mr", aliased_timestamp: Time.at(43))
+          person.save
           expect(person.reload.title).to eq("sir")
         end
 
-        it "does not persist the second field" do
-          expect {
-            person.update_attributes(title: "mr", aliased_timestamp: Time.at(43))
-          }.to raise_exception(Mongoid::Errors::ReadonlyAttribute)
+        it "does not update the second field" do
+          person.update_attributes(title: "mr", aliased_timestamp: Time.at(43))
+          person.save
           expect(person.reload.aliased_timestamp).to eq(Time.at(42))
         end
       end
@@ -264,30 +202,14 @@ describe Mongoid::Attributes::Readonly do
       context "when updating via update_attributes!" do
 
         it "does not update the first field" do
-          expect {
-            person.update_attributes!(title: "mr", aliased_timestamp: Time.at(43))
-          }.to raise_exception(Mongoid::Errors::ReadonlyAttribute)
-          expect(person.title).to eq("sir")
-        end
-
-        it "does not update the second field" do
-          expect {
-            person.update_attributes!(title: "mr", aliased_timestamp: Time.at(43))
-          }.to raise_exception(Mongoid::Errors::ReadonlyAttribute)
-          expect(person.aliased_timestamp).to eq(Time.at(42))
-        end
-
-        it "does not persist the first field" do
-          expect {
-            person.update_attributes!(title: "mr", aliased_timestamp: Time.at(43))
-          }.to raise_exception(Mongoid::Errors::ReadonlyAttribute)
+          person.update_attributes!(title: "mr", aliased_timestamp: Time.at(43))
+          person.save
           expect(person.reload.title).to eq("sir")
         end
 
-        it "does not persist the second field" do
-          expect {
-            person.update_attributes!(title: "mr", aliased_timestamp: Time.at(43))
-          }.to raise_exception(Mongoid::Errors::ReadonlyAttribute)
+        it "does not update the second field" do
+          person.update_attributes!(title: "mr", aliased_timestamp: Time.at(43))
+          person.save
           expect(person.reload.aliased_timestamp).to eq(Time.at(42))
         end
       end
@@ -297,7 +219,7 @@ describe Mongoid::Attributes::Readonly do
         it "raises an error" do
           expect {
             person.update_attribute(:title, "mr")
-          }.to raise_error(Mongoid::Errors::ReadonlyAttribute)
+          }.to raise_exception(Mongoid::Errors::ReadonlyAttribute)
         end
       end
 
@@ -306,7 +228,7 @@ describe Mongoid::Attributes::Readonly do
         it "raises an error" do
           expect {
             person.remove_attribute(:title)
-          }.to raise_error(Mongoid::Errors::ReadonlyAttribute)
+          }.to raise_exception(Mongoid::Errors::ReadonlyAttribute)
         end
       end
     end

--- a/spec/mongoid/persistable/savable_spec.rb
+++ b/spec/mongoid/persistable/savable_spec.rb
@@ -309,7 +309,7 @@ describe Mongoid::Persistable::Savable do
         expect {
           person.username = 'unloaded-attribute'
           person.save
-        }.to raise_error(Mongoid::Errors::ReadonlyAttribute)
+        }.to raise_error(ActiveModel::MissingAttributeError)
       end
 
       context 'when the changed attribute is aliased' do


### PR DESCRIPTION
See this gist for ActiveRecord's behavior:
https://gist.github.com/estolfo/01933abfff69bfb54c3336281b611780
