### PR TITLE
MONGOID-4832 Attribute validation should not allow false values for Hash and Array types

### DIFF
--- a/lib/mongoid/attributes.rb
+++ b/lib/mongoid/attributes.rb
@@ -347,7 +347,7 @@ module Mongoid
     #
     # @since 3.0.10
     def validate_attribute_value(access, value)
-      return unless fields[access] && value
+      return unless fields[access] && !value.nil?
       validatable_types = [ Hash, Array ]
       if validatable_types.include? fields[access].type
         unless value.is_a? fields[access].type

--- a/spec/mongoid/attributes_spec.rb
+++ b/spec/mongoid/attributes_spec.rb
@@ -1353,6 +1353,10 @@ describe Mongoid::Attributes do
         expect {
           person.map = []
         }.to raise_error(Mongoid::Errors::InvalidValue)
+
+        expect {
+          person.map = false
+        }.to raise_error(Mongoid::Errors::InvalidValue)
       end
 
       it "can set a Hash value" do
@@ -1370,6 +1374,10 @@ describe Mongoid::Attributes do
       it "raises an error when try to set an invalid value" do
         expect {
           person.aliases = {}
+        }.to raise_error(Mongoid::Errors::InvalidValue)
+
+        expect {
+          person.aliases = false
         }.to raise_error(Mongoid::Errors::InvalidValue)
       end
     end


### PR DESCRIPTION
See: https://jira.mongodb.org/browse/MONGOID-4832