### PR TITLE
Fix Mongoid::Errors::UnknownModel

### DIFF
--- a/lib/mongoid/factory.rb
+++ b/lib/mongoid/factory.rb
@@ -49,8 +49,11 @@ module Mongoid
         obj
       else
         camelized = type.camelize
-        raise Errors::UnknownModel.new(camelized, type) unless Object.const_defined?(camelized)
-        camelized.constantize.instantiate(attributes, selected_fields)
+        begin
+          camelized.constantize.instantiate(attributes, selected_fields)
+        rescue NameError
+          raise Errors::UnknownModel.new(camelized, type)
+        end
       end
     end
   end


### PR DESCRIPTION
Rails in development mode by default doesn't eager load classes, `Object.const_defined?` can return `false` for exists constants

**models/book.rb**
```ruby
class Book
  include Mongoid::Document
end
```

```
$ rails c
Running via Spring preloader in process 95641
Loading development environment (Rails 5.2.0.rc1)
2.5.0 :001 > Object.const_defined? 'Book'
 => true 
2.5.0 :002 > Object.const_defined? 'Book'
 => true 
2.5.0 :003 > reload!
Reloading...
 => true 
2.5.0 :004 > Object.const_defined? 'Book'
 => false 
2.5.0 :005 > ^C

$ RAILS_ENV=production rails c
Running via Spring preloader in process 96786
Loading production environment (Rails 6.0.0.alpha)
2.5.0 :001 > Object.const_defined? 'Book'
 => true 
2.5.0 :002 > Object.const_defined? 'Book'
 => true 
2.5.0 :003 > Object.const_defined? 'Book'
 => true 
2.5.0 :004 > reload!
Reloading...
2.5.0 :005 > Object.const_defined? 'Book'
 => true 
```

```ruby
class Tracker
  include Mongoid::Document
end

Benchmark.ips do |x|
  camelized = 'Tracker'
  attributes = {}
  selected_fields = {}
  type = (attributes || {})['_type']

  x.report "rescue" do 
    begin
      camelized.constantize.instantiate(attributes, selected_fields)
    rescue NameError
      raise Mongoid::Errors::UnknownModel.new(camelized, type)
    end
  end

  x.report "raise" do 
    raise Mongoid::Errors::UnknownModel.new(camelized, type) unless Object.const_defined?(camelized)
    camelized.constantize.instantiate(attributes, selected_fields)
  end

  x.compare!
end
```

```
Warming up --------------------------------------
              rescue    10.672k i/100ms
               raise    11.099k i/100ms
Calculating -------------------------------------
              rescue    127.237k (±13.0%) i/s -    629.648k in   5.037331s
               raise    120.092k (±11.7%) i/s -    599.346k in   5.065017s

Comparison:
              rescue:   127236.9 i/s
               raise:   120091.7 i/s - same-ish: difference falls within error

 => #<Benchmark::IPS::Report:0x00007fe0718406d0 @entries=[#<Benchmark::IPS::Report::Entry:0x00007fe072163fa0 @label="rescue", @microseconds=5037331.0, @iterations=629648, @stats=#<Benchmark::IPS::Stats::SD:0x00007fe0721680a0 @mean=127236.91457787201, @error=16595>, @measurement_cycle=10672, @show_total_time=true>, #<Benchmark::IPS::Report::Entry:0x00007fe06e9a8638 @label="raise", @microseconds=5065017.0, @iterations=599346, @stats=#<Benchmark::IPS::Stats::SD:0x00007fe06e9a8750 @mean=120091.69427794278, @error=14007>, @measurement_cycle=11099, @show_total_time=true>], @data=nil> 
```