### PR TITLE
RUBY-1906 Fix factory spec when run without MONGODB_URI using default host of "localhost" without port number


### DIFF
--- a/spec/mongoid/clients/factory_spec.rb
+++ b/spec/mongoid/clients/factory_spec.rb
@@ -41,7 +41,11 @@ describe Mongoid::Clients::Factory do
           end
 
           it "sets the cluster's seeds" do
-            expect(cluster.addresses.first.to_s).to eq(SpecConfig.instance.addresses.first)
+            address = SpecConfig.instance.addresses.first
+            unless address.include?(':')
+              address = "#{address}:27017"
+            end
+            expect(cluster.addresses.first.to_s).to eq(address)
           end
 
           it "sets the platform to Mongoid's platform constant" do
@@ -213,6 +217,9 @@ describe Mongoid::Clients::Factory do
 
       it "sets the cluster's addresses" do
         SpecConfig.instance.addresses.each do |address|
+          unless address.include?(':')
+            address = "#{address}:27017"
+          end
           expect(cluster_addresses).to include(address)
         end
       end
@@ -264,6 +271,9 @@ describe Mongoid::Clients::Factory do
 
     it "sets the cluster's addresses" do
       SpecConfig.instance.addresses.each do |address|
+        unless address.include?(':')
+          address = "#{address}:27017"
+        end
         expect(cluster_addresses).to include(address)
       end
     end
@@ -310,6 +320,9 @@ describe Mongoid::Clients::Factory do
 
     it "sets the cluster's addresses" do
       SpecConfig.instance.addresses.each do |address|
+        unless address.include?(':')
+          address = "#{address}:27017"
+        end
         expect(cluster_addresses).to include(address)
       end
     end


### PR DESCRIPTION
This PR adds the default port `:27017` when an address doesn't have a port number, so that simply running `rake` succeeds.