### PR TITLE
Stop modification of time zones when converting Time objects

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,3 +10,11 @@ group :test do
   gem 'benchmark-ips'
   gem 'rspec', '~> 3.7'
 end
+
+group :development, :testing do
+  platforms :mri do
+    if RUBY_VERSION >= '2.0.0'
+      gem 'byebug'
+    end
+  end
+end

--- a/lib/mongoid/criteria/queryable/extensions/time.rb
+++ b/lib/mongoid/criteria/queryable/extensions/time.rb
@@ -28,7 +28,7 @@ module Mongoid
           #
           # @since 1.0.0
           def __evolve_time__
-            utc
+            getutc
           end
 
           module ClassMethods

--- a/spec/lite_spec_helper.rb
+++ b/spec/lite_spec_helper.rb
@@ -3,3 +3,8 @@ $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
 
 require "mongoid"
 require "rspec"
+
+begin
+  require 'byebug'
+rescue LoadError
+end

--- a/spec/lite_spec_helper.rb
+++ b/spec/lite_spec_helper.rb
@@ -1,0 +1,5 @@
+$LOAD_PATH.unshift(File.dirname(__FILE__))
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
+
+require "mongoid"
+require "rspec"

--- a/spec/mongoid/criteria/queryable/extensions/time_spec.rb
+++ b/spec/mongoid/criteria/queryable/extensions/time_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require "lite_spec_helper"
 
 describe Time do
 
@@ -8,20 +8,25 @@ describe Time do
 
       context "when the time is not in utc" do
 
-        let(:date) do
-          Time.new(2010, 1, 1, 12, 0, 0)
+        let(:time) do
+          Time.new(2010, 1, 1, 14, 0, 0, '+02:00')
         end
 
         let(:evolved) do
-          described_class.evolve(date)
+          described_class.evolve(time)
         end
 
         let(:expected) do
-          Time.new(2010, 1, 1, 12, 0, 0).utc
+          Time.new(2010, 1, 1, 12, 0, 0, '+00:00')
         end
 
         it "returns the same time" do
           expect(evolved).to eq(expected)
+        end
+
+        it 'does not mutate original time' do
+          described_class.evolve(time)
+          expect(time.utc_offset).to eq(7200)
         end
 
         it "returns the time in utc" do
@@ -31,12 +36,12 @@ describe Time do
 
       context "when the time is already utc" do
 
-        let(:date) do
+        let(:time) do
           Time.new(2010, 1, 1, 12, 0, 0).utc
         end
 
         let(:evolved) do
-          described_class.evolve(date)
+          described_class.evolve(time)
         end
 
         let(:expected) do
@@ -57,12 +62,12 @@ describe Time do
 
       context "when the array is composed of times" do
 
-        let(:date) do
+        let(:time) do
           Time.new(2010, 1, 1, 12, 0, 0)
         end
 
         let(:evolved) do
-          described_class.evolve([ date ])
+          described_class.evolve([ time ])
         end
 
         let(:expected) do
@@ -80,16 +85,16 @@ describe Time do
 
       context "when the array is composed of strings" do
 
-        let(:date) do
+        let(:time) do
           Time.parse("1st Jan 2010 12:00:00+01:00")
         end
 
         let(:evolved) do
-          described_class.evolve([ date.to_s ])
+          described_class.evolve([ time.to_s ])
         end
 
         it "returns the strings as a times" do
-          expect(evolved).to eq([ date.to_time ])
+          expect(evolved).to eq([ time.to_time ])
         end
 
         it "returns the times in utc" do
@@ -146,7 +151,7 @@ describe Time do
 
     context "when provided a range" do
 
-      context "when the range are dates" do
+      context "when the range are times" do
 
         let(:min) do
           Time.new(2010, 1, 1, 12, 0, 0)
@@ -273,16 +278,16 @@ describe Time do
 
     context "when provided a string" do
 
-      let(:date) do
+      let(:time) do
         Time.parse("1st Jan 2010 12:00:00+01:00")
       end
 
       let(:evolved) do
-        described_class.evolve(date.to_s)
+        described_class.evolve(time.to_s)
       end
 
       it "returns the string as a time" do
-        expect(evolved).to eq(date.to_time)
+        expect(evolved).to eq(time.to_time)
       end
 
       it "returns the time in utc" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,10 @@ MODELS = File.join(File.dirname(__FILE__), "app/models")
 $LOAD_PATH.unshift(MODELS)
 
 require "action_controller"
+begin
+  require 'byebug'
+rescue LoadError
+end
 
 # These environment variables can be set if wanting to test against a database
 # that is not on the local machine.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,12 +1,9 @@
-$LOAD_PATH.unshift(File.dirname(__FILE__))
-$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
+require 'lite_spec_helper'
 
 MODELS = File.join(File.dirname(__FILE__), "app/models")
 $LOAD_PATH.unshift(MODELS)
 
 require "action_controller"
-require "mongoid"
-require "rspec"
 
 # These environment variables can be set if wanting to test against a database
 # that is not on the local machine.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,10 +4,6 @@ MODELS = File.join(File.dirname(__FILE__), "app/models")
 $LOAD_PATH.unshift(MODELS)
 
 require "action_controller"
-begin
-  require 'byebug'
-rescue LoadError
-end
 
 # These environment variables can be set if wanting to test against a database
 # that is not on the local machine.


### PR DESCRIPTION
I'm having problems with Mongoid queries modifying time variables. The following example shows how a Time object looses its time zone information after being used in a query where the Time object is used to query a field with the datatype DateTime. 

```
class Person
  include Mongoid::Document
  store_in collection: "persons"
  field :birthday, type: DateTime
end
=> #<Mongoid::Fields::Standard:0 ...

time = Time.new(1970, 1, 1, 0, 0, 0, "+05:00")
=> 1970-01-01 00:00:00 +0500

Person.where(:birthday => time)
=> #<Mongoid::Criteria ...

time
=> 1969-12-31 19:00:00 UTC
```

I understand that Mongo performs conversions to UTC, but it should not modify the variable 'time'. This modification does not happend when using DateTime. The problem occurs at lib/mongoid/criteria/queryable/extensions/time.rb @ 31

The method 'utc' is called on the object which modifies it. The Ruby documentation states: 

> Converts time to UTC (GMT), modifying the receiver.

[https://ruby-doc.org/core-2.2.0/Time.html#method-i-utc](https://ruby-doc.org/core-2.2.0/Time.html#method-i-utc)

I believe the fix is to call 'getutc' instead. 

> Returns a new Time object representing time in UTC.

[https://ruby-doc.org/core-2.2.0/Time.html#method-i-getutc](https://ruby-doc.org/core-2.2.0/Time.html#method-i-getutc)

**Screenshot**
![mongodb timezone](https://user-images.githubusercontent.com/2292084/41654836-fe2962b4-748a-11e8-8cc2-509e2d3f3901.png)

This is my first pull request and I couldn't find any guidelines, so bare with me.