### PR TITLE
Demonstrate removal of Mongoid::Document#touch

### DIFF
--- a/spec/mongoid/document_spec.rb
+++ b/spec/mongoid/document_spec.rb
@@ -10,6 +10,10 @@ describe Mongoid::Document do
     Person.new
   end
 
+  it "is touchable" do
+    expect(person).to respond_to(:touch)
+  end
+
   it "defines a _destroy method" do
     expect(Person.new).to respond_to(:_destroy)
   end


### PR DESCRIPTION
This test succeeds in v6.4.1 but starts failing with v7.0.0.beta. The changelogs do not seem to include a deprecation / breaking change notice.

Bug report @ https://jira.mongodb.org/browse/MONGOID-4545.