### PR TITLE
Adds new atomic method "add_each_to_set" which will do an $addToSet with the $each modifier

### DIFF
--- a/lib/mongoid/atomic/modifiers.rb
+++ b/lib/mongoid/atomic/modifiers.rb
@@ -130,6 +130,27 @@ module Mongoid
         end
       end
 
+      # Adds or appends an array operation with the $each specifier used
+      # in conjuction with $push.
+      #
+      # @example Add the operation.
+      #   modifications.add_operation(mods, field, value)
+      #
+      # @param [ Hash ] mods The modifications.
+      # @param [ String ] field The field.
+      # @param [ Hash ] value The atomic op.
+      #
+      # @since 7.0.0
+      def add_each_operation(mods, field, value)
+        if mods.has_key?(field)
+          value.each do |val|
+            mods[field]["$each"].push(val)
+          end
+        else
+          mods[field] = { "$each" => value }
+        end
+      end
+
       # Get the $addToSet operations or intialize a new one.
       #
       # @example Get the $addToSet operations.

--- a/lib/mongoid/contextual/atomic.rb
+++ b/lib/mongoid/contextual/atomic.rb
@@ -17,6 +17,20 @@ module Mongoid
         view.update_many("$addToSet" => collect_operations(adds))
       end
 
+      # Perform an atomic $addToSet/$each on the matching documents.
+      #
+      # @example Add the value to the set.
+      #   context.add_each_to_set(members: ["Dave", "Bill"], genres: ["Electro", "Disco"])
+      #
+      # @param [ Hash ] adds The operations.
+      #
+      # @return [ nil ] Nil.
+      #
+      # @since 7.0.0
+      def add_each_to_set(adds)
+        view.update_many("$addToSet" => collect_each_operations(adds))
+      end
+
       # Perform an atomic $bit operation on the matching documents.
       #
       # @example Perform the bitwise op.
@@ -117,10 +131,7 @@ module Mongoid
       #
       # @since 3.0.0
       def push_all(pushes)
-        push_each_updates = collect_operations(pushes).each.inject({}) do |ops, (field, elements)|
-          ops.merge!(field => { '$each' => elements })
-        end
-        view.update_many("$push" => push_each_updates)
+        view.update_many("$push" => collect_each_operations(pushes))
       end
 
       # Perform an atomic $rename of fields on the matching documents.
@@ -173,9 +184,14 @@ module Mongoid
       private
 
       def collect_operations(ops)
-        ops.inject({}) do |operations, (field, value)|
+        ops.each_with_object({}) do |(field, value), operations|
           operations[database_field_name(field)] = value.mongoize
-          operations
+        end
+      end
+
+      def collect_each_operations(ops)
+        ops.each_with_object({}) do |(field, value), operations|
+          operations[database_field_name(field)] = { "$each" => value.mongoize }
         end
       end
     end

--- a/lib/mongoid/contextual/atomic.rb
+++ b/lib/mongoid/contextual/atomic.rb
@@ -191,7 +191,7 @@ module Mongoid
 
       def collect_each_operations(ops)
         ops.each_with_object({}) do |(field, value), operations|
-          operations[database_field_name(field)] = { "$each" => value.mongoize }
+          operations[database_field_name(field)] = { "$each" => Array.wrap(value).mongoize }
         end
       end
     end

--- a/spec/mongoid/contextual/atomic_spec.rb
+++ b/spec/mongoid/contextual/atomic_spec.rb
@@ -98,6 +98,102 @@ describe Mongoid::Contextual::Atomic do
     end
   end
 
+  describe "#add_each_to_set" do
+
+    let!(:depeche_mode) do
+      Band.create(members: [ "Dave" ])
+    end
+
+    let!(:new_order) do
+      Band.create(members: [ "Peter" ])
+    end
+
+    let!(:smiths) do
+      Band.create
+    end
+
+    context "when the criteria has no sorting" do
+
+      let(:criteria) do
+        Band.all
+      end
+
+      let(:context) do
+        Mongoid::Contextual::Mongo.new(criteria)
+      end
+
+      before do
+        context.add_each_to_set(members: [ "Dave", "Joe" ])
+      end
+
+      it "does not add duplicates" do
+        expect(depeche_mode.reload.members).to eq([ "Dave", "Joe" ])
+      end
+
+      it "adds unique values" do
+        expect(new_order.reload.members).to eq([ "Peter", "Dave", "Joe" ])
+      end
+
+      it "adds to non initialized fields" do
+        expect(smiths.reload.members).to eq([ "Dave", "Joe" ])
+      end
+    end
+
+    context "when the criteria has sorting" do
+
+      let(:criteria) do
+        Band.asc(:name)
+      end
+
+      let(:context) do
+        Mongoid::Contextual::Mongo.new(criteria)
+      end
+
+      before do
+        context.add_each_to_set(members: [ "Dave", "Joe" ], genres: "Electro")
+      end
+
+      it "does not add duplicates" do
+        expect(depeche_mode.reload.members).to eq([ "Dave", "Joe" ])
+      end
+
+      it "adds multiple operations" do
+        expect(depeche_mode.reload.genres).to eq([ "Electro" ])
+      end
+
+      it "adds unique values" do
+        expect(new_order.reload.members).to eq([ "Peter", "Dave", "Joe" ])
+      end
+
+      it "adds to non initialized fields" do
+        expect(smiths.reload.members).to eq([ "Dave", "Joe" ])
+      end
+    end
+
+    context 'when the criteria has a collation', if: collation_supported? do
+
+      let(:criteria) do
+        Band.where(members: [ "DAVE" ]).collation(locale: 'en_US', strength: 2)
+      end
+
+      let(:context) do
+        Mongoid::Contextual::Mongo.new(criteria)
+      end
+
+      before do
+        context.add_each_to_set(members: [ "Dave", "Joe" ], genres: "Electro")
+      end
+
+      it "does not add duplicates" do
+        expect(depeche_mode.reload.members).to eq([ "Dave", "Joe" ])
+      end
+
+      it "adds multiple operations" do
+        expect(depeche_mode.reload.genres).to eq([ "Electro" ])
+      end
+    end
+  end
+
   describe "#bit" do
 
     let!(:depeche_mode) do


### PR DESCRIPTION
Replaces #4461

Also, we should consider aliasing/renaming pull_all to "pull_each", or else renaming this method as "add_all_to_set"