### PR TITLE
Avoid warnings on MRI ruby 2.7.x

### DIFF
--- a/lib/mongoid.rb
+++ b/lib/mongoid.rb
@@ -101,5 +101,5 @@ module Mongoid
   #   Mongoid.database = Mongo::Connection.new.db("test")
   #
   # @since 1.0.0
-  delegate(*(Config.public_instance_methods(false) - [ :logger=, :logger ] << { to: Config }))
+  delegate(*(Config.public_instance_methods(false) - [ :logger=, :logger ]), to: Config)
 end


### PR DESCRIPTION
Same as:

```
NOTE: Gem::Specification#rubyforge_project= is deprecated with no replacement. It will be removed on or after 2019-12-01.
    Gem::Specification#rubyforge_project= called from ../mongoid/mongoid.gemspec:27.
```

and 

```
..lib/mongoid.rb:104: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
    ../.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/activesupport-5.2.4.2/lib/active_support/core_ext/module/delegation.rb:154: warning: The called method `delegate' is defined here
```
