### PR TITLE
MONGOID-4806 MONGOID-4810 MONGOID-4813 Produce the same query shapes with Criteria#where and Criteri...

### DIFF
--- a/docs/tutorials/mongoid-queries.txt
+++ b/docs/tutorials/mongoid-queries.txt
@@ -326,7 +326,7 @@ conditions are added to the criteria:
 .. code-block:: ruby
 
   Band.where(name: 1).where(name: 2).selector
-  # => {"$and"=>[{"name"=>"1"}], "name"=>"2"}
+  # => {"name"=>"1", "$and"=>[{"name"=>"2"}]}
 
   Band.where(name: 1).or(name: 2).selector
   # => {"$or"=>[{"name"=>"1"}, {"name"=>"2"}]}

--- a/lib/mongoid/criteria/queryable.rb
+++ b/lib/mongoid/criteria/queryable.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 # encoding: utf-8
 
+require "mongoid/criteria/queryable/expandable"
 require "mongoid/criteria/queryable/extensions"
 require "mongoid/criteria/queryable/forwardable"
 require "mongoid/criteria/queryable/key"
@@ -13,6 +14,7 @@ require "mongoid/criteria/queryable/optional"
 require "mongoid/criteria/queryable/options"
 require "mongoid/criteria/queryable/selectable"
 require "mongoid/criteria/queryable/selector"
+require "mongoid/criteria/queryable/storable"
 
 module Mongoid
   class Criteria
@@ -25,6 +27,8 @@ module Mongoid
     #     include Queryable
     #   end
     module Queryable
+      include Storable
+      include Expandable
       include Mergeable
       include Aggregable
       include Selectable

--- a/lib/mongoid/criteria/queryable/expandable.rb
+++ b/lib/mongoid/criteria/queryable/expandable.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+# encoding: utf-8
+
+module Mongoid
+  class Criteria
+    module Queryable
+      # This module encapsulates methods that expand various high level
+      # query forms to the MongoDB hash condition selector syntax.
+      #
+      # @example Example high level form.
+      #   Band.where(:foo.gt => 5)
+      #
+      # @api private
+      module Expandable
+
+        private
+
+        # Expands the specified condition to MongoDB syntax.
+        #
+        # The condition must be a hash in one of the following forms:
+        # - {field_name: value}
+        # - {'field_name' => value}
+        # - {key_instance: value}
+        # - {'$operator' => operator_value_expression}
+        #
+        # This method expands the key instance form to the the operator form,
+        # and also converts hash key to string.
+        #
+        # The hash may contain multiple items, each representing a separate
+        # condition.
+        #
+        # @param [ Hash ] condition The condition to expand.
+        #
+        # @return [ Hash ] The expanded condition.
+        def expand_condition(condition)
+          mapped = condition.map do |field, value|
+            expand_one_condition(field, value)
+          end
+          Hash[mapped]
+        end
+
+        # Expands the specified condition to MongoDB syntax.
+        #
+        # This method is meant to be called when processing the items of
+        # a condition hash and the key and the value of each item are
+        # already available separately.
+        #
+        # The following parameter forms are accepted:
+        #
+        # - field is a string or symbol; value is the field query expresision
+        # - field is a Key instance; value is the field query expression
+        # - field is a string corresponding to a MongoDB operator; value is
+        #   the operator value expression.
+        #
+        # This method expands the field-value combination to the MongoDB
+        # selector syntax and returns an array of
+        # [expanded key, expanded value]. The expanded key is converted to
+        # a string if it wasn't already a string.
+        #
+        # @param [ String | Symbol | Key ] field The field to expand.
+        # @param [ Object ] value The field's value.
+        #
+        # @return [ Array<String, Object> ] The expanded field and value.
+        def expand_one_condition(field, value)
+          kv = field.__expr_part__(value.__expand_complex__, negating?)
+          [kv.keys.first.to_s, kv.values.first]
+        end
+
+      end
+    end
+  end
+end

