### PR TITLE
fix cloning document with polymorphic embedded documents with multiple language field

### DIFF
--- a/lib/mongoid/copyable.rb
+++ b/lib/mongoid/copyable.rb
@@ -74,8 +74,8 @@ module Mongoid
 
         if metadata.macro == :embeds_many
           attrs[metadata.key].each do |attr|
-            klass = attr.fetch('_type', metadata.class_name).constantize
-            process_localized_attributes(klass, attr)
+            embedded_klass = attr.fetch('_type', metadata.class_name).constantize
+            process_localized_attributes(embedded_klass, attr)
           end
         else
           process_localized_attributes(metadata.klass, attrs[metadata.key])

--- a/lib/mongoid/copyable.rb
+++ b/lib/mongoid/copyable.rb
@@ -74,7 +74,8 @@ module Mongoid
 
         if metadata.macro == :embeds_many
           attrs[metadata.key].each do |attr|
-            process_localized_attributes(metadata.klass, attr)
+            klass = attr.fetch('_type', metadata.class_name).constantize
+            process_localized_attributes(klass, attr)
           end
         else
           process_localized_attributes(metadata.klass, attrs[metadata.key])

--- a/spec/app/models/address_customized.rb
+++ b/spec/app/models/address_customized.rb
@@ -1,0 +1,3 @@
+class AddressCustomized < Address
+  field :alternative_name, localize: true
+end

--- a/spec/app/models/address_customized.rb
+++ b/spec/app/models/address_customized.rb
@@ -1,3 +1,0 @@
-class AddressCustomized < Address
-  field :alternative_name, localize: true
-end

--- a/spec/app/models/favorite_localized.rb
+++ b/spec/app/models/favorite_localized.rb
@@ -1,0 +1,3 @@
+class FavoriteLocalized < Favorite
+  field :title, localize: true
+end

--- a/spec/mongoid/copyable_spec.rb
+++ b/spec/mongoid/copyable_spec.rb
@@ -146,15 +146,14 @@ describe Mongoid::Copyable do
 
       context "when cloning a document with polymorphic embedded documents with multiple language field" do
 
-        let!(:address_customized) do
-          person.addresses.build({ street: "Bond", name: "Bond" }, AddressCustomized)
+        let!(:favorite_localized) do
+          person.favorites.build({ title: "Title" }, FavoriteLocalized)
         end
 
         before do
           I18n.enforce_available_locales = false
           I18n.locale = 'pt_BR'
-          person.addresses.each { |address| address.name = "descrição" }
-          person.addresses.type(AddressCustomized).first.alternative_name = "alternativa"
+          person.favorites.each { |favorite| favorite.title = "Título" }
           person.save
         end
 
@@ -172,12 +171,8 @@ describe Mongoid::Copyable do
 
         it 'sets embedded translations' do
           I18n.locale = 'pt_BR'
-          copy.addresses.each do |address|
-            expect(address.name).to eq("descrição")
-          end
-
-          copy.addresses.type(AddressCustomized).each do |address|
-            expect(address.alternative_name).to eq("alternativa")
+          copy.favorites.each do |favorite|
+            expect(favorite.title).to eq("Título")
           end
         end
 


### PR DESCRIPTION
Currently, localized fields are inferred from the class stored in relation's metadata.

However, in polymorphic embedded relations, each embedded document class can possibly define different localized fields. In the current implementation these are not taken into account and as a result localized fields on embedded polymorphic documents might not be correctly processed. 

I propose this patch, which first attempts to infer localized fields from the class defined in the `_type` attribute, falling back to the class defined on relation's metadata.

Questions:
* is there already a mechanism to convert `_type` attribute to a class, or is the `constantize` method sufficient? Would `safe_constantize` be preferred?
* I have added an extra class to the test suite (`AddressCustomized`), perhaps there is a cleaner way to test the behavior?