### PR TITLE
MONGOID-4741 Include timestamps in generated model by default

### DIFF
--- a/lib/rails/generators/mongoid/model/model_generator.rb
+++ b/lib/rails/generators/mongoid/model/model_generator.rb
@@ -11,7 +11,6 @@ module Mongoid
 
       check_class_collision
 
-      class_option :timestamps, type: :boolean
       class_option :parent,     type: :string, desc: "The parent class for the generated model"
       class_option :collection, type: :string, desc: "The collection for storing model's documents"
 

--- a/lib/rails/generators/mongoid/model/model_generator.rb
+++ b/lib/rails/generators/mongoid/model/model_generator.rb
@@ -11,6 +11,7 @@ module Mongoid
 
       check_class_collision
 
+      class_option :no_timestamps, type: :boolean
       class_option :parent,     type: :string, desc: "The parent class for the generated model"
       class_option :collection, type: :string, desc: "The collection for storing model's documents"
 

--- a/lib/rails/generators/mongoid/model/model_generator.rb
+++ b/lib/rails/generators/mongoid/model/model_generator.rb
@@ -11,7 +11,7 @@ module Mongoid
 
       check_class_collision
 
-      class_option :no_timestamps, type: :boolean
+      class_option :timestamps, type: :boolean, default: true
       class_option :parent,     type: :string, desc: "The parent class for the generated model"
       class_option :collection, type: :string, desc: "The collection for storing model's documents"
 

--- a/lib/rails/generators/mongoid/model/templates/model.rb.tt
+++ b/lib/rails/generators/mongoid/model/templates/model.rb.tt
@@ -2,6 +2,8 @@
 class <%= class_name %><%= " < #{options[:parent].classify}" if options[:parent] %>
 <% unless options[:parent] -%>
   include Mongoid::Document
+<% end -%>
+<% unless options[:no_timestamps] -%>
   include Mongoid::Timestamps
 <% end -%>
 <% if options[:collection] -%>

--- a/lib/rails/generators/mongoid/model/templates/model.rb.tt
+++ b/lib/rails/generators/mongoid/model/templates/model.rb.tt
@@ -2,8 +2,6 @@
 class <%= class_name %><%= " < #{options[:parent].classify}" if options[:parent] %>
 <% unless options[:parent] -%>
   include Mongoid::Document
-<% end -%>
-<% if options[:timestamps] -%>
   include Mongoid::Timestamps
 <% end -%>
 <% if options[:collection] -%>

--- a/lib/rails/generators/mongoid/model/templates/model.rb.tt
+++ b/lib/rails/generators/mongoid/model/templates/model.rb.tt
@@ -3,7 +3,7 @@ class <%= class_name %><%= " < #{options[:parent].classify}" if options[:parent]
 <% unless options[:parent] -%>
   include Mongoid::Document
 <% end -%>
-<% unless options[:no_timestamps] -%>
+<% if options[:timestamps] -%>
   include Mongoid::Timestamps
 <% end -%>
 <% if options[:collection] -%>


### PR DESCRIPTION
## Summary
The principal changes are as follows. 
- Remove `-timestamp` options from the files generated when use `rails g model` command
- Add `include Mongoid::Timestamps` instead of it.