### PR TITLE
Fix MONGOID-4874 Values seem to be lost when using add_to_set on a non-existent attribute on a loaded instance

### DIFF
--- a/lib/mongoid/persistable/pushable.rb
+++ b/lib/mongoid/persistable/pushable.rb
@@ -24,7 +24,13 @@ module Mongoid
       def add_to_set(adds)
         prepare_atomic_operation do |ops|
           process_atomic_operations(adds) do |field, value|
-            existing = send(field) || (attributes[field] ||= [])
+            existing = send(field) || attributes[field]
+            if existing.blank?
+              attributes[field] = []
+            else
+              attributes[field] = existing
+            end
+            existing = attributes[field]
             values = [ value ].flatten(1)
             values.each do |val|
               existing.push(val) unless existing.include?(val)

--- a/lib/mongoid/persistable/pushable.rb
+++ b/lib/mongoid/persistable/pushable.rb
@@ -25,12 +25,12 @@ module Mongoid
         prepare_atomic_operation do |ops|
           process_atomic_operations(adds) do |field, value|
             existing = send(field) || attributes[field]
-            if existing.blank?
+            if existing.nil?
               attributes[field] = []
-            else
-              attributes[field] = existing
+              # Read the value out of attributes:
+              # https://jira.mongodb.org/browse/MONGOID-4874
+              existing = attributes[field]
             end
-            existing = attributes[field]
             values = [ value ].flatten(1)
             values.each do |val|
               existing.push(val) unless existing.include?(val)

--- a/spec/mongoid/persistable/pushable_spec.rb
+++ b/spec/mongoid/persistable/pushable_spec.rb
@@ -7,7 +7,7 @@ describe Mongoid::Persistable::Pushable do
 
   describe "#add_to_set" do
 
-    context "when the document is a root document" do
+    context "when the document is a top level document" do
 
       shared_examples_for "a unique pushable root document" do
 
@@ -21,14 +21,6 @@ describe Mongoid::Persistable::Pushable do
 
         it "sets absent values" do
           expect(person.test_array).to eq([ 1 ])
-        end
-
-        it "stores changes in memory when loaded from database" do
-          Person.create!
-          person = Person.last
-          person.add_to_set({aliases: 1})
-
-          expect(person.aliases).to eq([1])
         end
 
         it "returns self objet" do
@@ -72,6 +64,60 @@ describe Mongoid::Persistable::Pushable do
         end
 
         it_behaves_like "a unique pushable root document"
+      end
+
+      context 'when the host model is not saved' do
+        context 'when attribute exists' do
+          let(:person) do
+            Person.new(aliases: [2])
+          end
+
+          it 'records the change' do
+            person.add_to_set({aliases: 1})
+
+            expect(person.aliases).to eq([2, 1])
+          end
+        end
+
+        context 'when attribute does not exist' do
+          let(:person) do
+            Person.new
+          end
+
+          it 'records the change' do
+            person.add_to_set({aliases: 1})
+
+            expect(person.aliases).to eq([1])
+          end
+        end
+      end
+
+      context 'when the host model is loaded from database' do
+        context 'when attribute exists' do
+          let(:person) do
+            Person.create!(aliases: [2])
+            person = Person.last
+          end
+
+          it 'records the change' do
+            person.add_to_set({aliases: 1})
+
+            expect(person.aliases).to eq([2, 1])
+          end
+        end
+
+        context 'when attribute does not exist' do
+          let(:person) do
+            Person.create!
+            person = Person.last
+          end
+
+          it 'records the change' do
+            person.add_to_set({aliases: 1})
+
+            expect(person.aliases).to eq([1])
+          end
+        end
       end
     end
 

--- a/spec/mongoid/persistable/pushable_spec.rb
+++ b/spec/mongoid/persistable/pushable_spec.rb
@@ -23,6 +23,14 @@ describe Mongoid::Persistable::Pushable do
           expect(person.test_array).to eq([ 1 ])
         end
 
+        it "stores changes in memory when loaded from database" do
+          Person.create!
+          person = Person.last
+          person.add_to_set({aliases: 1})
+
+          expect(person.aliases).to eq([1])
+        end
+
         it "returns self objet" do
           expect(add).to eq(person)
         end


### PR DESCRIPTION
It seems when an instance is loaded from a database, its `attributes`
method returns an instance of `BSON::Document`. This causes some
surprising behavior when we use `#add_to_set` on that loaded instance.

When a value is assigned to a `BSON::Document` instance, it gets
modified:

https://github.com/mongodb/bson-ruby/blob/master/lib/bson/document.rb#L87-L89

During modification, the attribute loses its reference to the original
value, however the `add_to_set` method relies on this reference:

https://github.com/mongodb/mongoid/blob/136ccbc140b25719f48ff5185bb471f90c063148/lib/mongoid/persistable/pushable.rb#L27-L31

Since that reference is broken, it no longer update the instance's
attribute and the value is lost in memory, though still retained in the
DB.

This ensures that the reference remains intact.