### PR TITLE
stop building every mongodb version on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,41 +13,16 @@ before_install:
   - gem update --system
   - gem update bundler
 
-matrix:
-  fast_finish: true
-  exclude:
-    - rvm: ruby-head
-      gemfile: gemfiles/rails_master.gemfile
-    - rvm: jruby-9.1.16.0
-      gemfile: gemfiles/rails_master.gemfile
-    - rvm: jruby-9.1.16.0
-      gemfile: gemfiles/driver_master.gemfile
-    - rvm: jruby-9.1.16.0
-      env: MONGODB=2.6.12
-    - rvm: jruby-9.1.16.0
-      env: MONGODB=3.4.10
-  allow_failures:
-    - rvm: ruby-head
-    - gemfile: gemfiles/rails_master.gemfile
-
 rvm:
   - 2.5.1
-  - ruby-head
-  - jruby-9.1.16.0
 
 gemfile:
   - Gemfile
-  - gemfiles/driver_master.gemfile
-  - gemfiles/rails_master.gemfile
 
 env:
   global:
     - CI="travis"
-    - JRUBY_OPTS="--server -J-Xms512m -J-Xmx1G"
-  matrix:
-    - MONGODB=2.6.12
-    - MONGODB=3.4.10
-    - MONGODB=3.6.2
+    - MONGODB=4.0.1
 
 before_script:
   - wget http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-${MONGODB}.tgz -O /tmp/mongodb.tgz


### PR DESCRIPTION
Given the long running times of our Travis jobs, it has been requested that we only test the latest version of MongoDB on Travis rather than every version (since we already test all versions on Evergreen)