### PR TITLE
Make localized strings able to fallback on :blank? values

### DIFF
--- a/lib/mongoid/fields/localized.rb
+++ b/lib/mongoid/fields/localized.rb
@@ -78,14 +78,28 @@ module Mongoid
       def lookup(object)
         locale = ::I18n.locale
 
-        value = if object.key?(locale.to_s)
+        value = localized_value(object, locale)
+
+        return value if [true, false].include?(value)
+        return value unless value.blank?
+        return unless fallbacks? && ::I18n.respond_to?(:fallbacks)
+
+        fallback_locale = ::I18n.fallbacks[locale].find do |loc|
+          value = localized_value(object, loc)
+          loc if [true, false].include?(value)
+          loc unless (value).blank?
+        end
+
+        return localized_value(object, fallback_locale)
+      end
+
+      private
+
+      def localized_value(object, locale)
+        if object.key?(locale.to_s)
           object[locale.to_s]
         elsif object.key?(locale)
           object[locale]
-        end
-        return value unless value.nil?
-        if fallbacks? && ::I18n.respond_to?(:fallbacks)
-          object[::I18n.fallbacks[locale].map(&:to_s).find{ |loc| object.has_key?(loc) }]
         end
       end
     end

--- a/spec/mongoid/fields/localized_spec.rb
+++ b/spec/mongoid/fields/localized_spec.rb
@@ -158,6 +158,29 @@ describe Mongoid::Fields::Localized do
                   expect(value).to be_nil
                 end
               end
+
+              context "when the current locale is nil" do
+
+                let(:value) do
+                  field.demongoize({ "de" => nil, "es" => "pruebas" })
+                end
+
+                it "returns nil" do
+                  expect(value).to eq("pruebas")
+                end
+              end
+
+              context "when the current locale is an empty string" do
+
+                let(:value) do
+                  field.demongoize({ "de" => "", "es" => "pruebas" })
+                end
+
+                it "returns nil" do
+                  # expect("".present?).to eq(false)
+                  expect(value).to eq("pruebas")
+                end
+              end
             end
 
             context "when no fallbacks are defined" do


### PR DESCRIPTION
I've found that it would be very helpful to fallback through `:blank?` values when working with localized string fields.

This patch makes it so that:
* we fallback on all `:blank?` values
* and only to `:present?` values

Thanks for considering this patch!