### PR TITLE
 Don't capture NoMethodError when instantiating STI

### DIFF
--- a/lib/mongoid/factory.rb
+++ b/lib/mongoid/factory.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # encoding: utf-8
 module Mongoid
 

--- a/lib/mongoid/factory.rb
+++ b/lib/mongoid/factory.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 # encoding: utf-8
 module Mongoid
 
@@ -50,11 +49,20 @@ module Mongoid
         obj
       else
         camelized = type.camelize
+
+        # Check if the class exists
         begin
-          camelized.constantize.instantiate(attributes, selected_fields)
+          constantized = camelized.constantize
         rescue NameError
           raise Errors::UnknownModel.new(camelized, type)
         end
+
+        # Check if the class is a Document class
+        if !constantized.respond_to?(:instantiate)
+          raise Errors::UnknownModel.new(camelized, type)
+        end
+
+        constantized.instantiate(attributes, selected_fields)
       end
     end
   end

--- a/spec/mongoid/factory_spec.rb
+++ b/spec/mongoid/factory_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "spec_helper"
 
 describe Mongoid::Factory do
@@ -209,6 +207,30 @@ describe Mongoid::Factory do
         expect {
           person
         }.to raise_exception(Mongoid::Errors::UnknownModel)
+      end
+
+    end
+
+    context 'when type is correct but the instantiation throws a NoMethodError' do
+      class BadPerson < Person
+        def instantiate
+          call_some_no_existant_method()
+          super
+        end
+      end
+
+      let(:attributes) do
+        { "title" => "Sir", "_type" => "BadPerson" }
+      end
+
+      let(:person) do
+        described_class.from_db(Person, attributes)
+      end
+
+      it 'raises a exception' do
+        expect {
+          person
+        }.to raise_exception(NoMethodError)
       end
 
     end

--- a/spec/mongoid/factory_spec.rb
+++ b/spec/mongoid/factory_spec.rb
@@ -216,8 +216,8 @@ describe Mongoid::Factory do
     context 'when type is correct but the instantiation throws a NoMethodError' do
       class BadPerson < Person
         def self.instantiate(*args)
-          call_some_no_existant_method
-          super(*args)
+          call_some_nonexistent_method(*args)
+          super
         end
       end
 

--- a/spec/mongoid/factory_spec.rb
+++ b/spec/mongoid/factory_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Mongoid::Factory do
@@ -214,8 +216,8 @@ describe Mongoid::Factory do
     context 'when type is correct but the instantiation throws a NoMethodError' do
       class BadPerson < Person
         def self.instantiate(*args)
-          call_some_no_existant_method(*args)
-          super
+          call_some_no_existant_method
+          super(*args)
         end
       end
 

--- a/spec/mongoid/factory_spec.rb
+++ b/spec/mongoid/factory_spec.rb
@@ -213,8 +213,8 @@ describe Mongoid::Factory do
 
     context 'when type is correct but the instantiation throws a NoMethodError' do
       class BadPerson < Person
-        def instantiate
-          call_some_no_existant_method()
+        def self.instantiate(*args)
+          call_some_no_existant_method(*args)
           super
         end
       end
@@ -224,7 +224,7 @@ describe Mongoid::Factory do
       end
 
       let(:person) do
-        described_class.from_db(Person, attributes)
+        described_class.from_db(BadPerson, attributes)
       end
 
       it 'raises a exception' do

--- a/spec/mongoid/factory_spec.rb
+++ b/spec/mongoid/factory_spec.rb
@@ -213,7 +213,7 @@ describe Mongoid::Factory do
 
     end
 
-    context 'when type is correct but the instantiation throws a NoMethodError' do
+    context 'when type is correct but the instantiation raises a NoMethodError' do
       class BadPerson < Person
         def self.instantiate(*args)
           call_some_nonexistent_method(*args)


### PR DESCRIPTION
NoMethodError is a child of NameError
If a class's instantiation throws a NoMethodError, the instantiation will fail with a Errors::UnknownModel error.
Change to only throw Errors::UnknownModel if the constantized class can not be found, or if the constantized class does not have an #instantiate method