### PR TITLE
Fix Settable: allow setting a nested value to a non-string (for 6.4 stable)

### DIFF
--- a/lib/mongoid/persistable/settable.rb
+++ b/lib/mongoid/persistable/settable.rb
@@ -25,14 +25,14 @@ module Mongoid
 
             field_and_value_hash = hasherizer(field.split('.'), value)
             field = field_and_value_hash.keys.first.to_s
+            value = field_and_value_hash[field]
 
-            if fields[field] && fields[field].type == Hash && attributes.key?(field) && !value.empty?
+            if fields[field] && fields[field].type == Hash && attributes.key?(field) && Hash === value && !value.empty?
               merger = proc { |key, v1, v2| Hash === v1 && Hash === v2 ? v1.merge(v2, &merger) : v2 }
-              value = (attributes[field] || {}).merge(field_and_value_hash[field], &merger)
-              process_attribute(field.to_s, value)
-            else
-              process_attribute(field.to_s, field_and_value_hash[field])
+              value = (attributes[field] || {}).merge(value, &merger)
             end
+
+            process_attribute(field.to_s, value)
 
             unless relations.include?(field.to_s)
               ops[atomic_attribute_name(field)] = attributes[field]

--- a/spec/mongoid/persistable/settable_spec.rb
+++ b/spec/mongoid/persistable/settable_spec.rb
@@ -329,7 +329,7 @@ describe Mongoid::Persistable::Settable do
           church.set('location.address.city' => 12345)
         end
 
-        it 'does not reset the nested hash' do
+        it 'updates the nested value to the correct value' do
           expect(church.name).to eq('Church1')
           expect(church.location).to eql({'address' => {'city' => 12345, 'street' => 'Yorckstr'}})
         end

--- a/spec/mongoid/persistable/settable_spec.rb
+++ b/spec/mongoid/persistable/settable_spec.rb
@@ -315,6 +315,25 @@ describe Mongoid::Persistable::Settable do
         end
       end
 
+      context 'when a leaf value in the nested hash is updated to a number' do
+
+        let(:church) do
+          Church.new.tap do |a|
+            a.location = {'address' => {'city' => 'Berlin', 'street' => 'Yorckstr'}}
+            a.name = 'Church1'
+            a.save
+          end
+        end
+
+        before do
+          church.set('location.address.city' => 12345)
+        end
+
+        it 'does not reset the nested hash' do
+          expect(church.name).to eq('Church1')
+          expect(church.location).to eql({'address' => {'city' => 12345, 'street' => 'Yorckstr'}})
+        end
+      end
 
       context 'when the nested hash is many levels deep' do
 


### PR DESCRIPTION
#4487 introduced a regression: one can no longer `$set` a nested hash value to anything that doesn't implement `empty?`.

This PR fixes a couple of bugs with the previous PR:
 - Pull out the `value` from `field_and_value_hash` _before_ checking if it's `empty?`; this ensures we're checking the actual value that is attempting to be set
 - Check that it is actually a `Hash` before checking if it's `empty?`

The reason previous tests passed is because they only checked that nested values could be set to a string, which implements `empty?`.

Relevant stacktrace here:
```ruby
      undefined method `empty?' for 1531794645:Fixnum
./tmp/bundle/ruby-2.3.7/ruby/2.3.0/gems/mongoid-6.4.1/lib/mongoid/persistable/settable.rb:29:in `block (2 levels) in set'
./tmp/bundle/ruby-2.3.7/ruby/2.3.0/gems/mongoid-6.4.1/lib/mongoid/persistable.rb:166:in `block (2 levels) in process_atomic_operations'
./tmp/bundle/ruby-2.3.7/ruby/2.3.0/gems/mongoid-6.4.1/lib/mongoid/attributes/readonly.rb:36:in `as_writable_attribute!'
./tmp/bundle/ruby-2.3.7/ruby/2.3.0/gems/mongoid-6.4.1/lib/mongoid/persistable.rb:165:in `block in process_atomic_operations'
./tmp/bundle/ruby-2.3.7/ruby/2.3.0/gems/mongoid-6.4.1/lib/mongoid/persistable.rb:164:in `each'
./tmp/bundle/ruby-2.3.7/ruby/2.3.0/gems/mongoid-6.4.1/lib/mongoid/persistable.rb:164:in `process_atomic_operations'
./tmp/bundle/ruby-2.3.7/ruby/2.3.0/gems/mongoid-6.4.1/lib/mongoid/persistable/settable.rb:24:in `block in set'
./tmp/bundle/ruby-2.3.7/ruby/2.3.0/gems/mongoid-6.4.1/lib/mongoid/persistable.rb:142:in `prepare_atomic_operation'
./tmp/bundle/ruby-2.3.7/ruby/2.3.0/gems/mongoid-6.4.1/lib/mongoid/persistable/settable.rb:23:in `set'
```