### PR TITLE
MongoDB 3.6 support: Replace $pushAll with $push + $each

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,11 +30,11 @@ env:
     - CI="travis"
     - JRUBY_OPTS="--server -J-Xms512m -J-Xmx1G"
   matrix:
-    - MONGODB=2.4.14
     - MONGODB=2.6.12
-    - MONGODB=3.0.14
-    - MONGODB=3.2.12
-    - MONGODB=3.4.3
+    - MONGODB=3.0.15
+    - MONGODB=3.2.18
+    - MONGODB=3.4.10
+    - MONGODB=3.6.1
 
 before_script:
   - wget http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-${MONGODB}.tgz -O /tmp/mongodb.tgz

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ rvm:
   - jruby-9.1.12.0
 
 matrix:
+  fast_finish: true
   allow_failures:
     - rvm: ruby-head
     - gemfile: gemfiles/rails_master.gemfile

--- a/docs/tutorials/mongoid-queries.txt
+++ b/docs/tutorials/mongoid-queries.txt
@@ -393,7 +393,7 @@ document inserts, updates, and deletion.
 
    * - ``Criteria#push_all``
 
-       *Perform a $pushAll on all matching documents.*
+       *Perform a $push with $each on all matching documents.*
 
      -
         .. code-block:: ruby

--- a/lib/mongoid/association/embedded/batchable.rb
+++ b/lib/mongoid/association/embedded/batchable.rb
@@ -136,7 +136,7 @@ module Mongoid
           inserts = pre_process_batch_insert(docs)
           if insertable?
             collection.find(selector).update_one(
-                positionally(selector, operation => { path => use_each ? { '$each' => Array.wrap(inserts) } : inserts })
+                positionally(selector, operation => { path => use_each ? { '$each' => inserts } : inserts })
             )
             post_process_batch_insert(docs)
           end

--- a/lib/mongoid/association/embedded/batchable.rb
+++ b/lib/mongoid/association/embedded/batchable.rb
@@ -136,7 +136,7 @@ module Mongoid
           inserts = pre_process_batch_insert(docs)
           if insertable?
             collection.find(selector).update_one(
-                positionally(selector, operation => { path => use_each ? { '$each' => inserts } : inserts })
+                positionally(selector, operation => { path => use_each ? { '$each' => Array.wrap(inserts) } : inserts })
             )
             post_process_batch_insert(docs)
           end

--- a/lib/mongoid/association/referenced/syncable.rb
+++ b/lib/mongoid/association/referenced/syncable.rb
@@ -81,7 +81,7 @@ module Mongoid
             adds, subs = new - (old || []), (old || []) - new
 
             # If we are autosaving we don't want a duplicate to get added - the
-            # $addToSet would run previously and then the $pushAll from the
+            # $addToSet would run previously and then the $push from the
             # inverse on the autosave would cause this. We delete each id from
             # what's in memory in case a mix of id addition and object addition
             # had occurred.

--- a/lib/mongoid/atomic.rb
+++ b/lib/mongoid/atomic.rb
@@ -110,10 +110,10 @@ module Mongoid
     #   performed in a single operation. Conflicting modifications are
     #   detected by the 'haveConflictingMod' function in MongoDB.
     #   Examination of the code suggests that two modifications (a $set
-    #   and a $pushAll, for example) conflict if:
+    #   and a $push, for example) conflict if:
     #     (1) the key paths being modified are equal.
     #     (2) one key path is a prefix of the other.
-    #   So a $set of 'addresses.0.street' will conflict with a $pushAll
+    #   So a $set of 'addresses.0.street' will conflict with a $push
     #   to 'addresses', and we will need to split our update into two
     #   pieces. We do not, however, attempt to match MongoDB's logic
     #   exactly. Instead, we assume that two updates conflict if the
@@ -218,7 +218,7 @@ module Mongoid
     # @example Get the pushes.
     #   person.atomic_pushes
     #
