### PR TITLE
Fix persistence context clear

### DIFF
--- a/lib/mongoid/persistence_context.rb
+++ b/lib/mongoid/persistence_context.rb
@@ -195,10 +195,10 @@ module Mongoid
         Thread.current["[mongoid][#{object.object_id}]:context"]
       end
 
-      # Get the persistence context for a particular class or model instance.
+      # Clear the persistence context for a particular class or model instance.
       #
-      # @example Get the persistence context for a class or model instance.
-      #  PersistenceContext.get(model)
+      # @example Clear the persistence context for a class or model instance.
+      #  PersistenceContext.clear(model)
       #
       # @param [ Class, Object ] object The class or model instance.
       # @param [ Mongo::Cluster ] cluster The original cluster before this context was used.

--- a/lib/mongoid/persistence_context.rb
+++ b/lib/mongoid/persistence_context.rb
@@ -208,6 +208,7 @@ module Mongoid
         if context = get(object)
           context.client.close unless (context.cluster.equal?(cluster) || cluster.nil?)
         end
+      ensure  
         Thread.current["[mongoid][#{object.object_id}]:context"] = nil
       end
     end


### PR DESCRIPTION
If you used Model.with() to specify a client and the name was invalid, it would make any subsequent calls to with() break even if valid.

PersistenceContext.clear(Model) wouldn't properly unset the context because calling on client would raise NoClientConfig.