### PR TITLE
MONGOID-4673 Fix DateTime.evolve - respect specified time zone

### DIFF
--- a/docs/tutorials/mongoid-documents.txt
+++ b/docs/tutorials/mongoid-documents.txt
@@ -88,18 +88,33 @@ and have a structure like so:
 Fields
 ------
 
-Even though MongoDB is a schemaless database, most uses will be with web applications where
-form parameters always come to the server as strings. Mongoid provides an easy mechanism for
-transforming these strings into their appropriate types through the definition of fields
-in a ``Mongoid::Document``.
+Even though MongoDB is a schemaless database and allows data to be stored
+as strings, Mongoid permits the application to declare the type of data
+stored in the various fields of a document. Field type declarations affect
+the following:
 
-Keep in mind that the field definitions determine how Mongoid behaves when writing and reading
-fields from the database. Changing the Model definition in the Model file does not change existing
-data. If you'd like to update a field type or options of existing data, you must write a script to do so.
-You will get errors otherwise.
+1. When assigning values to fields, the values are converted to the
+specified type.
+2. When persisting data to MongoDB, the data is sent in an appropriate
+type, permitting richer data manipulation within MongoDB or by other
+tools.
+3. When querying documents, query parameters are converted to the specified
+type before being sent to MongoDb.
+4. When retrieving documents from the database, field values are converted
+to the specified type.
 
-Consider a simple class for modeling a person in an application. A person may have a first name,
-last name, and middle name. We can define these attributes on a person by using the fields macro.
+Field type definitions determine how Mongoid behaves when constructing the
+queries, retrieving and writing fields from the database. Changing the field
+definitions in a model class does not alter data already stored in
+MongoDB. To update type or contents of fields of existing documents,
+the field must be re-saved to the database. Note that, due to Mongoid
+tracking which attributes on a model change and only saving the changed ones,
+it may be necessary to explicitly write a field value when changing the
+type of an existing field without changing the stored values.
+
+Consider a simple class for modeling a person in an application. A person may
+have a first name, last name, and middle name. We can define these attributes
+on a person by using the ``field`` macro.
 
 .. code-block:: ruby
 

--- a/docs/tutorials/mongoid-documents.txt
+++ b/docs/tutorials/mongoid-documents.txt
@@ -286,6 +286,72 @@ recommended to explicitly convert ``String``, ``Time`` and ``DateTime``
 objects to ``Date`` objects before assigning the values to fields of type
 ``Date``.
 
+DateTime Fields
+***************
+
+MongoDB stores all times as UTC timestamps. When assigning a value to a
+``DateTime`` field, or when querying a ``DateTime`` field, Mongoid
+converts the passed in value to a UTC ``Time`` before sending it to the
+MongoDB server.
+
+``Time``, ``ActiveSupport::TimeWithZone`` and ``DateTime`` objects embed
+time zone information, and the value persisted is the specified moment in
+time, in UTC. When the value is retrieved, the time zone in which it is
+returned is defined by the :ref:`configured time zone settings <time-zones>`.
+
+.. code-block:: ruby
+
+   class Ticket
+     include Mongoid::Document
+     field :opened_at, type: DateTime
+   end
+   
+   Mongoid.use_activesupport_time_zone = true
+   Time.zone = 'Berlin'
+   
+   ticket = Ticket.create!(opened_at: '2018-02-18 07:00:08 -0500')
+
+    ticket.opened_at
+    # => Sun, 18 Feb 2018 13:00:08 +0100
+    ticket
+    => #<Ticket _id: 5c13d4b9026d7c4e7870bb2f, opened_at: 2018-02-18 12:00:08 UTC>
+
+    Time.zone = 'America/New_York'
+    ticket.opened_at
+    # => Sun, 18 Feb 2018 07:00:08 -0500
+    
+    Mongoid.use_utc = true
+    ticket.opened_at
+    # => Sun, 18 Feb 2018 12:00:08 +0000
+
+Mongoid also supports casting integers and floats to ``DateTime``. When
+doing so, the integers/floats are assumed to be Unix timestamps (in UTC):
+
+.. code-block:: ruby
+
+    ticket.opened_at = 1544803974
+    ticket.opened_at
+    # => Fri, 14 Dec 2018 16:12:54 +0000
+
+If a string is used as a ``DateTime`` field value, the behavior depends on
+whether the string includes a time zone. If no time zone is specified,
+the :ref:`default Mongoid time zone <time-zones>` is used:
+
+.. code-block:: ruby
+
+    Time.zone = 'America/New_York'
+    ticket.opened_at = 'Mar 4, 2018 10:00:00'
+    ticket.opened_at
+    # => Sun, 04 Mar 2018 15:00:00 +0000
+
+If a time zone is specfied, it is respected:
+
+.. code-block:: ruby
+
+    ticket.opened_at = 'Mar 4, 2018 10:00:00 +01:00'
+    ticket.opened_at
+    # => Sun, 04 Mar 2018 09:00:00 +0000
+
 Defaults
 ********
 

