### PR TITLE
Updated  $elemMatch and conditionals to support nested queries

### DIFF
--- a/lib/mongoid/matchable.rb
+++ b/lib/mongoid/matchable.rb
@@ -18,6 +18,7 @@ require "mongoid/matchable/nor"
 require "mongoid/matchable/size"
 require "mongoid/matchable/elem_match"
 require "mongoid/matchable/regexp"
+require "mongoid/matchable/not"
 
 module Mongoid
 
@@ -47,6 +48,7 @@ module Mongoid
       "$or" => Or,
       "$nor" => Nor,
       "$size" => Size,
+      "$not" => Not
     }.with_indifferent_access.freeze
 
     # Determines if this document has the attributes to match the supplied
@@ -118,6 +120,9 @@ module Mongoid
       # @since 2.0.0.rc.7
       def matcher(document, key, value)
         if value.is_a?(Hash)
+          if key == :$not || value.keys.first == :$not
+            return Not.new(value, document)
+          end
           matcher = MATCHERS[value.keys.first]
           if matcher
             matcher.new(extract_attribute(document, key))

--- a/lib/mongoid/matchable.rb
+++ b/lib/mongoid/matchable.rb
@@ -48,7 +48,7 @@ module Mongoid
       "$or" => Or,
       "$nor" => Nor,
       "$size" => Size,
-      "$not" => Not
+      "$not" => Not,
     }.with_indifferent_access.freeze
 
     # Determines if this document has the attributes to match the supplied

--- a/lib/mongoid/matchable/and.rb
+++ b/lib/mongoid/matchable/and.rb
@@ -22,7 +22,7 @@ module Mongoid
           condition.keys.each do |k|
             key = k
             value = condition[k]
-            return false unless document._matches?(key => value)
+            return false unless safe_matches?(document, key, value)
           end
         end
         true

--- a/lib/mongoid/matchable/and.rb
+++ b/lib/mongoid/matchable/and.rb
@@ -22,7 +22,7 @@ module Mongoid
           condition.keys.each do |k|
             key = k
             value = condition[k]
-            return false unless safe_matches?(document, key, value)
+            return false unless recursive_matches?(document, key, value)
           end
         end
         true

--- a/lib/mongoid/matchable/default.rb
+++ b/lib/mongoid/matchable/default.rb
@@ -82,7 +82,7 @@ module Mongoid
       #
       # @return [ true, false ] True if matches, false if not.
       #
-      # @since 7.0.4
+      # @since 7.0.5
       def recursive_matches?(document, key, value)
         if document.is_a?(Document)
           document._matches?(key => value)

--- a/lib/mongoid/matchable/default.rb
+++ b/lib/mongoid/matchable/default.rb
@@ -84,7 +84,7 @@ module Mongoid
       #
       # @since 7.0.4
       def safe_matches?(document, key, value)
-        if value.is_a?(Document)
+        if document.is_a?(Document)
           document._matches?(key => value)
         else
           # If not a Document, then assume it's a Hash

--- a/lib/mongoid/matchable/default.rb
+++ b/lib/mongoid/matchable/default.rb
@@ -73,8 +73,8 @@ module Mongoid
       # Convenience method for checking _matches? on a Document or a Hash.
       #
       # @example Does the document of type Document or Hash match?
-      #   safe_matches?(default, "a", 1)
-      #   safe_matches?(:a => 1, "b", 2)
+      #   recursive_matches?(default, "a", 1)
+      #   recursive_matches?(:a => 1, "b", 2)
       #
       # @param [ Document, Hash ] document The object of type Document or Hash to call _matches? on
       # @param [ String ] key The key
@@ -83,16 +83,11 @@ module Mongoid
       # @return [ true, false ] True if matches, false if not.
       #
       # @since 7.0.4
-      def safe_matches?(document, key, value)
+      def recursive_matches?(document, key, value)
         if document.is_a?(Document)
           document._matches?(key => value)
         else
-          # If not a Document, then assume it's a Hash
-          if value.try(:first).try(:[],0) == "$not".freeze || value.try(:first).try(:[],0) == :$not
-            !Matchable.matcher(document, key, value.first[1])._matches?(value.first[1])
-          else
-            Matchable.matcher(document, key, value)._matches?(value)
-          end
+          Matchable.matcher(document, key, value)._matches?(value)
         end
       end
     end

