### PR TITLE
MONGOID-4666 Allow fields of type Regexp to be set to nil.

### DIFF
--- a/lib/mongoid/extensions/regexp.rb
+++ b/lib/mongoid/extensions/regexp.rb
@@ -18,6 +18,7 @@ module Mongoid
         #
         # @since 3.0.0
         def mongoize(object)
+          return nil if object.nil?
           ::Regexp.new(object)
         end
       end

--- a/lib/mongoid/extensions/time.rb
+++ b/lib/mongoid/extensions/time.rb
@@ -49,7 +49,7 @@ module Mongoid
         #
         # @since 3.0.0
         def demongoize(object)
-          return nil if object.blank?
+          return nil if object.nil?
           object = object.getlocal unless Mongoid::Config.use_utc?
           if Mongoid::Config.use_activesupport_time_zone?
             object = object.in_time_zone(Mongoid.time_zone)
@@ -69,7 +69,7 @@ module Mongoid
         #
         # @since 3.0.0
         def mongoize(object)
-          return nil if object.blank?
+          return nil if object.nil?
           begin
             time = object.__mongoize_time__
             if object.respond_to?(:sec_fraction)

--- a/lib/mongoid/extensions/time.rb
+++ b/lib/mongoid/extensions/time.rb
@@ -49,7 +49,7 @@ module Mongoid
         #
         # @since 3.0.0
         def demongoize(object)
-          return nil if object.nil?
+          return nil if object.blank?
           object = object.getlocal unless Mongoid::Config.use_utc?
           if Mongoid::Config.use_activesupport_time_zone?
             object = object.in_time_zone(Mongoid.time_zone)
@@ -69,7 +69,7 @@ module Mongoid
         #
         # @since 3.0.0
         def mongoize(object)
-          return nil if object.nil?
+          return nil if object.blank?
           begin
             time = object.__mongoize_time__
             if object.respond_to?(:sec_fraction)

--- a/spec/mongoid/extensions/regexp_spec.rb
+++ b/spec/mongoid/extensions/regexp_spec.rb
@@ -37,6 +37,29 @@ describe Mongoid::Extensions::Regexp do
       it "returns the provided value as a regex" do
         expect(value).to eq(/[^abc]/)
       end
+
+
+      context "when the string is empty" do
+
+        let(:value) do
+          Regexp.mongoize("")
+        end
+
+        it "returns an empty regex" do
+          expect(value).to eq(//)
+        end
+      end
+    end
+
+    context "when the value is nil" do
+
+      let(:value) do
+        Regexp.mongoize(nil)
+      end
+
+      it "returns the nil" do
+        expect(value).to be_nil
+      end
     end
   end
 


### PR DESCRIPTION
Currently, setting a field of type regexp to nil results in the Ruby type error: `TypeError: no implicit conversion of nil into String` 

This PR nil guards the regexp mongoize extension similar to with the Time extension (mongoid/lib/mongoid/extensions/time.rb:72)

Please let me know if this should be submitted differently.