### PR TITLE
MONGOID-4539 Fix behavior of create_with to match ActiveRecord

### DIFF
--- a/docs/tutorials/mongoid-queries.txt
+++ b/docs/tutorials/mongoid-queries.txt
@@ -147,7 +147,8 @@ Mongoid also has some helpful methods on criteria.
    * - ``Criteria#find_or_create_by``
 
        *Find a document by the provided attributes, and if not found
-       create and return a newly persisted one.*
+       create and return a newly persisted one. Note that attributes provided in the arguments to
+       this method will override any set in ``create_with``*
 
      -
         .. code-block:: ruby

--- a/lib/mongoid/criteria/modifiable.rb
+++ b/lib/mongoid/criteria/modifiable.rb
@@ -5,6 +5,7 @@ module Mongoid
     module Modifiable
 
       # @attribute [r] create_attrs Additional attributes to add to the Document upon creation.
+      # @api private
       attr_reader :create_attrs
 
       # Build a document given the selector and return it.
@@ -60,6 +61,9 @@ module Mongoid
       end
 
       # Define attributes with which new documents will be created.
+      #
+      # Note that if `find_or_create_by` is called after this in a method chain, the attributes in
+      # the query will override those from this method.
       #
       # @example Define attributes to be used when a new document is created.
       #   Person.create_with(job: 'Engineer').find_or_create_by(employer: 'MongoDB')

--- a/lib/mongoid/criteria/modifiable.rb
+++ b/lib/mongoid/criteria/modifiable.rb
@@ -4,6 +4,9 @@ module Mongoid
   class Criteria
     module Modifiable
 
+      # @attribute [r] create_attrs Additional attributes to add to the Document upon creation.
+      attr_reader :create_attrs
+
       # Build a document given the selector and return it.
       # Complex criteria, such as $in and $or operations will get ignored.
       #
@@ -65,7 +68,9 @@ module Mongoid
       #
       # @since 5.1.0
       def create_with(attrs = {})
-        where(selector.merge(attrs))
+        tap do
+          (@create_attrs ||= {}).merge!(attrs)
+        end
       end
 
       # Find the first +Document+ given the conditions, or creates a new document
@@ -173,7 +178,8 @@ module Mongoid
       #
       # @since 3.0.0
       def create_document(method, attrs = nil, &block)
-        attributes = selector.reduce(attrs ? attrs.dup : {}) do |hash, (key, value)|
+        attrs = (create_attrs || {}).merge(attrs || {})
+        attributes = selector.reduce(attrs) do |hash, (key, value)|
           unless invalid_key?(hash, key) || invalid_embedded_doc?(value)
             hash[key] = value
           end

--- a/lib/mongoid/criteria/queryable/selectable.rb
+++ b/lib/mongoid/criteria/queryable/selectable.rb
@@ -25,7 +25,7 @@ module Mongoid
         # @since 2.0.0
         POLYGON = "Polygon"
 
-        # @attribute [rw] negating If the next spression is negated.
+        # @attribute [rw] negating If the next expression is negated.
         # @attribute [rw] selector The query selector.
         attr_accessor :negating, :selector
 

--- a/spec/mongoid/criteria/modifiable_spec.rb
+++ b/spec/mongoid/criteria/modifiable_spec.rb
@@ -1677,6 +1677,25 @@ describe Mongoid::Criteria::Modifiable do
             expect(new_person.age).to eq(50)
           end
 
+          context 'when a matching document is already in the collection' do
+            let(:query) do
+              { 'username' => 'foo', 'age' => 12 }
+            end
+
+            let(:person) do
+              Person.create!(query)
+            end
+
+            let(:found_person) do
+              Person.create_with(attrs).find_or_create_by(query)
+            end
+
+            it 'finds the matching document' do
+              person
+              expect(found_person.id).to eq(person.id)
+            end
+          end
+
           context 'when the attributes are shared with the write method args' do
 
             let(:query) do
