### PR TITLE
fix s3 uploads

### DIFF
--- a/.evergreen/.evg.yml
+++ b/.evergreen/.evg.yml
@@ -240,12 +240,12 @@ functions:
       params:
         script: |
           ${PREPARE_SHELL}
-          find $MONGO_ORCHESTRATION_HOME -name \*.log | xargs tar czf ${PROJECT_DIRECTORY}/mongodb-logs.tar.gz
+          find $MONGO_ORCHESTRATION_HOME -name \*.log | xargs tar czf mongodb-logs.tar.gz
     - command: s3.put
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: ${PROJECT_DIRECTORY}/mongodb-logs.tar.gz
+        local_file: mongodb-logs.tar.gz
         remote_file: ${UPLOAD_BUCKET}/${build_variant}/${revision}/${version_id}/${build_id}/logs/${task_id}-${execution}-mongodb-logs.tar.gz
         bucket: mciuploads
         permissions: public-read


### PR DESCRIPTION
Mongoid analog of https://github.com/mongodb/mongo-ruby-driver/pull/924

Currently, the s3 uploads of the server logs fail on evergreen due to a quirk in how the s3.put command deals with absolute paths (see the first line starting with "[2018/04/12 16:42:06.791] Command failed: missing file" in [this log](https://evergreen.mongodb.com/task_log_raw/mongoid_rhel70_all_driver_all_ruby_standalone__mongodb_version~3.6_topology~standalone_ruby~ruby_2.5.0_driver~latest_test_patch_c60e67afaf094c91e09ac1021e5be5d68102f6c7_5acfbfe6e3c331457936751e_18_04_12_20_22_12/0?type=T&text=true). To fix this, we can just use save the tarball in the current working directory and upload it from there instead of relying on a proper expansion of $PROJECT_DIRECTORY.

See [here](https://evergreen.mongodb.com/build/mongoid_rhel70_all_driver_all_ruby_standalone__mongodb_version~3.6_topology~standalone_ruby~ruby_2.5.0_driver~latest_patch_c60e67afaf094c91e09ac1021e5be5d68102f6c7_5acfc9c0e3c33145793845c6_18_04_12_21_04_29) for an example of the logs being correctly uploaded after this patch is applied.