-    # @return [ Hash ] The $pushAll operations.
+    # @return [ Hash ] The $push operations.
     #
     # @since 2.1.0
     def atomic_pushes

--- a/lib/mongoid/atomic/modifiers.rb
+++ b/lib/mongoid/atomic/modifiers.rb
@@ -68,7 +68,7 @@ module Mongoid
         modifications.each_pair do |field, value|
           push_fields[field] = field
           mods = push_conflict?(field) ? conflicting_pushes : pushes
-          add_each_operation(mods, field, Array.wrap(value))
+          add_each_operation(mods, field, value)
         end
       end
 
@@ -138,6 +138,7 @@ module Mongoid
       #
       # @since 7.0.0
       def add_each_operation(mods, field, value)
+        value = Array.wrap(value)
         if mods.has_key?(field)
           value.each do |val|
             mods[field]["$each"].push(val)

--- a/lib/mongoid/atomic/modifiers.rb
+++ b/lib/mongoid/atomic/modifiers.rb
@@ -68,7 +68,7 @@ module Mongoid
         modifications.each_pair do |field, value|
           push_fields[field] = field
           mods = push_conflict?(field) ? conflicting_pushes : pushes
-          add_operation(mods, field, Array.wrap(value))
+          add_each_operation(mods, field, Array.wrap(value))
         end
       end
 
@@ -123,6 +123,27 @@ module Mongoid
           end
         else
           mods[field] = value
+        end
+      end
+
+      # Adds or appends an array operation with the $each specifier used
+      # in conjuction with $push.
+      #
+      # @example Add the operation.
+      #   modifications.add_operation(mods, field, value)
+      #
+      # @param [ Hash ] mods The modifications.
+      # @param [ String ] field The field.
+      # @param [ Hash ] value The atomic op.
+      #
+      # @since 7.0.0
+      def add_each_operation(mods, field, value)
+        if mods.has_key?(field)
+          value.each do |val|
+            mods[field]["$each"].push(val)
+          end
+        else
+          mods[field] = { "$each" => value }
         end
       end
 
@@ -190,7 +211,7 @@ module Mongoid
       #
       # @since 2.2.0
       def conflicting_pushes
-        conflicts["$pushAll"] ||= {}
+        conflicts["$push"] ||= {}
       end
 
       # Get the conflicting set modifications.
@@ -277,16 +298,16 @@ module Mongoid
         self["$pull"] ||= {}
       end
 
-      # Get the $pushAll operations or intialize a new one.
+      # Get the $push operations or intialize a new one.
       #
-      # @example Get the $pushAll operations.
+      # @example Get the $push operations.
       #   modifiers.pushes
       #
-      # @return [ Hash ] The $pushAll operations.
+      # @return [ Hash ] The $push operations.
       #
       # @since 2.1.0
       def pushes
-        self["$pushAll"] ||= {}
+        self["$push"] ||= {}
       end
 
       # Get the $set operations or intialize a new one.

--- a/lib/mongoid/atomic/modifiers.rb
+++ b/lib/mongoid/atomic/modifiers.rb
@@ -205,8 +205,8 @@ module Mongoid
 
       # Get the conflicting push modifications.
       #
-      # @example Get the conflicting pushs.
-      #   modifiers.conflicting_pushs
+      # @example Get the conflicting pushes.
+      #   modifiers.conflicting_pushes
       #
       # @return [ Hash ] The conflicting push operations.
       #

--- a/lib/mongoid/contextual/atomic.rb
+++ b/lib/mongoid/contextual/atomic.rb
@@ -106,7 +106,7 @@ module Mongoid
         view.update_many("$push" => collect_operations(pushes))
       end
 
-      # Perform an atomic $pushAll operation on the matching documents.
+      # Perform an atomic $push with $each operation on the matching documents.
       #
       # @example Push the values to the matching docs.
       #   context.push(members: [ "Alan", "Fletch" ])
@@ -117,7 +117,7 @@ module Mongoid
       #
       # @since 3.0.0
       def push_all(pushes)
