### PR TITLE
MONGOID-4852 add release notes for 7.0 and document missing features

### DIFF
--- a/docs/tutorials/mongoid-configuration.txt
+++ b/docs/tutorials/mongoid-configuration.txt
@@ -243,10 +243,7 @@ can be configured.
       # error. (default: true)
       belongs_to_required_by_default: true
       
-      # Raise an exception when a field is defined in a model and it has a
-      # method of the same name already defined. Also prevents a field from
-      # being redefined. Use :overwrite option when defining a field to
-      # overwrite existing method/field definition. (default: false)
+      # Raise an exception when a field is redefined. (default: false)
       duplicate_fields_exception: false
       
       # Include the root model name in json serialization. (default: false)

--- a/docs/tutorials/mongoid-configuration.txt
+++ b/docs/tutorials/mongoid-configuration.txt
@@ -229,6 +229,26 @@ can be configured.
 
     # Configure Mongoid specific options. (optional)
     options:
+      # Application name that is printed to the mongodb logs upon establishing
+      # a connection in server versions >= 3.4. Note that the name cannot
+      # exceed 128 bytes. It is also used as the database name if the
+      # database name is not explicitly defined. (default: nil)
+      app_name: MyApplicationName
+      
+      # Create indexes in background by default. (default: false)
+      background_indexing: false
+      
+      # Mark belongs_to associations as required by default, so that saving a
+      # model with a missing belongs_to association will trigger a validation
+      # error. (default: true)
+      belongs_to_required_by_default: true
+      
+      # Raise an exception when a field is defined in a model and it has a
+      # method of the same name already defined. Also prevents a field from
+      # being redefined. Use :overwrite option when defining a field to
+      # overwrite existing method/field definition. (default: false)
+      duplicate_fields_exception: false
+      
       # Include the root model name in json serialization. (default: false)
       include_root_in_json: false
 

--- a/docs/tutorials/mongoid-configuration.txt
+++ b/docs/tutorials/mongoid-configuration.txt
@@ -235,6 +235,14 @@ can be configured.
       # Include the _type field in serialization. (default: false)
       include_type_for_serialization: false
 
+      # Whether to join nested persistence contexts for atomic operations
+      # to parent contexts by default. (default: false)
+      join_contexts: false
+
+      # Set the Mongoid and Ruby driver log levels when Mongoid is not using
+      # Ruby on Rails logger instance. (default: :info)
+      log_level: :info
+      
       # Preload all models in development, needed when models use
       # inheritance. (default: false)
       preload_models: false
@@ -256,14 +264,6 @@ can be configured.
       # further information. Most applications should not use this option.
       # (default: false)
       use_utc: false
-
-      # Set the Mongoid and Ruby driver log levels when Mongoid is not using
-      # Ruby on Rails logger instance. (default: :info)
-      log_level: :info
-      
-      # Whether to join nested persistence contexts for atomic operations
-      # to parent contexts by default. (default: false)
-      join_contexts: false
 
 The Ruby driver options may be found in 
 `the driver documentation <https://docs.mongodb.com/ruby-driver/current/tutorials/ruby-driver-create-client/>`_.

--- a/docs/tutorials/mongoid-documents.txt
+++ b/docs/tutorials/mongoid-documents.txt
@@ -620,9 +620,41 @@ in object is a ``Point`` first, in case we also want to be able to pass in ordin
 Reserved Names
 **************
 
-If you define a field on your document that conflicts with a reserved method name in Mongoid,
-the configuration will raise an error. For a list of these you may look at
-``Mongoid.destructive_fields``.
+Attempting to define a field on a document that conflicts with a reserved
+method name in Mongoid will raise an error. The list of reserved names can
+be obtained by invoking the ``Mongoid.destructive_fields`` method.
+
+Field Redefinition
+******************
+
+By default Mongoid allows redefining fields on a model. To raise an error
+when a field is redefined, set the ``duplicate_fields_exception``
+:ref:`configuration option <configuration-options>` to ``true``.
+
+With the option set to true, the following example will raise an error:
+
+.. code-block:: ruby
+
+  class Person
+    include Mongoid::Document
+    
+    field :name
+    
+    field :name, type: String
+  end
+
+To define the field anyway, use the ``overwrite: true`` option:
+
+.. code-block:: ruby
+
+  class Person
+    include Mongoid::Document
+    
+    field :name
+    
+    field :name, type: String, overwrite: true
+  end
+
 
 Custom Ids
 **********