--- a/lib/mongoid/criteria/queryable/key.rb
+++ b/lib/mongoid/criteria/queryable/key.rb
@@ -103,16 +103,24 @@ module Mongoid
 
         # Instantiate the new key.
         #
-        # @example Instantiate the key.
-        #   Key.new("age", "$gt")
+        # @example Instantiate a key.
+        #   Key.new("age", :__override__, "$gt")
+        #
+        # @example Instantiate a key for sorting.
+        #   Key.new(:field, :__override__, 1)
         #
         # @param [ String, Symbol ] name The field name.
         # @param [ Symbol ] strategy The name of the merge strategy.
-        # @param [ String ] operator The Mongo operator.
+        # @param [ String | Integer ] operator The MongoDB operator,
+        #   or sort direction (1 or -1).
         # @param [ String ] expanded The Mongo expanded operator.
         #
         # @since 1.0.0
         def initialize(name, strategy, operator, expanded = nil, &block)
+          unless operator.is_a?(String) || operator.is_a?(Integer)
+            raise ArgumentError, "Operator must be a string or an integer: #{operator.inspect}"
+          end
+
           @name, @strategy, @operator, @expanded, @block =
             name, strategy, operator, expanded, block
         end

--- a/lib/mongoid/criteria/queryable/mergeable.rb
+++ b/lib/mongoid/criteria/queryable/mergeable.rb
@@ -52,12 +52,13 @@ module Mongoid
         # @example Reset the strategies.
         #   mergeable.reset_strategies!
         #
-        # @return [ nil ] nil.
+        # @return [ Criteria ] self.
         #
         # @since 1.0.0
         def reset_strategies!
           self.strategy = nil
           self.negating = nil
+          self
         end
 
         private

