### PR TITLE
Rails controller runtime logging

### DIFF
--- a/docs/tutorials/mongoid-rails.txt
+++ b/docs/tutorials/mongoid-rails.txt
@@ -136,12 +136,13 @@ Similar to Active Record, Mongoid tells raise to return specific http codes when
   Mongoid::Errors::DocumentNotFound : 404
   Mongoid::Errors::Validations : 422
 
-Controller runtime instrumentation
+Controller Runtime Instrumentation
 **********************************
 
-Mongoid provides it's own runtime metric to Rails' internal instrumentation
-event `process_action.action_controller`. It is accessible in the payload by `mongoid_runtime` key.
-The measurement is made via internal Mongo monitoring subscription.
+Mongoid provides its runtime metric to Rails' internal instrumentation
+event `process_action.action_controller`. It is accessible in the payload via
+`mongoid_runtime` key. The measurement is made via an internal Mongo driver
+monitoring subscription.
 
 Rake Tasks
 ----------

--- a/docs/tutorials/mongoid-rails.txt
+++ b/docs/tutorials/mongoid-rails.txt
@@ -136,6 +136,13 @@ Similar to Active Record, Mongoid tells raise to return specific http codes when
   Mongoid::Errors::DocumentNotFound : 404
   Mongoid::Errors::Validations : 422
 
+Controller runtime instrumentation
+**********************************
+
+Mongoid provides it's own runtime metric to Rails' internal instrumentation
+event `process_action.action_controller`. It is accessible in the payload by `mongoid_runtime` key.
+The measurement is made via internal Mongo monitoring subscription.
+
 Rake Tasks
 ----------
 

--- a/docs/tutorials/mongoid-rails.txt
+++ b/docs/tutorials/mongoid-rails.txt
@@ -139,10 +139,22 @@ Similar to Active Record, Mongoid tells raise to return specific http codes when
 Controller Runtime Instrumentation
 **********************************
 
-Mongoid provides its runtime metric to Rails' internal instrumentation
-event `process_action.action_controller`. It is accessible in the payload via
-`mongoid_runtime` key. The measurement is made via an internal Mongo driver
-monitoring subscription.
+Mongoid provides time spent executing MongoDB commands (obtained via a
+driver command monitoring subscription) to Rails' instrumentation event
+`process_action.action_controller`. This time is logged together with view
+time like so:
+
+.. code-block:: none
+
+  Completed 200 OK in 2739ms (Views: 12.6ms | MongoDB: 0.2ms)
+
+This logging is set up automatically.
+
+Note: the time indicated is the time taken by MongoDB cluster to execute
+MongoDB operations, plus the time taken to send commands and receive
+results from MongoDB over the network. It does not include time taken by
+the driver and Mongoid to generate the queries or type cast and otherwise
+process the results.
 
 Rake Tasks
 ----------

--- a/lib/mongoid/railtie.rb
+++ b/lib/mongoid/railtie.rb
@@ -103,6 +103,18 @@ module Rails
         puts "There is a configuration error with the current mongoid.yml."
         puts e.message
       end
+
+      initializer 'mongoid.runtime-metric' do
+        require 'mongoid/railties/controller_runtime'
+
+        ActiveSupport.on_load :action_controller do
+          include ::Mongoid::Railties::ControllerRuntime::ControllerExtension
+        end
+
+        Mongo::Monitoring::Global.subscribe Mongo::Monitoring::COMMAND,
+            ::Mongoid::Railties::ControllerRuntime::Instrument.new
+      end
+
     end
   end
 end

--- a/lib/mongoid/railtie.rb
+++ b/lib/mongoid/railtie.rb
@@ -104,8 +104,13 @@ module Rails
         puts e.message
       end
 
-      initializer 'mongoid.runtime-metric' do
-        require 'mongoid/railties/controller_runtime'
+      # Include Controller extension that measures Mongoid runtime
+      # during request processing. The value then appears in Rails'
+      # instrumentation event `process_action.action_controller`.
+      #
+      # The measurement is made via internal Mongo monitoring subscription
+      initializer "mongoid.runtime-metric" do
+        require "mongoid/railties/controller_runtime"
 
         ActiveSupport.on_load :action_controller do
           include ::Mongoid::Railties::ControllerRuntime::ControllerExtension

--- a/lib/mongoid/railtie.rb
+++ b/lib/mongoid/railtie.rb
@@ -117,7 +117,7 @@ module Rails
         end
 
         Mongo::Monitoring::Global.subscribe Mongo::Monitoring::COMMAND,
-            ::Mongoid::Railties::ControllerRuntime::Instrument.new
+            ::Mongoid::Railties::ControllerRuntime::Collector.new
       end
 
     end

--- a/lib/mongoid/railties/controller_runtime.rb
+++ b/lib/mongoid/railties/controller_runtime.rb
@@ -1,0 +1,67 @@
+module Mongoid
+  module Railties
+    module ControllerRuntime
+
+      module ControllerExtension
+        extend ActiveSupport::Concern
+
+        protected
+
+        attr_internal :mongo_runtime
+
+        def cleanup_view_runtime
+          mongo_rt_before_render = Instrument.reset_runtime
+          runtime = super
+          mongo_rt_after_render = Instrument.reset_runtime
+          self.mongo_runtime = mongo_rt_before_render + mongo_rt_after_render
+          runtime - mongo_rt_after_render
+        end
+
+        def append_info_to_payload payload
+          super
+          payload[:mongo_runtime] = (mongo_runtime || 0) + Instrument.reset_runtime
+        end
+
+        module ClassMethods
+
+          def log_process_action payload
+            messages, mongo_runtime = super, payload[:mongo_runtime]
+            messages << ("MongoDB: %.1fms" % mongo_runtime.to_f) if mongo_runtime
+            messages
+          end
+
+        end
+
+      end
+
+      class Instrument
+
+        VARIABLE_NAME = 'Mongoid.controller_runtime'.freeze
+
+        def started _; end
+
+        def completed e
+          Instrument.runtime += e.duration
+        end
+        alias :succeeded :completed
+        alias :failed :completed
+
+        def self.runtime
+          Thread.current[VARIABLE_NAME] ||= 0
+        end
+
+        def self.runtime= value
+          Thread.current[VARIABLE_NAME] = value
+        end
+
+        def self.reset_runtime
+          _runtime = runtime
+          self.runtime = 0
+          _runtime
+        end
+
+      end
+
+    end
+  end
+end

