### PR TITLE
MONGOID-4728 Adds Support for $eq operator in Matchable

### DIFF
--- a/lib/mongoid/matchable.rb
+++ b/lib/mongoid/matchable.rb
@@ -3,6 +3,7 @@
 require "mongoid/matchable/default"
 require "mongoid/matchable/all"
 require "mongoid/matchable/and"
+require "mongoid/matchable/eq"
 require "mongoid/matchable/exists"
 require "mongoid/matchable/gt"
 require "mongoid/matchable/gte"
@@ -33,6 +34,7 @@ module Mongoid
       "$all" => All,
       "$elemMatch" => ElemMatch,
       "$and" => And,
+      "$eq" => Eq,
       "$exists" => Exists,
       "$gt" => Gt,
       "$gte" => Gte,
@@ -43,7 +45,7 @@ module Mongoid
       "$nin" => Nin,
       "$or" => Or,
       "$nor" => Nor,
-      "$size" => Size
+      "$size" => Size,
     }.with_indifferent_access.freeze
 
     # Determines if this document has the attributes to match the supplied

--- a/lib/mongoid/matchable/eq.rb
+++ b/lib/mongoid/matchable/eq.rb
@@ -3,7 +3,7 @@
 module Mongoid
   module Matchable
 
-    # Performs non-equivalency checks.
+    # Performs equivalency checks.
     class Eq < Default
 
       # Return true if the attribute and first value are equal.
@@ -13,7 +13,7 @@ module Mongoid
       #
       # @param [ Hash ] value The values to check.
       #
-      # @return [ true, false ] If a value exists.
+      # @return [ true, false ] True if matches, false if not.
       def _matches?(value)
         super(value.values.first)
       end

--- a/lib/mongoid/matchable/eq.rb
+++ b/lib/mongoid/matchable/eq.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+# encoding: utf-8
+module Mongoid
+  module Matchable
+
+    # Performs non-equivalency checks.
+    class Eq < Default
+
+      # Return true if the attribute and first value are equal.
+      #
+      # @example Do the values match?
+      #   matcher._matches?({ :key => 10 })
+      #
+      # @param [ Hash ] value The values to check.
+      #
+      # @return [ true, false ] If a value exists.
+      def _matches?(value)
+        super(value.values.first)
+      end
+    end
+  end
+end

--- a/lib/mongoid/matchable/ne.rb
+++ b/lib/mongoid/matchable/ne.rb
@@ -13,7 +13,7 @@ module Mongoid
       #
       # @param [ Hash ] value The values to check.
       #
-      # @return [ true, false ] If a value exists.
+      # @return [ true, false ] True if matches, false if not.
       def _matches?(value)
         !super(value.values.first)
       end

--- a/spec/mongoid/matchable/eq_spec.rb
+++ b/spec/mongoid/matchable/eq_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Mongoid::Matchable::Eq do
+
+  let(:matcher) do
+    described_class.new("first")
+  end
+
+  describe "#_matches?" do
+
+    context "when the values are equal" do
+
+      it "returns true" do
+        expect(matcher._matches?("$eq" => "first")).to be true
+      end
+    end
+
+    context "when the values are not equal" do
+
+      it "returns false" do
+        expect(matcher._matches?("$eq" => "second")).to be false
+      end
+    end
+
+    context "when the value is an array" do
+
+      let(:array_matcher) do
+        described_class.new([ "first" ])
+      end
+
+      context "when the value is in the array" do
+
+        it "returns true" do
+          expect(array_matcher._matches?("$eq" => "first")).to be true
+        end
+      end
+
+      context "when the value is not in the array" do
+
+        it "returns false" do
+          expect(array_matcher._matches?("$eq" => "second")).to be false
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Currently Matchable doesn't support `#_matches?` against selectors that use the mongodb `$eq` operator. This adds support for it to do so.