--- a/lib/mongoid/criteria/queryable/storable.rb
+++ b/lib/mongoid/criteria/queryable/storable.rb
@@ -1,0 +1,226 @@
+# frozen_string_literal: true
+# encoding: utf-8
+
+module Mongoid
+  class Criteria
+    module Queryable
+      # This module encapsulates methods that write query expressions into
+      # the Criteria's selector.
+      #
+      # The query expressions must have already been expanded as necessary.
+      # The methods of this module do not perform processing on expression
+      # values.
+      #
+      # Methods in this module do not handle negation - if negation is needed,
+      # it must have already been handled upstream of these methods.
+      #
+      # @api private
+      module Storable
+
+        # Adds an operator expression to the selector.
+        #
+        # This method takes the operator and the operator value expression
+        # separately for callers' convenience. It can be considered to
+        # handle storing the hash `{operator => op_expr}`.
+        #
+        # If the selector already has the specified operator in it (on the
+        # top level), the new condition given in op_expr is added to the
+        # existing conditions for the specified operator. This is
+        # straightforward for $and; for other logical operators, the behavior
+        # of this method is to add the new conditions to the existing operator.
+        # For example, if the selector is currently:
+        #
+        #     {'foo' => 'bar', '$or' => [{'hello' => 'world'}]}
+        #
+        # ... and operator is '$or' and op_expr is `{'test' => 123'}`,
+        # the resulting selector will be:
+        #
+        #     {'foo' => 'bar', '$or' => [{'hello' => 'world'}, {'test' => 123}]}
+        #
+        # This does not implement an OR between the existing selector and the
+        # new operator expression - handling this is the job of upstream
+        # methods. This method simply stores op_expr into the selector on the
+        # assumption that the existing selector is the correct left hand side
+        # of the operation already.
+        #
+        # For non-logical query-level operators like $where and $text, if
+        # there already is a top-level operator with the same name, the
+        # op_expr is added to the selector via a top-level $and operator,
+        # thus producing a selector having both operator values.
+        #
+        # This method does not simplify values (i.e. if the selector is
+        # currently empty and operator is $and, op_expr is written to the
+        # selector with $and even if the $and can in principle be elided).
+        #
+        # This method mutates the receiver.
+        #
+        # @param [ String ] operator The operator to add.
+        # @param [ Hash ] op_expr Operator value to add.
+        #
+        # @return [ Storable ] self.
+        def add_operator_expression(operator, op_expr)
+          unless operator.is_a?(String)
+            raise ArgumentError, "Operator must be a string: #{operator}"
+          end
+
+          unless operator[0] == ?$
+            raise ArgumentError, "Operator must begin with $: #{operator}"
+          end
+
+          if %w($and $nor $or).include?(operator)
+            return add_logical_operator_expression(operator, op_expr)
+          end
+
+          # For other operators, if the operator already exists in the
+          # query, add the new condition with $and, otherwise add the
+          # new condition to the top level.
+          if selector[operator]
+            add_logical_operator_expression('$and', [{operator => op_expr}])
+          else
+            selector.store(operator, op_expr)
+          end
+        end
+
+        # Adds a logical operator expression to the selector.
+        #
+        # This method only handles logical operators ($and, $nor and $or).
+        # It raises ArgumentError if called with another operator. Note that
+        # in MongoDB, $not is a field-level operator and not a query-level one
+        # $not is not handled by this method as a result.
+        #
+        # This method takes the operator and the operator value expression
+        # separately for callers' convenience. It can be considered to
+        # handle storing the hash `{operator => op_expr}`.
+        #
+        # If the selector already has the specified operator in it (on the
+        # top level), the new condition given in op_expr is added to the
+        # existing conditions for the specified operator. This is
+        # straightforward for $and; for other logical operators, the behavior
+        # of this method is to add the new conditions to the existing operator.
+        # For example, if the selector is currently:
+        #
+        #     {'foo' => 'bar', '$or' => [{'hello' => 'world'}]}
+        #
+        # ... and operator is '$or' and op_expr is `{'test' => 123'}`,
+        # the resulting selector will be:
+        #
+        #     {'foo' => 'bar', '$or' => [{'hello' => 'world'}, {'test' => 123}]}
+        #
+        # This does not implement an OR between the existing selector and the
+        # new operator expression - handling this is the job of upstream
+        # methods. This method simply stores op_expr into the selector on the
+        # assumption that the existing selector is the correct left hand side
+        # of the operation already.
+        #
+        # This method does not simplify values (i.e. if the selector is
+        # currently empty and operator is $and, op_expr is written to the
+        # selector with $and even if the $and can in principle be elided).
+        #
+        # This method mutates the receiver.
+        #
+        # @param [ String ] operator The operator to add.
+        # @param [ Hash ] op_expr Operator value to add.
+        #
+        # @return [ Storable ] self.
+        def add_logical_operator_expression(operator, op_expr)
+          unless operator.is_a?(String)
+            raise ArgumentError, "Operator must be a string: #{operator}"
+          end
+
+          unless %w($and $nor $or).include?(operator)
+            raise ArgumentError, "This method only handles logical operators ($and, $nor, $or). Operator given: #{operator}"
+          end
+
+          unless op_expr.is_a?(Array)
+            raise ArgumentError, "Operator value expression must be an array: #{op_expr}"
+          end
+
+          if selector.length == 1 && selector.keys.first == operator
+            new_value = selector.values.first + op_expr
+            selector.store(operator, new_value)
+          elsif operator == '$and' || selector.empty?
+            # $and can always be added to top level and it will be combined
+            # with whatever other conditions exist.
+            selector.store(operator, op_expr)
+          else
+            # Other operators need to operate explicitly on the previous
+            # conditions and the new condition.
+            new_value = [selector.to_hash.dup] + op_expr
+            selector.replace(operator => new_value)
+          end
+
+          self
+        end
+
+        # Adds a field expression to the query.
+        #
+        # field must be a field name, and it must be a string. The upstream
+        # code must have converted other field/key types to the simple string
+        # form by the time this method is invoked.
+        #
+        # This method performs no processing on the provided field value.
+        #
+        # Mutates the receiver.
+        #
+        # @param [ String ] field The field name.
+        # @param [ Object ] value The field value.
+        #
+        # @return [ Storable ] self.
+        def add_field_expression(field, value)
+          unless field.is_a?(String)
+            raise ArgumentError, "Field must be a string: #{field}"
+          end
+
+          if field[0] == ?$
+            raise ArgumentError, "Field cannot be an operator (i.e. begin with $): #{field}"
+          end
+
+          if selector[field]
+            # We already have a restriction by the field we are trying
+            # to restrict, combine the restrictions.
+            if value.is_a?(Hash) && selector[field].is_a?(Hash) &&
+              value.keys.all? { |key|
+                key_s = key.to_s
+                key_s[0] == ?$ && !selector[field].key?(key_s)
+              }
+            then
+              # Multiple operators can be combined on the same field by
+              # adding them to the existing hash.
+              new_value = selector[field].merge(value)
+              selector.store(field, new_value)
+            else
+              add_operator_expression('$and', [{field => value}])
+            end
+          else
+            selector.store(field, value)
+          end
+
+          self
+        end
+
+        # Adds an arbitrary expression to the query.
+        #
+        # Field can either be a field name or an operator.
+        #
+        # Mutates the receiver.
+        #
+        # @param [ String ] field Field name or operator name.
+        # @param [ Object ] value Field value or operator expression.
+        #
+        # @return [ Storable ] self.
+        def add_one_expression(field, value)
+          unless field.is_a?(String)
+            raise ArgumentError, "Field must be a string: #{field}"
+          end
+
+          if field[0] == ?$
+            add_operator_expression(field, value)
+          else
+            add_field_expression(field, value)
+          end
+        end
+
+      end
+    end
+  end
+end

