### PR TITLE
docs: socket_timeout default is nil, not 5

### DIFF
--- a/docs/tutorials/mongoid-configuration.txt
+++ b/docs/tutorials/mongoid-configuration.txt
@@ -153,7 +153,7 @@ various options in the comments above each key:
           connect_timeout: 10
 
           # The timeout to wait to execute operations on a socket before raising an error.
-          # (default: 5)
+          # (default: nil)
           socket_timeout: 5
 
           # The name of the replica set to connect to. Servers provided as seeds that do


### PR DESCRIPTION
Update the Mongoid Configuration tutorial to show the default for `socket_timeout` is `nil` not `5`.

From the mongo driver documentation:

> *socket_timeout*
> The number of seconds to wait for an operation to execute on a socket before raising a timeout exception. It should take into account network latency and operation duration. The default is no value; the default is effectively infinity. Please consider using max_time_ms per-operation instead, as the socket_timeout does not stop the operation on the server; a long-running operation will continue to run on the server, beyond a socket timeout being reached.

— https://docs.mongodb.com/ruby-driver/master/tutorials/ruby-driver-create-client/index.html#details-on-timeout-options

Nothing in the driver code appears to set/default `socket_timeout` to anything, so it remains `nil`.

The only place mongoid arguably defaults `socket_timeout` to `5` is in `lib/rails/generators/mongoid/config/templates/mongoid.yml`, however that's a commented out example config line, not a default.

Note, this is also shown as `default: 5` on https://docs.mongodb.com/mongoid/7.0/tutorials/mongoid-installation/#anatomy-of-a-mongoid-config — I'm not sure where that page is built from.