### PR TITLE
Add support for $nor to the Mongoid matcher.

### DIFF
--- a/lib/mongoid/matchable.rb
+++ b/lib/mongoid/matchable.rb
@@ -12,6 +12,7 @@ require "mongoid/matchable/lte"
 require "mongoid/matchable/ne"
 require "mongoid/matchable/nin"
 require "mongoid/matchable/or"
+require "mongoid/matchable/nor"
 require "mongoid/matchable/size"
 require "mongoid/matchable/elem_match"
 require "mongoid/matchable/regexp"
@@ -41,6 +42,7 @@ module Mongoid
       "$ne" => Ne,
       "$nin" => Nin,
       "$or" => Or,
+      "$nor" => Nor,
       "$size" => Size
     }.with_indifferent_access.freeze
 

--- a/lib/mongoid/matchable.rb
+++ b/lib/mongoid/matchable.rb
@@ -127,6 +127,7 @@ module Mongoid
           case key.to_s
             when "$or" then Or.new(value, document)
             when "$and" then And.new(value, document)
+            when "$nor" then Nor.new(value, document)
             else Default.new(extract_attribute(document, key))
           end
         end

--- a/lib/mongoid/matchable/nor.rb
+++ b/lib/mongoid/matchable/nor.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # encoding: utf-8
 module Mongoid
   module Matchable

--- a/lib/mongoid/matchable/nor.rb
+++ b/lib/mongoid/matchable/nor.rb
@@ -1,0 +1,33 @@
+# encoding: utf-8
+module Mongoid
+  module Matchable
+
+    # Defines behavior for handling $nor expressions in embedded documents.
+    class Nor < Default
+
+      # Does the supplied query match the attribute?
+      #
+      # @example Does this match?
+      #   matcher._matches?("$nor" => [ { field => value } ])
+      #
+      # @param [ Array ] conditions The or expression.
+      #
+      # @return [ true, false ] True if matches, false if not.
+      #
+      # @since 2.0.0.rc.7
+      def _matches?(conditions)
+        conditions.each do |condition|
+          res = true
+          condition.keys.each do |k|
+            key = k
+            value = condition[k]
+            res &&= !document._matches?(key => value)
+            break unless res
+          end
+          return res if res
+        end
+        return false
+      end
+    end
+  end
+end

--- a/lib/mongoid/matchable/nor.rb
+++ b/lib/mongoid/matchable/nor.rb
@@ -17,16 +17,16 @@ module Mongoid
       # @since 2.0.0.rc.7
       def _matches?(conditions)
         conditions.each do |condition|
-          res = true
           condition.keys.each do |k|
             key = k
             value = condition[k]
-            res &&= !document._matches?(key => value)
-            break unless res
+            # $nor returns true if all conditions in the array fail, so if one matches, then we failed
+            if document._matches?(key => value)
+              return false
+            end
           end
-          return res if res
         end
-        return false
+        return true
       end
     end
   end

--- a/lib/mongoid/matchable/nor.rb
+++ b/lib/mongoid/matchable/nor.rb
@@ -26,16 +26,11 @@ module Mongoid
           # prohibits
           return false
         end
-        conditions.each do |condition|
-          condition.each do |key, value|
-            # $nor returns true if all conditions in the array fail,
-            # so if one matches, then we failed
-            if document._matches?(key => value)
-              return false
-            end
+        conditions.none? do |condition|
+          condition.all? do |key, value|
+            document._matches?(key => value)
           end
         end
-        return true
       end
     end
   end

--- a/lib/mongoid/matchable/nor.rb
+++ b/lib/mongoid/matchable/nor.rb
@@ -8,6 +8,9 @@ module Mongoid
 
       # Does the supplied query match the attribute?
       #
+      # Note: an empty array as an argument to $nor is prohibited by
+      # MongoDB server. Mongoid does allow this and returns false in this case.
+      #
       # @example Does this match?
       #   matcher._matches?("$nor" => [ { field => value } ])
       #
