### PR TITLE
Remove `rubyforge_project` from gemspec because rubyforge was EOL

### DIFF
--- a/mongoid.gemspec
+++ b/mongoid.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version     = ">= 2.2"
   s.required_rubygems_version = ">= 1.3.6"
-  s.rubyforge_project         = "mongoid"
 
   s.add_dependency("activemodel", [">= 5.1", "<6.1"])
   s.add_dependency("mongo", ['>=2.5.1', '<3.0.0'])


### PR DESCRIPTION
It's because rubyforge was EOL. I referred to rubygems/rubygems#2798.

Following is a warning message for this.
```
NOTE: Gem::Specification#rubyforge_project= is deprecated with no replacement. It will be removed on or after 2019-12-01.
Gem::Specification#rubyforge_project= called from /Users/tnakata/.rbenv/versions/2.7.0-dev/lib/ruby/gems/2.7.0/bundler/gems/mongoid-555eb55c9d9f/mongoid.gemspec:27.
```