### PR TITLE
Array filter updates

### DIFF
--- a/lib/mongoid/contextual/mongo.rb
+++ b/lib/mongoid/contextual/mongo.rb
@@ -490,8 +490,11 @@ module Mongoid
       # @return [ nil, false ] False if no attributes were provided.
       #
       # @since 3.0.0
-      def update(attributes = nil)
-        update_documents(attributes)
+      def update(attributes = nil, nested_string = nil, array_filters = [])
+        binding.pry
+        nested_string.present? ?
+            update_embedded_documents(attributes, nested_string, array_filters) :
+            update_documents(attributes)
       end
 
       # Update all the matching documents atomically.
@@ -504,8 +507,11 @@ module Mongoid
       # @return [ nil, false ] False if no attributes were provided.
       #
       # @since 3.0.0
-      def update_all(attributes = nil)
-        update_documents(attributes, :update_many)
+      def update_all(attributes = nil, nested_string = nil, array_filters = [])
+        binding.pry
+        nested_string.present? ?
+            update_embedded_documents(attributes, nested_string, array_filters) :
+            update_documents(attributes, :update_many)
       end
 
       private
@@ -545,6 +551,36 @@ module Mongoid
         return false unless attributes
         attributes = Hash[attributes.map { |k, v| [klass.database_field_name(k.to_s), v] }]
         view.send(method, attributes.__consolidate__(klass))
+      end
+
+      # Update the embedded documents for the provided method with filters
+      #
+      # @api private
+      #
+      # @example Update the documents.
+      #   context.update_embedded_documents(attrs, nested, array_filters)
+      #
+      # @param [ Hash ] attributes The updates.
+      # @param [ Symbol ] method The method to use.
+      # @param [ String ] nesting Mongo syntax for updating nested documents.
+      #
+      # @example nesting param.
+      #  "legs.$[].sport_event.competitors.$[i]"
+      #
+      # @param [ Array ] array_filters Array filters for the identifiers specified in nesting.
+      #
+      # @example array_filters params
+      #  [{ "i.name" => "Manchester United"}]
+      #
+      # @param [ Symbol ] method The method to use.
+      #
+      # @return [ true, false ] If the update succeeded.
+      #
+      # @since 3.0.4
+      def update_embedded_documents(attributes, nesting_string, array_filters, method = :update_one)
+        return false unless attributes && nesting_string && array_filters
+        attributes = Hash[attributes.map { |k, v| ["#{nesting_string}. #{klass.database_field_name(k.to_s)}", v] }]
+        view.send(method, attributes.__consolidate__(klass), { array_filters: array_filters })
       end
 
       # Apply the field limitations.

--- a/lib/mongoid/extensions/hash.rb
+++ b/lib/mongoid/extensions/hash.rb
@@ -42,7 +42,7 @@ module Mongoid
       def __consolidate__(klass)
         consolidated = {}
         each_pair do |key, value|
-          if key =~ /\$/
+          if key.to_s.starts_with?('$')
             value.each_pair do |_key, _value|
               value[_key] = (key == "$rename") ? _value.to_s : mongoize_for(key, klass, _key, _value)
             end

--- a/mongoid.gemspec
+++ b/mongoid.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.rubyforge_project         = "mongoid"
 
   s.add_dependency("activemodel", ["~> 5.1"])
-  s.add_dependency("mongo", ['>=2.4.1', '<3.0.0'])
+  s.add_dependency("mongo", ["~> 2.5.0.beta"])
 
   s.files        = Dir.glob("lib/**/*") + %w(CHANGELOG.md LICENSE README.md Rakefile)
   s.test_files   = Dir.glob("spec/**/*")

--- a/mongoid.gemspec
+++ b/mongoid.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.rubyforge_project         = "mongoid"
 
   s.add_dependency("activemodel", ["~> 5.1"])
-  s.add_dependency("mongo", ["~> 2.5.0.beta"])
+  s.add_dependency("mongo", ['>= 2.5.0.beta', '<3.0.0'])
 
   s.files        = Dir.glob("lib/**/*") + %w(CHANGELOG.md LICENSE README.md Rakefile)
   s.test_files   = Dir.glob("spec/**/*")


### PR DESCRIPTION
Noticing the update on `arrayFilters` in [mongo v3.6.0](https://docs.mongodb.com/manual/reference/command/update/#update-command-arrayfilters)  and the [mongo driver support](https://github.com/mongodb/mongo-ruby-driver/pull/884/) for it, currently in v2.5.0beta ([RUBY-1224](https://jira.mongodb.org/browse/RUBY-1224)), I have decided to try to use them through mongoid.

Therefore I came up with the following approach: `.where(filters).nested_update(embedded_attr_hash, nested_string, filers_array, multi: true)` where 
`embedded_attr_hash = {name: 'test_team', sport_code: 'test_code', ...}`, 
`nested_string='legs.$[].sport_event.competitors.$[j].name'`, 
`filers_array=[ {"j.tote_id" => 545} ]`.

instead of performing somthing like 
`collection.update_many({model_filters}, 
{"$set" => {"legs.$[].sport_event.competitors.$[j].name" => "test team", "legs.$[].sport_event.competitors.$[j].sport_code" => "test code", ...}}, 
{ "array_filters" => [ {"j.tote_id" => 545} ] }`

I wanted to share the above through this PR and check whether it fits your vision for mongoid, if it's a good approach for getting the desired result and decide whether I should keep improving it (and how) / adding tests for it or just keep it on my fork :(.