--- a/spec/mongoid/criteria/findable_spec.rb
+++ b/spec/mongoid/criteria/findable_spec.rb
@@ -1250,7 +1250,7 @@ describe Mongoid::Criteria::Findable do
       let(:criteria) { Mongoid::Criteria.new(Band).where(id: 2) }
 
       it 'adds id' do
-        expect(result.selector).to eq('$and' => [{'_id' => 2}], '_id' => 1)
+        expect(result.selector).to eq('_id' => 2, '$and' => [{'_id' => 1}])
       end
     end
   end

--- a/spec/mongoid/criteria/queryable/expandable_spec.rb
+++ b/spec/mongoid/criteria/queryable/expandable_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+# encoding: utf-8
+
+require "spec_helper"
+
+describe Mongoid::Criteria::Queryable::Expandable do
+
+  let(:query) do
+    Mongoid::Query.new
+  end
+
+  describe '#expand_condition' do
+
+    let(:expanded) do
+      query.send(:expand_condition, condition)
+    end
+
+    context 'field name => value' do
+      shared_examples_for 'expands' do
+
+        it 'expands' do
+          expanded.should == {'foo' => 'bar'}
+        end
+      end
+
+      context 'string key' do
+        let(:condition) do
+          {'foo' => 'bar'}
+        end
+
+        it_behaves_like 'expands'
+      end
+
+      context 'symbol key' do
+        let(:condition) do
+          {foo: 'bar'}
+        end
+
+        it_behaves_like 'expands'
+      end
+    end
+
+    context 'Key instance => value' do
+      let(:key) do
+        Mongoid::Criteria::Queryable::Key.new(:foo, :__override__, '$gt')
+      end
+
+      let(:condition) do
+        {key => 'bar'}
+      end
+
+      it 'expands' do
+        expanded.should == {'foo' => {'$gt' => 'bar'}}
+      end
+    end
+
+=begin
+    context 'operator => operator value expression' do
+      shared_examples_for 'expands' do
+
+        it 'expands' do
+          expanded.should == {'foo' => 'bar'}
+        end
+      end
+
+      context 'string key' do
+        let(:condition) do
+          {'$in' => %w(bar)}
+        end
+
+        it_behaves_like 'expands'
+      end
+
+      context 'symbol key' do
+        let(:condition) do
+          {:$in => %w(bar)}
+        end
+
+        it_behaves_like 'expands'
+      end
+    end
+=end
+  end
+end

