### PR TITLE
Failed test: update in callback of nested embedded documents not persisted. [No need to merge]

### DIFF
--- a/spec/mongoid/updates_in_callbacks_of_nested_embedded_documents_spec.rb
+++ b/spec/mongoid/updates_in_callbacks_of_nested_embedded_documents_spec.rb
@@ -1,0 +1,67 @@
+require "spec_helper"
+
+describe "Callbacks in nested embedded document" do
+
+  class Track
+
+    field :price
+
+    # same issue when using before_validation
+    after_validation :set_price_when_not_exist
+
+    private
+
+    def set_price_when_not_exist
+      if self.price.blank?
+        self.price = calculate_price
+      end
+    end
+
+    def calculate_price
+      # some logic goes here in actual code
+      100
+    end
+  end
+
+  describe "when creating new document" do
+
+    it "persistes values in embedded document callbacks" do
+      band = Band.create records: [
+        {
+          name: "Record 1", tracks: [{name: "Track 1"}]
+        }
+      ]
+
+      expect(band.records.first.tracks.first.name).to eq("Track 1")
+      expect(band.records.first.tracks.first.price).to eq(100)
+    end
+
+  end
+
+  describe "when updating document" do
+
+    let!(:band) do
+      Band.create
+    end
+
+    it "persistes values in embedded document callbacks" do
+      band = Band.create
+
+      band.update_attributes records: [
+        {
+          name: "Record 1", tracks: [{name: "Track 1"}]
+        }
+      ]
+
+      expect(band.records.first.tracks.first.name).to eq("Track 1")
+      expect(band.records.first.tracks.first.price).to eq(100)
+
+      reloaded_from_db = Band.find_by id: band.id
+
+      expect(reloaded_from_db.records.first.tracks.first.name).to eq("Track 1")
+      expect(reloaded_from_db.records.first.tracks.first.price).to eq(100)    # FAILED: expected: 100, but got: nil
+    end
+
+  end
+
+end


### PR DESCRIPTION
This commit contains a failed test. `update` on nested embedded document not persisted. (See line 62)

`band` -> `record` -> `track` are nested embedded documents. Attribute assignment in callbacks for `track` model is not persisted in database.

Note: `create` method works well. And also there is no issue for direct embedded document (`record` model in this test)

I submitted an other issue before https://jira.mongodb.org/browse/MONGOID-4425 it looks like related. Hope this helps.

Any ideas for this one? Thanks a lot.