--- a/docs/tutorials/mongoid-documents.txt
+++ b/docs/tutorials/mongoid-documents.txt
@@ -1005,11 +1005,14 @@ calling ``Model#previous_changes``.
    # View the previous changes.
    person.previous_changes # { "name" => [ "Alan Parsons", "Alan Garner" ] }
 
-Readonly Attributes
+.. _read-only:
+
+Read-Only Attributes
 -------------------
 
-You can tell Mongoid that certain attributes are readonly. This will allow documents to be
-created with these attributes, but changes to them will be filtered out.
+You can tell Mongoid that certain attributes are read-only. This will allow
+documents to be created with these attributes, but changes to them will be
+ignored when using mass update methods such as ``update_attributes``:
 
 .. code-block:: ruby
 
@@ -1024,8 +1027,8 @@ created with these attributes, but changes to them will be filtered out.
    band = Band.create(name: "Placebo")
    band.update_attributes(name: "Tool") # Filters out the name change.
 
-If you explicitly try to update or remove the attribute by itself, then a ``ReadonlyAttribute``
-error will be raised.
+If you explicitly try to update or remove a read-only attribute by itself,
+a ``ReadonlyAttribute`` exception will be raised:
 
 .. code-block:: ruby
 

--- a/docs/tutorials/mongoid-indexes.txt
+++ b/docs/tutorials/mongoid-indexes.txt
@@ -72,6 +72,10 @@ the collection is large and index creation may take a long time:
       index({ ssn: 1 }, { unique: true, background: true })
     end
 
+If the ``background_indexing`` :ref:`configuration option
+<configuration-options>` is true, the indexes are created in the background
+unless the ``background: false`` option is provided.
+
 *Deprecated:* When using MongoDB 2.6, you can drop the duplicate entries
 for unique indexes that are defined for a column that might
 already have duplicate values by specifying the ``drop_dups`` option:

--- a/docs/tutorials/mongoid-persistence.txt
+++ b/docs/tutorials/mongoid-persistence.txt
@@ -474,10 +474,12 @@ changes performed by each block as soon as the block ends:
   end
 
 This behavior can be changed by specifying the ``join_context: true`` option
-to ``#atomically``. When using this option, nested ``#atomically`` blocks
-are joined with the outer blocks, and only the outermost block (or the
-first block where ``join_contexts`` is false) actually writes changes to
-the cluster. For example:
+to ``#atomically``, or globally by setting the ``join_contexts``
+:ref:`configuration option <configuration-options>` to ``true``. When
+context joining is enabled, nested ``#atomically`` blocks are joined with
+the outer blocks, and only the outermost block (or the first block where
+``join_contexts`` is false) actually writes changes to the cluster.
+For example:
 
 .. code-block:: ruby
 

--- a/docs/tutorials/mongoid-queries.txt
+++ b/docs/tutorials/mongoid-queries.txt
@@ -775,8 +775,11 @@ Mongoid also has some helpful methods on criteria.
 
    * - ``Criteria#find``
 
-       *Find a document or multiple documents by their ids. Will raise
-       an error by default if any of the ids do not match.*
+       *Find a document or multiple documents by their ids. If the*
+       ``raise_not_found_error`` *configuration option is set to* ``true``
+       *which is the default and any of the ids are not found, raise an error.
+       If the* ``raise_not_found_error`` *configuration option is set to*
+       ``false``, return an array of documents that have the specified ids.*
 
      -
         .. code-block:: ruby
