### PR TITLE
Use valid_options method instead of constant

### DIFF
--- a/lib/mongoid/relations/options.rb
+++ b/lib/mongoid/relations/options.rb
@@ -32,7 +32,7 @@ module Mongoid
       #
       # @since 2.1.0
       def validate!(options)
-        valid_options = options[:relation]::VALID_OPTIONS + COMMON
+        valid_options = options[:relation].valid_options + COMMON
         options.keys.each do |key|
           if !valid_options.include?(key)
             raise Errors::InvalidOptions.new(


### PR DESCRIPTION
I think this was changed by mistake in https://github.com/mongodb/mongoid/pull/4269/files#diff-8defad7996cfab9e288a4049e3b5c0c6L35