--- a/docs/tutorials/mongoid-documents.txt
+++ b/docs/tutorials/mongoid-documents.txt
@@ -99,7 +99,7 @@ specified type.
 type, permitting richer data manipulation within MongoDB or by other
 tools.
 3. When querying documents, query parameters are converted to the specified
-type before being sent to MongoDb.
+type before being sent to MongoDB.
 4. When retrieving documents from the database, field values are converted
 to the specified type.
 

--- a/lib/mongoid/criteria/queryable/extensions/date_time.rb
+++ b/lib/mongoid/criteria/queryable/extensions/date_time.rb
@@ -18,11 +18,8 @@ module Mongoid
           # @since 1.0.0
           def __evolve_time__
             usec = strftime("%6N").to_f
-            if utc?
-              ::Time.utc(year, month, day, hour, min, sec, usec)
-            else
-              ::Time.local(year, month, day, hour, min, sec, usec).utc
-            end
+            u = utc
+            ::Time.utc(u.year, u.month, u.day, u.hour, u.min, u.sec, usec)
           end
 
           module ClassMethods

--- a/spec/mongoid/criteria/queryable/extensions/date_time_spec.rb
+++ b/spec/mongoid/criteria/queryable/extensions/date_time_spec.rb
@@ -17,7 +17,7 @@ describe DateTime do
       end
 
       let(:expected) do
-        Time.new(2010, 1, 1, 12, 0, 0).utc
+        Time.utc(2010, 1, 1, 11, 0, 0)
       end
 
       it "returns the time" do
@@ -84,7 +84,7 @@ describe DateTime do
       end
 
       let(:expected) do
-        Time.new(2010, 1, 1, 12, 0, 0).utc
+        Time.utc(2010, 1, 1, 11, 0, 0)
       end
 
       it "returns the time" do
@@ -127,7 +127,7 @@ describe DateTime do
         end
 
         let(:expected) do
-          Time.new(2010, 1, 1, 12, 0, 0).utc
+          Time.utc(2010, 1, 1, 11, 0, 0)
         end
 
         it "returns the array with evolved times" do
@@ -222,11 +222,11 @@ describe DateTime do
         end
 
         let(:expected_min) do
-          Time.new(2010, 1, 1, 12, 0, 0)
+          Time.utc(2010, 1, 1, 11, 0, 0)
         end
 
         let(:expected_max) do
-          Time.new(2010, 1, 3, 12, 0, 0)
+          Time.utc(2010, 1, 3, 11, 0, 0)
         end
 
         it "returns a selection of times" do

--- a/spec/mongoid/criteria/queryable/extensions/date_time_spec.rb
+++ b/spec/mongoid/criteria/queryable/extensions/date_time_spec.rb
@@ -141,16 +141,20 @@ describe DateTime do
 
       context "when the array is composed of strings" do
 
