### PR TITLE
Make {attr}_before_type_cast behave same as read_attribute_before_type_cast

### DIFF
--- a/lib/mongoid/fields.rb
+++ b/lib/mongoid/fields.rb
@@ -438,11 +438,7 @@ module Mongoid
       def create_field_getter_before_type_cast(name, meth)
         generated_methods.module_eval do
           re_define_method("#{meth}_before_type_cast") do
-            if has_attribute_before_type_cast?(name)
-              read_attribute_before_type_cast(name)
-            else
-              send meth
-            end
+            read_attribute_before_type_cast(name)
           end
         end
       end


### PR DESCRIPTION
Without this commit, `#{attr}_before_type_cast()` falls back to `send(attr)`, whereas `read_attribute_before_type_cast()` falls back to `read_raw_attribute()`. In most cases this works, but if a getter for the attribute is present and no pre-typecasted value is available, they can return different values.

This remedies the issue by causing `#{attr}_before_type_cast()` to simply be a shortcut to `read_attribute_before_type_cast(attr)`.