@@ -792,9 +795,9 @@ Mongoid also has some helpful methods on criteria.
 
    * - ``Criteria#find_by``
 
-       *Find a document by the provided attributes, and if not found
-       raise an error or return nil depending on the
-       * ``raise_not_found_error`` *configuration option.*
+       *Find a document by the provided attributes. If not found,
+       raise an error or return nil depending on the value of the*
+       ``raise_not_found_error`` *configuration option.*
 
      -
         .. code-block:: ruby
@@ -1186,7 +1189,6 @@ by a provided name. Just like normal criteria, they are lazy and chainable.
 
   Band.english.rock # Get the English rock bands.
 
-
 Named scopes can take procs and blocks for accepting parameters or
 extending functionality.
 
@@ -1212,6 +1214,25 @@ extending functionality.
 
   Band.named("Depeche Mode") # Find Depeche Mode.
   Band.active.deutsch # Find active German bands.
+
+By default, Mongoid allows defining a scope that would shadow an existing
+class method, as the following example shows:
+
+.. code-block:: ruby
+
+  class Product
+    include Mongoid::Document
+    
+    def self.fresh
+      true
+    end
+    
+    scope :fresh, ->{ where(fresh: true) }
+  end
+
+To have Mongoid raise an error when a scope would overwrite an existing class
+method, set the ``scope_overwrite_exception`` :ref:`configuration option
+<configuration-options>` to ``true``.
 
 Default Scopes
 **************

--- a/docs/tutorials/mongoid-relations.txt
+++ b/docs/tutorials/mongoid-relations.txt
@@ -1151,3 +1151,115 @@ the ``_id`` field which is then used to load full models. An alternative is
 to not perform such a projection and work with raw fields, which would eliminate
 having to send the list of document ids to Mongoid in the second query
 (which could be large).
+
+.. _aggregation-pipeline-builder-dsl:
+
+Aggregation Pipeline Builder DSL
+********************************
+
+Mongoid provides limited support for constructing the aggregation pipeline
+itself using a high-level DSL. The following aggregation pipeline operators
+are supported:
+
+- `$group <https://docs.mongodb.com/manual/reference/operator/aggregation/group/>`_
+- `$project <https://docs.mongodb.com/manual/reference/operator/aggregation/project/>`_
+- `$unwind <https://docs.mongodb.com/manual/reference/operator/aggregation/unwind/>`_
+
+To construct a pipeline, call the corresponding aggregation pipeine methods
+on a ``Criteria`` instance. Aggregation pipeline operations are added to the
+``pipeline`` attribute of the ``Criteria`` instance. To execute the pipeline,
+pass the ``pipeline`` attribute value to ``Collection#aggragegate`` method.
+
+For example, given the following models:
+
+.. code-block:: ruby
+
+  class Tour
+    include Mongoid::Document
+    
+    embeds_many :participants
+    
+    field :name, type: String
+    field :states, type: Array
+  end
+  
+  class Participant
+    include Mongoid::Document
+    
+    embedded_in :tour
+    
+    field :name, type: String
+  end
+
+We could find out which states a participant visited:
+
+.. code-block:: ruby
+
+  criteria = Tour.where('participants.name' => 'Serenity',).
+    unwind(:states).
+    group(_id: 'states', :states.add_to_set => '$states').
+    project(_id: 0, states: 1)
+  
+  pp criteria.pipeline
+  # => [{"$match"=>{"participants.name"=>"Serenity"}},
+  #     {"$unwind"=>"$states"},
+  #     {"$group"=>{"_id"=>"states", "states"=>{"$addToSet"=>"$states"}}},
+  #     {"$project"=>{"_id"=>0, "states"=>1}}]
+  
+  Tour.collection.aggregate(criteria.pipeline).to_a
+
+group
+~~~~~
+
+The ``group`` method adds a `$group aggregation pipeline stage
+<https://docs.mongodb.com/manual/reference/operator/aggregation/group/>`_.
+
+The field expressions support Mongoid symbol-operator syntax:
+
+.. code-block:: ruby
+
+    criteria = Tour.all.group(_id: 'states', :states.add_to_set => '$states')
+    criteria.pipeline
+    # => [{"$group"=>{"_id"=>"states", "states"=>{"$addToSet"=>"$states"}}}]
+
+Alternatively, standard MongoDB aggregation pipeline syntax may be used:
+
+.. code-block:: ruby
+
+    criteria = Tour.all.group(_id: 'states', states: {'$addtoSet' => '$states'})
+
+project
+~~~~~~~
+
+The ``project`` method adds a `$project aggregation pipeline stage
+<https://docs.mongodb.com/manual/reference/operator/aggregation/project/>`_.
+
+The argument should be a Hash specifying the projection:
+
+.. code-block:: ruby
+
+    criteria = Tour.all.project(_id: 0, states: 1)
+    criteria.pipeline
+    # => [{"$project"=>{"_id"=>0, "states"=>1}}]
+
+.. _unwind-dsl:
+
+unwind
+~~~~~~
+
+The ``unwind`` method adds an `$unwind aggregation pipeline stage
+<https://docs.mongodb.com/manual/reference/operator/aggregation/unwind/>`_.
+
+The argument can be a field name, specifyable as a symbol or a string, or
+a Hash or a ``BSON::Document`` instance:
+
+.. code-block:: ruby
+
+    criteria = Tour.all.unwind(:states)
+    criteria = Tour.all.unwind('states')
+    criteria.pipeline
+    # => [{"$unwind"=>"$states"}]
+    
+    criteria = Tour.all.unwind(path: '$states')
+    criteria.pipeline
+    # => [{"$unwind"=>{:path=>"$states"}}]

