### PR TITLE
Changed default host in mongoid generaator to 127.0.0.1

### DIFF
--- a/lib/rails/generators/mongoid/config/templates/mongoid.yml
+++ b/lib/rails/generators/mongoid/config/templates/mongoid.yml
@@ -9,7 +9,7 @@ development:
       # Provides the hosts the default client can connect to. Must be an array
       # of host:port pairs. (required)
       hosts:
-        - localhost:27017
+        - 127.0.0.1:27017
       options:
         # Change the default write concern. (default = { w: 1 })
         # write:


### PR DESCRIPTION
Changed default host in mongoid generator to 127.0.0.1 to prevent error "MONGODB | Address family not supported by protocol family - connect(2) for [::1]:27017"