### PR TITLE
Support a dynamic collection name

### DIFF
--- a/lib/mongoid/contextual/mongo.rb
+++ b/lib/mongoid/contextual/mongo.rb
@@ -342,7 +342,7 @@ module Mongoid
       # @since 3.0.0
       def initialize(criteria)
         @criteria, @klass, @cache = criteria, criteria.klass, criteria.options[:cache]
-        @collection = @klass.collection
+        @collection = criteria.collection
         criteria.send(:merge_type_selection)
         @view = collection.find(criteria.selector, session: _session)
         apply_options

--- a/lib/mongoid/factory.rb
+++ b/lib/mongoid/factory.rb
@@ -47,6 +47,9 @@ module Mongoid
         if criteria && criteria.association && criteria.parent_document
           obj.set_relation(criteria.association.inverse, criteria.parent_document)
         end
+        # Use the collection name from the criteria so that any changes to this model
+        # are saved back to the collection from which it was retrieved.
+        obj.collection_name = criteria.collection_name if criteria
         obj
       else
         camelized = type.camelize
@@ -63,7 +66,9 @@ module Mongoid
           raise Errors::UnknownModel.new(camelized, type)
         end
 
-        constantized.instantiate(attributes, selected_fields)
+        obj = constantized.instantiate(attributes, selected_fields)
+        obj.collection_name = criteria.collection_name if criteria
+        obj
       end
     end
   end

--- a/spec/mongoid/clients/options_spec.rb
+++ b/spec/mongoid/clients/options_spec.rb
@@ -74,6 +74,32 @@ describe Mongoid::Clients::Options, retry: 3 do
         end
       end
 
+      context 'when not passing a block' do
+
+        let(:collection_name) do
+          Minim.with(options).collection_name
+        end
+
+        let(:persistence_context) do
+          Minim.with(options).persistence_context
+        end
+
+        let(:options) { { collection: 'another-collection' } }
+
+        it 'uses the collection' do
+          expect(collection_name).to eq(options[:collection].to_sym)
+        end
+
+        it 'does not change the context' do
+          expect(Minim.persistence_context).to eq(persistence_context)
+        end
+
+        it 'does not include the collection option in the client options' do
+          expect(persistence_context.client.options[:collection]).to be_nil
+          expect(persistence_context.client.options['collection']).to be_nil
+        end
+      end
+
       context 'when passing a block', if: testing_locally? do
 
         let!(:connections_before) do
@@ -183,6 +209,10 @@ describe Mongoid::Clients::Options, retry: 3 do
 
         it 'uses that collection' do
           expect(persistence_context.collection.name).to eq(options[:collection])
+        end
+
+        it 'uses that collection when no block is supplied' do
+          expect(Minim.with(options).collection_name).to eq(options[:collection].to_sym)
         end
       end
 
@@ -437,8 +467,14 @@ describe Mongoid::Clients::Options, retry: 3 do
           { collection: 'other' }
         end
 
+        let(:collection_name) do
+          test_model.with(options) do |object|
+            object.collection_name
+          end
+        end
+
         it 'uses that collection' do
-          expect(persistence_context.collection.name).to eq(options[:collection])
+          expect(collection_name).to eq(options[:collection].to_sym)
         end
       end
 

--- a/spec/mongoid/contextual/mongo_spec.rb
+++ b/spec/mongoid/contextual/mongo_spec.rb
@@ -1363,6 +1363,20 @@ describe Mongoid::Contextual::Mongo do
     it "sets the view selector" do
       expect(context.view.selector).to eq({ "name" => "Depeche Mode" })
     end
+
+    it "sets the collection" do
+      expect(context.collection).to eq(Band.collection)
+    end
+
+    context "with a different collection name" do
+      let(:criteria) do
+        Band.with(collection: 'other').where(name: "Depeche Mode").no_timeout
+      end
+
+      it "sets the collection" do
+        expect(context.collection.name).to eq("other")
+      end
+    end
   end
 
   [ :length, :size ].each do |method|

--- a/spec/mongoid/factory_spec.rb
+++ b/spec/mongoid/factory_spec.rb
@@ -236,5 +236,32 @@ describe Mongoid::Factory do
       end
 
     end
+
+    context "when built from within the context of a criteria" do
+
+      let(:criteria) do
+        Person.with(collection: 'other').where(title: "Sir")
+      end
+
+      let(:attributes) do
+        { "_type" => "Person", "title" => "Sir" }
+      end
+
+      let(:document) do
+        described_class.from_db(Person, attributes, criteria)
+      end
+
+      it "generates based on the type" do
+        expect(document).to be_a(Person)
+      end
+
+      it "sets the attributes" do
+        expect(document.title).to eq("Sir")
+      end
+
+      it "retains the collection name" do
+        expect(document.collection_name).to eq(:other)
+      end
+    end
   end
 end


### PR DESCRIPTION
Sometimes we want to create a model and then use that model for different Mongo collections, ideally chosen dynamically at run-time.

For Example, for a static one-to-one mapping between a model and its class:
~~~ruby
Band.create!(name: "Depeche Mode")
band = Band.where(name: "Depeche Mode").first
band.rating = 23
band.save!
~~~

Dynamically changing the collection name at run-time:
~~~ruby
Band.with(collection: 'other_bands').create!(name: "Depeche Mode")

band = Band.with(collection: 'other_bands').where(name: "Depeche Mode").first
band.rating = 23
band.save!
~~~

In Mongoid 5.4, the above kind of worked. It was extremely inefficient and led to all kinds of problems because every call to `with` resulted in a brand new persistence context. Additionally, the `save!` would not save the changed document back to the `other_bands` collection.

In Mongoid 6/7 it uses a block in order to cleanup the persistence context on completion:
~~~ruby
Band.with(collection: 'other_bands') do
  Band.create!(name: "Depeche Mode")
  band = Band.with(collection: 'other_bands').where(name: "Depeche Mode").first
  band.rating = 23
  band.save!
end
~~~

Even in the above case, creating a brand new persistence context when only the `collection_name` has changed is extremely inefficient, and it requires the constant use of the block anytime a modified document is saved.

How about we make `collection` a special case since it does not need a new persistence context every time the collection name is changed. And, if we make the instance of the model remember its collection name then we don't have to complicate any code that attempts to persist any changes to that document.

That would make the following code possible:

~~~ruby
Band.with(collection: 'other_bands').create!(name: "Depeche Mode")

band = Band.with(collection: 'other_bands').first

# Don't have to carry around separately the name of the collection
# that this instance of `band` comes from.
# And avoids yet another persistence context to save the change.
band.rating = 23
band.save!
~~~

Or even allow the collection name to be supplied directly when creating a new model:
~~~ruby
Band.create!(collection_name: 'other_bands', name: "Depeche Mode")
~~~