### PR TITLE
Add translated message for restrict_with_error association

### DIFF
--- a/lib/config/locales/en.yml
+++ b/lib/config/locales/en.yml
@@ -2,6 +2,8 @@ en:
   mongoid:
     errors:
       messages:
+        restrict_with_error_dependent_destroy:
+          "Cannot delete record because associated objects exist at %{association}."
         blank_in_locale:
           "can't be blank in %{location}"
         message_title: "message"

--- a/lib/mongoid/association/depending.rb
+++ b/lib/mongoid/association/depending.rb
@@ -131,7 +131,9 @@ module Mongoid
 
       def _dependent_restrict_with_error!(association)
         if (relation = send(association.name)) && !relation.blank?
-          errors.add(association.name, RESTRICT_ERROR_MSG)
+          association_name_translated = ::I18n.translate("activerecord.models.#{association.name}", default: association.name.to_s)
+
+          errors.add(:base, :restrict_with_error_dependent_destroy, association: association_name_translated)
           throw(:abort, false)
         end
       end

--- a/spec/mongoid/association/depending_spec.rb
+++ b/spec/mongoid/association/depending_spec.rb
@@ -849,8 +849,11 @@ describe Mongoid::Association::Depending do
 
       it 'adds an error to the parent object' do
         expect(person.delete).to be(false)
-        expect(person.errors[:restrictable_posts].first).to be(
-          Mongoid::Association::Depending::RESTRICT_ERROR_MSG)
+
+        key_message = "#{Mongoid::Errors::MongoidError::BASE_KEY}.restrict_with_error_dependent_destroy"
+        expect(person.errors[:base].first).to eq(
+          ::I18n.translate(key_message, association: :restrictable_posts)
+        )
       end
     end
 


### PR DESCRIPTION
When trying to destroy an object with a restrict_with_error dependent, the resulting error message is fixed.
Theses changes allow internationalize the error message, displaying which model is related to the object being destroyed.