@@ -17,6 +20,12 @@ module Mongoid
       #
       # @since 7.1.0
       def _matches?(conditions)
+        if conditions.length == 0
+          # MongoDB does not allow $nor array to be empty, but
+          # Mongoid accepts an empty array for $or which MongoDB also
+          # prohibits
+          return false
+        end
         conditions.each do |condition|
           condition.each do |key, value|
             # $nor returns true if all conditions in the array fail,

--- a/lib/mongoid/matchable/nor.rb
+++ b/lib/mongoid/matchable/nor.rb
@@ -15,13 +15,12 @@ module Mongoid
       #
       # @return [ true, false ] True if matches, false if not.
       #
-      # @since 2.0.0.rc.7
+      # @since 7.1.0
       def _matches?(conditions)
         conditions.each do |condition|
-          condition.keys.each do |k|
-            key = k
-            value = condition[k]
-            # $nor returns true if all conditions in the array fail, so if one matches, then we failed
+          condition.each do |key, value|
+            # $nor returns true if all conditions in the array fail,
+            # so if one matches, then we failed
             if document._matches?(key => value)
               return false
             end

--- a/spec/app/models/array_field.rb
+++ b/spec/app/models/array_field.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ArrayField
+  include Mongoid::Document
+
+  field :af, type: Array
+end

--- a/spec/mongoid/matchable/nor_spec.rb
+++ b/spec/mongoid/matchable/nor_spec.rb
@@ -33,8 +33,8 @@ describe Mongoid::Matchable::Nor do
 
       context "when none of the values are not equal" do
 
-        it "returns false" do
-          expect(matcher._matches?([])).to be false
+        it "returns true" do
+          expect(matcher._matches?([])).to be true
         end
       end
 
@@ -122,8 +122,8 @@ describe Mongoid::Matchable::Nor do
           person.age = 100
         end
 
-        it "returns true" do
-          expect(matches).to be true
+        it "returns false" do
+          expect(matches).to be false
         end
       end
     end

--- a/spec/mongoid/matchable/nor_spec.rb
+++ b/spec/mongoid/matchable/nor_spec.rb
@@ -1,0 +1,131 @@
+require "spec_helper"
+
+describe Mongoid::Matchable::Nor do
+
+  let(:person) do
+    Person.new
+  end
+
+  let(:matcher) do
+    described_class.new("value", person)
+  end
+
+  describe "#_matches?" do
+
+    context "when provided a simple expression" do
+
+      context "when any of the values are not equal" do
+
+        let(:matches) do
+          matcher._matches?(
+            [ { title: "Sir" }, { title: "King" } ]
+          )
+        end
+
+        before do
+          person.title = "Queen"
+        end
+
+        it "returns true" do
+          expect(matches).to be true
+        end
+      end
+
+      context "when none of the values are not equal" do
+
+        it "returns false" do
+          expect(matcher._matches?([])).to be false
+        end
+      end
+
+      context "when the expression is a $not" do
+
+        let(:matches) do
+          matcher._matches?([ { title: {:$not => /Foobar/ } }])
+        end
+
+        context "when the value matches" do
+
+          it "returns false" do
+            expect(matches).to be false
+          end
+        end
+
+        context "when the value does not match" do
+
+          before do
+            person.title = "Foobar baz"
+          end
+
+          it "returns true" do
+            expect(matches).to be true
+          end
+        end
+      end
+    end
+
+    context "when provided a complex expression" do
+
+      context "when any of the values are not equal" do
+
+        let(:matches) do
+          matcher._matches?(
+            [
+              { title: { "$in" => [ "Sir", "Madam" ] } },
+              { title: "King" }
+            ]
+          )
+        end
+
+        before do
+          person.title = "Queen"
+        end
+
+        it "returns true" do
+          expect(matches).to be true
+        end
+      end
+
+      context "when none of the values are equal" do
+
+        let(:matches) do
+          matcher._matches?(
+            [
+              { title: { "$in" => [ "Prince", "Madam" ] } },
+              { title: "King" }
+            ]
+          )
+        end
+
+        before do
+          person.title = "Sir"
+        end
+
+        it "returns true" do
+          expect(matches).to be true
+        end
+      end
+
+      context "when expression contain multiple fields" do
+
+        let(:matches) do
+          matcher._matches?(
+            [
+              { title: "Sir", age: 23 },
+              { title: "King", age: 100 }
+            ]
+          )
+        end
+
+        before do
+          person.title = "Queen"
+          person.age = 100
+        end
+
+        it "returns true" do
+          expect(matches).to be true
+        end
+      end
+    end
+  end
+end

