### PR TITLE
Update mongoid.yml to add _uri_ option

### DIFF
--- a/lib/rails/generators/mongoid/config/templates/mongoid.yml
+++ b/lib/rails/generators/mongoid/config/templates/mongoid.yml
@@ -3,6 +3,11 @@ development:
   clients:
     # Defines the default client. (required)
     default:
+      # A uri may be defined for a client:
+      # uri: 'mongodb://user:password@myhost1.mydomain.com:27017/my_db'
+
+      # Otherwise define the parameters separately
+      
       # Defines the name of the default database that Mongoid can connect to.
       # (required).
       database: <%= database_name || app_name %>_development

--- a/lib/rails/generators/mongoid/config/templates/mongoid.yml
+++ b/lib/rails/generators/mongoid/config/templates/mongoid.yml
@@ -3,12 +3,11 @@ development:
   clients:
     # Defines the default client. (required)
     default:
-      # A uri may be defined for a client:
-      # uri: 'mongodb://user:password@myhost1.mydomain.com:27017/my_db'
+      # Mongoid can connect to a URI accepted by the driver:
+      # uri: mongodb://user:password@mongodb.domain.com:27017/<%= database_name || app_name %>_development
 
-      # Otherwise define the parameters separately
-      
-      # Defines the name of the default database that Mongoid can connect to.
+      # Otherwise define the parameters separately.
+      # This defines the name of the default database that Mongoid can connect to.
       # (required).
       database: <%= database_name || app_name %>_development
       # Provides the hosts the default client can connect to. Must be an array


### PR DESCRIPTION
The very important option for `uri` was missing in the doc! It exists in the official [docs](https://docs.mongodb.com/mongoid/master/tutorials/mongoid-configuration/) but not in the generated `mongoid.yml`.