-        view.update_many("$pushAll" => collect_operations(pushes))
+        view.update_many("$push" => collect_operations(pushes, true))
       end
 
       # Perform an atomic $rename of fields on the matching documents.
@@ -169,9 +169,9 @@ module Mongoid
 
       private
 
-      def collect_operations(ops)
+      def collect_operations(ops, use_each = false)
         ops.inject({}) do |operations, (field, value)|
-          operations[database_field_name(field)] = value.mongoize
+          operations[database_field_name(field)] = use_each ? { '$each' => value.mongoize } : value.mongoize
           operations
         end
       end

--- a/lib/mongoid/contextual/atomic.rb
+++ b/lib/mongoid/contextual/atomic.rb
@@ -117,7 +117,7 @@ module Mongoid
       #
       # @since 3.0.0
       def push_all(pushes)
-        view.update_many("$push" => collect_operations(pushes, true))
+        view.update_many("$push" => collect_each_operations(pushes))
       end
 
       # Perform an atomic $rename of fields on the matching documents.
@@ -169,10 +169,15 @@ module Mongoid
 
       private
 
-      def collect_operations(ops, use_each = false)
-        ops.inject({}) do |operations, (field, value)|
-          operations[database_field_name(field)] = use_each ? { '$each' => value.mongoize } : value.mongoize
-          operations
+      def collect_operations(ops)
+        ops.each_with_object({}) do |(field, value), operations|
+          operations[database_field_name(field)] = value.mongoize
+        end
+      end
+
+      def collect_each_operations(ops)
+        ops.each_with_object({}) do |(field, value), operations|
+          operations[database_field_name(field)] = { "$each" => Array.wrap(value).mongoize }
         end
       end
     end