--- a/spec/mongoid/criteria/queryable/selectable_spec.rb
+++ b/spec/mongoid/criteria/queryable/selectable_spec.rb
@@ -2168,6 +2168,8 @@ describe Mongoid::Criteria::Queryable::Selectable do
 
   describe "#where" do
 
+    let(:query_method) { :where }
+
     context "when provided no criterion" do
 
       let(:selection) do
@@ -2187,24 +2189,7 @@ describe Mongoid::Criteria::Queryable::Selectable do
       end
     end
 
-    context "when provided nil" do
-
-      let(:selection) do
-        query.where(nil)
-      end
-
-      it "does not add any criterion" do
-        expect(selection.selector).to eq({})
-      end
-
-      it "returns the query" do
-        expect(selection).to eq(query)
-      end
-
-      it "returns a cloned query" do
-        expect(selection).to_not equal(query)
-      end
-    end
+    it_behaves_like 'requires a non-nil argument'
 
     context "when provided a string" do
 
@@ -2938,7 +2923,7 @@ describe Mongoid::Criteria::Queryable::Selectable do
 
         it "merges the strategies on the same field" do
           expect(selection.selector).to eq(
-            { "field" => { "$gt" => 5, "$lt" => 10, "$ne" => 7 }}
+            "field" => { "$gt" => 5, "$lt" => 10, "$ne" => 7 }
           )
         end
       end
@@ -2950,7 +2935,7 @@ describe Mongoid::Criteria::Queryable::Selectable do
         end
 
         it "combines conditions" do
-          expect(selection.selector).to eq('$and' => [{'field' => 5}], "field" => 10 )
+          expect(selection.selector).to eq("field" => 5, '$and' => [{'field' => 10}] )
         end
       end
     end
@@ -2965,7 +2950,7 @@ describe Mongoid::Criteria::Queryable::Selectable do
 
         it "merges the strategies on the same field" do
           expect(selection.selector).to eq(
-            { "field" => { "$gt" => 5, "$lt" => 10, "$ne" => 7 }}
+            "field" => { "$gt" => 5, "$lt" => 10, "$ne" => 7 }
           )
         end
       end