--- a/docs/tutorials/mongoid-relations.txt
+++ b/docs/tutorials/mongoid-relations.txt
@@ -726,6 +726,8 @@ to the association.
 
   band.save # Fires all save callbacks on the band, albums, and label.
 
+.. _dependent-behavior:
+
 Dependent Behavior
 ******************
 

--- a/docs/tutorials/mongoid-relations.txt
+++ b/docs/tutorials/mongoid-relations.txt
@@ -132,8 +132,10 @@ Belongs To
 A ``belongs_to`` macro is used when a document is the child in a ``has_one``
 or ``has_many`` association. By default, in order for a document to
 be saved, each of its ``belongs_to`` associations must be provided a value.
-To override this requirement, you can use the option ``optional: false``
-on the ``belong_to`` association.
+To override this requirement for a particular association, use the option
+``optional: false`` on the ``belong_to`` association. To override this
+requirement globally, set the ``belongs_to_required_by_default``
+:ref:`configuration option <configuration-options>` to ``false``.
 
 Defining
 ~~~~~~~~

--- a/docs/tutorials/mongoid-upgrade.txt
+++ b/docs/tutorials/mongoid-upgrade.txt
@@ -240,6 +240,9 @@ ActiveRecord.
 Referenced associations now support all :ref:`dependent behaviors <dependent-behavior>`
 that `ActiveRecord supports <http://guides.rubyonrails.org/association_basics.html>`_.
 
+:ref:`$unwind <unwind-dsl>` operator support added to the :ref:`aggregation
+pipeline builder DSL <aggregation-pipeline-builder-dsl>`.
+
 This major version of Mongoid has a number of significant refactors, bug fixes
 and behavior corrections.
 

--- a/docs/tutorials/mongoid-upgrade.txt
+++ b/docs/tutorials/mongoid-upgrade.txt
@@ -232,7 +232,9 @@ Support for Ruby 2.2 and JRuby 9.1 has been dropped.
 Upgrading to Mongoid 7.0
 ------------------------
 
-The following sections describe major changes in Mongoid 7.0.
+Significant improvements and changes in Mongoid 7.0 are listed below.
+Please note that improvements that have been backported to Mongoid 6.x are
+not included in this list.
 
 The behavior of :ref:`read-only attributes <read-only>` now matches that of
 ActiveRecord.
