### PR TITLE
MONGOID-4848 Add server 4.4 configurations to evergreen

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -354,6 +354,10 @@ axes:
   - id: "mongodb-version"
     display_name: MongoDB Version
     values:
+      - id: "4.4"
+        display_name: "MongoDB 4.4"
+        variables:
+           VERSION: "4.4"
       - id: "4.2"
         display_name: "MongoDB 4.2"
         variables:
@@ -548,7 +552,7 @@ buildvariants:
   matrix_spec:
     driver: [current, master, stable]
     ruby: "ruby-2.7"
-    mongodb-version: "4.2"
+    mongodb-version: "4.4"
     topology: ["replica-set", "sharded-cluster"]
   display_name: "${ruby}, ${driver}, ${mongodb-version}, ${topology}"
   run_on:
@@ -560,7 +564,7 @@ buildvariants:
     driver: "current"
     # ruby-head temporarily omitted: https://jira.mongodb.org/browse/MONGOID-4833
     ruby: [ruby-2.6, ruby-2.3]
-    mongodb-version: "4.0"
+    mongodb-version: "4.2"
     topology: "replica-set"
   display_name: "${ruby}, ${driver}, ${mongodb-version}, ${topology}"
   run_on:
@@ -571,7 +575,7 @@ buildvariants:
   matrix_spec:
     driver: "current"
     ruby: "ruby-2.6"
-    mongodb-version: ["3.6", "3.4", "3.2"]
+    mongodb-version: ["4.0", "3.6", "3.4", "3.2"]
     topology: "standalone"
   display_name: "${ruby}, ${driver}, ${mongodb-version}, ${topology}"
   run_on:

--- a/docs/tutorials/mongoid-queries.txt
+++ b/docs/tutorials/mongoid-queries.txt
@@ -1656,6 +1656,72 @@ Valid options to ``#out`` are:
 - ``reduce: "name"``: Store in a collection with the
   provided name, and reduce all existing results in that collection.
 
