### PR TITLE
Add default locale back to fallback locales

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,10 +22,10 @@ gemfile:
 matrix:
   include:
   - name: I18n 1.0 >
-    before_script: gem install i18n -v 1.0.0
+    before_install: gem install i18n -v 1.0.0
     env: I18N_VERSION=1.0.0
   - name: I18n 1.1.0 <
-    before_script: gem install i18n -v 1.1.0
+    before_install: gem install i18n -v 1.1.0
     env: I18N_VERSION=1.1.0
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,15 @@ rvm:
 gemfile:
   - Gemfile
 
+matrix:
+  include:
+  - name: I18n 1.0 >
+    before_script: gem install i18n -v 1.0.0
+    env: I18N_VERSION=1.0.0
+  - name: I18n 1.1.0 <
+    before_script: gem install i18n -v 1.1.0
+    env: I18N_VERSION=1.1.0
+
 env:
   global:
     - CI="travis"

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,11 @@ matrix:
   - name: I18n 1.0 >
     before_install: gem install i18n -v 1.0.0
     env: I18N_VERSION=1.0.0
+    gemfile: Gemfile.i18n
   - name: I18n 1.1.0 <
     before_install: gem install i18n -v 1.1.0
     env: I18N_VERSION=1.1.0
+    gemfile: Gemfile
 
 env:
   global:

--- a/Gemfile.i18n
+++ b/Gemfile.i18n
@@ -1,0 +1,24 @@
+source 'https://rubygems.org'
+gemspec
+
+gem 'rake'
+gem 'i18n', '1.0.0'
+gem 'actionpack', '~> 5.1'
+gem 'activemodel', '~> 5.1'
+
+
+group :test do
+  gem 'rspec-retry'
+  gem 'benchmark-ips'
+  gem 'rspec', '~> 3.7'
+  platforms :mri do
+    gem 'timeout-interrupt'
+  end
+end
+
+group :development, :testing do
+  gem 'yard'
+  platforms :mri do
+    gem 'byebug'
+  end
+end

--- a/Gemfile.i18n.lock
+++ b/Gemfile.i18n.lock
@@ -1,0 +1,101 @@
+PATH
+  remote: .
+  specs:
+    mongoid (7.1.0)
+      activemodel (>= 5.1, < 6.0.0)
+      mongo (>= 2.5.1, < 3.0.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    actionpack (5.2.1)
+      actionview (= 5.2.1)
+      activesupport (= 5.2.1)
+      rack (~> 2.0)
+      rack-test (>= 0.6.3)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.0, >= 1.0.2)
+    actionview (5.2.1)
+      activesupport (= 5.2.1)
+      builder (~> 3.1)
+      erubi (~> 1.4)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.0, >= 1.0.3)
+    activemodel (5.2.1)
+      activesupport (= 5.2.1)
+    activesupport (5.2.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    benchmark-ips (2.7.2)
+    bson (4.3.0)
+    builder (3.2.3)
+    byebug (10.0.2)
+    concurrent-ruby (1.0.5)
+    crass (1.0.4)
+    diff-lcs (1.3)
+    erubi (1.7.1)
+    ffi (1.9.25)
+    ffi-libc (0.1.0)
+      ffi (~> 1.0)
+    i18n (1.0.0)
+      concurrent-ruby (~> 1.0)
+    loofah (2.2.2)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.5.9)
+    mini_portile2 (2.3.0)
+    minitest (5.11.3)
+    mongo (2.6.2)
+      bson (>= 4.3.0, < 5.0.0)
+    nokogiri (1.8.4)
+      mini_portile2 (~> 2.3.0)
+    rack (2.0.5)
+    rack-test (1.1.0)
+      rack (>= 1.0, < 3)
+    rails-dom-testing (2.0.3)
+      activesupport (>= 4.2.0)
+      nokogiri (>= 1.6)
+    rails-html-sanitizer (1.0.4)
+      loofah (~> 2.2, >= 2.2.2)
+    rake (12.3.1)
+    rspec (3.8.0)
+      rspec-core (~> 3.8.0)
+      rspec-expectations (~> 3.8.0)
+      rspec-mocks (~> 3.8.0)
+    rspec-core (3.8.0)
+      rspec-support (~> 3.8.0)
+    rspec-expectations (3.8.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.8.0)
+    rspec-mocks (3.8.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.8.0)
+    rspec-retry (0.6.1)
+      rspec-core (> 3.3)
+    rspec-support (3.8.0)
+    thread_safe (0.3.6)
+    timeout-interrupt (0.3.0)
+      ffi-libc
+    tzinfo (1.2.5)
+      thread_safe (~> 0.1)
+    yard (0.9.16)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  actionpack (~> 5.1)
+  activemodel (~> 5.1)
+  benchmark-ips
+  byebug
+  i18n (= 1.0.0)
+  mongoid!
+  rake
+  rspec (~> 3.7)
+  rspec-retry
+  timeout-interrupt
+  yard
+
+BUNDLED WITH
+   1.16.4

--- a/lib/mongoid/fields/localized.rb
+++ b/lib/mongoid/fields/localized.rb
@@ -86,7 +86,9 @@ module Mongoid
         end
         return value unless value.nil?
         if fallbacks? && ::I18n.respond_to?(:fallbacks)
-          object[::I18n.fallbacks[locale].map(&:to_s).find{ |loc| object.has_key?(loc) }]
+          fallback_locales = ::I18n.fallbacks[locale].map(&:to_s)
+          fallback_locales << ::I18n.default_locale.to_s
+          object[fallback_locales.find{ |loc| object.has_key?(loc) }]
         end
       end
     end

--- a/spec/mongoid/fields/localized_spec.rb
+++ b/spec/mongoid/fields/localized_spec.rb
@@ -191,6 +191,32 @@ describe Mongoid::Fields::Localized do
                 expect(value).to eq('testen')
               end
             end
+
+            context 'when default locale is provided' do
+              before do
+                ::I18n.locale = :sv
+              end
+
+              after do
+                ::I18n.locale = :en
+                ::I18n.default_locale = :en
+              end
+
+              let(:value) do
+                field.demongoize({ 'de' => 'world'})
+              end
+
+              it 'returns default translation' do
+                ::I18n.default_locale = :de
+                expect(value).to eq('world')
+              end
+
+              it 'returns nil if all locales are missing' do
+                ::I18n.default_locale = :ru
+                expect(value).to be_nil
+              end
+
+            end
           end
         end
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -146,6 +146,7 @@ ActiveSupport::Inflector.inflections do |inflect|
 end
 
 I18n.config.enforce_available_locales = false
+puts "I18n version: #{I18n::VERSION}"
 
 RSpec.configure do |config|
   config.raise_errors_for_deprecations!


### PR DESCRIPTION
In version 1.1.0 of I18n the behavior of I18n fallbacks changed svenfuchs/i18n#415 from including the default locale to not including the default locale.

This PR restores the behavior of document field localization to pre 1.1.0 of i18n.

Dunno if this is a good default but at least it restores how it used to be. What do you think?