### PR TITLE
docs: mongoid-installation - remove table column widths

### DIFF
--- a/docs/tutorials/mongoid-installation.txt
+++ b/docs/tutorials/mongoid-installation.txt
@@ -38,7 +38,6 @@ and thus requires Ruby 2.2.2 or higher.
 
 .. list-table::
    :header-rows: 1
-   :widths: 28 30 30 30
 
    * - Ruby Version
      - MongoDB 3.0.x


### PR DESCRIPTION
Remove table column widths in mongoid-installation tutorial doc as the number of column widths and the number of columns are not in sync