### PR TITLE
MONGOID-4729 Skip query if all keys from docs are nil

### DIFF
--- a/lib/mongoid/association/referenced/eager.rb
+++ b/lib/mongoid/association/referenced/eager.rb
@@ -65,7 +65,10 @@ module Mongoid
           #
           # @since 4.0.0
           def each_loaded_document
-            criteria = @association.klass.any_in(key => keys_from_docs)
+            doc_keys = keys_from_docs
+            return @association.klass.none if doc_keys.all?(&:nil?)
+
+            criteria = @association.klass.any_in(key => doc_keys)
             criteria.inclusions = criteria.inclusions - [@association]
             criteria.each do |doc|
               yield doc

--- a/spec/mongoid/association/referenced/belongs_to/eager_spec.rb
+++ b/spec/mongoid/association/referenced/belongs_to/eager_spec.rb
@@ -175,11 +175,14 @@ describe Mongoid::Association::Referenced::BelongsTo::Eager do
       end
 
       it "only queries once for the parent documents" do
+        found_ticket = false
         expect_query(1) do
           Ticket.all.includes(:person).each do |ticket|
             expect(ticket.person).to eq nil
+            found_ticket = true
           end
         end
+        expect(found_ticket).to be true
       end
     end
   end

--- a/spec/mongoid/association/referenced/belongs_to/eager_spec.rb
+++ b/spec/mongoid/association/referenced/belongs_to/eager_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+require_relative '../has_many_models'
 
 describe Mongoid::Association::Referenced::BelongsTo::Eager do
 
@@ -165,19 +166,13 @@ describe Mongoid::Association::Referenced::BelongsTo::Eager do
     context "when all the values for the belongs_to association are nil" do
 
       before do
-        class Ticket
-          include Mongoid::Document
-
-          belongs_to :person
-        end
-
-        2.times { |i| Ticket.create!(person: nil) }
+        2.times { |i| HmmTicket.create!(person: nil) }
       end
 
       it "only queries once for the parent documents" do
         found_ticket = false
         expect_query(1) do
-          Ticket.all.includes(:person).each do |ticket|
+          HmmTicket.all.includes(:person).each do |ticket|
             expect(ticket.person).to eq nil
             found_ticket = true
           end

--- a/spec/mongoid/association/referenced/belongs_to/eager_spec.rb
+++ b/spec/mongoid/association/referenced/belongs_to/eager_spec.rb
@@ -57,7 +57,7 @@ describe Mongoid::Association::Referenced::BelongsTo::Eager do
       Post.create!(person: person)
     end
 
-    it "sets the relation into the parent" do
+    it "sets the association into the parent" do
       docs.each do |doc|
         expect(doc).to receive(:set_relation).with(:person, :foo)
       end
@@ -75,7 +75,7 @@ describe Mongoid::Association::Referenced::BelongsTo::Eager do
       3.times { |i| Account.create!(person: person, name: "savings#{i}") }
     end
 
-    context "when including the belongs_to relation" do
+    context "when including the belongs_to association" do
 
       it "queries twice" do
 
@@ -87,7 +87,7 @@ describe Mongoid::Association::Referenced::BelongsTo::Eager do
       end
     end
 
-    context "when the relation is not polymorphic" do
+    context "when the association is not polymorphic" do
 
       let(:eager) do
         Post.includes(:person).last
@@ -130,13 +130,13 @@ describe Mongoid::Association::Referenced::BelongsTo::Eager do
           expect(eager.ivar(:person)).to be nil
         end
 
-        it "has a nil relation" do
+        it "has a nil association" do
           expect(eager.person).to be nil
         end
       end
     end
 
-    context "when the relation is polymorphic" do
+    context "when the association is polymorphic" do
 
       let!(:movie) do
         Movie.create(name: "Bladerunner")
@@ -162,7 +162,7 @@ describe Mongoid::Association::Referenced::BelongsTo::Eager do
       end
     end
 
-    context "when all the values for the belongs_to relation are nil" do
+    context "when all the values for the belongs_to association are nil" do
 
       before do
         class Ticket

--- a/spec/mongoid/association/referenced/belongs_to/eager_spec.rb
+++ b/spec/mongoid/association/referenced/belongs_to/eager_spec.rb
@@ -161,5 +161,26 @@ describe Mongoid::Association::Referenced::BelongsTo::Eager do
         expect(game.person_id).to eql(id)
       end
     end
+
+    context "when all the values for the belongs_to relation are nil" do
+
+      before do
+        class Ticket
+          include Mongoid::Document
+
+          belongs_to :person
+        end
+
+        2.times { |i| Ticket.create!(person: nil) }
+      end
+
+      it "only queries once for the parent documents" do
+        expect_query(1) do
+          Ticket.all.includes(:person).each do |ticket|
+            expect(ticket.person).to eq nil
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/mongoid/association/referenced/has_and_belongs_to_many/eager_spec.rb
+++ b/spec/mongoid/association/referenced/has_and_belongs_to_many/eager_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+require_relative '../has_and_belongs_to_many_models'
 
 describe Mongoid::Association::Referenced::HasAndBelongsToMany::Eager do
 
