### PR TITLE
MONGOID-4593 Modify Settable#set hash merge behavior to match $set

### DIFF
--- a/lib/mongoid/persistable/settable.rb
+++ b/lib/mongoid/persistable/settable.rb
@@ -14,6 +14,29 @@ module Mongoid
       # @example Set the values.
       #   document.set(title: "sir", dob: Date.new(1970, 1, 1))
       #
+      # The key can be a dotted sequence of keys, in which case the
+      # top level field is treated as a nested hash and any missing keys
+      # are created automatically:
+      #
+      # @example Set the values using nested hash semantics.
+      #   document.set('author.title' => 'Sir')
+      #   # => document.author == {'title' => 'Sir'}
+      #
+      # Performing a nested set like this merges values of intermediate keys:
+      #
+      # @example Nested hash value merging.
+      #   document.set('author.title' => 'Sir')
+      #   document.set('author.name' => 'Linus Torvalds')
+      #   # => document.author == {'title' => 'Sir', 'name' => 'Linus Torvalds'}
+      #
+      # If the top level field was not a hash, its original value is discarded
+      # and the field is replaced with a hash.
+      #
+      # @example Nested hash overwriting a non-hash value.
+      #   document.set('author' => 'John Doe')
+      #   document.set('author.title' => 'Sir')
+      #   # => document.author == {'title' => 'Sir'}
+      #
       # @param [ Hash ] setters The field/value pairs to set.
       #
       # @return [ Document ] The document.

--- a/lib/mongoid/persistable/settable.rb
+++ b/lib/mongoid/persistable/settable.rb
@@ -92,10 +92,5 @@ module Mongoid
         end
       end
     end
-
-    def hasherizer(keys, value)
-      return value if keys.empty?
-      {}.tap { |hash| hash[keys.shift] = hasherizer(keys, value) }
-    end
   end
 end

--- a/lib/mongoid/persistable/settable.rb
+++ b/lib/mongoid/persistable/settable.rb
@@ -37,6 +37,11 @@ module Mongoid
       #   document.set('author.title' => 'Sir')
       #   # => document.author == {'title' => 'Sir'}
       #
+      # Note that unlike MongoDB's $set, Mongoid's set writes out the entire
+      # field even when setting a subset of the field via the nested hash
+      # semantics. This means performing a $set with nested hash semantics
+      # can overwrite other hash keys within the top level field in the database.
+      #
       # @param [ Hash ] setters The field/value pairs to set.
       #
       # @return [ Document ] The document.

--- a/lib/mongoid/persistable/settable.rb
+++ b/lib/mongoid/persistable/settable.rb
@@ -25,14 +25,14 @@ module Mongoid
 
             field_and_value_hash = hasherizer(field.split('.'), value)
             field = field_and_value_hash.keys.first.to_s
+            value = field_and_value_hash[field]
 
-            if fields[field] && fields[field].type == Hash && attributes.key?(field)
+            if fields[field] && fields[field].type == Hash && attributes.key?(field) && Hash === value && !value.empty?
               merger = proc { |key, v1, v2| Hash === v1 && Hash === v2 ? v1.merge(v2, &merger) : v2 }
-              value = (attributes[field] || {}).merge(field_and_value_hash[field], &merger)
-              process_attribute(field.to_s, value)
-            else
-              process_attribute(field.to_s, field_and_value_hash[field])
+              value = (attributes[field] || {}).merge(value, &merger)
             end
+
+            process_attribute(field.to_s, value)
 
             unless relations.include?(field.to_s)
               ops[atomic_attribute_name(field)] = attributes[field]

--- a/spec/config/mongoid.yml
+++ b/spec/config/mongoid.yml
@@ -3,7 +3,9 @@ test:
     default:
       database: mongoid_test
       hosts:
-        - <%=ENV["MONGOID_SPEC_HOST"]%>:<%=ENV["MONGOID_SPEC_PORT"]%>
+        <% SpecConfig.instance.addresses.each do |address| %>
+          - <%= address %>
+        <% end %>
       options:
         user: "mongoid-user"
         password: "password"
@@ -16,7 +18,9 @@ test:
     reports:
       database: reports
       hosts:
-        - <%=ENV["MONGOID_SPEC_HOST"]%>:<%=ENV["MONGOID_SPEC_PORT"]%>
+        <% SpecConfig.instance.addresses.each do |address| %>
+          - <%= address %>
+        <% end %>
       options:
         user: "mongoid-user"
         password: "password"
