### PR TITLE
shard key selector issue

### DIFF
--- a/lib/mongoid/shardable.rb
+++ b/lib/mongoid/shardable.rb
@@ -37,7 +37,7 @@ module Mongoid
     def shard_key_selector
       selector = {}
       shard_key_fields.each do |field|
-        selector[field.to_s] = attribute_was(field) || send(field)
+        selector[field.to_s] = new_record? ? send(field) : attribute_was(field)
       end
       selector
     end

--- a/lib/mongoid/shardable.rb
+++ b/lib/mongoid/shardable.rb
@@ -37,7 +37,7 @@ module Mongoid
     def shard_key_selector
       selector = {}
       shard_key_fields.each do |field|
-        selector[field.to_s] = send(field)
+        selector[field.to_s] = attribute_was(field) || send(field)
       end
       selector
     end

--- a/spec/mongoid/shardable_spec.rb
+++ b/spec/mongoid/shardable_spec.rb
@@ -49,23 +49,24 @@ describe Mongoid::Shardable do
     end
   end
 
-  describe "#shard_key_selector" do
+  describe '#shard_key_selector' do
+    subject { instance.shard_key_selector }
+    let(:klass) { Band }
+    let(:instance) { klass.new(name: name) }
+    let(:name) { 'Jo' }
 
-    let(:klass) do
-      Band
-    end
+    before { klass.shard_key(:name) }
 
-    let(:object) do
-      klass.new
-    end
+    it { is_expected.to eq({ 'name' => name }) }
 
-    before do
-      klass.shard_key(:name)
-      object.name = "Jo"
-    end
+    context 'changing shard_key value on persisted record' do
+      let(:instance) { klass.create(name: name) }
 
-    it "returns a hash of shard key names and values" do
-      expect(object.shard_key_selector).to eq({ "name" => "Jo" })
+      before do
+        instance.name = 'Izi4'
+      end
+
+      it { is_expected.to eq({ 'name' => name }) }
     end
   end
 end

--- a/spec/mongoid/shardable_spec.rb
+++ b/spec/mongoid/shardable_spec.rb
@@ -52,21 +52,40 @@ describe Mongoid::Shardable do
   describe '#shard_key_selector' do
     subject { instance.shard_key_selector }
     let(:klass) { Band }
-    let(:instance) { klass.new(name: name) }
-    let(:name) { 'Jo' }
+    let(:value) { 'a-brand-name' }
 
     before { klass.shard_key(:name) }
 
-    it { is_expected.to eq({ 'name' => name }) }
+    context 'when record is new' do
+      let(:instance) { klass.new(name: value) }
 
-    context 'changing shard_key value on persisted record' do
-      let(:instance) { klass.create(name: name) }
+      it { is_expected.to eq({ 'name' => value }) }
 
-      before do
-        instance.name = 'Izi4'
+      context 'changing shard key value' do
+        let(:new_value) { 'a-new-value' }
+
+        before do
+          instance.name = new_value
+        end
+
+        it { is_expected.to eq({ 'name' => new_value }) }
       end
+    end
 
-      it { is_expected.to eq({ 'name' => name }) }
+    context 'when record is persisted' do
+      let(:instance) { klass.create(name: value) }
+
+      it { is_expected.to eq({ 'name' => value }) }
+
+      context 'changing shard key value' do
+        let(:new_value) { 'a-new-value' }
+
+        before do
+          instance.name = new_value
+        end
+
+        it { is_expected.to eq({ 'name' => value }) }
+      end
     end
   end
 end


### PR DESCRIPTION
Issue description:
When updating field that is also shard key, a wrong value is generated by `Mongoid::Shardable#shard_key_selector`.
Example:
```
2.4.1 :004 > t=Test.create(name: 'asd', ip: '127.0.0.1')
D, [2017-11-10T20:35:54.749102 #26512] DEBUG -- : MONGODB | localhost:27017 | mongoid_test.insert | STARTED | {"insert"=>"mongoid_tests", "documents"=>[{"_id"=>BSON::ObjectId('5a05f18af06f086790a5abbf'), "name"=>"asd", "ip"=>"127.0.0.1"}], "ordered"=>true}
 => #<Test _id: 5a05f18af06f086790a5abbf, name: "asd", ip: "127.0.0.1"> 
2.4.1 :005 > t.update_attributes(ip: '127.0.0.2')
D, [2017-11-10T20:36:07.373379 #26512] DEBUG -- : MONGODB | localhost:27017 | mongoid_test.update | STARTED | {"update"=>"mongoid_tests", "updates"=>[{"q"=>{"_id"=>BSON::ObjectId('5a05f18af06f086790a5abbf'), "ip"=>"127.0.0.2"}, "u"=>{"$set"=>{"ip"=>"127.0.0.2"}}, "multi"=>false, "upsert"=>false}], "ordered"=>true}
 => true 
2.4.1 :006 > t.reload
D, [2017-11-10T20:36:54.297448 #26512] DEBUG -- : MONGODB | localhost:27017 | mongoid_test.find | STARTED | {"find"=>"mongoid_tests", "filter"=>{"_id"=>BSON::ObjectId('5a05f18af06f086790a5abbf')}}
 => #<Test _id: 5a05f18af06f086790a5abbf, name: "asd", ip: "127.0.0.1"> 
```
As you can see, when updating record, an unpersisted value of `:ip` is used in filter.
After changes in this PR:
```
2.4.1 :005 > t.update_attributes(ip: '127.0.0.2')
D, [2017-11-10T20:40:17.553021 #26611] DEBUG -- : MONGODB | localhost:27017 | mongoid_test.update | STARTED | {"update"=>"mongoid_tests", "updates"=>[{"q"=>{"_id"=>BSON::ObjectId('5a05f18af06f086790a5abbf'), "ip"=>"127.0.0.1"}, "u"=>{"$set"=>{"ip"=>"127.0.0.2"}}, "multi"=>false, "upsert"=>false}], "ordered"=>true}
 => true 
2.4.1 :006 > t.reload
D, [2017-11-10T20:42:05.510011 #26611] DEBUG -- : MONGODB | localhost:27017 | mongoid_test.find | STARTED | {"find"=>"mongoid_tests", "filter"=>{"_id"=>BSON::ObjectId('5a05f18af06f086790a5abbf')}}
 => #<Test _id: 5a05f18af06f086790a5abbf, name: "asd", ip: "127.0.0.2"> 
```

Gist with test class definition https://gist.github.com/intale/e1d0b0877c00268c12f020d9b3cefca4.

P.S. Branched from master and, as a result, inherited some failing tests from there.