### PR TITLE
Indexing rake tasks silently fail on Rails 6

### DIFF
--- a/lib/mongoid/railties/database.rake
+++ b/lib/mongoid/railties/database.rake
@@ -76,7 +76,13 @@ namespace :db do
 
   namespace :mongoid do
     task :load_models do
-      ::Rails.application.eager_load! if defined?(::Rails)
+      if defined?(::Rails)
+        if ::Rails.respond_to?(:autoloaders) && ::Rails.autoloaders.zeitwerk_enabled?
+          Zeitwerk::Loader.eager_load_all
+        else
+          ::Rails.application.eager_load!
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### Overview

In Mongoid 7.x with Rails 6 with Zeitwerk enabled, Mongoid fails to load models properly. As a result, all indexing tasks (`db:mongoid:create_indexes` and friends) skip the requested indexing operation for the unloaded models.

Because this *silently* causes indexes to fail to create *in production*, I consider this a high priority bug.


### Background

New Rails 6 apps enable Zeitwerk by default. Further, any Rails app that has been upgraded to `config.load_defaults 6.0` also defaults to using Zeitwerk. Accordingly, the impact of this bug is potentially wide.

Affects all tasks that depend on `db:mongoid:load_models`: `db:mongoid:create_indexes`, `db:mongoid:remove_indexes`, `db:mongoid:remove_undefined_indexes`, and `db:mongoid:shard_collections`.

Tested with `mongoid` 7.0.6 and `mongo` 2.11.4, but the problem code is unchanged on `master` as of now.


### Expected behavior

Running `rails db:mongoid:create_indexes` and friends will see all of the app's models and update indexes accordingly.

If logging is at debug (or maybe info), there will be log entries showing index activity for each model.


### Actual behavior

In production, 0 indexes are affected, even with several models defined.
In development, a subset were affected, likely due to auto-loading triggered as part of our dev environment setup. This likely varies based on the app.

Log entries are absent for some/all models.


### Cause

`db:mongoid:load_models` uses `Rails.application.eager_load!` which is now a no-op when Zeitwerk is enabled (see Rails 6 source).

Failing to load the models can be confirmed by adding a simple rake task to show loaded models using the same list as used by the indexing tasks.

```ruby
task test_models: [:environment, 'db:mongoid:load_models'] do
  puts "Mongoid.models.count: #{Mongoid.models.count}"
  puts Mongoid.models.join(', ')
end
```

Without PR:
```bash
$ RAILS_ENV=production rails db:test_models
Mongoid.models.count: 0
```


### Fix

This PR includes a patch to detect Zeitwerk and use its eager loader.

With PR:
```bash
$ RAILS_ENV=production rails db:test_models
Mongoid.models.count: 26
```

See also: MONGOID-4802, MONGOID-4831.