### PR TITLE
Add truncate_logs comment to config generator

### DIFF
--- a/lib/rails/generators/mongoid/config/templates/mongoid.yml
+++ b/lib/rails/generators/mongoid/config/templates/mongoid.yml
@@ -98,13 +98,15 @@ development:
         # A passphrase for the private key.
         # ssl_key_pass_phrase: password
 
-        # Whether or not to do peer certification validation. (default: true)
+        # Whether to do peer certification validation. (default: true)
         # ssl_verify: true
 
-        # The file containing a set of concatenated certification authority certifications
+        # The file containing concatenated certificate authority certificates
         # used to validate certs passed from the other end of the connection.
         # ssl_ca_cert: /path/to/ca.cert
-
+        
+        # Whether to truncate long log lines. (default: true)
+        # truncate_logs: true
 
   # Configure Mongoid specific options. (optional)
   options:


### PR DESCRIPTION
It's not the first time that I had to search for this option and it's quite a popular question on Stackoverflow as well. Ideally I'd like to see this uncommented in the default generated config file but just adding the comment should help a lot of folks.

https://stackoverflow.com/questions/34753530/how-to-not-truncate-mongoid-logs