@@ -135,19 +136,13 @@ describe Mongoid::Association::Referenced::HasAndBelongsToMany::Eager do
     context "when all the values for the has_and_belongs_to_many association are empty" do
 
       before do
-        class Ticket
-          include Mongoid::Document
-        end
-
-        Person.has_and_belongs_to_many :tickets
-
-        2.times { |i| Person.create! }
+        2.times { |i| HabtmmPerson.create! }
       end
 
       it "only queries once for the parent documents" do
         found_person = false
         expect_query(1) do
-          Person.all.includes(:tickets).each do |person|
+          HabtmmPerson.all.includes(:tickets).each do |person|
             expect(person.tickets).to eq []
             found_person = true
           end

--- a/spec/mongoid/association/referenced/has_and_belongs_to_many/eager_spec.rb
+++ b/spec/mongoid/association/referenced/has_and_belongs_to_many/eager_spec.rb
@@ -43,7 +43,7 @@ describe Mongoid::Association::Referenced::HasAndBelongsToMany::Eager do
       Person.create!(houses: 3.times.map { House.create! })
     end
 
-    context "when including the has_and_belongs_to_many relation" do
+    context "when including the has_and_belongs_to_many association" do
 
       it "queries twice" do
         expect_query(2) do
@@ -62,7 +62,7 @@ describe Mongoid::Association::Referenced::HasAndBelongsToMany::Eager do
       end
     end
 
-    context "when the relation is not polymorphic" do
+    context "when the association is not polymorphic" do
 
       let(:eager) do
         Person.asc(:_id).includes(:preferences).last
@@ -132,7 +132,7 @@ describe Mongoid::Association::Referenced::HasAndBelongsToMany::Eager do
       end
     end
 
-    context "when all the values for the has_and_belongs_to_many relation are empty" do
+    context "when all the values for the has_and_belongs_to_many association are empty" do
 
       before do
         class Ticket

--- a/spec/mongoid/association/referenced/has_and_belongs_to_many/eager_spec.rb
+++ b/spec/mongoid/association/referenced/has_and_belongs_to_many/eager_spec.rb
@@ -145,11 +145,14 @@ describe Mongoid::Association::Referenced::HasAndBelongsToMany::Eager do
       end
 
       it "only queries once for the parent documents" do
+        found_person = false
         expect_query(1) do
           Person.all.includes(:tickets).each do |person|
             expect(person.tickets).to eq []
+            found_person = true
           end
         end
+        expect(found_person).to be true
       end
     end
   end

--- a/spec/mongoid/association/referenced/has_and_belongs_to_many/eager_spec.rb
+++ b/spec/mongoid/association/referenced/has_and_belongs_to_many/eager_spec.rb
@@ -131,5 +131,26 @@ describe Mongoid::Association::Referenced::HasAndBelongsToMany::Eager do
         end
       end
     end
+
+    context "when all the values for the has_and_belongs_to_many relation are empty" do
+
+      before do
+        class Ticket
+          include Mongoid::Document
+        end
+
+        Person.has_and_belongs_to_many :tickets
+
+        2.times { |i| Person.create! }
+      end
+
+      it "only queries once for the parent documents" do
+        expect_query(1) do
+          Person.all.includes(:tickets).each do |person|
+            expect(person.tickets).to eq []
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/mongoid/association/referenced/has_and_belongs_to_many_models.rb
+++ b/spec/mongoid/association/referenced/has_and_belongs_to_many_models.rb
@@ -35,3 +35,13 @@ class HabtmmSignature
   field :name, type: String
   field :year, type: Integer
 end
+
+class HabtmmTicket
+  include Mongoid::Document
+end
+
+class HabtmmPerson
+  include Mongoid::Document
+
+  has_and_belongs_to_many :tickets, class_name: 'HabtmmTicket'
+end

--- a/spec/mongoid/association/referenced/has_many_models.rb
+++ b/spec/mongoid/association/referenced/has_many_models.rb
@@ -29,3 +29,9 @@ class HmmStudent
   field :name, type: String
   field :grade, type: Integer, default: 3
 end
+
+class HmmTicket
+  include Mongoid::Document
+
+  belongs_to :person
+end


### PR DESCRIPTION
Let's say we have a "seats" collection and seats can optionally belong to a user. If we query all the seats and eager load the users, but none of the seats actually belong to a user, Mongoid will still query the database for users where the id is ```{"$in"=>[nil]}```. I see something like this in the logs: ```{"find"=>"users", "filter"=>{"_id"=>{"$in"=>[nil]}}...```

This change will skip the trip to the db if all the foreign keys are nil.

I applied the change to the v7.0.2 release and it worked for me. On v7.0.2 with this change, all the specs passed.