### PR TITLE
fix query date parser with ActiveSupport timezone

### DIFF
--- a/lib/mongoid/criteria/queryable/extensions/string.rb
+++ b/lib/mongoid/criteria/queryable/extensions/string.rb
@@ -16,7 +16,7 @@ module Mongoid
           #
           # @since 1.0.0
           def __evolve_date__
-            time = ::Time.parse(self)
+            time = __evolve_time__.utc
             ::Time.utc(time.year, time.month, time.day, 0, 0, 0, 0)
           end
 
@@ -29,7 +29,7 @@ module Mongoid
           #
           # @since 1.0.0
           def __evolve_time__
-            ::Time.parse(self).utc
+            __mongoize_time__.utc
           end
 
           # Get the string as a mongo expression, adding $ to the front.

--- a/lib/mongoid/criteria/queryable/extensions/string.rb
+++ b/lib/mongoid/criteria/queryable/extensions/string.rb
@@ -16,7 +16,7 @@ module Mongoid
           #
           # @since 1.0.0
           def __evolve_date__
-            time = __evolve_time__.utc
+            time = ::Time.parse(self)
             ::Time.utc(time.year, time.month, time.day, 0, 0, 0, 0)
           end
 

--- a/spec/mongoid/criteria/queryable/extensions/string_spec.rb
+++ b/spec/mongoid/criteria/queryable/extensions/string_spec.rb
@@ -33,6 +33,49 @@ describe String do
         expect(evolved).to eq(Time.new(2010, 1, 1, 0, 0, 0, 0).utc)
       end
     end
+
+    context "when the string without timezone" do
+
+      context "when using active support's time zone" do
+
+        before do
+          Mongoid.use_activesupport_time_zone = true
+          ::Time.zone = "Tokyo"
+        end
+
+        let(:date) do
+          "2010-01-01 5:00:00"
+        end
+
+        let(:evolved) do
+          date.__evolve_time__
+        end
+
+        it "parses string using active support's time zone" do
+          expect(evolved).to eq(Time.zone.parse(date).utc.beginning_of_day)
+        end
+      end
+
+      context "when not using active support's time zone" do
+
+        before do
+          Mongoid.use_activesupport_time_zone = false
+          ::Time.zone = nil
+        end
+
+        let(:date) do
+          "2010-01-01 5:00:00"
+        end
+
+        let(:evolved) do
+          date.__evolve_time__
+        end
+
+        it "parses string using system time zone" do
+          expect(evolved).to eq(Time.parse(date).utc.beginning_of_day)
+        end
+      end
+    end
   end
 
   describe "#__evolve_time__" do
@@ -64,6 +107,49 @@ describe String do
 
       it "returns the string as a utc time" do
         expect(evolved).to eq(Time.new(2010, 1, 1, 11, 0, 0, 0).utc)
+      end
+    end
+
+    context "when the string without timezone" do
+
+      context "when using active support's time zone" do
+
+        before do
+          Mongoid.use_activesupport_time_zone = true
+          ::Time.zone = "Tokyo"
+        end
+
+        let(:date) do
+          "2010-01-01 5:00:00"
+        end
+
+        let(:evolved) do
+          date.__evolve_time__
+        end
+
+        it "parses string using active support's time zone" do
+          expect(evolved).to eq(Time.zone.parse(date).utc)
+        end
+      end
+
+      context "when not using active support's time zone" do
+
+        before do
+          Mongoid.use_activesupport_time_zone = false
+          ::Time.zone = nil
+        end
+
+        let(:date) do
+          "2010-01-01 5:00:00"
+        end
+
+        let(:evolved) do
+          date.__evolve_time__
+        end
+
+        it "parses string using system time zone" do
+          expect(evolved).to eq(Time.parse(date).utc)
+        end
       end
     end
   end

--- a/spec/mongoid/criteria/queryable/extensions/string_spec.rb
+++ b/spec/mongoid/criteria/queryable/extensions/string_spec.rb
@@ -33,49 +33,6 @@ describe String do
         expect(evolved).to eq(Time.new(2010, 1, 1, 0, 0, 0, 0).utc)
       end
     end
-
-    context "when the string without timezone" do
-
-      context "when using active support's time zone" do
-
-        before do
-          Mongoid.use_activesupport_time_zone = true
-          ::Time.zone = "Tokyo"
-        end
-
-        let(:date) do
-          "2010-01-01 5:00:00"
-        end
-
-        let(:evolved) do
-          date.__evolve_time__
-        end
-
-        it "parses string using active support's time zone" do
-          expect(evolved).to eq(Time.zone.parse(date).utc.beginning_of_day)
-        end
-      end
-
-      context "when not using active support's time zone" do
-
-        before do
-          Mongoid.use_activesupport_time_zone = false
-          ::Time.zone = nil
-        end
-
-        let(:date) do
-          "2010-01-01 5:00:00"
-        end
-
-        let(:evolved) do
-          date.__evolve_time__
-        end
-
-        it "parses string using system time zone" do
-          expect(evolved).to eq(Time.parse(date).utc.beginning_of_day)
-        end
-      end
-    end
   end
 
   describe "#__evolve_time__" do


### PR DESCRIPTION
Mongoid ignored Active Support timezone when parses time from string inside query object. So I used method from https://github.com/mongodb/mongoid/blob/master/lib/mongoid/extensions/string.rb extension to parse dates from strings. 

