### PR TITLE
MONGOID-4838: Add in setter-method check for attribute before passing attrs into new

### DIFF
--- a/lib/mongoid/copyable.rb
+++ b/lib/mongoid/copyable.rb
@@ -24,7 +24,11 @@ module Mongoid
       attrs = clone_document.except("_id", "id")
       dynamic_attrs = {}
       attrs.reject! do |attr_name, value|
-        dynamic_attrs.merge!(attr_name => value) unless self.attribute_names.include?(attr_name)
+        if !self.attribute_names.include?(attr_name)
+          dynamic_attrs.merge!(attr_name => value) 
+        else
+          !self.respond_to?("#{attr_name}=")
+        end
       end
       self.class.new(attrs).tap do |object|
         dynamic_attrs.each do |attr_name, value|


### PR DESCRIPTION
We're using `#clone` in production, and have had to occasionally remove fields from classes, and did not see a need to fully migrate the data to unset the attribute on each instance. 

However, we're now running into `NoMethoError`s when calling `.clone` because it uses `self.class.new(attrs)` to instantiate the a data-filled object. I guess an alternative might be to literally call `instantiate` on the class and then tap into it, cycle through attrs in the same `dynamic_attrs` is assigned. I guess it comes down to if we want it to be a proper clone, with all of the attributes, even the ones without getters/setters on the class presently, or just a clone of a valid object based on the fields that are currently configured on the class.

Any thoughts?