### PR TITLE
Fix cloning documents with deep embedded documents

### DIFF
--- a/lib/mongoid/copyable.rb
+++ b/lib/mongoid/copyable.rb
@@ -73,8 +73,9 @@ module Mongoid
         next unless attrs.present? && attrs[association.key].present?
 
         if association.is_a?(Association::Embedded::EmbedsMany)
-          attrs[association.name.to_s].each_with_index do |attr, index|
-            process_localized_attributes(send(association.name)[index].class, attr)
+          attrs[association.name.to_s].each do |attr|
+            embedded_klass = attr.fetch('_type', association.class_name).constantize
+            process_localized_attributes(embedded_klass, attr)
           end
         else
           process_localized_attributes(association.klass, attrs[association.key])

--- a/spec/mongoid/copyable_spec.rb
+++ b/spec/mongoid/copyable_spec.rb
@@ -35,6 +35,10 @@ describe Mongoid::Copyable do
         person.build_game(name: "Tron")
       end
 
+      let!(:name_translations) do
+        person.name.translations.build(language: 'en')
+      end
+
       context "when the document has an id field in the database" do
 
         let!(:band) do
@@ -245,12 +249,24 @@ describe Mongoid::Copyable do
             expect(copy.addresses).to eq(person.addresses)
           end
 
+          it "copys deep embeds many documents" do
+            expect(copy.name.translations).to eq(person.name.translations)
+          end
+
           it "sets the embedded many documents as new" do
             expect(copy.addresses.first).to be_new_record
           end
 
+          it "sets the deep embedded many documents as new" do
+            expect(copy.name.translations.first).to be_new_record
+          end
+
           it "creates new embeds many instances" do
             expect(copy.addresses).to_not equal(person.addresses)
+          end
+
+          it "creates new deep embeds many instances" do
+            expect(copy.name.translations).to_not equal(person.name.translations)
           end
 
           it "copys embeds one documents" do


### PR DESCRIPTION
Given you have the following relations

```ruby
class Person
  include Mongoid::Document
  embeds_one :name
end

class Name
  include Mongoid::Document
  embeds_many :translations
end

class Translation
  include Mongoid::Document
  embedded_in :name
end
```

If you try to clone the `person`, you get the following error:

```ruby
Person.new(name: Name.new(translations: [Translation.new])).clone

# NoMethodError: undefined method `translations' for #<Person _id: 5b364ccba64769539ad9b0c4, > 
# from mongoid/lib/mongoid/copyable.rb:77:in `block (2 levels) in process_localized_attributes'
```

This is related to this PR: https://github.com/mongodb/mongoid/pull/4455 and reverts this commit: https://github.com/mongodb/mongoid/commit/cd54dcb603c5ad22deb885d8395ef40564e60eb0#diff-499230fc3e0945686550bb7bd4fda9e9

Fixes https://jira.mongodb.org/browse/MONGOID-4560