+Raw Results
+-----------
+
+Results of Map/Reduce execution can be retrieved via the ``execute`` method
+or its aliases ``raw`` and ``results``:
+
+.. code-block:: ruby
+
+  mr = Band.where(:likes.gt => 100).map_reduce(map, reduce).out(inline: 1)
+  
+  mr.execute
+  # => {"results"=>[{"_id"=>"Tool", "value"=>{"likes"=>200.0}}],
+        "timeMillis"=>14,
+        "counts"=>{"input"=>4, "emit"=>4, "reduce"=>1, "output"=>1},
+        "ok"=>1.0,
+        "$clusterTime"=>{"clusterTime"=>#<BSON::Timestamp:0x00005633c2c2ad20 @seconds=1590105400, @increment=1>, "signature"=>{"hash"=><BSON::Binary:0x12240 type=generic data=0x0000000000000000...>, "keyId"=>0}},
+        "operationTime"=>#<BSON::Timestamp:0x00005633c2c2aaf0 @seconds=1590105400, @increment=1>}
+
+
+Statistics
+----------
+
+MongoDB servers 4.2 and lower provide Map/Reduce execution statistics. As of
+MongoDB 4.4, Map/Reduce is implemented via the aggregation pipeline and
+statistics described in this section are not available.
+
+The following methods are provided on the ``MapReduce`` object:
+
+- ``counts``: Number of documents read, emitted, reduced and output through
+  the pipeline.
+- ``input``, ``emitted``, ``reduced``, ``output``: individual count methods.
+  Note that ``emitted`` and ``reduced`` methods are named differently from
+  hash keys in ``counts``.
+- ``time``: The time, in milliseconds, that Map/Reduce pipeline took to execute.
+
+The following code illustrates retrieving the statistics:
+
+.. code-block:: ruby
+
+  mr = Band.where(:likes.gt => 100).map_reduce(map, reduce).out(inline: 1)
+  
+  mr.counts
+  # => {"input"=>4, "emit"=>4, "reduce"=>1, "output"=>1}
+  
+  mr.input
+  # => 4
+  
+  mr.emitted
+  # => 4
+  
+  mr.reduced
+  # => 1
+  
+  mr.output
+  # => 1
+  
+  mr.time
+  # => 14
+
+.. note::
+
+  Each statistics method invocation re-executes the Map/Reduce pipeline.
+  The results of execution are not stored by Mongoid. Consider using the
+  ``execute`` method to retrieve the raw results and obtaining the statistics
+  from the raw results if multiple statistics are desired.
+
 
 Full Text Search
 ================

--- a/spec/mongoid/contextual/map_reduce_spec.rb
+++ b/spec/mongoid/contextual/map_reduce_spec.rb
@@ -78,6 +78,7 @@ describe Mongoid::Contextual::MapReduce do
   end
 
   describe "#counts" do
+    max_server_version '4.2'
 
     let(:criteria) do
       Band.all
@@ -106,7 +107,8 @@ describe Mongoid::Contextual::MapReduce do
       end
 
       it "iterates over the results" do
-        expect(results.entries).to eq([
+        ordered_results = results.entries.sort_by { |doc| doc['_id'] }
+        expect(ordered_results.entries).to eq([
           { "_id" => "Depeche Mode", "value" => { "likes" => 200 }},
           { "_id" => "Tool", "value" => { "likes" => 100 }}
         ])
@@ -127,7 +129,8 @@ describe Mongoid::Contextual::MapReduce do
       end
 
       it "iterates over the results" do
-        expect(results.entries).to eq(expected_results)
+        ordered_results = results.entries.sort_by { |doc| doc['_id'] }
+        expect(ordered_results).to eq(expected_results)
       end
 
       it 'outputs to the collection' do
@@ -147,6 +150,7 @@ describe Mongoid::Contextual::MapReduce do
       end
 
       context "when the statstics are requested" do
+        max_server_version '4.2'
 
         it "raises an error" do
           expect {
@@ -210,6 +214,7 @@ describe Mongoid::Contextual::MapReduce do
   end
 
   describe "#emitted" do
+    max_server_version '4.2'
 
     let(:emitted) do
       map_reduce.out(inline: 1).emitted
@@ -261,6 +266,7 @@ describe Mongoid::Contextual::MapReduce do
   end
 
   describe "#input" do
+    max_server_version '4.2'
 
     let(:input) do
       map_reduce.out(inline: 1).input
@@ -311,6 +317,7 @@ describe Mongoid::Contextual::MapReduce do
   end
 
   describe "#output" do
+    max_server_version '4.2'
 
     let(:output) do
       map_reduce.out(inline: 1).output
@@ -343,12 +350,16 @@ describe Mongoid::Contextual::MapReduce do
       end
 
       context 'when a read preference is defined' do
+        require_topology :replica_set
+        # On 4.4 it seems the server inserts on the primary, not on the server
+        # that executed the map/reduce.
+        max_server_version '4.2'
 
         let(:criteria) do
           Band.all.read(mode: :secondary)
         end
 
-        it "uses the read preference", if: testing_replica_set? do
+        it "uses the read preference" do
 
           expect {
             replace_map_reduce.raw
@@ -359,6 +370,7 @@ describe Mongoid::Contextual::MapReduce do
   end
 
   describe "#reduced" do
+    max_server_version '4.2'
 
     let(:reduced) do
       map_reduce.out(inline: 1).reduced
@@ -389,6 +401,7 @@ describe Mongoid::Contextual::MapReduce do
   end
 
   describe "#time" do
+    max_server_version '4.2'
 
     let(:time) do
       map_reduce.out(inline: 1).time

--- a/spec/mongoid/contextual/mongo_spec.rb
+++ b/spec/mongoid/contextual/mongo_spec.rb
@@ -1556,6 +1556,10 @@ describe Mongoid::Contextual::Mongo do
       }}
     end
 
+    let(:ordered_results) do
+      results['results'].sort_by { |doc| doc['_id'] }
+    end
+
     context "when no selection is provided" do
 
       let(:criteria) do
@@ -1587,36 +1591,40 @@ describe Mongoid::Contextual::Mongo do
       end
 
       it "contains the entire raw results" do
-        expect(results["results"]).to eq([
+        expect(ordered_results).to eq([
           { "_id" => "Depeche Mode", "value" => { "likes" => 200 }},
           { "_id" => "Tool", "value" => { "likes" => 100 }}
         ])
       end
 
-      it "contains the execution time" do
-        expect(results.time).to_not be_nil
-      end
+      context 'when statistics are available' do
+        max_server_version '4.2'
 
-      it "contains the count statistics" do
-        expect(results["counts"]).to eq({
-          "input" => 2, "emit" => 2, "reduce" => 0, "output" => 2
-        })
-      end
+        it "contains the execution time" do
+          expect(results.time).to_not be_nil
+        end
 
-      it "contains the input count" do
-        expect(results.input).to eq(2)
-      end
+        it "contains the count statistics" do
+          expect(results["counts"]).to eq({
+            "input" => 2, "emit" => 2, "reduce" => 0, "output" => 2
+          })
+        end
 
-      it "contains the emitted count" do
-        expect(results.emitted).to eq(2)
-      end
+        it "contains the input count" do
+          expect(results.input).to eq(2)
+        end
 
-      it "contains the reduced count" do
-        expect(results.reduced).to eq(0)
-      end
+        it "contains the emitted count" do
+          expect(results.emitted).to eq(2)
+        end
 
-      it "contains the output count" do
-        expect(results.output).to eq(2)
+        it "contains the reduced count" do
+          expect(results.reduced).to eq(0)
+        end
+
+        it "contains the output count" do
+          expect(results.output).to eq(2)
+        end
       end
     end
 
@@ -1645,35 +1653,39 @@ describe Mongoid::Contextual::Mongo do
       end
 
       it "contains the entire raw results" do
-        expect(results["results"]).to eq([
+        expect(ordered_results).to eq([
           { "_id" => "Depeche Mode", "value" => { "likes" => 200 }}
         ])
       end
 
-      it "contains the execution time" do
-        expect(results.time).to_not be_nil
-      end
+      context 'when statistics are available' do
+        max_server_version '4.2'
 
-      it "contains the count statistics" do
-        expect(results["counts"]).to eq({
-          "input" => 1, "emit" => 1, "reduce" => 0, "output" => 1
-        })
-      end
+        it "contains the execution time" do
+          expect(results.time).to_not be_nil
+        end
 
-      it "contains the input count" do
-        expect(results.input).to eq(1)
-      end
+        it "contains the count statistics" do
+          expect(results["counts"]).to eq({
+            "input" => 1, "emit" => 1, "reduce" => 0, "output" => 1
+          })
+        end
 
-      it "contains the emitted count" do
-        expect(results.emitted).to eq(1)
-      end
+        it "contains the input count" do
+          expect(results.input).to eq(1)
+        end
 
-      it "contains the reduced count" do
-        expect(results.reduced).to eq(0)
-      end
+        it "contains the emitted count" do
+          expect(results.emitted).to eq(1)
+        end
 
-      it "contains the output count" do
-        expect(results.output).to eq(1)
+        it "contains the reduced count" do
+          expect(results.reduced).to eq(0)
+        end
+
+        it "contains the output count" do
+          expect(results.output).to eq(1)
+        end
       end
     end
 
@@ -1713,7 +1725,7 @@ describe Mongoid::Contextual::Mongo do
       end
 
       it "contains the entire raw results" do
-        expect(results["results"]).to eq([
+        expect(ordered_results).to eq([
           { "_id" => "Depeche Mode", "value" => { "likes" => 200 }},
           { "_id" => "Tool", "value" => { "likes" => 100 }}
         ])

--- a/spec/mongoid/criteria_spec.rb
+++ b/spec/mongoid/criteria_spec.rb
@@ -2337,7 +2337,7 @@ describe Mongoid::Criteria do
       end
 
       it "returns the map/reduce results" do
-        expect(map_reduce).to eq([
+        expect(map_reduce.sort_by { |doc| doc['_id'] }).to eq([
           { "_id" => "Depeche Mode", "value" => { "likes" => 200 }},
           { "_id" => "Tool", "value" => { "likes" => 100 }}
         ])

--- a/spec/mongoid/criteria_spec.rb
+++ b/spec/mongoid/criteria_spec.rb
@@ -3617,6 +3617,8 @@ describe Mongoid::Criteria do
       end
 
       it "returns the matching documents" do
+        skip 'https://jira.mongodb.org/browse/MONGOID-4886'
+
         expect(criteria).to eq([ match ])
       end
     end
@@ -3628,6 +3630,8 @@ describe Mongoid::Criteria do
       end
 
       it "returns the matching documents" do
+        skip 'https://jira.mongodb.org/browse/MONGOID-4886'
+
         expect(criteria).to eq([ match ])
       end
     end

--- a/spec/mongoid/shardable_models.rb
+++ b/spec/mongoid/shardable_models.rb
@@ -19,7 +19,7 @@ class SmActor
 
   # This is not a usable shard configuration for the server.
   # We just have it for unit tests.
-  shard_key age: 1, 'gender' => :hashed
+  shard_key age: 1, 'gender' => :hashed, 'hello' => :hashed
 end
 
 class SmAssistant

--- a/spec/mongoid/shardable_spec.rb
+++ b/spec/mongoid/shardable_spec.rb
@@ -48,12 +48,12 @@ describe Mongoid::Shardable do
 
       context 'with string value' do
         it 'sets shard key fields to symbol value' do
-          SmActor.shard_key_fields.should == %i(age gender)
+          SmActor.shard_key_fields.should == %i(age gender hello)
         end
 
         it 'sets shard config' do
           SmActor.shard_config.should == {
-            key: {age: 1, gender: 'hashed'},
+            key: {age: 1, gender: 'hashed', hello: 'hashed'},
             options: {},
           }
         end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -81,10 +81,6 @@ def non_legacy_server?
   Mongoid::Clients.default.cluster.servers.first.features.write_command_enabled?
 end
 
-def testing_replica_set?
-  Mongoid::Clients.default.cluster.replica_set?
-end
-
 def collation_supported?
   Mongoid::Clients.default.cluster.next_primary.features.collation_enabled?
 end


### PR DESCRIPTION
- Add 4.4 configurations
- Add documentation for map/reduce statistics, which are no longer available in 4.4
- Skip map/reduce statistics tests on 4.4
- Skip code with scope tests until 4886 is done
- Sort map/reduce results in tests because they arrive in different order in 4.4 after being executed through aggregation pipeline
- 4.4 allows a combination of hashed and non-hashed shard keys, use two hashed keys which 4.4 does not allow instead to produce failures