--- a/lib/mongoid/matchable/default.rb
+++ b/lib/mongoid/matchable/default.rb
@@ -44,7 +44,7 @@ module Mongoid
       # @example Get the first value.
       #   matcher.first(:test => "value")
       #
-      # @param [ Hash ] hash The has to pull from.
+      # @param [ Hash ] hash The hash to pull from.
       #
       # @return [ Object ] The first value.
       #
@@ -68,6 +68,32 @@ module Mongoid
         attribute.__array__.any? {|attr|
           attr ? attr.send(operator, first(value)) : false
         }
+      end
+
+      # Convenience method for checking _matches? on a Document or a Hash.
+      #
+      # @example Does the document of type Document or Hash match?
+      #   safe_matches?(default, "a", 1)
+      #   safe_matches?(:a => 1, "b", 2)
+      #
+      # @param [ Document, Hash ] document The object of type Document or Hash to call _matches? on
+      # @param [ String ] key The key
+      # @param [ Object ] value The value to check if it matches.
+      #
+      # @return [ true, false ] True if matches, false if not.
+      #
+      # @since 7.0.4
+      def safe_matches?(document, key, value)
+        if value.is_a?(Document)
+          document._matches?(key => value)
+        else
+          # If not a Document, then assume it's a Hash
+          if value.try(:first).try(:[],0) == "$not".freeze || value.try(:first).try(:[],0) == :$not
+            !Matchable.matcher(document, key, value.first[1])._matches?(value.first[1])
+          else
+            Matchable.matcher(document, key, value)._matches?(value)
+          end
+        end
       end
     end
   end

--- a/lib/mongoid/matchable/elem_match.rb
+++ b/lib/mongoid/matchable/elem_match.rb
@@ -26,7 +26,12 @@ module Mongoid
             if v.try(:first).try(:[],0) == "$not".freeze || v.try(:first).try(:[],0) == :$not
               !Matchable.matcher(sub_document, k, v.first[1])._matches?(v.first[1])
             else
-              Matchable.matcher(sub_document, k, v)._matches?(v)
+              if k == :$not
+                # If the key is :$not, then the value must be an operator query
+                !Matchable.matcher(sub_document, v.first[0], v.first[1])._matches?(v.first[1])
+              else
+                Matchable.matcher(sub_document, k, v)._matches?(v)
+              end
             end
           end
         end

--- a/lib/mongoid/matchable/elem_match.rb
+++ b/lib/mongoid/matchable/elem_match.rb
@@ -25,13 +25,11 @@ module Mongoid
           elem_match.all? do |k, v|
             if v.try(:first).try(:[],0) == "$not".freeze || v.try(:first).try(:[],0) == :$not
               !Matchable.matcher(sub_document, k, v.first[1])._matches?(v.first[1])
+            elsif k == :$not
+              # If the key is :$not, then the value must be an operator query
+              !Matchable.matcher(sub_document, v.first[0], v.first[1])._matches?(v.first[1])
             else
-              if k == :$not
-                # If the key is :$not, then the value must be an operator query
-                !Matchable.matcher(sub_document, v.first[0], v.first[1])._matches?(v.first[1])
-              else
-                Matchable.matcher(sub_document, k, v)._matches?(v)
-              end
+              Matchable.matcher(sub_document, k, v)._matches?(v)
             end
           end
         end

--- a/lib/mongoid/matchable/nor.rb
+++ b/lib/mongoid/matchable/nor.rb
@@ -29,7 +29,7 @@ module Mongoid
         end
         conditions.none? do |condition|
           condition.all? do |key, value|
-            document._matches?(key => value)
+            safe_matches?(document, key, value)
           end
         end
       end

--- a/lib/mongoid/matchable/nor.rb
+++ b/lib/mongoid/matchable/nor.rb
@@ -21,7 +21,7 @@ module Mongoid
       #
       # @since 7.1.0
       def _matches?(conditions)
-        if conditions.length == 0
+        if conditions.blank?
           # MongoDB does not allow $nor array to be empty, but
           # Mongoid accepts an empty array for $or which MongoDB also
           # prohibits
@@ -29,7 +29,7 @@ module Mongoid
         end
         conditions.none? do |condition|
           condition.all? do |key, value|
-            safe_matches?(document, key, value)
+            recursive_matches?(document, key, value)
           end
         end
       end