--- a/spec/mongoid/atomic/modifiers_spec.rb
+++ b/spec/mongoid/atomic/modifiers_spec.rb
@@ -211,11 +211,8 @@ describe Mongoid::Atomic::Modifiers do
 
         it "adds the push all modifiers" do
           expect(modifiers).to eq(
-            { "$pushAll" =>
-              { "addresses" => [
-                  { "street" => "Oxford St" }
-                ]
-              }
+            { "$push" =>
+              { "addresses" => { "$each" => [{ "street" => "Oxford St" }] } }
             }
           )
         end
@@ -238,11 +235,11 @@ describe Mongoid::Atomic::Modifiers do
 
         it "adds the push all modifiers" do
           expect(modifiers).to eq(
-            { "$pushAll" =>
-              { "addresses" => [
+            { "$push" =>
+              { "addresses" => { "$each" => [
                   { "street" => "Hobrechtstr." },
                   { "street" => "Pflugerstr." }
-                ]
+                ] }
               }
             }
           )
@@ -270,11 +267,8 @@ describe Mongoid::Atomic::Modifiers do
         it "adds the push all modifiers to the conflicts hash" do
           expect(modifiers).to eq(
             { "$set" => { "addresses.0.street" => "Bond" },
-              conflicts: { "$pushAll" =>
-                { "addresses" => [
-                    { "street" => "Oxford St" }
-                  ]
-                }
+              conflicts: { "$push" =>
+                { "addresses" => { "$each" => [{ "street" => "Oxford St" }] } }
               }
             }
           )
@@ -300,11 +294,8 @@ describe Mongoid::Atomic::Modifiers do
           expect(modifiers).to eq(
             { "$pullAll" => {
               "addresses" => { "street" => "Bond St" }},
-              conflicts: { "$pushAll" =>
-                { "addresses" => [
-                    { "street" => "Oxford St" }
-                  ]
-                }
+              conflicts: { "$push" =>
+                { "addresses" => { "$each" => [{ "street" => "Oxford St" }] } }
               }
             }
           )
@@ -328,13 +319,10 @@ describe Mongoid::Atomic::Modifiers do
 
         it "adds the push all modifiers to the conflicts hash" do
           expect(modifiers).to eq(
-            { "$pushAll" => {
-              "addresses.0.locations" => [{ "street" => "Bond St" }]},
-              conflicts: { "$pushAll" =>
-                { "addresses" => [
-                    { "street" => "Oxford St" }
-                  ]
-                }
+            { "$push" => {
+              "addresses.0.locations" => { "$each" => [{ "street" => "Bond St" }] } },
+              conflicts: { "$push" =>
+                { "addresses" => { "$each" => [{ "street" => "Oxford St" }] } }
               }
             }
           )

--- a/spec/mongoid/atomic_spec.rb
+++ b/spec/mongoid/atomic_spec.rb
@@ -76,13 +76,11 @@ describe Mongoid::Atomic do
             person.addresses.build(street: "Oxford St")
           end
 
-          it "returns a $set and $pushAll for modifications" do
+          it "returns a $set and $push for modifications" do
             expect(person.atomic_updates).to eq(
               {
                 "$set" => { "title" => "Sir" },
-                "$pushAll" => { "addresses" => [
-                    { "_id" => "oxford-st", "street" => "Oxford St" }
-                  ]}
+                "$push" => { "addresses" => { "$each" => [{ "_id" => "oxford-st", "street" => "Oxford St" }] } }
               }
             )
           end
@@ -197,8 +195,8 @@ describe Mongoid::Atomic do
                       "addresses.0.street" => "Bond St"
                     },
                     conflicts: {
-                      "$pushAll" => {
-                        "addresses.0.locations" => [{ "_id" => location.id, "name" => "Home" }]
+                      "$push" => {
+                        "addresses.0.locations" => { "$each" => [{ "_id" => location.id, "name" => "Home" }] }
                       }
                     }
                   }
@@ -215,8 +213,8 @@ describe Mongoid::Atomic do
                       "addresses.0.street" => "Bond St"
                     },
                     conflicts: {
-                      "$pushAll" => {
-                        "addresses.0.locations" => [{ "_id" => location.id, "name" => "Home" }]
+                      "$push" => {
+                        "addresses.0.locations" => { "$each" => [{ "_id" => location.id, "name" => "Home" }] }
                       }
                     }
                   }
@@ -263,15 +261,15 @@ describe Mongoid::Atomic do
                       "addresses.0.street" => "Bond St"
                     },
                     conflicts: {
-                      "$pushAll" => {
-                        "addresses" => [{
+                      "$push" => {
+                        "addresses" => { "$each" => [{
                           "_id" => new_address.id,
                           "street" => "Another",
                           "locations" => [
                             "_id" => location.id,
                             "name" => "Home"
                           ]
-                        }]
+                        }] }
                       }
                     }
                   }
@@ -310,15 +308,15 @@ describe Mongoid::Atomic do
                   "$set" => {
                     "title" => "Sir"
                   },
-                  "$pushAll" => {
-                    "addresses" => [{
+                  "$push" => {
+                    "addresses" => { "$each" => [{
                       "_id" => new_address.id,
                       "street" => "Ipanema",
                       "locations" => [
                         "_id" => location.id,
                         "name" => "Home"
                       ]
-                    }]
+                    }] }
                   },
                   conflicts: {
                     "$set" => { "addresses.0.street"=>"Bond St" }
@@ -339,21 +337,21 @@ describe Mongoid::Atomic do
             address.locations.build(name: "Home")
           end
 
-          it "returns the proper $sets and $pushAlls for all levels" do
+          it "returns the proper $sets and $pushes for all levels" do
             expect(person.atomic_updates).to eq(
               {
                 "$set" => {
                   "title" => "Sir",
                 },
-                "$pushAll" => {
-                  "addresses" => [{
+                "$push" => {
+                  "addresses" => { "$each" => [{
                     "_id" => address.id,
                     "street" => "Another",
                     "locations" => [
                       "_id" => location.id,
                       "name" => "Home"
                     ]
-                  }]
+                  }] }
                 }
               }
             )

--- a/spec/mongoid/persistable/savable_spec.rb
+++ b/spec/mongoid/persistable/savable_spec.rb
@@ -189,8 +189,8 @@ describe Mongoid::Persistable::Savable do
               "title" => "King",
               "name.first_name" => "Ryan"
             },
-            "$pushAll"=> {
-              "addresses" => [ { "_id" => address.id, "street" => "Bond St" } ]
+            "$push"=> {
+              "addresses" => { "$each" => [{ "_id" => address.id, "street" => "Bond St" }] }
             }
           })
         end

--- a/spec/mongoid/positional_spec.rb
+++ b/spec/mongoid/positional_spec.rb
@@ -17,8 +17,8 @@ describe Mongoid::Positional do
           "children.0.field" => "value",
           "children.0.children.1.children.3.field" => "value"
         },
-        "$pushAll" => {
-          "children.0.children.1.children.3.fields" => [ "value", "value" ]
+        "$push" => {
+          "children.0.children.1.children.3.fields" => { "$each" => [ "value", "value" ] }
         }
       }
     end
@@ -113,8 +113,8 @@ describe Mongoid::Positional do
               "children.$.field" => "value",
               "children.0.children.1.children.3.field" => "value"
             },
-            "$pushAll" => {
-              "children.0.children.1.children.3.fields" => [ "value", "value" ]
+            "$push" => {
+              "children.0.children.1.children.3.fields" => { "$each" => [ "value", "value" ] }
             }
           }
         end
@@ -141,8 +141,8 @@ describe Mongoid::Positional do
               "children.0.field" => "value",
               "children.0.children.1.children.3.field" => "value"
             },
-            "$pushAll" => {
-              "children.0.children.1.children.3.fields" => [ "value", "value" ]
+            "$push" => {
+              "children.0.children.1.children.3.fields" => { "$each" => [ "value", "value" ] }
             }
           }
         end
@@ -170,8 +170,8 @@ describe Mongoid::Positional do
             "children.$.field" => "value",
             "children.0.children.1.children.3.field" => "value"
           },
-          "$pushAll" => {
-            "children.0.children.1.children.3.fields" => [ "value", "value" ]
+          "$push" => {
+            "children.0.children.1.children.3.fields" => { "$each" => [ "value", "value" ] }
           }
         }
       end
@@ -203,8 +203,8 @@ describe Mongoid::Positional do
             "children.$.field" => "value",
             "children.0.children.1.children.3.field" => "value"
           },
