### PR TITLE
Fix error in QueryCache when retrieving a result larger than batch_size from cache

### DIFF
--- a/lib/mongoid/query_cache.rb
+++ b/lib/mongoid/query_cache.rb
@@ -160,9 +160,9 @@ module Mongoid
         "#<Mongoid::QueryCache::CachedCursor:0x#{object_id} @view=#{@view.inspect}>"
       end
 
-      # The cache can be iterated again, if get more was never called
+      # The cache can be iterated again, if the result was completed in one batch
       def iterable_again?
-        !@get_more_called
+        @batch_count.to_i <= 1
       end
 
       private
@@ -170,7 +170,8 @@ module Mongoid
       def process(result)
         documents = super
 
-        if @cursor_id.zero? && !@get_more_called
+        @batch_count = @batch_count.to_i + 1
+        if @cursor_id.zero? && @batch_count == 1
           @cached_documents = documents
         end
 

--- a/lib/mongoid/query_cache.rb
+++ b/lib/mongoid/query_cache.rb
@@ -171,7 +171,7 @@ module Mongoid
         documents = super
 
         @batch_count = @batch_count.to_i + 1
-        if @cursor_id.zero? && @batch_count == 1
+        if result.cursor_id.zero? && @batch_count == 1
           @cached_documents = documents
         end
 

--- a/lib/mongoid/query_cache.rb
+++ b/lib/mongoid/query_cache.rb
@@ -231,9 +231,9 @@ module Mongoid
         return super if system_collection? || !QueryCache.enabled?
 
         cursor = fetch_cached_cursor do
-          read_with_retry do
-            server = server_selector.select_server(cluster)
-            CachedCursor.new(view, send_initial_query(server), server)
+          session = client.send(:get_session, @options)
+          read_with_retry(session, server_selector) do |server|
+            CachedCursor.new(view, send_initial_query(server, session), server, session: session)
           end
         end
         cursor.each do |doc|

--- a/lib/mongoid/query_cache.rb
+++ b/lib/mongoid/query_cache.rb
@@ -170,7 +170,7 @@ module Mongoid
       def process(result)
         documents = super
 
-        if @cursor_id.zero?
+        if @cursor_id.zero? && !@get_more_called
           @cached_documents = documents
         end
 

--- a/spec/mongoid/query_cache_spec.rb
+++ b/spec/mongoid/query_cache_spec.rb
@@ -504,6 +504,11 @@ describe Mongoid::QueryCache do
       it 'does not cache the result' do
         expect(Band.batch_size(batch_size).all.map(&:id).size).to eq(10)
       end
+
+      it 'works with repeated accesses' do
+        expect(Band.batch_size(batch_size).pluck(:name).length).to eq(10)
+        expect(Band.batch_size(batch_size).pluck(:name).length).to eq(10)
+      end
     end
   end
 end


### PR DESCRIPTION
Hi,

after upgrading mongoid and mongo we encountered an error "Cannot restart iteration of a cursor which issued a getMore" when performing a query with a result set larger than the batch size for the second time.

It happens in `QueryCache::View#each`, when iterating a cached cursor with `@get_more_called` a second time, which triggers https://github.com/mongodb/mongo-ruby-driver/blob/master/lib/mongo/cursor.rb#L144

- **The first commit provides a spec which reproduces the error.**
- The second commit provides a fix, by only reusing cursors with `@get_more_called == false`. I simplified the code while implementing the fix, because I found it difficult to follow the logic in the old implementation. 
  (Call to `cursor.to_a[0...limit.abs]` which is never returned. 
  Logic in `#process` was copypasta but `super` does just fine.)
- The third commit fixes the "Legacy read_with_retry invocation" which came from missing arguments.
- The fourth commit updates `#each` to be closer to the original `Iterable#each` implementation, just for completeness.

Feel free to cherry-pick what you need and to let me know what you think.

Cheers 🍻 