--- a/spec/rails/controller_extension/controller_runtime_spec.rb
+++ b/spec/rails/controller_extension/controller_runtime_spec.rb
@@ -1,0 +1,110 @@
+require "spec_helper"
+require "mongoid/railties/controller_runtime"
+
+describe "Mongoid::Railties::ControllerRuntime" do
+  controller_runtime = Mongoid::Railties::ControllerRuntime
+  collector = controller_runtime::Collector
+
+  def set_metric value
+    Thread.current["Mongoid.controller_runtime"] = value
+  end
+
+  def clear_metric!
+    set_metric 0
+  end
+
+  describe "Collector" do
+
+    it "stores the metric in thread-safe manner" do
+      clear_metric!
+      expect(collector.runtime).to eq(0)
+      set_metric 42
+      expect(collector.runtime).to eq(42)
+    end
+
+    it "sets metric on both succeeded and failed" do
+      instance = collector.new
+      event_payload = OpenStruct.new duration: 42
+
+      clear_metric!
+      instance.succeeded event_payload
+      expect(collector.runtime).to eq(42)
+
+      clear_metric!
+      instance.failed event_payload
+      expect(collector.runtime).to eq(42)
+    end
+
+    it "resets the metric and returns the value" do
+      clear_metric!
+      expect(collector.reset_runtime).to eq(0)
+      set_metric 42
+      expect(collector.reset_runtime).to eq(42)
+      expect(collector.runtime).to eq(0)
+    end
+
+  end
+
+  reference_controller_class = Class.new do
+    def process_action *_
+      @process_action = true
+    end
+
+    def cleanup_view_runtime *_
+      @cleanup_view_runtime.call
+    end
+
+    def append_info_to_payload *_
+      @append_info_to_payload = true
+    end
+
+    def self.log_process_action *_
+      @log_process_action.call
+    end
+  end
+
+  controller_class = Class.new reference_controller_class do
+    include controller_runtime::ControllerExtension
+  end
+
+  let(:controller){ controller_class.new }
+
+  it "resets the metric before each action" do
+    set_metric 42
+    controller.send :process_action
+    expect(collector.runtime).to be(0)
+    expect(controller.instance_variable_get "@process_action").to be(true)
+  end
+
+  it "strips the metric of other sources of the runtime" do
+    set_metric 1
+    controller.instance_variable_set "@cleanup_view_runtime", ->{
+      controller.instance_variable_set "@cleanup_view_runtime", true
+      set_metric 13
+      42
+    }
+    returned = controller.send :cleanup_view_runtime
+    expect(controller.instance_variable_get "@cleanup_view_runtime").to be(true)
+    expect(controller.mongoid_runtime).to eq(14)
+    expect(returned).to be(29)
+  end
+
+  it "appends the metric to payload" do
+    payload = {}
+    set_metric 42
+    controller.send :append_info_to_payload, payload
+    expect(controller.instance_variable_get "@append_info_to_payload").to be(true)
+    expect(payload[:mongoid_runtime]).to eq(42)
+  end
+
+  it "adds metric to log message" do
+    controller_class.instance_variable_set "@log_process_action", ->{
+      controller_class.instance_variable_set "@log_process_action", true
+      []
+    }
+    messages = controller_class.log_process_action mongoid_runtime: 42.101
+    expect(controller_class.instance_variable_get "@log_process_action").to be(true)
+    expect(messages).to eq(["MongoDB: 42.1ms"])
+  end
+
+end

--- a/spec/rails/controller_extension/controller_runtime_spec.rb
+++ b/spec/rails/controller_extension/controller_runtime_spec.rb
@@ -71,7 +71,7 @@ describe "Mongoid::Railties::ControllerRuntime" do
 
   it "resets the metric before each action" do
     set_metric 42
-    controller.send :process_action
+    controller.send(:process_action, 'foo')
     expect(collector.runtime).to be(0)
     expect(controller.instance_variable_get "@process_action").to be(true)
   end


### PR DESCRIPTION
Hi there, I'm bringing back an issue about logging mongoid runtime per rails controller action. 

there was https://github.com/mongodb/mongoid/pull/3885 that failed to get into mongoid, not sure why, but now that code is incompatible.

the log message `Completed 200 OK in 52ms (Views: 0.2ms | ActiveRecord: 0.4ms | MongoDB: 0.1ms)` is nice but marginal feature.

we needed to collect some metrics about our rails application; this allows us to use standard rails notification:

```ruby
ActiveSupport::Notifications.subscribe 'process_action.action_controller' do |*args|
  data = args.extract_options!
  data[:mongo_runtime] # accessible here
end
```

and please, would it be possible to put it in older versions too? (we're currently on mongoid 5.1)