### PR TITLE
Fixup the falsey logic of `__nested__`

### DIFF
--- a/lib/mongoid/extensions/hash.rb
+++ b/lib/mongoid/extensions/hash.rb
@@ -106,8 +106,11 @@ module Mongoid
         value = self
         keys.each do |key|
           return nil if value.nil?
-          nested = value[key] || value[key.to_i]
-          value = nested
+          value_for_key = value[key]
+          if value_for_key.nil? && key.to_i.to_s == key
+            value_for_key = value[key.to_i]
+          end
+          value = value_for_key
         end
         value
       end

--- a/spec/mongoid/extensions/hash_spec.rb
+++ b/spec/mongoid/extensions/hash_spec.rb
@@ -230,10 +230,27 @@ describe Mongoid::Extensions::Hash do
     it "should retrieve a nested value under the provided key" do
       expect(nested).to eq "hundred"
     end
+
+    context 'and the value is falsey' do
+      let(:hash) do
+        { "100" => { "name" => false } }
+      end
+      it "should retrieve the falsey nested value under the provided key" do
+        expect(nested).to eq false
+      end
+    end
+
+    context 'and the value is nil' do
+      let(:hash) do
+        { "100" => { 0 => "Please don't return this value!" } }
+      end
+      it "should retrieve the nil nested value under the provided key" do
+        expect(nested).to eq nil
+      end
+    end
   end
 
   context "when the hash key is an integer" do
-
     let(:hash) do
       { 100 => { "name" => "hundred" } }
     end


### PR DESCRIPTION
Right now, when you have a document with a key that is `false`, the `__nested__` method on hashes will incorrectly return `nil`

For example:

```ruby
# Imagine we have some nested data on our document
my_document["nested_data"]
# => { some_boolean_value: false }

# Looking up this nested value without dot notation returns the correct value
my_document.nested_data["some_boolean_value"]
# => false

#Doing the same thing with `read_attribute` causes the value to be `nil`
my_document.read_attribute("nested_data.some_boolean_value")
# => nil
```

Internally within the nested function we end up doing `false || nil` which ruby evaluates to `nil`.
`false` is a completely valid value in this case and we should return that.

More worryingly is if you have an integer keyed hash:

```ruby
my_document["nested_data"]
# => { 0: "Some value for zero", 1: "Some value for one" }

# attempt to read a string key that doesn't exist
my_document.read_attribute("nested_data.this_doesnt_exist")
# => "Some value for zero"
```

😱 

Internally, there is a `to_i` call on the string key, ruby's madness converts this to `0` which in this case ends up with us returning the incorrect data.

Changes in this PR:
* Only check for integer version of the key if the value is `nil` and the key is definitely just an integer.