### PR TITLE
MONGOID-4503 Support passing array_filters to update methods

### DIFF
--- a/lib/mongoid/contextual/mongo.rb
+++ b/lib/mongoid/contextual/mongo.rb
@@ -486,12 +486,16 @@ module Mongoid
       #   context.update({ "$set" => { name: "Smiths" }})
       #
       # @param [ Hash ] attributes The new attributes for the document.
+      # @param [ Hash ] opts The update operation options.
+      #
+      # @option opts [ Array ] :array_filters A set of filters specifying to which array elements
+      #   an update should apply.
       #
       # @return [ nil, false ] False if no attributes were provided.
       #
       # @since 3.0.0
-      def update(attributes = nil)
-        update_documents(attributes)
+      def update(attributes = nil, opts = {})
+        update_documents(attributes, :update_one, opts)
       end
 
       # Update all the matching documents atomically.
@@ -500,12 +504,16 @@ module Mongoid
       #   context.update_all({ "$set" => { name: "Smiths" }})
       #
       # @param [ Hash ] attributes The new attributes for each document.
+      # @param [ Hash ] opts The update operation options.
+      #
+      # @option opts [ Array ] :array_filters A set of filters specifying to which array elements
+      #   an update should apply.
       #
       # @return [ nil, false ] False if no attributes were provided.
       #
       # @since 3.0.0
-      def update_all(attributes = nil)
-        update_documents(attributes, :update_many)
+      def update_all(attributes = nil, opts = {})
+        update_documents(attributes, :update_many, opts)
       end
 
       private
@@ -541,10 +549,10 @@ module Mongoid
       # @return [ true, false ] If the update succeeded.
       #
       # @since 3.0.4
-      def update_documents(attributes, method = :update_one)
+      def update_documents(attributes, method = :update_one, opts = {})
         return false unless attributes
         attributes = Hash[attributes.map { |k, v| [klass.database_field_name(k.to_s), v] }]
-        view.send(method, attributes.__consolidate__(klass))
+        view.send(method, attributes.__consolidate__(klass), opts)
       end
 
       # Apply the field limitations.

--- a/spec/app/models/band.rb
+++ b/spec/app/models/band.rb
@@ -20,6 +20,7 @@ class Band
 
   embeds_many :records, cascade_callbacks: true
   embeds_many :notes, as: :noteable, cascade_callbacks: true, validate: false
+  embeds_many :labels
   embeds_one :label, cascade_callbacks: true
 
   has_many :same_name, class_name: 'Agent', inverse_of: :same_name

--- a/spec/mongoid/contextual/mongo_spec.rb
+++ b/spec/mongoid/contextual/mongo_spec.rb
@@ -2094,6 +2094,41 @@ describe Mongoid::Contextual::Mongo do
         expect(context.update).to be false
       end
     end
+
+    context 'when provided array filters', if: array_filters_supported? do
+
+      before do
+        Band.delete_all
+        b = Band.new(name: 'Depeche Mode')
+        b.labels << Label.new(name: 'Warner')
+        b.labels << Label.new(name: 'Sony')
+        b.labels << Label.new(name: 'Cbs')
+        b.save
+
+        b = Band.new(name: 'FKA Twigs')
+        b.labels << Label.new(name: 'Warner')
+        b.labels << Label.new(name: 'Cbs')
+        b.save
+      end
+
+
+      let(:criteria) do
+        Band.where(name: 'Depeche Mode')
+      end
+
+      let!(:update) do
+        context.update({ '$set' => { 'labels.$[i].name' => 'Sony' } },
+                       array_filters: [{ 'i.name' => 'Cbs' }])
+      end
+
+      it 'applies the array filters' do
+        expect(Band.where(name: 'Depeche Mode').first.labels.collect(&:name)).to match_array(['Warner', 'Sony', 'Sony'])
+      end
+
+      it 'does not affect other documents' do
+        expect(Band.where(name: 'FKA Twigs').first.labels.collect(&:name)).to match_array(['Warner', 'Cbs'])
+      end
+    end
   end
 
   describe "#update_all" do
@@ -2229,6 +2264,41 @@ describe Mongoid::Contextual::Mongo do
 
       it "returns false" do
         expect(context.update_all).to be false
+      end
+    end
+
+    context 'when provided array filters', if: array_filters_supported? do
+
+      before do
+        Band.delete_all
+        b = Band.new(name: 'Depeche Mode')
+        b.labels << Label.new(name: 'Warner')
+        b.labels << Label.new(name: 'Sony')
+        b.labels << Label.new(name: 'Cbs')
+        b.save
+
+        b = Band.new(name: 'FKA Twigs')
+        b.labels << Label.new(name: 'Warner')
+        b.labels << Label.new(name: 'Cbs')
+        b.save
+      end
+
+
+      let(:criteria) do
+        Band.all
+      end
+
+      let!(:update) do
+        context.update_all({ '$set' => { 'labels.$[i].name' => 'Sony' } },
+                       array_filters: [{ 'i.name' => 'Cbs' }])
+      end
+
+      it 'applies the array filters' do
+        expect(Band.where(name: 'Depeche Mode').first.labels.collect(&:name)).to match_array(['Warner', 'Sony', 'Sony'])
+      end
+
+      it 'updates all documents' do
+        expect(Band.where(name: 'FKA Twigs').first.labels.collect(&:name)).to match_array(['Warner', 'Sony'])
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -84,6 +84,10 @@ def collation_supported?
 end
 alias :decimal128_supported? :collation_supported?
 
+def array_filters_supported?
+  Mongoid::Clients.default.cluster.next_primary.features.array_filters_enabled?
+end
+
 def testing_locally?
   !(ENV['CI'] == 'travis')
 end


### PR DESCRIPTION
Example usage:

```ruby
Band.where(name: 'FKA Twigs').update_all({ '$set' => { 'labels.$[i].name' => 'Sony' } },
                                         array_filters: [{ 'i.name' => 'Cbs' }])
```