--- a/spec/mongoid/criteria/queryable/storable_spec.rb
+++ b/spec/mongoid/criteria/queryable/storable_spec.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+# encoding: utf-8
+
+require "spec_helper"
+
+describe Mongoid::Criteria::Queryable::Storable do
+
+  let(:query) do
+    Mongoid::Query.new
+  end
+
+  shared_examples_for 'logical operator expressions' do
+
+    context '$and operator' do
+      context '$and to empty query' do
+        let(:modified) do
+          query.send(query_method, '$and', [{'foo' => 'bar'}])
+        end
+
+        it 'adds to top level' do
+          modified.selector.should == {'$and' => [{'foo' => 'bar'}]}
+        end
+      end
+
+      context '$and to query with other keys' do
+        let(:query) do
+          Mongoid::Query.new.where(zoom: 'zoom')
+        end
+
+        let(:modified) do
+          query.send(query_method, '$and', [{'foo' => 'bar'}])
+        end
+
+        it 'adds to top level' do
+          modified.selector.should == {'zoom' => 'zoom',
+            '$and' => [{'foo' => 'bar'}]}
+        end
+      end
+
+      context '$and to query with $and' do
+        let(:query) do
+          Mongoid::Query.new.where('$and' => [{zoom: 'zoom'}])
+        end
+
+        let(:modified) do
+          query.send(query_method, '$and', [{'foo' => 'bar'}])
+        end
+
+        it 'adds to existing $and' do
+          modified.selector.should == {
+            '$and' => [{'zoom' => 'zoom'}, {'foo' => 'bar'}]}
+        end
+      end
+
+    end
+
+    context '$or operator' do
+      context '$or to empty query' do
+        let(:modified) do
+          query.send(query_method, '$or', [{'foo' => 'bar'}])
+        end
+
+        it 'adds to top level' do
+          modified.selector.should == {'$or' => [{'foo' => 'bar'}]}
+        end
+      end
+
+      context '$or to query with other keys' do
+        let(:query) do
+          Mongoid::Query.new.where(zoom: 'zoom')
+        end
+
+        let(:modified) do
+          query.send(query_method, '$or', [{'foo' => 'bar'}])
+        end
+
+        it 'replaces top level' do
+          modified.selector.should == {
+            '$or' => [{'zoom' => 'zoom'}, {'foo' => 'bar'}]}
+        end
+      end
+
+      context '$or to query with $or' do
+        let(:query) do
+          Mongoid::Query.new.where('$or' => [{zoom: 'zoom'}])
+        end
+
+        let(:modified) do
+          query.send(query_method, '$or', [{'foo' => 'bar'}])
+        end
+
+        it 'adds to existing $or' do
+          modified.selector.should == {
+            '$or' => [{'zoom' => 'zoom'}, {'foo' => 'bar'}]}
+        end
+      end
+
+    end
+  end
+
+  describe '#add_operator_expression' do
+    let(:query_method) { :add_operator_expression }
+
+    it_behaves_like 'logical operator expressions'
+  end
+
+  describe '#add_logical_operator_expression' do
+    let(:query_method) { :add_logical_operator_expression }
+
+    it_behaves_like 'logical operator expressions'
+  end
+end

--- a/spec/mongoid/criteria_spec.rb
+++ b/spec/mongoid/criteria_spec.rb
@@ -3549,7 +3549,7 @@ describe Mongoid::Criteria do
       let(:criteria) { Band.where(foo: 1).where(foo: 2) }
 
       it 'combines criteria' do
-        expect(criteria.selector).to eq('$and' => [{'foo' => 1}], 'foo' => 2)
+        expect(criteria.selector).to eq('foo' => 1, '$and' => [{'foo' => 2}])
       end
     end
 
@@ -3557,15 +3557,17 @@ describe Mongoid::Criteria do
       let(:criteria) { Band.where(foo: 1, bar: 3).where(foo: 2) }
 
       it 'combines criteria' do
-        expect(criteria.selector).to eq('$and' => [{'foo' => 1, 'bar' => 3}], 'foo' => 2)
+        expect(criteria.selector).to eq(
+          'foo' => 1, '$and' => [{'foo' => 2}], 'bar' => 3)
       end
     end
 
     context 'when given same key in separate calls and other criteria are added later' do
       let(:criteria) { Band.where(foo: 1).where(foo: 2).where(bar: 3) }
 
-      it 'adds other criteria to top level' do
-        expect(criteria.selector).to eq('$and' => [{'foo' => 1}], 'foo' => 2, 'bar' => 3)
+      it 'combines criteria' do
+        expect(criteria.selector).to eq(
+          'foo' => 1, '$and' => [{'foo' => 2}], 'bar' => 3)
       end
     end
   end


### PR DESCRIPTION
a#and

- MONGOID-4806 Produce the same query shapes with Criteria#where and Criteria#and
- MONGOID-4810 Make Criteria#where reject nil arguments
- MONGOID-4813 Implement negation of $where queries via Criteria#where method

This change also adds Expandable and Storable modules under Critera::Queryable to handle query
expansion and writes to selectors, respectively. The plan is to migrate existing code from
Selectable/Mergeable modules into Expandable and Storable over time.