@@ -243,14 +245,11 @@ that `ActiveRecord supports <http://guides.rubyonrails.org/association_basics.ht
 :ref:`$unwind <unwind-dsl>` operator support added to the :ref:`aggregation
 pipeline builder DSL <aggregation-pipeline-builder-dsl>`.
 
-This major version of Mongoid has a number of significant refactors, bug fixes
-and behavior corrections.
+``background_indexing`` Mongoid :ref:`configuration option
+<configuration-options>` added.
 
-Please see the list of behavior changes for version
-`7.0.0 <https://github.com/mongodb/mongoid/releases/tag/v7.0.0>`_
-and version
-`7.0.0.beta <https://github.com/mongodb/mongoid/releases/tag/v7.0.0.beta>`_
-for specific changes that might be required in your code.
+Mongoid 7.0 requires MongoDB server 2.6 or newer, Ruby 2.2.2 or higher and
+supports Rails 5.1-6.0.
 
 
 Upgrading to Mongoid 6

--- a/docs/tutorials/mongoid-upgrade.txt
+++ b/docs/tutorials/mongoid-upgrade.txt
@@ -237,6 +237,9 @@ The following sections describe major changes in Mongoid 7.0.
 The behavior of :ref:`read-only attributes <read-only>` now matches that of
 ActiveRecord.
 
+Referenced associations now support all :ref:`dependent behaviors <dependent-behavior>`
+that `ActiveRecord supports <http://guides.rubyonrails.org/association_basics.html>`_.
+
 This major version of Mongoid has a number of significant refactors, bug fixes
 and behavior corrections.
 

--- a/docs/tutorials/mongoid-upgrade.txt
+++ b/docs/tutorials/mongoid-upgrade.txt
@@ -10,6 +10,13 @@ Upgrading Mongoid
    :depth: 1
    :class: singlecol
 
+This page describes significant changes and improvements in Mongoid releases.
+The complete list of releases is available `on GitHub
+<https://github.com/mongodb/mongoid/releases>`_ and `in JIRA
+<https://jira.mongodb.org/projects/MONGOID?selectedItem=com.atlassian.jira.jira-projects-plugin:release-page>`;
+please consult GitHub releases for detailed release notes and JIRA for
+the complete list of issues fixed in each release, including bug fixes.
+
 
 Upgrading to Mongoid 7.1
 ------------------------
