### PR TITLE
[MONGOID-4850] Consolidate delegation

### DIFF
--- a/lib/mongoid.rb
+++ b/lib/mongoid.rb
@@ -3,7 +3,6 @@
 
 require "support/ruby_version"
 
-require "delegate"
 require "time"
 require "set"
 
@@ -109,5 +108,5 @@ module Mongoid
   #   Mongoid.database = Mongo::Connection.new.db("test")
   #
   # @since 1.0.0
-  delegate(*(Config.public_instance_methods(false) - [ :logger=, :logger ] << { to: Config }))
+  delegate(*(Config.public_instance_methods(false) - [:logger=, :logger]), to: Config)
 end

--- a/lib/mongoid.rb
+++ b/lib/mongoid.rb
@@ -3,7 +3,7 @@
 
 require "support/ruby_version"
 
-require "forwardable"
+require "delegate"
 require "time"
 require "set"
 
@@ -36,7 +36,6 @@ end
 I18n.load_path << File.join(File.dirname(__FILE__), "config", "locales", "en.yml")
 
 module Mongoid
-  extend Forwardable
   extend Loggable
   extend self
 
@@ -110,5 +109,5 @@ module Mongoid
   #   Mongoid.database = Mongo::Connection.new.db("test")
   #
   # @since 1.0.0
-  def_delegators Config, *(Config.public_instance_methods(false) - [ :logger=, :logger ])
+  delegate(*(Config.public_instance_methods(false) - [ :logger=, :logger ] << { to: Config }))
 end

--- a/lib/mongoid/association/many.rb
+++ b/lib/mongoid/association/many.rb
@@ -7,11 +7,10 @@ module Mongoid
     # This is the superclass for all many to one and many to many association
     # proxies.
     class Many < Association::Proxy
-      extend Forwardable
       include ::Enumerable
 
-      def_delegators :criteria, :avg, :max, :min, :sum
-      def_delegators :_target, :length, :size
+      delegate :avg, :max, :min, :sum, to: :criteria
+      delegate :length, :size, to: :_target
 
       # Is the association empty?
       #

--- a/lib/mongoid/association/proxy.rb
+++ b/lib/mongoid/association/proxy.rb
@@ -9,8 +9,6 @@ module Mongoid
     # This class is the superclass for all association proxy objects, and contains
     # common behavior for all of them.
     class Proxy
-      extend Forwardable
-
       alias :extend_proxy :extend
 
       # We undefine most methods to get them sent through to the target.
@@ -38,9 +36,9 @@ module Mongoid
       attr_accessor :_target
 
       # Backwards compatibility with Mongoid beta releases.
-      def_delegators :_association, :foreign_key, :inverse_foreign_key
-      def_delegators :binding, :bind_one, :unbind_one
-      def_delegator :_base, :collection_name
+      delegate :foreign_key, :inverse_foreign_key, to: :_association
+      delegate :bind_one, :unbind_one, to: :binding
+      delegate :collection_name, to: :_base
 
       # Convenience for setting the target and the association metadata properties since
       # all proxies will need to do this.

--- a/lib/mongoid/association/referenced/has_many/enumerable.rb
+++ b/lib/mongoid/association/referenced/has_many/enumerable.rb
@@ -11,7 +11,6 @@ module Mongoid
           # target that can be a criteria or array of _loaded documents. This
           # handles both cases or a combination of the two.
           class Enumerable
-            extend Forwardable
             include ::Enumerable
 
             # The three main instance variables are collections of documents.
@@ -21,7 +20,7 @@ module Mongoid
             # @attribute [rw] _unloaded A criteria representing persisted docs.
             attr_accessor :_added, :_loaded, :_unloaded
 
-            def_delegators [], :is_a?, :kind_of?
+            delegate :is_a?, :kind_of?, to: []
 
             # Check if the enumerable is equal to the other object.
             #

--- a/lib/mongoid/association/referenced/has_many/proxy.rb
+++ b/lib/mongoid/association/referenced/has_many/proxy.rb
@@ -9,10 +9,9 @@ module Mongoid
         # This class defines the behavior for all associations that are a
         # one-to-many between documents in different collections.
         class Proxy < Association::Many
