### PR TITLE
MONGOID-4483 Demongoize attributes when accessing via [] or read_attribute

### DIFF
--- a/lib/mongoid/attributes.rb
+++ b/lib/mongoid/attributes.rb
@@ -29,7 +29,7 @@ module Mongoid
     #
     # @since 1.0.0
     def attribute_present?(name)
-      attribute = read_attribute(name)
+      attribute = read_raw_attribute(name)
       !attribute.blank? || attribute == false
     rescue ActiveModel::MissingAttributeError
       false
@@ -92,21 +92,15 @@ module Mongoid
     #
     # @since 1.0.0
     def read_attribute(name)
-      normalized = database_field_name(name.to_s)
-      if attribute_missing?(normalized)
-        raise ActiveModel::MissingAttributeError, "Missing attribute: '#{name}'."
-      end
-      if hash_dot_syntax?(normalized)
-        attributes.__nested__(normalized)
-      else
-        attributes[normalized]
-      end
+      field = fields[name.to_s]
+      raw = read_raw_attribute(name)
+      field ? field.demongoize(raw) : raw
     end
     alias :[] :read_attribute
 
     # Read a value from the attributes before type cast. If the value has not
     # yet been assigned then this will return the attribute's existing value
-    # using read_attribute.
+    # using read_raw_attribute.
     #
     # @example Read an attribute before type cast.
     #   person.read_attribute_before_type_cast(:price)
@@ -122,7 +116,7 @@ module Mongoid
       if attributes_before_type_cast.key?(attr)
         attributes_before_type_cast[attr]
       else
-        read_attribute(attr)
+        read_raw_attribute(attr)
       end
     end
 
@@ -291,6 +285,20 @@ module Mongoid
     # @since 1.0.0
     def typed_value_for(key, value)
       fields.key?(key) ? fields[key].mongoize(value) : value.mongoize
+    end
+
+    private
+
+    def read_raw_attribute(name)
+      normalized = database_field_name(name.to_s)
+      if attribute_missing?(normalized)
+        raise ActiveModel::MissingAttributeError, "Missing attribute: '#{name}'."
+      end
+      if hash_dot_syntax?(normalized)
+        attributes.__nested__(normalized)
+      else
+        attributes[normalized]
+      end
     end
 
     module ClassMethods

--- a/lib/mongoid/attributes/dynamic.rb
+++ b/lib/mongoid/attributes/dynamic.rb
@@ -41,7 +41,7 @@ module Mongoid
         class_eval <<-READER, __FILE__, __LINE__ + 1
           def #{name}
             attribute_will_change!(#{name.inspect})
-            read_attribute(#{name.inspect})
+            read_raw_attribute(#{name.inspect})
           end
         READER
       end
@@ -147,7 +147,7 @@ module Mongoid
           getter = attr.reader
           define_dynamic_reader(getter)
           attribute_will_change!(attr.reader)
-          read_attribute(getter)
+          read_raw_attribute(getter)
         end
       end
     end

--- a/lib/mongoid/changeable.rb
+++ b/lib/mongoid/changeable.rb
@@ -227,7 +227,7 @@ module Mongoid
     # @since 2.3.0
     def attribute_will_change!(attr)
       unless changed_attributes.key?(attr)
-        changed_attributes[attr] = read_attribute(attr).__deep_copy__
+        changed_attributes[attr] = read_raw_attribute(attr).__deep_copy__
       end
     end
 

--- a/lib/mongoid/fields.rb
+++ b/lib/mongoid/fields.rb
@@ -411,7 +411,7 @@ module Mongoid
       def create_field_getter(name, meth, field)
         generated_methods.module_eval do
           re_define_method(meth) do
-            raw = read_attribute(name)
+            raw = read_raw_attribute(name)
             if lazy_settable?(field, raw)
               write_attribute(name, field.eval_default(self))
             else
@@ -480,7 +480,7 @@ module Mongoid
       def create_field_check(name, meth)
         generated_methods.module_eval do
           re_define_method("#{meth}?") do
-            value = read_attribute(name)
+            value = read_raw_attribute(name)
             lookup_attribute_presence(name, value)
           end
         end

--- a/lib/mongoid/serializable.rb
+++ b/lib/mongoid/serializable.rb
@@ -101,7 +101,7 @@ module Mongoid
         value = send(name)
         attrs[name] = value ? value.serializable_hash(options) : nil
       elsif names.include?(name) && !fields.key?(name)
-        attrs[name] = read_attribute(name)
+        attrs[name] = read_raw_attribute(name)
       elsif !attribute_missing?(name)
         attrs[name] = send(name)
       end

--- a/spec/mongoid/attributes_spec.rb
+++ b/spec/mongoid/attributes_spec.rb
@@ -42,7 +42,7 @@ describe Mongoid::Attributes do
             context "accessing via []" do
 
               it "does not raise an error" do
-                expect(from_db["desc"]).to eq("en" => "test")
+                expect(from_db["desc"]).to eq("test")
               end
             end
 
@@ -165,7 +165,7 @@ describe Mongoid::Attributes do
         context "when passing just the name" do
 
           it "returns the full value" do
-            expect(person[:desc]).to eq("en" => "testing")
+            expect(person[:desc]).to eq("testing")
           end
         end
 

--- a/spec/mongoid/attributes_spec.rb
+++ b/spec/mongoid/attributes_spec.rb
@@ -150,6 +150,17 @@ describe Mongoid::Attributes do
 
   describe "#[]" do
 
+    context 'when the document has a custom attribute type' do
+
+      let(:bar) do
+        Bar.create(lat_lng: LatLng.new(52.30, 13.25))
+      end
+
+      it 'returns the demongoized version of the attribute' do
+        expect(bar.reload[:lat_lng]).to be_a(LatLng)
+      end
+    end
+
     context "when the document is a new record" do
 
       let(:person) do
@@ -267,6 +278,20 @@ describe Mongoid::Attributes do
   end
 
   describe "#[]=" do
+
+    context 'when the document has a custom attribute type' do
+
+      let(:bar) do
+        Bar.new.tap do |b|
+          b[:lat_lng] = LatLng.new(52.30, 13.25)
+          b.save
+        end
+      end
+
+      it 'sets the demongoized version of the attribute' do
+        expect(bar.reload.lat_lng).to be_a(LatLng)
+      end
+    end
 
     let(:person) do
       Person.new
@@ -767,6 +792,17 @@ describe Mongoid::Attributes do
   end
 
   describe "#read_attribute" do
+
+    context 'when the document has a custom attribute type' do
+
+      let(:bar) do
+        Bar.create(lat_lng: LatLng.new(52.30, 13.25))
+      end
+
+      it 'returns the demongoized version of the attribute' do
+        expect(bar.reload.read_attribute(:lat_lng)).to be_a(LatLng)
+      end
+    end
 
     context "when the document is a new record" do
 


### PR DESCRIPTION
This is a behavior change, but corrects Mongoid's behavior to be consistent with ActiveRecord.