@@ -250,6 +257,10 @@ pipeline builder DSL <aggregation-pipeline-builder-dsl>`.
 
 Mongoid 7.0 requires MongoDB server 2.6 or newer, Ruby 2.2.2 or higher and
 supports Rails 5.1-6.0.
+
+New in version 7.0.3: Embedded matchers now support the ``$eq`` operator.
+
+New in version 7.0.5: Mongoid now officially supports Rails 6.0.
 
 
 Upgrading to Mongoid 6

--- a/docs/tutorials/mongoid-upgrade.txt
+++ b/docs/tutorials/mongoid-upgrade.txt
@@ -232,6 +232,11 @@ Support for Ruby 2.2 and JRuby 9.1 has been dropped.
 Upgrading to Mongoid 7.0
 ------------------------
 
+The following sections describe major changes in Mongoid 7.0.
+
+The behavior of :ref:`read-only attributes <read-only>` now matches that of
+ActiveRecord.
+
 This major version of Mongoid has a number of significant refactors, bug fixes
 and behavior corrections.
 

--- a/lib/mongoid/config.rb
+++ b/lib/mongoid/config.rb
@@ -32,10 +32,7 @@ module Mongoid
     # error.
     option :belongs_to_required_by_default, default: true
 
-    # Raise an exception when a field is defined in a model and it has a
-    # method of the same name already defined. Also prevents a field from
-    # being redefined. Use :overwrite option when defining a field to
-    # overwrite existing method/field definition.
+    # Raise an exception when a field is redefined.
     option :duplicate_fields_exception, default: false
 
     # Include the root model name in json serialization.

--- a/lib/mongoid/config.rb
+++ b/lib/mongoid/config.rb
@@ -18,14 +18,34 @@ module Mongoid
 
     LOCK = Mutex.new
 
-    option :include_root_in_json, default: false
-    option :include_type_for_serialization, default: false
-    option :preload_models, default: false
-    option :raise_not_found_error, default: true
-    option :scope_overwrite_exception, default: false
+    # Application name that is printed to the mongodb logs upon establishing
+    # a connection in server versions >= 3.4. Note that the name cannot
+    # exceed 128 bytes. It is also used as the database name if the
+    # database name is not explicitly defined.
+    option :app_name, default: nil
+
+    # Create indexes in background by default.
+    option :background_indexing, default: false
+
+    # Mark belongs_to associations as required by default, so that saving a
+    # model with a missing belongs_to association will trigger a validation
+    # error.
+    option :belongs_to_required_by_default, default: true
+
+    # Raise an exception when a field is defined in a model and it has a
+    # method of the same name already defined. Also prevents a field from
+    # being redefined. Use :overwrite option when defining a field to
+    # overwrite existing method/field definition.
     option :duplicate_fields_exception, default: false
-    option :use_activesupport_time_zone, default: true
-    option :use_utc, default: false
+
+    # Include the root model name in json serialization.
+    option :include_root_in_json, default: false
+
+    # # Include the _type field in serialization.
+    option :include_type_for_serialization, default: false
+
+    # Whether to join nested persistence contexts for atomic operations
+    # to parent contexts by default.
     option :join_contexts, default: false
 
     # The log level.
@@ -38,9 +58,22 @@ module Mongoid
     # configuration file is the log level given by this option honored.
     option :log_level, default: :info
 
-    option :belongs_to_required_by_default, default: true
-    option :app_name, default: nil
-    option :background_indexing, default: false
+    # Preload all models in development, needed when models use inheritance.
+    option :preload_models, default: false
+
+    # Raise an error when performing a #find and the document is not found.
+    option :raise_not_found_error, default: true
+
+    # Raise an error when defining a scope with the same name as an
+    # existing method.
+    option :scope_overwrite_exception, default: false
+
+    # Use ActiveSupport's time zone in time operations instead of the
+    # Ruby default time zone.
+    option :use_activesupport_time_zone, default: true
+
+    # Return stored times as UTC.
+    option :use_utc, default: false
 
     # Has Mongoid been configured? This is checking that at least a valid
     # client config exists.

--- a/lib/mongoid/criteria/queryable/pipeline.rb
+++ b/lib/mongoid/criteria/queryable/pipeline.rb
@@ -33,7 +33,7 @@ module Mongoid
         # Add a group operation to the aggregation pipeline.
         #
         # @example Add a group operation.
-        #   pipeline.group(:count.sum => 1, :max.max => "likes")
+        #   pipeline.group(:_id => "foo", :count.sum => 1, :max.max => "likes")
         #
         # @param [ Hash ] entry The group entry.
         #
@@ -76,7 +76,8 @@ module Mongoid
         #   pipeline.unwind(:field)
         #   pipeline.unwind(document)
         #
-        # @param [ String, Symbol, Hash ] field_or_doc The name of the field or a document.
+        # @param [ String, Symbol, Hash ] field_or_doc A field name or a
+        #   document.
         #
         # @return [ Pipeline ] The pipeline.
         #

--- a/lib/rails/generators/mongoid/config/templates/mongoid.yml
+++ b/lib/rails/generators/mongoid/config/templates/mongoid.yml
@@ -114,12 +114,40 @@ development:
 
   # Configure Mongoid specific options. (optional)
   options:
-    # Includes the root model name in json serialization. (default: false)
+    # Application name that is printed to the mongodb logs upon establishing
+    # a connection in server versions >= 3.4. Note that the name cannot
+    # exceed 128 bytes. It is also used as the database name if the
+    # database name is not explicitly defined. (default: nil)
+    # app_name: MyApplicationName
+    
+    # Create indexes in background by default. (default: false)
+    # background_indexing: false
+    
+    # Mark belongs_to associations as required by default, so that saving a
+    # model with a missing belongs_to association will trigger a validation
+    # error. (default: true)
+    # belongs_to_required_by_default: true
+    
+    # Raise an exception when a field is defined in a model and it has a
+    # method of the same name already defined. Also prevents a field from
+    # being redefined. Use :overwrite option when defining a field to
+    # overwrite existing method/field definition. (default: false)
+    # duplicate_fields_exception: false
+    
+    # Include the root model name in json serialization. (default: false)
     # include_root_in_json: false
 
     # Include the _type field in serialization. (default: false)
     # include_type_for_serialization: false
 
+    # Whether to join nested persistence contexts for atomic operations
+    # to parent contexts by default. (default: false)
+    # join_contexts: false
+
+    # Set the Mongoid and Ruby driver log levels when Mongoid is not using
+    # Ruby on Rails logger instance. (default: :info)
+    # log_level: :info
+    
     # Preload all models in development, needed when models use
     # inheritance. (default: false)
     # preload_models: false
@@ -132,32 +160,16 @@ development:
     # existing method. (default: false)
     # scope_overwrite_exception: false
 
-    # Raise an error when defining a field with the same name as an
-    # existing method. (default: false)
-    # duplicate_fields_exception: false
-
-    # Use Active Support's time zone in conversions. (default: true)
+    # Use ActiveSupport's time zone in time operations instead of
+    # the Ruby default time zone. See the time zone section below for
+    # further information. (default: true)
     # use_activesupport_time_zone: true
 
-    # Ensure all times are UTC in the app side. (default: false)
+    # Return stored times as UTC. See the time zone section below for
+    # further information. Most applications should not use this option.
+    # (default: false)
     # use_utc: false
 
-    # Set the Mongoid and Ruby driver log levels when not in a Rails
-    # environment. The Mongoid logger will be set to the Rails logger
-    # otherwise.(default: :info)
-    # log_level: :info
-
-    # Control whether `belongs_to` association is required. By default
-    # `belongs_to` will trigger a validation error if the association
-    # is not present. (default: true)
-    # belongs_to_required_by_default: true
-
-    # Application name that is printed to the mongodb logs upon establishing a
-    # connection in server versions >= 3.4. Note that the name cannot exceed 128 bytes.
-    # app_name: MyApplicationName
-
-    # Use background indexes by default if `background` option not specified. (default: false)
-    # background_indexing: false
 test:
   clients:
     default:

--- a/lib/rails/generators/mongoid/config/templates/mongoid.yml
+++ b/lib/rails/generators/mongoid/config/templates/mongoid.yml
@@ -128,10 +128,7 @@ development:
     # error. (default: true)
     # belongs_to_required_by_default: true
     
-    # Raise an exception when a field is defined in a model and it has a
-    # method of the same name already defined. Also prevents a field from
-    # being redefined. Use :overwrite option when defining a field to
-    # overwrite existing method/field definition. (default: false)
+    # Raise an exception when a field is redefined. (default: false)
     # duplicate_fields_exception: false
     
     # Include the root model name in json serialization. (default: false)


### PR DESCRIPTION
https://jira.mongodb.com/browse/MONGOID-4852

Most of this PR is documenting the features that were added in the 7.0 development cycle rather than release notes themselves which are quite brief.

- I've finally located the aggregation pipeline builder DSL. It is very minimal though, only supports 3 operators.
- A big chunk of the diff is the rework of Mongoid option documentation. They were mentioned in 3 places (definition itself, tutorial documentation and mongoid.yml config template) with each defining/explaining some options that none of the others documented. Now all 3 have identical documentation.
- Added Mongoid option references to the rest of documentation where the affected functionality is described.