--- a/spec/mongoid/matchable/nor_spec.rb
+++ b/spec/mongoid/matchable/nor_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Mongoid::Matchable::Nor do

--- a/spec/mongoid/matchable/nor_spec.rb
+++ b/spec/mongoid/matchable/nor_spec.rb
@@ -24,8 +24,8 @@ describe Mongoid::Matchable::Nor do
           )
         end
 
-        before do
-          person.title = "Queen"
+        let(:person) do
+          Person.new(title: 'Queen')
         end
 
         it "returns true" do
@@ -33,7 +33,23 @@ describe Mongoid::Matchable::Nor do
         end
       end
 
-      context "when none of the values are not equal" do
+      context "when all of the values are equal" do
+        let(:matches) do
+          matcher._matches?(
+            [ { title: "Sir" }, { title: "King" } ]
+          )
+        end
+
+        let(:person) do
+          Person.new(title: 'King')
+        end
+
+        it "returns false" do
+          expect(matches).to be false
+        end
+      end
+
+      context "when there are no values" do
 
         it "returns true" do
           expect(matcher._matches?([])).to be true

--- a/spec/mongoid/matchable/nor_spec.rb
+++ b/spec/mongoid/matchable/nor_spec.rb
@@ -189,6 +189,16 @@ describe Mongoid::Matchable::Nor do
             Person.new(title: 'Queen', age: 23)
           end
 
+          it "returns true" do
+            expect(matches).to be true
+          end
+        end
+
+        context 'and model has identical values in all of the fields' do
+          let(:target) do
+            Person.new(title: 'Sir', age: 23)
+          end
+
           it "returns false" do
             expect(matches).to be false
           end

--- a/spec/mongoid/matchable_spec.rb
+++ b/spec/mongoid/matchable_spec.rb
@@ -88,7 +88,7 @@ describe Mongoid::Matchable do
           let(:selector) do
             { "occupants.0" => "Tim" }
           end
-          
+
           it "returns true" do
             expect(document.locations.first._matches?(selector)).to be true
           end
@@ -768,6 +768,31 @@ describe Mongoid::Matchable do
 
           let(:selector) do
             { "$or" => [ { number: 10 }, { number: { "$lt" => 99 } } ] }
+          end
+
+          it "returns false" do
+            expect(document._matches?(selector)).to be false
+          end
+        end
+      end
+
+      context "with an $nor selector" do
+
+        context "when the attributes match" do
+
+          let(:selector) do
+            { "$nor" => [ { number: 10 }, { number: { "$gt" => 199 } } ] }
+          end
+
+          it "returns true" do
+            expect(document._matches?(selector)).to be true
+          end
+        end
+
+        context "when the attributes do not match" do
+
+          let(:selector) do
+            { "$nor" => [ { number: 10 }, { number: { "$gt" => 99 } } ] }
           end
 
           it "returns false" do


### PR DESCRIPTION
Lets you use the `$nor` comparison operator for local comparisons: https://docs.mongodb.com/manual/reference/operator/query/nor/

If this is accepted, it would be great to backport to at least the 6.4 branch, too.