-        let(:date) do
-          DateTime.parse("1st Jan 2010 12:00:00+01:00")
+        let(:date_str) do
+          "1st Jan 2010 12:00:00+01:00"
         end
 
         let(:evolved) do
-          described_class.evolve([ date.to_s ])
+          described_class.evolve([ date_str ])
+        end
+
+        let(:expected) do
+          Time.utc(2010, 1, 1, 11, 0, 0)
         end
 
         it "returns the strings as a times" do
-          expect(evolved).to eq([ date.to_time ])
+          expect(evolved).to eq([ expected ])
         end
 
         it "returns the times in utc" do
@@ -243,20 +247,28 @@ describe DateTime do
       context "when the range are strings" do
 
         let(:min) do
-          DateTime.new(2010, 1, 1, 12, 0, 0)
+          "1st Jan 2010 12:00:00+01:00"
         end
 
         let(:max) do
-          DateTime.new(2010, 1, 3, 12, 0, 0)
+          "3rd Jan 2010 12:00:00+01:00"
+        end
+
+        let(:expected_min) do
+          Time.utc(2010, 1, 1, 11, 0, 0)
+        end
+
+        let(:expected_max) do
+          Time.utc(2010, 1, 3, 11, 0, 0)
         end
 
         let(:evolved) do
-          described_class.evolve(min.to_s..max.to_s)
+          described_class.evolve(min..max)
         end
 
         it "returns a selection of times" do
           expect(evolved).to eq(
-            { "$gte" => min.to_time, "$lte" => max.to_time }
+            { "$gte" => expected_min, "$lte" => expected_max }
           )
         end
 
@@ -334,16 +346,20 @@ describe DateTime do
 
     context "when provided a string" do
 
-      let(:date) do
-        DateTime.parse("1st Jan 2010 12:00:00+01:00")
+      let(:date_str) do
+        "1st Jan 2010 12:00:00+01:00"
       end
 
       let(:evolved) do
-        described_class.evolve(date.to_s)
+        described_class.evolve(date_str)
+      end
+
+      let(:expected) do
+        Time.utc(2010, 1, 1, 11, 0, 0)
       end
 
       it "returns the string as a time" do
-        expect(evolved).to eq(date.to_time)
+        expect(evolved).to eq(expected)
       end
 
       it "returns the time in utc" do


### PR DESCRIPTION
`DateTime.__evolve_time__` is supposed to return the `DateTime` as a `Time` in UTC.

However, when converting a non-UTC `DateTime` to a UTC `Time`, it throws away the `DateTime`'s timezone, instead assuming that it's in local time.

This PR fixes `__evolve_time__` to instead convert the `DateTime` to UTC, and then pass the result to `Time.utc`.

All the spec was wrong too; updated.

Before:
```ruby
DateTime.now.utc
=> 2018-12-08 06:14:21 UTC
DateTime.evolve(DateTime.now.in_time_zone('Eastern Time (US & Canada)').to_datetime)
=> 2018-12-08 09:14:21 UTC
DateTime.evolve(DateTime.now.in_time_zone('Pacific Time (US & Canada)').to_datetime)
=> 2018-12-08 06:14:21 UTC
DateTime.evolve(DateTime.now.in_time_zone('America/Menominee').to_datetime)
=> 2018-12-08 08:14:21 UTC
```

After:
```ruby
DateTime.now.utc
=> 2018-12-08 06:21:07 UTC
DateTime.evolve(DateTime.now.in_time_zone('Eastern Time (US & Canada)').to_datetime)
=> 2018-12-08 06:21:07 UTC
DateTime.evolve(DateTime.now.in_time_zone('Pacific Time (US & Canada)').to_datetime)
=> 2018-12-08 06:21:07 UTC
DateTime.evolve(DateTime.now.in_time_zone('America/Menominee').to_datetime)
=> 2018-12-08 06:21:07 UTC
```