### PR TITLE
Ensure without_default_scope does not suppress default scopes of other models

### DIFF
--- a/lib/mongoid/scopable.rb
+++ b/lib/mongoid/scopable.rb
@@ -103,7 +103,7 @@ module Mongoid
       #
       # @since 3.0.0
       def default_scopable?
-        default_scoping? && !Threaded.executing?(:without_default_scope)
+        default_scoping? && !Threaded.without_default_scope?(self)
       end
 
       # Get a queryable, either the last one on the scope stack or a fresh one.
@@ -245,10 +245,10 @@ module Mongoid
       #
       # @since 3.0.0
       def without_default_scope
-        Threaded.begin_execution("without_default_scope")
+        Threaded.begin_without_default_scope(self)
         yield
       ensure
-        Threaded.exit_execution("without_default_scope")
+        Threaded.exit_without_default_scope(self)
       end
 
       private

--- a/lib/mongoid/threaded.rb
+++ b/lib/mongoid/threaded.rb
@@ -171,7 +171,7 @@ module Mongoid
     #
     # @param [ Class ] klass The model to suppress default scoping on.
     #
-    # @since VERSION
+    # @api private
     def begin_without_default_scope(klass)
       stack(:without_default_scope).push(klass)
     end
@@ -183,7 +183,7 @@ module Mongoid
     #
     # @param [ Class ] klass The model to unsuppress default scoping on.
     #
-    # @since VERSION
+    # @api private
     def exit_without_default_scope(klass)
       stack(:without_default_scope).delete(klass)
     end
@@ -279,7 +279,7 @@ module Mongoid
     #
     # @param [ Class ] klass The model to check for default scope suppression.
     #
-    # @since VERSION
+    # @api private
     def without_default_scope?(klass)
       stack(:without_default_scope).include?(klass)
     end

--- a/lib/mongoid/threaded.rb
+++ b/lib/mongoid/threaded.rb
@@ -164,6 +164,30 @@ module Mongoid
       validations_for(document.class).delete_one(document._id)
     end
 
+    # Begin suppressing default scopes for given model on the current thread.
+    #
+    # @example Begin without default scope stack.
+    #   Threaded.begin_without_default_scope(klass)
+    #
+    # @param [ Class ] klass The model to suppress default scoping on.
+    #
+    # @since VERSION
+    def begin_without_default_scope(klass)
+      stack(:without_default_scope).push(klass)
+    end
+
+    # Exit suppressing default scopes for given model on the current thread.
+    #
+    # @example Exit without default scope stack.
+    #   Threaded.exit_without_default_scope(klass)
+    #
+    # @param [ Class ] klass The model to unsuppress default scoping on.
+    #
+    # @since VERSION
+    def exit_without_default_scope(klass)
+      stack(:without_default_scope).delete(klass)
+    end
+
     # Get the global client override.
     #
     # @example Get the global client override.
@@ -246,6 +270,18 @@ module Mongoid
         Thread.current[CURRENT_SCOPE_KEY] ||= {}
         Thread.current[CURRENT_SCOPE_KEY][klass] = scope
       end
+    end
+
+    # Is the given klass' default scope suppressed on the current thread?
+    #
+    # @example Is the given klass' default scope suppressed?
+    #   Threaded.without_default_scope?(klass)
+    #
+    # @param [ Class ] klass The model to check for default scope suppression.
+    #
+    # @since VERSION
+    def without_default_scope?(klass)
+      stack(:without_default_scope).include?(klass)
     end
 
     # Is the document autosaved on the current thread?

--- a/spec/mongoid/scopable_spec.rb
+++ b/spec/mongoid/scopable_spec.rb
@@ -1132,6 +1132,19 @@ describe Mongoid::Scopable do
     it "sets the threading options" do
       Band.without_default_scope do
         expect(Mongoid::Threaded).to be_executing(:without_default_scope)
+        expect(Mongoid::Threaded.without_default_scope?(Band)).to be(true)
+      end
+    end
+
+    it "suppresses default scope on the given model within the given block" do
+      Appointment.without_default_scope do
+        expect(Appointment.all.selector).to be_empty
+      end
+    end
+
+    it "does not affect other models' default scopes within the given block" do
+      Appointment.without_default_scope do
+        expect(Audio.all.selector).not_to be_empty
       end
     end
   end

--- a/spec/mongoid/threaded_spec.rb
+++ b/spec/mongoid/threaded_spec.rb
@@ -235,4 +235,72 @@ describe Mongoid::Threaded do
       end
     end
   end
+
+  describe "#begin_without_default_scope" do
+
+    let(:klass) do
+      Appointment
+    end
+
+    after do
+      described_class.exit_without_default_scope(klass)
+    end
+
+    it "adds the given class to the without_default_scope stack" do
+      described_class.begin_without_default_scope(klass)
+
+      expect(described_class.stack(:without_default_scope)).to include(klass)
+    end
+  end
+
+  describe "#exit_without_default_scope" do
+
+    let(:klass) do
+      Appointment
+    end
+
+    before do
+      described_class.begin_without_default_scope(klass)
+    end
+
+    it "removes the given class from the without_default_scope stack" do
+      described_class.exit_without_default_scope(klass)
+
+      expect(described_class.stack(:without_default_scope)).not_to include(klass)
+    end
+  end
+
+  describe "#without_default_scope?" do
+
+    let(:klass) do
+      Appointment
+    end
+
+    context "when klass has begun without_default_scope" do
+
+      before do
+        described_class.begin_without_default_scope(klass)
+      end
+
+      after do
+        described_class.exit_without_default_scope(klass)
+      end
+
+      it "returns true" do
+        expect(described_class.without_default_scope?(klass)).to be(true)
+      end
+    end
+
+    context "when klass has exited without_default_scope" do
+
+      before do
+        described_class.begin_without_default_scope(klass)
+        described_class.exit_without_default_scope(klass)
+      end
+
+      it "returns false" do
+        expect(described_class.without_default_scope?(klass)).to be(false)
+      end
+    end
+  end
 end


### PR DESCRIPTION
The method `Mongoid::Scopable.without_default_scope` has the peculiar behavior of suppressing default scopes of models not called upon to do so. For example:

```ruby
Appointment.without_default_scope do
  # the following should be true, obviously
  Appointment.all.selector.empty? #=> true

  # the following should be false, as Audio has a default scope that we are not trying
  # to suppress in this block, given the receiver of `without_default_scope`.
  Audio.all.selector.empty? #=> true
end
```

I have fixed this behavior, and have written specs to ensure it continues exhibiting the appropriate behavior. Additional methods were added to `Mongoid::Threaded` to allow for easily adding and removing classes from the `:without_default_scope` stack of the current thread, which now contains all the classes whose default scopes are being actively suppressed, rather than just containing `true` to denote a global suppression of default scopes.

I have left blank the `@since` doc attribute of the new methods in `Mongoid::Threaded`, since I do not know what version these would be released in. Moreover, this commit should be backportable to mongoid 5.x.