@@ -38,7 +42,9 @@ test_with_max_staleness:
     default:
       database: mongoid_test
       hosts:
-        - <%=ENV["MONGOID_SPEC_HOST"]%>:<%=ENV["MONGOID_SPEC_PORT"]%>
+        <% SpecConfig.instance.addresses.each do |address| %>
+          - <%= address %>
+        <% end %>
       options:
         read:
           mode: :primary_preferred

--- a/spec/mongoid/clients_spec.rb
+++ b/spec/mongoid/clients_spec.rb
@@ -427,7 +427,7 @@ describe Mongoid::Clients do
       let(:client_name) { :alternative }
 
       before do
-        Mongoid.clients[client_name] = { database: database_id_alt, hosts: [ "#{HOST}:#{PORT}" ] }
+        Mongoid.clients[client_name] = { database: database_id_alt, hosts: SpecConfig.instance.addresses }
       end
 
       after do

--- a/spec/mongoid/config_spec.rb
+++ b/spec/mongoid/config_spec.rb
@@ -370,7 +370,9 @@ describe Mongoid::Config do
           end
 
           it "sets the default hosts" do
-            expect(default[:hosts]).to eq(["127.0.0.1:27017"])
+            expect(default[:hosts]).to eq(SpecConfig.instance.addresses)
+            # and make sure the value is not empty
+            expect(default[:hosts].first).to include(':')
           end
 
           context "when the default has options" do

--- a/spec/mongoid/config_spec.rb
+++ b/spec/mongoid/config_spec.rb
@@ -370,7 +370,7 @@ describe Mongoid::Config do
           end
 
           it "sets the default hosts" do
-            expect(default[:hosts]).to eq(["#{HOST}:#{PORT}"])
+            expect(default[:hosts]).to eq(["127.0.0.1:27017"])
           end
 
           context "when the default has options" do

--- a/spec/mongoid/persistable/settable_spec.rb
+++ b/spec/mongoid/persistable/settable_spec.rb
@@ -388,6 +388,24 @@ describe Mongoid::Persistable::Settable do
         end
       end
     end
+
+    context 'when nested field is not an array' do
+      let(:church) do
+        Church.create!(
+          location: {'address' => 5}
+        )
+      end
+
+      context 'setting to an array' do
+        it 'sets values to the array' do
+          church.set('location.address' => ['three'])
+
+          expect(church.location).to eq('address' => ['three'])
+          church.reload
+          expect(church.location).to eq('address' => ['three'])
+        end
+      end
+    end
   end
 
   context 'when the field is not already set locally' do

--- a/spec/mongoid/persistable/settable_spec.rb
+++ b/spec/mongoid/persistable/settable_spec.rb
@@ -424,6 +424,22 @@ describe Mongoid::Persistable::Settable do
         end
       end
     end
+
+    context 'when nesting into a field that is not a hash' do
+      let(:church) do
+        Church.create!(
+          location: {'address' => 5}
+        )
+      end
+
+      it 'sets field to new hash value discarding original value' do
+        church.set('location.address.a' => 'test')
+
+        expect(church.location).to eq('address' => {'a' => 'test'})
+        church.reload
+        expect(church.location).to eq('address' => {'a' => 'test'})
+      end
+    end
   end
 
   context 'when the field is not already set locally' do

--- a/spec/mongoid/persistable/settable_spec.rb
+++ b/spec/mongoid/persistable/settable_spec.rb
@@ -360,6 +360,34 @@ describe Mongoid::Persistable::Settable do
         end
       end
     end
+
+    context 'when nested field is an array' do
+      let(:church) do
+        Church.create!(
+          location: {'address' => ['one', 'two']}
+        )
+      end
+
+      context 'setting to a different array' do
+        it 'sets values to new array discarding old values' do
+          church.set('location.address' => ['three'])
+
+          expect(church.location).to eq('address' => ['three'])
+          church.reload
+          expect(church.location).to eq('address' => ['three'])
+        end
+      end
+
+      context 'changing from an array to a number' do
+        it 'sets value to the number' do
+          church.set('location.address' => 5)
+
+          expect(church.location).to eq('address' => 5)
+          church.reload
+          expect(church.location).to eq('address' => 5)
+        end
+      end
+    end
   end
 
   context 'when the field is not already set locally' do

--- a/spec/mongoid/persistable/settable_spec.rb
+++ b/spec/mongoid/persistable/settable_spec.rb
@@ -353,7 +353,7 @@ describe Mongoid::Persistable::Settable do
             expect(church.location).to eql({'address' => {'state' => {'address' => {'city' => 'Munich', 'street' => 'Yorckstr'}}}})
           end
 