-          "$pushAll" => {
-            "children.0.children.1.children.3.fields" => [ "value", "value" ]
+          "$push" => {
+            "children.0.children.1.children.3.fields" => { "$each" => [ "value", "value" ] }
           }
         }
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -88,6 +88,13 @@ def testing_locally?
   !(ENV['CI'] == 'travis')
 end
 
+def mongodb_version_gte?(version)
+  db_version = Mongoid.default_client.command(buildInfo: 1).first[:version].split('.').map(&:to_i)
+  version = version.split('.').map(&:to_i) if version.is_a?(String)
+  version = version.fill(0, version.size...3) if version.size < 3
+  (db_version <=> version) >= 0
+end
+
 # Set the database that the spec suite connects to.
 Mongoid.configure do |config|
   config.load_configuration(CONFIG)


### PR DESCRIPTION
Fixes MONGOID-4499 and adds full support for Mongoid 3.6
- Replace $pushAll with $push + $each (as $pushAll no longer supported in MongoDB 3.6)
- Add MongoDB 3.6 to Travis
- Drop support for MongoDB 2.4, as it does not support $push + $each (and is now 4 years old)
- Handle spec which behaves different on MongoDB 3.6:

```
person.update_attributes(map: { "bad.key" => "value" })
```

Before 3.6, this spec raises a `Mongo::Error::OperationFailure`. After 3.6, it is allowed and you can call:

```
person.map["bad.key"] == "value"
```