### PR TITLE
MONGOD-4749 Fix: association with class_name: '::SomeClass'

### DIFF
--- a/lib/mongoid/association/relatable.rb
+++ b/lib/mongoid/association/relatable.rb
@@ -483,7 +483,13 @@ module Mongoid
       def resolve_name(mod, name)
         cls = exc = nil
         parts = name.to_s.split('::')
-        namespace_hierarchy(mod).each do |ns|
+        if parts.first == ''
+          parts.shift
+          hierarchy = [Object]
+        else
+          hierarchy = namespace_hierarchy(mod)
+        end
+        hierarchy.each do |ns|
           begin
             parts.each do |part|
               # Simple const_get sometimes pulls names out of weird scopes,

--- a/spec/app/models/other_owner_object.rb
+++ b/spec/app/models/other_owner_object.rb
@@ -1,0 +1,2 @@
+class OtherOwnerObject
+end

--- a/spec/mongoid/association/referenced/belongs_to_spec.rb
+++ b/spec/mongoid/association/referenced/belongs_to_spec.rb
@@ -1624,6 +1624,17 @@ describe Mongoid::Association::Referenced::BelongsTo do
       end
     end
 
+    context 'when the :class_name option is scoped with ::' do
+
+      let(:options) do
+        { class_name: '::OtherOwnerObject' }
+      end
+
+      it 'returns the class name option' do
+        expect(association.relation_class_name).to eq('::OtherOwnerObject')
+      end
+    end
+
     context 'when the class_name option is not specified' do
 
       it 'uses the name of the relation to deduce the class name' do
@@ -1646,33 +1657,23 @@ describe Mongoid::Association::Referenced::BelongsTo do
 
     context 'when the :class_name option is specified' do
 
-      let!(:_class) do
-        class OtherOwnerObject; end
-        OtherOwnerObject
-      end
-
       let(:options) do
         { class_name: 'OtherOwnerObject' }
       end
 
-      it 'returns the class name option' do
-        expect(association.relation_class).to eq(_class)
+      it 'returns the named class' do
+        expect(association.relation_class).to eq(OtherOwnerObject)
       end
     end
 
     context 'when the :class_name option is scoped with ::' do
 
-      let!(:_class) do
-        class OtherOwnerObject; end
-        OtherOwnerObject
-      end
-
       let(:options) do
         { class_name: '::OtherOwnerObject' }
       end
 
-      it 'returns the class name option' do
-        expect(association.relation_class).to eq(_class)
+      it 'returns the named class' do
+        expect(association.relation_class).to eq(OtherOwnerObject)
       end
     end
 

--- a/spec/mongoid/association/referenced/belongs_to_spec.rb
+++ b/spec/mongoid/association/referenced/belongs_to_spec.rb
@@ -1660,6 +1660,22 @@ describe Mongoid::Association::Referenced::BelongsTo do
       end
     end
 
+    context 'when the :class_name option is scoped with ::' do
+
+      let!(:_class) do
+        class OtherOwnerObject; end
+        OtherOwnerObject
+      end
+
+      let(:options) do
+        { class_name: '::OtherOwnerObject' }
+      end
+
+      it 'returns the class name option' do
+        expect(association.relation_class).to eq(_class)
+      end
+    end
+
     context 'when the class_name option is not specified' do
 
       it 'uses the name of the relation to deduce the class name' do


### PR DESCRIPTION
Following the rework of the `:class_name` option in v7.0.3, a value of '::SomeClass' causes a NameError exception. This fixes it so it works again (as it did in 7.0.2 and prior).

Example:
```
class Child
  include Mongoid::Document
  belongs_to :parent, class_name: '::OtherClass'
end
```