-          it 'removes lowel level attributes of the nested hash' do
+          it 'removes lower level attributes of the nested hash' do
             church.set('location.address.state.address' => 'hello')
 
             expect(church.name).to eq('Church1')
@@ -369,7 +369,7 @@ describe Mongoid::Persistable::Settable do
             expect(church.location).to eql({'address' => {'state' => {'address' => {'city' => {'hello' => 'world'}, 'street' => 'Yorckstr'}}}})
           end
 
-          it 'removes lowel level attributes of the nested hash' do
+          it 'removes lower level attributes of the nested hash' do
             church.set('location.address.state.address' => {'hello' => 'world'})
 
             expect(church.name).to eq('Church1')

--- a/spec/mongoid/persistable/settable_spec.rb
+++ b/spec/mongoid/persistable/settable_spec.rb
@@ -278,7 +278,22 @@ describe Mongoid::Persistable::Settable do
       end
     end
 
-    context 'when the field is a bested hash' do
+    context 'when the field is a nested hash' do
+
+      context 'when the field is reset to an empty hash' do
+
+        before do
+          church.set('location' => {})
+        end
+
+        it 'updates the field locally' do
+          expect(church.location).to eq({})
+        end
+
+        it 'updates the field in the database' do
+          expect(church.reload.location).to eq({})
+        end
+      end
 
       context 'when a leaf value in the nested hash is updated' do
 
@@ -300,6 +315,25 @@ describe Mongoid::Persistable::Settable do
         end
       end
 
+      context 'when a leaf value in the nested hash is updated to a number' do
+
+        let(:church) do
+          Church.new.tap do |a|
+            a.location = {'address' => {'city' => 'Berlin', 'street' => 'Yorckstr'}}
+            a.name = 'Church1'
+            a.save
+          end
+        end
+
+        before do
+          church.set('location.address.city' => 12345)
+        end
+
+        it 'updates the nested value to the correct value' do
+          expect(church.name).to eq('Church1')
+          expect(church.location).to eql({'address' => {'city' => 12345, 'street' => 'Yorckstr'}})
+        end
+      end
 
       context 'when the nested hash is many levels deep' do
 

--- a/spec/mongoid/persistable/settable_spec.rb
+++ b/spec/mongoid/persistable/settable_spec.rb
@@ -211,7 +211,7 @@ describe Mongoid::Persistable::Settable do
       Church.new.tap do |a|
         a.location = { 'city' => 'Berlin' }
         a.name = 'Church1'
-        a.save
+        a.save!
       end
     end
 
@@ -280,7 +280,7 @@ describe Mongoid::Persistable::Settable do
 
     context 'when the field is a nested hash' do
 
-      context 'when the field is reset to an empty hash' do
+      context 'when the field is set to an empty hash' do
 
         before do
           church.set('location' => {})
@@ -301,7 +301,7 @@ describe Mongoid::Persistable::Settable do
           Church.new.tap do |a|
             a.location = {'address' => {'city' => 'Berlin', 'street' => 'Yorckstr'}}
             a.name = 'Church1'
-            a.save
+            a.save!
           end
         end
 
@@ -321,7 +321,7 @@ describe Mongoid::Persistable::Settable do
           Church.new.tap do |a|
             a.location = {'address' => {'city' => 'Berlin', 'street' => 'Yorckstr'}}
             a.name = 'Church1'
-            a.save
+            a.save!
           end
         end
 
@@ -341,17 +341,22 @@ describe Mongoid::Persistable::Settable do
           Church.new.tap do |a|
             a.location = {'address' => {'state' => {'address' => {'city' => 'Berlin', 'street' => 'Yorckstr'}}}}
             a.name = 'Church1'
-            a.save
+            a.save!
           end
         end
 
-        before do
+        it 'keeps peer attributes of the nested hash' do
           church.set('location.address.state.address.city' => 'Munich')
-        end
 
-        it 'does not reset the nested hash' do
           expect(church.name).to eq('Church1')
           expect(church.location).to eql({'address' => {'state' => {'address' => {'city' => 'Munich', 'street' => 'Yorckstr'}}}})
+        end
+
+        it 'removes lowel level attributes of the nested hash' do
+          church.set('location.address.state.address' => 'hello')
+
+          expect(church.name).to eq('Church1')
+          expect(church.location).to eql({'address' => {'state' => {'address' => 'hello'}}})
         end
       end
     end

