### PR TITLE
Fix typo in documentation for And.rb

### DIFF
--- a/lib/mongoid/matchable/and.rb
+++ b/lib/mongoid/matchable/and.rb
@@ -2,7 +2,7 @@
 module Mongoid
   module Matchable
 
-    # Defines behavior for handling $or expressions in embedded documents.
+    # Defines behavior for handling $and expressions in embedded documents.
     class And < Default
 
       # Does the supplied query match the attribute?


### PR DESCRIPTION
Change $or to $and in documentation for And.rb