--- a/lib/mongoid/matchable/not.rb
+++ b/lib/mongoid/matchable/not.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+# encoding: utf-8
+
+module Mongoid
+  module Matchable
+
+    # Performs a logical NOT operation.
+    class Not < Default
+
+      # Return true if the attribute does not match the value.
+      #
+      # @example Do the values not match?
+      #   matcher._matches?({ :key => 10 })
+      #
+      # @return [ true, false ] True if the value does not match, false otherwise
+      def _matches?(condition)
+        if document.is_a?(Document)
+          document._matches?(condition.first[0] => condition.first[1])
+        else
+          !recursive_matches?(document, condition.first[0], condition.first[1])
+        end
+      end
+    end
+  end
+end

--- a/lib/mongoid/matchable/or.rb
+++ b/lib/mongoid/matchable/or.rb
@@ -23,7 +23,7 @@ module Mongoid
           condition.keys.each do |k|
             key = k
             value = condition[k]
-            res &&= document._matches?(key => value)
+            res &&= safe_matches?(document, key, value)
             break unless res
           end
           return res if res

--- a/lib/mongoid/matchable/or.rb
+++ b/lib/mongoid/matchable/or.rb
@@ -23,7 +23,7 @@ module Mongoid
           condition.keys.each do |k|
             key = k
             value = condition[k]
-            res &&= safe_matches?(document, key, value)
+            res &&= recursive_matches?(document, key, value)
             break unless res
           end
           return res if res

--- a/spec/mongoid/matchable/elem_match_spec.rb
+++ b/spec/mongoid/matchable/elem_match_spec.rb
@@ -105,5 +105,199 @@ describe Mongoid::Matchable::ElemMatch do
         expect(matcher._matches?("$elemMatch" => {"a" => 3, "b" => 2})).to be false
       end
     end
+
+    context "when nesting queries" do
+      context "and using nested and" do
+        it "returns true for nested eq" do
+          query = {
+            :$elemMatch => {
+              :$and => [
+                {:a => {:$eq => 1}},
+                {:b => {:$eq => 2}}
+              ]
+            }
+          }
+          expect(matcher._matches?(query)).to be true
+        end
+
+        it "returns true for raw value" do
+          query = {
+            :$elemMatch => {
+              :$and => [
+                {:a => 1},
+                {:b => 2}
+              ]
+            }
+          }
+          expect(matcher._matches?(query)).to be true
+        end
+
+        it "returns false when partially false" do
+          query = {
+            :$elemMatch => {
+              :$and => [
+                {:a => {:$eq => 1}},
+                {:b => {:$eq => 20}}
+              ]
+            }
+          }
+          expect(matcher._matches?(query)).to be false
+        end
+
+        it "returns false when partially false on raw values" do
+          query = {
+            :$elemMatch => {
+              :$and => [
+                {:a => 1},
+                {:b => 20}
+              ]
+            }
+          }
+          expect(matcher._matches?(query)).to be false
+        end
+
+        it "returns false when fully false" do
+          query = {
+            :$elemMatch => {
+              :$and => [
+                {:a => {:$eq => 10}},
+                {:b => {:$eq => 20}}
+              ]
+            }
+          }
+          expect(matcher._matches?(query)).to be false
+        end
+
+        it "returns false when fully false on raw values" do
+          query = {
+            :$elemMatch => {
+              :$and => [
+                {:a => 10},
+                {:b => 20}
+              ]
+            }
+          }
+          expect(matcher._matches?(query)).to be false
+        end
+      end
+
+      context "and using nested or" do
+        it "returns true" do
+          query = {
+            :$elemMatch => {
+              :$or => [
+                {:a => {:$eq => 1}},
+                {:b => {:$eq => 1}}
+              ]
+            }
+          }
+          expect(matcher._matches?(query)).to be true
+        end
+
+        it "returns true on raw values" do
+          query = {
+            :$elemMatch => {
+              :$or => [
+                {:a => 1},
+                {:b => 1}
+              ]
+            }
+          }
+          expect(matcher._matches?(query)).to be true
+        end
+
+        it "returns false" do
+          query = {
+            :$elemMatch => {
+              :$or => [
+                {:a => {:$eq => 10}},
+                {:b => {:$eq => 10}}
+              ]
+            }
+          }
+          expect(matcher._matches?(query)).to be false
+        end
+
+        it "returns false on raw values" do
+          query = {
+            :$elemMatch => {
+              :$or => [
+                {:a => 10},
+                {:b => 10}
+              ]
+            }
+          }
+          expect(matcher._matches?(query)).to be false
+        end
+      end
+
+      context "and using nested nor" do
+        it "returns true" do
+          query = {
+            :$elemMatch => {
+              :$nor => [
+                {:a => {:$eq => 1}},
+                {:b => {:$eq => 2}}
+              ]
+            }
+          }
+          expect(matcher._matches?(query)).to be true
+        end
+
+        it "returns true on raw values" do
+          query = {
+            :$elemMatch => {
+              :$nor => [
+                {:a => 1},
+                {:b => 2}
+              ]
+            }
+          }
+          expect(matcher._matches?(query)).to be true
+        end
+
+        it "returns false" do
+          query = {
+            :$elemMatch => {
+              :$nor => [
+                {:a => {:$lt => 10}},
+                {:b => {:$lt => 10}}
+              ]
+            }
+          }
+          expect(matcher._matches?(query)).to be false
+        end
+      end
+
+      context "and using multiple nested statements" do
+        let(:attribute) {[{"a" => 1, "b" => 1}, {"a" => 1, "b" => 1}, {"a" => 3, "b" => 3}]}
+
+        it "returns true" do
+          query = {
+            :$elemMatch => {
+              :b => 3,
+              :$or => [
+                {:a => {:$ne => 1}},
+                {:b => {:$ne => 1}}
+              ]
+            }
+          }
+          expect(matcher._matches?(query)).to be true
+        end
+
+        it "returns false" do
+          query = {
+            :$elemMatch => {
+              :b => 1,
+              :$or => [
+                {:a => {:$gt => 5}},
+                {:b => {:$lt => 1}}
+              ]
+            }
+          }
+          expect(matcher._matches?(query)).to be false
+        end
+      end
+    end
   end
 end

