### PR TITLE
fix elemMatch when symbol is used in query

### DIFF
--- a/lib/mongoid/matchable/elem_match.rb
+++ b/lib/mongoid/matchable/elem_match.rb
@@ -13,13 +13,15 @@ module Mongoid
       #
       # @return [ true, false ] If the values match.
       def _matches?(value)
-        if !@attribute.is_a?(Array) || !value.kind_of?(Hash) || !value["$elemMatch"].kind_of?(Hash)
+        elem_match = value["$elemMatch"] || value[:$elemMatch]
+
+        if !@attribute.is_a?(Array) || !value.kind_of?(Hash) || !elem_match.kind_of?(Hash)
           return false
         end
 
         return @attribute.any? do |sub_document|
-          value["$elemMatch"].all? do |k, v|
-            if v.try(:first).try(:[],0) == "$not".freeze
+          elem_match.all? do |k, v|
+            if v.try(:first).try(:[],0) == "$not".freeze || v.try(:first).try(:[],0) == :$not
               !Matchable.matcher(sub_document, k, v.first[1])._matches?(v.first[1])
             else
               Matchable.matcher(sub_document, k, v)._matches?(v)

--- a/spec/mongoid/matchable/elem_match_spec.rb
+++ b/spec/mongoid/matchable/elem_match_spec.rb
@@ -62,6 +62,12 @@ describe Mongoid::Matchable::ElemMatch do
       end
     end
 
+    context "when using symbols and a :$not operator that matches" do
+      it "returns true" do
+        expect(matcher._matches?(:$elemMatch => {"a" => {:$not => 4}})).to be true
+      end
+    end
+
     context "when there is not a sub document that matches the criteria" do
 
       it "returns false" do


### PR DESCRIPTION
This fixes an issue when :$elemMatch is used in a query as opposed to "$elemMatch"