### PR TITLE
6.4.0 stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,41 +13,16 @@ before_install:
   - gem update --system
   - gem update bundler
 
-matrix:
-  fast_finish: true
-  exclude:
-    - rvm: ruby-head
-      gemfile: gemfiles/rails_master.gemfile
-    - rvm: jruby-9.1.15.0
-      gemfile: gemfiles/rails_master.gemfile
-    - rvm: jruby-9.1.15.0
-      gemfile: gemfiles/driver_master.gemfile
-    - rvm: jruby-9.1.15.0
-      env: MONGODB=2.6.12
-    - rvm: jruby-9.1.15.0
-      env: MONGODB=3.4.10
-  allow_failures:
-    - rvm: ruby-head
-    - gemfile: gemfiles/rails_master.gemfile
-
 rvm:
-  - 2.5
-  - ruby-head
-  - jruby-9.1.15.0
+  - 2.4.1
 
 gemfile:
   - Gemfile
-  - gemfiles/driver_master.gemfile
-  - gemfiles/rails_master.gemfile
 
 env:
   global:
     - CI="travis"
-    - JRUBY_OPTS="--server -J-Xms512m -J-Xmx1G"
-  matrix:
-    - MONGODB=2.6.12
-    - MONGODB=3.4.10
-    - MONGODB=3.6.2
+    - MONGODB=3.4.17
 
 before_script:
   - wget http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-${MONGODB}.tgz -O /tmp/mongodb.tgz

--- a/lib/mongoid/persistence_context.rb
+++ b/lib/mongoid/persistence_context.rb
@@ -107,6 +107,10 @@ module Mongoid
     #
     # @since 6.0.0
     def client
+      client_options = send(:client_options)
+      if client_options[:read].is_a?(Symbol)
+        client_options = client_options.merge(read: {mode: client_options[:read]})
+      end
       @client ||= (client = Clients.with_name(client_name)
                     client = client.use(database_name) if database_name_option
                     client.with(client_options))

--- a/spec/mongoid/clients/factory_spec.rb
+++ b/spec/mongoid/clients/factory_spec.rb
@@ -132,8 +132,8 @@ describe Mongoid::Clients::Factory do
 
             let(:config) do
               {
-                default: { hosts: [ "127.0.0.1:27017" ], database: database_id },
-                secondary: { uri: "mongodb://127.0.0.1:27017,127.0.0.1:27018/mongoid_test" }
+                default: { hosts: [ "127.0.0.1:1234" ], database: database_id },
+                secondary: { uri: "mongodb://127.0.0.1:1234,127.0.0.1:5678/mongoid_test" }
               }
             end
 
@@ -162,7 +162,7 @@ describe Mongoid::Clients::Factory do
             end
 
             it "sets the cluster's seeds" do
-              expect(seeds).to eq([ "127.0.0.1:27017", "127.0.0.1:27018" ])
+              expect(seeds).to eq([ "127.0.0.1:1234", "127.0.0.1:5678" ])
             end
           end
         end

--- a/spec/mongoid/clients/options_spec.rb
+++ b/spec/mongoid/clients/options_spec.rb
@@ -177,25 +177,40 @@ describe Mongoid::Clients::Options do
 
       context 'when returning a criteria' do
 
-        let(:context_and_criteria) do
-          collection = nil
-          cxt = Band.with(read: :secondary) do |klass|
-            collection = klass.all.collection
-            klass.persistence_context
+        shared_context 'applies secondary read preference' do
+
+          let(:context_and_criteria) do
+            collection = nil
+            cxt = Band.with(read_secondary_option) do |klass|
+              collection = klass.all.collection
+              klass.persistence_context
+            end
+            [ cxt, collection ]
           end
-          [ cxt, collection ]
+
+          let(:persistence_context) do
+            context_and_criteria[0]
+          end
+
+          let(:client) do
+            context_and_criteria[1].client
+          end
+
+          it 'applies the options to the criteria client' do
+            expect(client.options['read']).to eq('mode' => :secondary)
+          end
         end
 
-        let(:persistence_context) do
-          context_and_criteria[0]
+        context 'read: :secondary shorthand' do
+          let(:read_secondary_option) { {read: :secondary} }
+
+          it_behaves_like 'applies secondary read preference'
         end
 
-        let(:client) do
-          context_and_criteria[1].client
-        end
+        context 'read: {mode: :secondary}' do
+          let(:read_secondary_option) { {read: {mode: :secondary}} }
 
-        it 'applies the options to the criteria client' do
-          expect(client.options['read']).to eq(:secondary)
+          it_behaves_like 'applies secondary read preference'
         end
       end
 

--- a/spec/mongoid/clients/sessions_spec.rb
+++ b/spec/mongoid/clients/sessions_spec.rb
@@ -16,17 +16,17 @@ describe Mongoid::Clients::Sessions do
   end
 
   let(:subscriber) do
-    Mongoid::Clients.with_name(:other).instance_variable_get(:@monitoring).subscribers['Command'].find do |s|
+    Mongoid::Clients.with_name(:other).send(:monitoring).subscribers['Command'].find do |s|
       s.is_a?(EventSubscriber)
     end
   end
 
   let(:insert_events) do
-    subscriber.started_events.select { |event| event.command_name == :insert }
+    subscriber.started_events.select { |event| event.command_name == 'insert' }
   end
 
   let(:update_events) do
-    subscriber.started_events.select { |event| event.command_name == :update }
+    subscriber.started_events.select { |event| event.command_name == 'update' }
   end
 
   context 'when a session is used on a model class' do


### PR DESCRIPTION
This PR cherry picks the commits needed to get 6.4.0-stable passing on evergreen as well as updates the travis config to match the structure of master's.

See https://evergreen.mongodb.com/version/5b96d209c9ec4420668d6ab7 for the Evergreen job (minus the travis changes commit)