@@ -1765,6 +1784,25 @@ describe Mongoid::Criteria::Modifiable do
           it 'gives the find method arg precedence' do
             expect(new_person.username).to eq('Beet')
             expect(new_person.age).to be(50)
+          end
+
+          context 'when a matching document is already in the collection' do
+            let(:query) do
+              { 'username' => 'foo', 'age' => 12 }
+            end
+
+            let(:person) do
+              Person.create!(query)
+            end
+
+            let(:found_person) do
+              criteria.create_with(attrs).find_or_create_by(query)
+            end
+
+            it 'finds the matching document' do
+              person
+              expect(found_person.id).to eq(person.id)
+            end
           end
         end
       end

--- a/spec/mongoid/criteria/modifiable_spec.rb
+++ b/spec/mongoid/criteria/modifiable_spec.rb
@@ -1645,11 +1645,15 @@ describe Mongoid::Criteria::Modifiable do
         { 'username' => 'Turnip' }
       end
 
-      it 'returns a criteria with the defined attributes' do
-        expect(Person.create_with(attrs).selector).to eq(attrs)
+      it 'does not modify the selector' do
+        expect(Person.create_with(attrs).selector[:username]).to be_nil
       end
 
-      context 'when a method is chained' do
+      it 'create_attrs is modified' do
+        expect(Person.create_with(attrs).create_attrs).to eq(attrs)
+      end
+
+      context 'when a create is chained' do
 
         context 'when a write method is chained' do
 
@@ -1683,7 +1687,7 @@ describe Mongoid::Criteria::Modifiable do
               Person.create_with(attrs).find_or_create_by(query)
             end
 
-            it 'gives the write method args precedence' do
+            it 'gives the find method args precedence' do
               expect(new_person.username).to eq('Beet')
               expect(new_person.age).to eq(50)
             end
@@ -1710,8 +1714,12 @@ describe Mongoid::Criteria::Modifiable do
             { 'username' => 'Beet', 'age' => 50 }
           end
 
+          it 'does not modify the selector' do
+            expect(criteria.create_with(attrs).selector).to eq(criteria_selector)
+          end
+
           it 'overwrites all the original attributes' do
-            expect(criteria.create_with(attrs).selector).to eq(attrs)
+            expect(criteria.create_with(attrs).create_attrs).to eq(attrs)
           end
         end
       end
@@ -1722,8 +1730,12 @@ describe Mongoid::Criteria::Modifiable do
           { 'username' => 'Beet' }
         end
 
+        it 'does not modify the selector' do
+          expect(criteria.create_with(attrs).selector).to eq(criteria_selector)
+        end
+
         it 'only overwrites the shared attributes' do
-          expect(criteria.create_with(attrs).selector).to eq(criteria_selector.merge!(attrs))
+          expect(criteria.create_with(attrs).create_attrs).to eq(attrs)
         end
       end
 
@@ -1732,12 +1744,11 @@ describe Mongoid::Criteria::Modifiable do
         let(:attrs) do
           { 'username' => 'Turnip' }
         end
-
         let(:query) do
           { 'username' => 'Beet', 'age' => 50 }
         end
 
-        context 'when a write method is chained' do
+        context 'when a create method is chained' do
 
           it 'executes the method' do
             expect(criteria.create_with(attrs).new.username).to eq('Turnip')
@@ -1751,9 +1762,9 @@ describe Mongoid::Criteria::Modifiable do
             criteria.create_with(attrs).find_or_create_by(query)
           end
 
-          it 'executes the query' do
+          it 'gives the find method arg precedence' do
             expect(new_person.username).to eq('Beet')
-            expect(new_person.age).to eq(50)
+            expect(new_person.age).to be(50)
           end
         end
       end


### PR DESCRIPTION
I ran each of the operations against ActiveRecord to determine how it behaves and modified the tests to assert those results instead. This PR does change the results of a number of operations, but the API  remains the same, so it doesn't require a major version bump.