### PR TITLE
Add Ruby 2.5 & rails to support matrix (#4511) (#4551)

### DIFF
--- a/docs/tutorials/mongoid-installation.txt
+++ b/docs/tutorials/mongoid-installation.txt
@@ -32,24 +32,33 @@ Compatibility
 -------------
 
 Note the following compatibility matrix to determine if Mongoid is
-supported on your runtime and server. Note that Mongoid 6.x is compatible with
-Rails 5 and thus requires >= Ruby 2.2.2.
+compatible with your Ruby version and MongoDB server. Note that Mongoid
+is currently compatible with Rails 5 and depends on ActiveModel 5.1 or higher,
+and thus requires Ruby 2.2.2 or higher.
 
 .. list-table::
    :header-rows: 1
-   :widths: 28 30 30 30
 
    * - Ruby Version
-     - MongoDB 3.0.x
-     - MongoDB 3.2.x
+     - MongoDB 4.0.x
+     - MongoDB 3.6.x
      - MongoDB 3.4.x
+     - MongoDB 3.2.x
+     - MongoDB 3.0.x
+     - MongoDB 2.6.x
 
-   * - MRI 2.1.x
-     - No
-     - No
-     - No
+   * - MRI 2.5.0+
+     - Yes
+     - Yes
+     - Yes
+     - Yes
+     - Yes
+     - Yes
 
-   * - MRI 2.2.2
+   * - MRI 2.4.1+
+     - Yes
+     - Yes
+     - Yes
      - Yes
      - Yes
      - Yes
@@ -58,8 +67,30 @@ Rails 5 and thus requires >= Ruby 2.2.2.
      - Yes
      - Yes
      - Yes
+     - Yes
+     - Yes
+     - Yes
 
-   * - MRI 2.4.1
+   * - MRI 2.2.2+
+     - Yes
+     - Yes
+     - Yes
+     - Yes
+     - Yes
+     - YES
+
+   * - MRI 2.1.x
+     - No
+     - No
+     - No
+     - No
+     - No
+     - No
+
+   * - JRuby 9.2.x
+     - Yes
+     - Yes
+     - Yes
      - Yes
      - Yes
      - Yes
@@ -68,6 +99,12 @@ Rails 5 and thus requires >= Ruby 2.2.2.
      - Yes
      - Yes
      - Yes
+     - Yes
+     - Yes
+     - Yes
+
+Refer to :ref:`Rails considerations <rails-compatibility>`
+for the Ruby on Rails compatibility matrix.
 
 .. _mongoid-configuration:
 

--- a/docs/tutorials/mongoid-rails.txt
+++ b/docs/tutorials/mongoid-rails.txt
@@ -11,8 +11,73 @@ Rails Considerations
    :class: singlecol
 
 Mongoid was built and targeted towards Rails applications, even though it will
-work in any environment. However if you are using Rails consult the next sections
-on how Mongoid hooks into a Rails application.
+work in any Ruby application. This document explains how
+to use Mongoid with a Rails application.
+
+.. _rails-compatibility:
+
+Rails Version Compatibility
+---------------------------
+
+Refer to the following compatibility matrix to determine which version
+of Mongoid to use with your Rails application.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Mongoid Version
+     - Rails 5.2
+     - Rails 5.1
+     - Rails 5.0
+     - Rails 4.2
+
+   * - Mongoid 7.0
+     - Yes
+     - Yes
+     - No
+     - No
+
+   * - Mongoid 6.4
+     - Yes
+     - Yes
+     - No
+     - No
+
+   * - Mongoid 6.3
+     - Yes
+     - Yes
+     - No
+     - No
+
+   * - Mongoid 6.2
+     - Yes
+     - Yes
+     - No
+     - No
+
+   * - Mongoid 6.1
+     - No
+     - No
+     - Yes
+     - No
+
+   * - Mongoid 6.0
+     - No
+     - No
+     - Yes
+     - No
+
+   * - Mongoid 5.4
+     - No
+     - No
+     - No
+     - Yes
+
+   * - Mongoid 5.2
+     - No
+     - No
+     - No
+     - Yes
 
 
 Using Mongoid with a new Rails application

--- a/docs/tutorials/mongoid-upgrade.txt
+++ b/docs/tutorials/mongoid-upgrade.txt
@@ -6,7 +6,7 @@ Upgrade Mongoid
 
 Upgrade to 6.x Series
 `````````````````````
-Mongoid 6.x is compatible with Rails 5 and thus requires >= Ruby 2.2.2.
+Mongoid 6.x is compatible with Rails 5 and requires Ruby 2.2.2 or higher.
 
 Please see the list of behavior changes for version `6.0.0.beta <https://github.com/mongodb/mongoid/releases/tag/v6.0.0.beta>`_
 and version `6.0.0.rc0 <https://github.com/mongodb/mongoid/releases/tag/v6.0.0.rc0>`_ for specific changes that might be
@@ -20,8 +20,9 @@ For all users dropping down to the driver level for operations, please see the d
 documentation for help with that API.
 
 All Mongoid configuration options have changed, as the underlying driver has changed
-from Moped to the core MongoDB Ruby driver. Please see the
-:ref:`configuration section <mongoid-configuration-5.x>` for a detailed description of all new options.
+from Moped to the official MongoDB Ruby driver. Please see the
+:ref:`configuration section <mongoid-configuration>` for a detailed description
+of all the new options.
 
 All references to session are now replaced with client. This includes the ``mongoid.yml``
 configuration, ``store_in`` options, and all exceptions and modules with Session in the name.
@@ -29,10 +30,12 @@ configuration, ``store_in`` options, and all exceptions and modules with Session
 ``find_and_modify`` has been removed and replaced with 3 options: ``find_one_and_update``,
 ``find_one_and_delete`` and ``find_one_and_replace``.
 
-``text_search`` has been removed as it is now a $text option in a query from 2.6 on.
-
-Mongoid no longer supports MongoDB 2.2 - support is now for only 2.4 and higher.
+``text_search`` has been removed as it is now a $text option in a query from
+MongoDB 2.6 onward.
 
 ``first`` and ``last`` no longer add an ``_id`` sort when no sorting options have been
 provided. In order to guarantee that a document is the first or last, it needs to now
 contain an explicit sort.
+
+Mongoid 5.x supports MongoDB 2.4 and higher only - MongoDB 2.2 is no longer
+supported.


### PR DESCRIPTION
Backport of https://github.com/mongodb/mongoid/commit/12e6b3effe7d9f68846db762cd5df103d03d1e3d to 6.4.0-stable