-          extend Forwardable
 
-          def_delegator :criteria, :count
-          def_delegators :_target, :first, :in_memory, :last, :reset, :uniq
+          delegate :count, to: :criteria
+          delegate :first, :in_memory, :last, :reset, :uniq, to: :_target
 
           # Appends a document or array of documents to the association. Will set
           # the parent and update the index in the process.

--- a/lib/mongoid/config.rb
+++ b/lib/mongoid/config.rb
@@ -10,11 +10,11 @@ module Mongoid
   # This module defines all the configuration options for Mongoid, including
   # the database connections.
   module Config
-    extend Forwardable
-    extend Options
     extend self
+    extend Options
 
-    def_delegators ::Mongoid, :logger, :logger=
+    delegate :logger=, to: ::Mongoid
+    delegate :logger, to: ::Mongoid
 
     LOCK = Mutex.new
 

--- a/lib/mongoid/config/options.rb
+++ b/lib/mongoid/config/options.rb
@@ -34,11 +34,8 @@ module Mongoid
         defaults[name] = settings[name] = options[:default]
 
         class_eval do
-          # log_level accessor is defined specially below
-          unless name.to_sym == :log_level
-            define_method(name) do
-              settings[name]
-            end
+          define_method(name) do
+            settings[name]
           end
 
           define_method("#{name}=") do |value|

--- a/lib/mongoid/contextual.rb
+++ b/lib/mongoid/contextual.rb
@@ -8,22 +8,21 @@ require "mongoid/contextual/none"
 
 module Mongoid
   module Contextual
-    extend Forwardable
 
     # The aggregate operations provided in the aggregate module get delegated
     # through to the context from the criteria.
-    def_delegators :context, *Aggregable::Mongo.public_instance_methods(false)
+    delegate(*Aggregable::Mongo.public_instance_methods(false), to: :context)
 
     # The atomic operations provided in the atomic context get delegated
     # through to the context from the criteria.
-    def_delegators :context, *Atomic.public_instance_methods(false)
+    delegate(*Atomic.public_instance_methods(false), to: :context)
 
     # The methods in the contexts themselves should all get delegated to,
     # including destructive, modification, and optional methods.
-    def_delegators :context, *(Mongo.public_instance_methods(false) - [ :skip, :limit ])
+    delegate(*(Mongo.public_instance_methods(false) - [ :skip, :limit ]), to: :context)
 
     # This gets blank and empty included.
-    def_delegators :context, *Queryable.public_instance_methods(false)
+    delegate(*Queryable.public_instance_methods(false), to: :context)
 
     # Get the context in which criteria queries should execute. This is either
     # in memory (for embedded documents) or mongo (for root level documents.)

--- a/lib/mongoid/contextual/geo_near.rb
+++ b/lib/mongoid/contextual/geo_near.rb
@@ -4,12 +4,11 @@
 module Mongoid
   module Contextual
     class GeoNear
-      extend Forwardable
       include Enumerable
       include Command
 
-      def_delegator :results, :[]
-      def_delegators :entries, :==, :empty?
+      delegate :[], to: :results
+      delegate :==, :empty?, to: :entries
 
       # Get the average distance for all documents from the point in the
       # command.

--- a/lib/mongoid/contextual/map_reduce.rb
+++ b/lib/mongoid/contextual/map_reduce.rb
@@ -4,12 +4,11 @@
 module Mongoid
   module Contextual
     class MapReduce
-      extend Forwardable
       include Enumerable
       include Command
 
-      def_delegators :results, :[]
-      def_delegators :entries, :==, :empty?
+      delegate :[], to: :results
+      delegate :==, :empty?, to: :entries
 
       # Get all the counts returned by the map/reduce.
       #

--- a/lib/mongoid/contextual/mongo.rb
+++ b/lib/mongoid/contextual/mongo.rb
@@ -11,7 +11,6 @@ require "mongoid/association/eager_loadable"
 module Mongoid
   module Contextual
     class Mongo
-      extend Forwardable
       include Enumerable
       include Aggregable::Mongo
       include Atomic
@@ -350,7 +349,7 @@ module Mongoid
         apply_options
       end
 
