### PR TITLE
Remove QueryCache#read_or_server_selector

### DIFF
--- a/lib/mongoid/query_cache.rb
+++ b/lib/mongoid/query_cache.rb
@@ -222,7 +222,7 @@ module Mongoid
           super
         else
           unless cursor = cached_cursor
-            server = read_or_server_selector.select_server(cluster)
+            server = server_selector.select_server(cluster)
             cursor = CachedCursor.new(view, send_initial_query(server), server)
             QueryCache.cache_table[cache_key] = cursor
           end
@@ -234,10 +234,6 @@ module Mongoid
       end
 
       private
-
-      def read_or_server_selector
-        respond_to?(:server_selector, true) ? server_selector : read
-      end
 
       def cached_cursor
         if limit


### PR DESCRIPTION
This is now obsolete as driver version 2.5.0 is required. The additional check can be removed.

See cadffdbba1b9d33dc3fe4134c74f41bccce122d7.