### PR TITLE
fix before_remove and after_remove relation callbacks and add shift r…

### DIFF
--- a/lib/mongoid/association/embedded/embeds_many/proxy.rb
+++ b/lib/mongoid/association/embedded/embeds_many/proxy.rb
@@ -271,6 +271,29 @@ module Mongoid
             end
           end
 
+          # Shift documents off the relation. This can be a single document or
+          # multiples, and will automatically persist the changes.
+          #
+          # @example Shift a single document.
+          #   relation.shift
+          #
+          # @example Shift multiple documents.
+          #   relation.shift(3)
+          #
+          # @param [ Integer ] count The number of documents to shift, or 1 if not
+          #   provided.
+          #
+          # @return [ Document, Array<Document> ] The shifted document(s).
+          def shift(count = nil)
+            if count
+              if _target.size > 0 && docs = _target[0, count]
+                docs.each { |doc| delete(doc) }
+              end
+            else
+              delete(_target[0])
+            end
+          end
+
           # Substitutes the supplied target documents for the existing documents
           # in the relation.
           #

--- a/spec/mongoid/association/embedded/embeds_many/proxy_spec.rb
+++ b/spec/mongoid/association/embedded/embeds_many/proxy_spec.rb
@@ -2544,6 +2544,25 @@ describe Mongoid::Association::Embedded::EmbedsMany::Proxy do
         person.addresses.create(street: "hermannstr")
       end
 
+      context "when the number is zero" do
+
+        let!(:popped) do
+          person.addresses.pop(0)
+        end
+
+        it "returns an empty array" do
+          expect(popped).to eq([])
+        end
+
+        it "does not remove the document from the relation" do
+          expect(person.addresses).to eq([ address_one, address_two ])
+        end
+
+        it "does not persist the pop" do
+          expect(person.reload.addresses).to eq([ address_one, address_two ])
+        end
+      end
+
       context "when the number is not larger than the relation" do
 
         let!(:popped) do
@@ -2644,11 +2663,28 @@ describe Mongoid::Association::Embedded::EmbedsMany::Proxy do
         person.addresses.create(street: "hermannstr")
       end
 
+      context "when the number is zero" do
+
+        let!(:shifted) do
+          person.addresses.shift(0)
+        end
+
+        it "returns an empty array" do
+          expect(shifted).to eq([])
+        end
+
+        it "does not remove the document from the relation" do
+          expect(person.addresses).to eq([ address_one, address_two ])
+        end
+
+        it "does not persist the shift" do
+          expect(person.reload.addresses).to eq([ address_one, address_two ])
+        end
+      end
+
       context "when the number is not larger than the relation" do
 
         let!(:shifted) do
-          # person.addresses.create(street: "kos")
-          # binding.pry
           person.addresses.shift(2)
         end
 


### PR DESCRIPTION
When object of a model has `embeds_many` relation with `before_remove` or `after_remove` relation callbacks. Callback does not work when `shift` method is called on `embeds_many` relation. This pr fix it.