--- a/spec/mongoid/persistable/settable_spec.rb
+++ b/spec/mongoid/persistable/settable_spec.rb
@@ -345,18 +345,36 @@ describe Mongoid::Persistable::Settable do
           end
         end
 
-        it 'keeps peer attributes of the nested hash' do
-          church.set('location.address.state.address.city' => 'Munich')
+        context 'setting value to a string' do
+          it 'keeps peer attributes of the nested hash' do
+            church.set('location.address.state.address.city' => 'Munich')
 
-          expect(church.name).to eq('Church1')
-          expect(church.location).to eql({'address' => {'state' => {'address' => {'city' => 'Munich', 'street' => 'Yorckstr'}}}})
+            expect(church.name).to eq('Church1')
+            expect(church.location).to eql({'address' => {'state' => {'address' => {'city' => 'Munich', 'street' => 'Yorckstr'}}}})
+          end
+
+          it 'removes lowel level attributes of the nested hash' do
+            church.set('location.address.state.address' => 'hello')
+
+            expect(church.name).to eq('Church1')
+            expect(church.location).to eql({'address' => {'state' => {'address' => 'hello'}}})
+          end
         end
 
-        it 'removes lowel level attributes of the nested hash' do
-          church.set('location.address.state.address' => 'hello')
+        context 'setting value to a hash' do
+          it 'keeps peer attributes of the nested hash' do
+            church.set('location.address.state.address.city' => {'hello' => 'world'})
 
-          expect(church.name).to eq('Church1')
-          expect(church.location).to eql({'address' => {'state' => {'address' => 'hello'}}})
+            expect(church.name).to eq('Church1')
+            expect(church.location).to eql({'address' => {'state' => {'address' => {'city' => {'hello' => 'world'}, 'street' => 'Yorckstr'}}}})
+          end
+
+          it 'removes lowel level attributes of the nested hash' do
+            church.set('location.address.state.address' => {'hello' => 'world'})
+
+            expect(church.name).to eq('Church1')
+            expect(church.location).to eql({'address' => {'state' => {'address' => {'hello' => 'world'}}}})
+          end
         end
       end
     end

--- a/spec/mongoid/persistence_context_spec.rb
+++ b/spec/mongoid/persistence_context_spec.rb
@@ -536,7 +536,7 @@ describe Mongoid::PersistenceContext do
     end
 
     before do
-      Mongoid.clients[:alternative] = { database: :mongoid_test, hosts: [ "#{HOST}:#{PORT}" ] }
+      Mongoid.clients[:alternative] = { database: :mongoid_test, hosts: SpecConfig.instance.addresses }
     end
 
     after do

--- a/spec/support/spec_config.rb
+++ b/spec/support/spec_config.rb
@@ -1,0 +1,35 @@
+require 'singleton'
+
+class SpecConfig
+  include Singleton
+
+  def initialize
+    if ENV['MONGODB_URI']
+      @mongodb_uri = Mongo::URI.new(ENV['MONGODB_URI'])
+    end
+  end
+
+  def addresses
+    if @mongodb_uri
+      @mongodb_uri.servers
+    else
+      ['127.0.0.1']
+    end
+  end
+
+  def mri?
+    !jruby?
+  end
+
+  def jruby?
+    RUBY_PLATFORM =~ /\bjava\b/
+  end
+
+  def platform
+    RUBY_PLATFORM
+  end
+
+  def client_debug?
+    %w(1 true yes).include?((ENV['CLIENT_DEBUG'] || '').downcase)
+  end
+end


### PR DESCRIPTION
_Breaking change: changes hash merge behavior which has the potential to delete old data._

This PR changes the `Mongoid::Persistable::Settable#set` behavior to match `$set` in MongoDB. It also fixes a bug where `set` cannot be used to set a field to an empty hash.

If we have the following model:
```ruby
class Church
  include Mongoid::Document
  field :location, type: Hash
end
```
and an instance with the value:
```ruby
church = Church.new(location: { 'b' => 'c' })
```
and we call:
```ruby
church.set(location: { 'd' => 'e' })
```

The current behavior merges the hash with the new value:
```ruby
church.location => {"b"=>"c", "d"=>"e"}
```

This PR changes this behavior such that the hash is set to:
```ruby
church.location => {"d"=>"e"}
```

Fixes https://jira.mongodb.org/browse/MONGOID-4593.
Also fixes https://jira.mongodb.org/browse/MONGOID-4525 which hasn't been fixed on master yet.

Overrides #4487 / #4510 / #4515.