-      def_delegator :@klass, :database_field_name
+      delegate(:database_field_name, to: :@klass)
 
       # Get the last document in the database for the criteria's selector.
       #

--- a/lib/mongoid/fields/standard.rb
+++ b/lib/mongoid/fields/standard.rb
@@ -4,13 +4,12 @@
 module Mongoid
   module Fields
     class Standard
-      extend Forwardable
 
       # Defines the behavior for defined fields in the document.
       # Set readers for the instance variables.
       attr_accessor :default_val, :label, :name, :options
 
-      def_delegators :type, :demongoize, :evolve, :mongoize
+      delegate :demongoize, :evolve, :mongoize, to: :type
 
       # Adds the atomic changes for this type of resizable field.
       #

--- a/lib/mongoid/findable.rb
+++ b/lib/mongoid/findable.rb
@@ -8,16 +8,15 @@ module Mongoid
   #
   # @since 4.0.0
   module Findable
-    extend Forwardable
 
-    def_delegators :with_default_scope, *(
+    delegate *(
       Criteria::Queryable::Selectable.forwardables +
       Criteria::Queryable::Optional.forwardables
-    )
+    ), to: :with_default_scope
 
     # These are methods defined on the criteria that should also be accessible
     # directly from the class level.
-    def_delegators :with_default_scope,
+    delegate \
       :aggregates,
       :avg,
       :create_with,
@@ -46,7 +45,7 @@ module Mongoid
       :sum,
       :text_search,
       :update,
-      :update_all
+      :update_all, to: :with_default_scope
 
     # Returns a count of records in the database.
     # If you want to specify conditions use where.

--- a/lib/mongoid/persistence_context.rb
+++ b/lib/mongoid/persistence_context.rb
@@ -8,13 +8,11 @@ module Mongoid
   #
   # @since 6.0.0
   class PersistenceContext
-    extend Forwardable
-
     # Delegate the cluster method to the client.
-    def_delegators :client, :cluster
+    delegate :cluster, to: :client
 
     # Delegate the storage options method to the object.
-    def_delegators :@object, :storage_options
+    delegate :storage_options, to: :@object
 
     # The options defining this persistence context.
     #

--- a/lib/mongoid/serializable.rb
+++ b/lib/mongoid/serializable.rb
@@ -13,10 +13,8 @@ module Mongoid
     # We need to redefine where the JSON configuration is getting defined,
     # similar to +ActiveRecord+.
     included do
-      extend Forwardable
-
       undef_method :include_root_in_json
-      def_delegator ::Mongoid, :include_root_in_json
+      delegate :include_root_in_json, to: ::Mongoid
     end
 
     # Gets the document as a serializable hash, used by ActiveModel's JSON

--- a/lib/mongoid/timestamps/timeless.rb
+++ b/lib/mongoid/timestamps/timeless.rb
@@ -44,13 +44,11 @@ module Mongoid
       end
 
       class << self
-        extend Forwardable
 
         def timeless_table
           Thread.current['[mongoid]:timeless'] ||= Hash.new
         end
-
-        def_delegators :timeless_table, :[]=, :[]
+        delegate :[]=, :[], to: :timeless_table
       end
 
       private

--- a/spec/app/models/customer.rb
+++ b/spec/app/models/customer.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+# encoding: utf-8
+
+class Customer
+  include Mongoid::Document
+
+  embeds_one :address, as: :addressable
+
+  delegate :name, to: :address
+end

--- a/spec/integration/associations/embedded_spec.rb
+++ b/spec/integration/associations/embedded_spec.rb
@@ -118,4 +118,13 @@ describe 'embedded associations' do
       it_behaves_like 'an embedded association'
     end
   end
+
+  context 'when a model uses #delegate from ActiveSupport' do
+    it 'delegates the method call without error' do
+      address = Address.new(name: 'ACME Inc.')
+      customer = Customer.create!(address: address)
+
+      expect(customer.name).to eq(address.name)
+    end
+  end
 end


### PR DESCRIPTION
https://jira.mongodb.org/browse/MONGOID-4850

Since the gem already requires "active_support/core_ext" which includes

https://api.rubyonrails.org/classes/Module.html#method-i-delegate

we can remove all other variants of delegators and consolidate
delegation on this one way to do it.