### PR TITLE
remove warning: instance variable @__parent not initialized

### DIFF
--- a/lib/mongoid/traversable.rb
+++ b/lib/mongoid/traversable.rb
@@ -8,7 +8,7 @@ module Mongoid
     extend ActiveSupport::Concern
 
     def _parent
-      @__parent
+      @__parent ||= nil
     end
 
     def _parent=(p)


### PR DESCRIPTION
warning shows when running specs on my application