### PR TITLE
MONGOID-4681 Replace BigDecimal.new with BigDecimal()

### DIFF
--- a/lib/mongoid/extensions/big_decimal.rb
+++ b/lib/mongoid/extensions/big_decimal.rb
@@ -54,7 +54,7 @@ module Mongoid
         #
         # @since 3.0.0
         def demongoize(object)
-          object && object.numeric? ? ::BigDecimal.new(object.to_s) : nil
+          object && object.numeric? ? ::BigDecimal(object.to_s) : nil
         end
 
         # Mongoize an object of any type to how it's stored in the db as a String.

--- a/lib/mongoid/extensions/big_decimal.rb
+++ b/lib/mongoid/extensions/big_decimal.rb
@@ -54,7 +54,7 @@ module Mongoid
         #
         # @since 3.0.0
         def demongoize(object)
-          object && object.numeric? ? ::BigDecimal(object.to_s) : nil
+          object && object.numeric? ? BigDecimal(object.to_s) : nil
         end
 
         # Mongoize an object of any type to how it's stored in the db as a String.

--- a/spec/mongoid/criteria/queryable/extensions/big_decimal_spec.rb
+++ b/spec/mongoid/criteria/queryable/extensions/big_decimal_spec.rb
@@ -9,7 +9,7 @@ describe BigDecimal do
     context "when provided a big decimal" do
 
       let(:big_decimal) do
-        BigDecimal.new("123456.789")
+        BigDecimal("123456.789")
       end
 
       it "returns the decimal as a string" do
@@ -27,11 +27,11 @@ describe BigDecimal do
     context "when provided an array of big decimals" do
 
       let(:bd_one) do
-        BigDecimal.new("123456.789")
+        BigDecimal("123456.789")
       end
 
       let(:bd_two) do
-        BigDecimal.new("123333.789")
+        BigDecimal("123333.789")
       end
 
       let(:array) do

--- a/spec/mongoid/criteria/queryable/selector_spec.rb
+++ b/spec/mongoid/criteria/queryable/selector_spec.rb
@@ -372,11 +372,11 @@ describe Mongoid::Criteria::Queryable::Selector do
         context "when providing an array" do
 
           let(:big_one) do
-            BigDecimal.new("1.2321")
+            BigDecimal("1.2321")
           end
 
           let(:big_two) do
-            BigDecimal.new("4.2222")
+            BigDecimal("4.2222")
           end
 
           let(:array) do

--- a/spec/mongoid/criteria_spec.rb
+++ b/spec/mongoid/criteria_spec.rb
@@ -3482,7 +3482,7 @@ describe Mongoid::Criteria do
       context "when querying on a big decimal" do
 
         let(:sales) do
-          BigDecimal.new('0.1')
+          BigDecimal('0.1')
         end
 
         let!(:band) do

--- a/spec/mongoid/extensions/big_decimal_spec.rb
+++ b/spec/mongoid/extensions/big_decimal_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 describe Mongoid::Extensions::BigDecimal do
 
   let(:big_decimal) do
-    BigDecimal.new("123456.789")
+    BigDecimal("123456.789")
   end
 
   describe ".demongoize" do
@@ -28,7 +28,7 @@ describe Mongoid::Extensions::BigDecimal do
       end
 
       it "returns a BigDecimal" do
-        expect(BigDecimal.demongoize(string)).to eq(BigDecimal.new(string))
+        expect(BigDecimal.demongoize(string)).to eq(BigDecimal(string))
       end
     end
 
@@ -39,7 +39,7 @@ describe Mongoid::Extensions::BigDecimal do
       end
 
       it "returns a BigDecimal" do
-        expect(BigDecimal.demongoize(string)).to eq(BigDecimal.new(string))
+        expect(BigDecimal.demongoize(string)).to eq(BigDecimal(string))
       end
     end
 
@@ -50,7 +50,7 @@ describe Mongoid::Extensions::BigDecimal do
       end
 
       it "returns a BigDecimal" do
-        expect(BigDecimal.demongoize(string)).to eq(BigDecimal.new(string))
+        expect(BigDecimal.demongoize(string)).to eq(BigDecimal(string))
       end
     end
 
@@ -186,7 +186,7 @@ describe Mongoid::Extensions::BigDecimal do
     context "when the value is the BigDecimal zero" do
 
       let(:big_decimal) do
-        BigDecimal.new("0.0")
+        BigDecimal("0.0")
       end
 
       it "returns a BigDecimal" do
@@ -197,7 +197,7 @@ describe Mongoid::Extensions::BigDecimal do
     context "when the value is the BigDecimal negative zero" do
 
       let(:big_decimal) do
-        BigDecimal.new("-0.0")
+        BigDecimal("-0.0")
       end
 
       it "returns a BigDecimal" do
@@ -328,7 +328,7 @@ describe Mongoid::Extensions::BigDecimal do
     context "when the value is BigDecimal NaN" do
 
       let(:nan) do
-        BigDecimal.new("NaN")
+        BigDecimal("NaN")
       end
 
       it "returns a String" do
@@ -339,7 +339,7 @@ describe Mongoid::Extensions::BigDecimal do
     context "when the value is BigDecimal Infinity" do
 
       let(:infinity) do
-        BigDecimal.new("Infinity")
+        BigDecimal("Infinity")
       end
 
       it "returns a String" do
@@ -350,7 +350,7 @@ describe Mongoid::Extensions::BigDecimal do
     context "when the value is BigDecimal negative Infinity" do
 
       let(:neg_infinity) do
-        BigDecimal.new("-Infinity")
+        BigDecimal("-Infinity")
       end
 
       it "returns a String" do

--- a/spec/mongoid/fields_spec.rb
+++ b/spec/mongoid/fields_spec.rb
@@ -1188,7 +1188,7 @@ describe Mongoid::Fields do
     end
 
     let(:decimal) do
-      BigDecimal.new("1000000.00")
+      BigDecimal("1000000.00")
     end
 
     context "when setting to a big decimal" do

--- a/spec/mongoid/persistable/incrementable_spec.rb
+++ b/spec/mongoid/persistable/incrementable_spec.rb
@@ -68,15 +68,15 @@ describe Mongoid::Persistable::Incrementable do
       context "when providing big decimal values" do
 
         let(:five) do
-          BigDecimal.new("5.0")
+          BigDecimal("5.0")
         end
 
         let(:neg_ten) do
-          BigDecimal.new("-10.0")
+          BigDecimal("-10.0")
         end
 
         let(:thirty) do
-          BigDecimal.new("30.0")
+          BigDecimal("30.0")
         end
 
         let!(:inc) do
@@ -153,15 +153,15 @@ describe Mongoid::Persistable::Incrementable do
       context "when providing big decimal values" do
 
         let(:five) do
-          BigDecimal.new("5.0")
+          BigDecimal("5.0")
         end
 
         let(:neg_ten) do
-          BigDecimal.new("-10.0")
+          BigDecimal("-10.0")
         end
 
         let(:thirty) do
-          BigDecimal.new("30.0")
+          BigDecimal("30.0")
         end
 
         let!(:inc) do


### PR DESCRIPTION
To fix warning:

> BigDecimal.new is deprecated; use BigDecimal() method instead

Since:  ruby v2_6_1 & v2_6_0_rc2

Source: https://github.com/ruby/ruby/commit/62b55d9483d72a11345300296190b1e9c0ffd652#diff-cdf5d288e028f232ff6979d98276904a