--- a/spec/mongoid/matchable/not_spec.rb
+++ b/spec/mongoid/matchable/not_spec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+# encoding: utf-8
+
+require "spec_helper"
+
+describe Mongoid::Matchable::Not do
+  let(:person) do
+    Person.new
+  end
+
+  let(:matcher) do
+    described_class.new("value", person)
+  end
+
+  describe "#_matches?" do
+    context "when inverting a simple expression" do
+      let(:matches) do
+        query = {
+          :title => {
+            :$not => {:$eq => "Sir"}
+          }
+        }
+        matcher._matches?(query)
+      end
+
+      context "when the inner expression matches" do
+        before do
+          person.title = "Sir"
+        end
+
+        it "returns false" do
+          expect(matches).to be false
+        end
+      end
+
+      context "when the inner expression does not match" do
+        before do
+          person.title = "Madam"
+        end
+
+        it "returns true" do
+          expect(matches).to be true
+        end
+      end
+    end
+
+    context "when inverting a complex expression" do
+      let(:matches) do
+        query = {
+          :age => {
+            :$not => {:$gt => 50}
+          }
+        }
+        matcher._matches?(query)
+      end
+
+      context "when the inner expression matches" do
+        before do
+          person.age = 60
+        end
+
+        it "returns false" do
+          expect(matches).to be false
+        end
+      end
+
+      context "when the inner expression does not match" do
+        before do
+          person.age = 40
+        end
+
+        it "returns true" do
+          expect(matches).to be true
+        end
+      end
+    end
+
+    context "when inverting a complex nested expression" do
+      let(:matches) do
+        query = {
+          :not => {
+            :$not => {
+              :$not => {
+                :age => {
+                  :$gt => 50
+                }
+              }
+            }
+          }
+        }
+        matcher._matches?(query)
+      end
+
+      context "when the inner expression matches" do
+        before do
+          person.age = 60
+        end
+
+        it "returns false" do
+          expect(matches).to be false
+        end
+      end
+
+      context "when the inner expression does not match" do
+        before do
+          person.age = 40
+        end
+
+        it "returns true" do
+          expect(matches).to be true
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Updated `and, or, nor` to instead call a new `recursive_matches?` method on the `default.rb` file. 

The `recursive_matches?` method checks if the document is a `Hash` and doesn't try to call `_matches?` on it.

Recursive support was cleaner to add with the addition of a proper `not.rb` for the `:$not` operator

---------

The original issue (that this PR fixes) was that nested conditionals (like `:$or`) inside of a `:$elemMatch` would raise ```NoMethodError: undefined method `_matches?' for {"a"=>1, "b"=>1}:Hash``` since a Hash value would get evaluated internally inside the `:$elemMatch` execution.