### PR TITLE
MONGOID-4902 Include shard key when reloading documents for improved query performance with Atlas Global Write clusters

### DIFF
--- a/docs/tutorials/mongoid-upgrade.txt
+++ b/docs/tutorials/mongoid-upgrade.txt
@@ -216,6 +216,33 @@ example, the following two approaches result in the same generated selector:
     #   class:    Band
     #   embedded: false>
 
+Use Shard Key On Reload
+-----------------------
+
+Minor change: Mongoid 7.1 modifies the ``reload`` method to perform a find
+command using the model's shard key if one exists. This improves the performance,
+of ``reload`` against sharded clusters, especially those that shard documents
+based on the physical location of the shards.
+
+Consider a class ``Band`` whose documents are sharded by the ``name`` key.
+
+Example Mongoid 7.1 behavior:
+
+.. code-block:: ruby
+
+  band = Band.create(name: "Destiny's Child")
+  band.reload
+  # Command logs: { "find"=>"bands", "filter"=>{ "_id"=>BSON::ObjectId('...') "name"=>"Destiny's Child" } }
+
+Example Mongoid 7.0 behavior:
+
+.. code-block:: ruby
+
+  band = Band.create(name: "Destiny's Child")
+  band.reload
+  # Command logs: { "find"=>"bands", "filter"=>{"_id"=>BSON::ObjectId('...') } }
+
+
 Ruby Version Support
 --------------------
 

--- a/docs/tutorials/mongoid-upgrade.txt
+++ b/docs/tutorials/mongoid-upgrade.txt
@@ -221,10 +221,18 @@ Use Shard Key On Reload
 
 Minor change: Mongoid 7.1 modifies the ``reload`` method to perform a find
 command using the model's shard key if one exists. This improves the performance,
-of ``reload`` against sharded clusters, especially those that shard documents
-based on the physical location of the shards.
+of ``reload`` against sharded clusters, especially on Atlas Global Clusters.
 
 Consider a class ``Band`` whose documents are sharded by the ``name`` key.
+
+.. code-block:: ruby
+
+  class Band
+    include Mongoid::Document
+    field :name, type: String
+
+    shard_key :name
+  end
 
 Example Mongoid 7.1 behavior:
 

--- a/docs/tutorials/mongoid-upgrade.txt
+++ b/docs/tutorials/mongoid-upgrade.txt
@@ -17,6 +17,44 @@ The complete list of releases is available `on GitHub
 please consult GitHub releases for detailed release notes and JIRA for
 the complete list of issues fixed in each release, including bug fixes.
 
+Upgrading to Mongoid 7.2
+========================
+
+The following sections describe major changes in Mongoid 7.2.
+
+Use Shard Key On Reload
+-----------------------
+
+Minor change: Mongoid 7.2 modifies the ``reload`` method to perform a find
+command using the model's shard key if one exists. This improves the performance
+of ``reload`` against sharded clusters, especially on Atlas Global Clusters.
+
+Consider a class ``Band`` whose documents are sharded by the ``name`` key.
+
+.. code-block:: ruby
+
+  class Band
+    include Mongoid::Document
+    field :name, type: String
+
+    shard_key :name
+  end
+
+Example Mongoid 7.1 behavior:
+
+.. code-block:: ruby
+
+  band = Band.create(name: "Destiny's Child")
+  band.reload
+  # Command logs: { "find"=>"bands", "filter"=>{ "_id"=>BSON::ObjectId('...') "name"=>"Destiny's Child" } }
+
+Example Mongoid 7.0 behavior:
+
+.. code-block:: ruby
+
+  band = Band.create(name: "Destiny's Child")
+  band.reload
+  # Command logs: { "find"=>"bands", "filter"=>{"_id"=>BSON::ObjectId('...') } }
 
 Upgrading to Mongoid 7.1
 ========================
@@ -215,40 +253,6 @@ example, the following two approaches result in the same generated selector:
     #   options:  {}
     #   class:    Band
     #   embedded: false>
-
-Use Shard Key On Reload
------------------------
-
-Minor change: Mongoid 7.1 modifies the ``reload`` method to perform a find
-command using the model's shard key if one exists. This improves the performance,
-of ``reload`` against sharded clusters, especially on Atlas Global Clusters.
-
-Consider a class ``Band`` whose documents are sharded by the ``name`` key.
-
-.. code-block:: ruby
-
-  class Band
-    include Mongoid::Document
-    field :name, type: String
-
-    shard_key :name
-  end
-
-Example Mongoid 7.1 behavior:
-
-.. code-block:: ruby
-
-  band = Band.create(name: "Destiny's Child")
-  band.reload
-  # Command logs: { "find"=>"bands", "filter"=>{ "_id"=>BSON::ObjectId('...') "name"=>"Destiny's Child" } }
-
-Example Mongoid 7.0 behavior:
-
-.. code-block:: ruby
-
-  band = Band.create(name: "Destiny's Child")
-  band.reload
-  # Command logs: { "find"=>"bands", "filter"=>{"_id"=>BSON::ObjectId('...') } }
 
 
 Ruby Version Support

--- a/docs/tutorials/mongoid-upgrade.txt
+++ b/docs/tutorials/mongoid-upgrade.txt
@@ -17,17 +17,24 @@ The complete list of releases is available `on GitHub
 please consult GitHub releases for detailed release notes and JIRA for
 the complete list of issues fixed in each release, including bug fixes.
 
+
 Upgrading to Mongoid 7.2
 ========================
 
 The following sections describe major changes in Mongoid 7.2.
 
-Use Shard Key On Reload
------------------------
+Shard Key Used For Reloading
+----------------------------
 
-Minor change: Mongoid 7.2 modifies the ``reload`` method to perform a find
-command using the model's shard key if one exists. This improves the performance
-of ``reload`` against sharded clusters, especially on Atlas Global Clusters.
+Minor change: When sharding is used, Mongoid 7.2 expects the shard key declared
+in models to match the shard key in the database for the respective collections.
+In Mongoid 7.2 model reloading (either explicit via the ``reload`` method
+or implicit as part of persistence operations) uses the shard key, if one is
+defined, in the ``find`` command in addition to the ``id`` field value.
+This improves the performance of document reloading, and consequently some
+persistence operations, in sharded clusters, especially those with
+`geographically distributed shards
+<https://docs.atlas.mongodb.com/global-clusters/>`_.
 
 Consider a class ``Band`` whose documents are sharded by the ``name`` key.
 
@@ -40,7 +47,7 @@ Consider a class ``Band`` whose documents are sharded by the ``name`` key.
     shard_key :name
   end
 
-Example Mongoid 7.1 behavior:
+Example Mongoid 7.2 behavior:
 
 .. code-block:: ruby
 
@@ -48,13 +55,17 @@ Example Mongoid 7.1 behavior:
   band.reload
   # Command logs: { "find"=>"bands", "filter"=>{ "_id"=>BSON::ObjectId('...') "name"=>"Destiny's Child" } }
 
-Example Mongoid 7.0 behavior:
+Example Mongoid 7.1 behavior:
 
 .. code-block:: ruby
 
   band = Band.create(name: "Destiny's Child")
   band.reload
   # Command logs: { "find"=>"bands", "filter"=>{"_id"=>BSON::ObjectId('...') } }
+
+Mongoid provides :ref:`sharding management Rake tasks <sharding-management>`
+to shard collections according to shard keys declared in models.
+
 
 Upgrading to Mongoid 7.1
 ========================

--- a/docs/tutorials/sharding.txt
+++ b/docs/tutorials/sharding.txt
@@ -81,6 +81,31 @@ configured in the association as the field name:
     index country: 1
   end
 
+.. _global-clusters:
+
+MongoDB Atlas Global Clusters
+=============================
+
+When working with MongoDB Atlas Global Clusters, you need to declare a compound
+shard key on the collection. The first key must be the ``location`` field.
+
+.. code-block:: ruby
+
+  field :location, type: String, default: 'US'
+
+
+You can read more about `Global Cluster Sharding here
+<https://docs.atlas.mongodb.com/global-cluster-sharding/>`_
+
+In order to maintain fast write operations to the Global Cluster, you should
+declare at least the ``location`` field as a shard key in your model:
+
+.. code-block:: ruby
+
+  shard_key :location, :_id
+
+When defined correctly, Mongoid will use these keys when performing all document
+writes to the Global Cluster, as well as reloads to the document.
 
 .. _sharding-management:
 

--- a/docs/tutorials/sharding.txt
+++ b/docs/tutorials/sharding.txt
@@ -81,34 +81,16 @@ configured in the association as the field name:
     index country: 1
   end
 
-When ``reload`` is called on a Mongoid model instance, the method will
-use shard keys defined on the model (if any) to perform the underlying MongoDB query.
+.. note::
 
-.. code-block:: ruby
+  If a model declares a shard key, Mongoid expects the respective collection
+  to be sharded with the specified shard key. When reloading models, Mongoid
+  will provide the shard key in addition to the ``id`` field value to the
+  ``find`` command to improve query performance, especially on `geographically
+  distributed sharded clusters <https://docs.atlas.mongodb.com/global-clusters/>`_.
+  If the collection is not sharded with the specified shard key, queries
+  may produce incorrect results.
 
-
-.. _global-clusters:
-
-MongoDB Atlas Global Clusters
-=============================
-
-On MongoDB Atlast Global Clusters, every document in a collection must include
-the ``location`` field.
-
-.. code-block:: ruby
-
-  field :location, type: String, default: 'US'
-
-The collection must also be sharded using a compound key where the ``location``
-field is the first key.
-
-.. code-block:: ruby
-
-  shard_key :location, :id
-
-See the `Global Cluster Sharding documentation
-<https://docs.atlas.mongodb.com/global-cluster-sharding/>`_ for more information
-about Atlas Global Clusters.
 
 .. _sharding-management:
 

--- a/docs/tutorials/sharding.txt
+++ b/docs/tutorials/sharding.txt
@@ -90,7 +90,7 @@ When working with MongoDB Atlas Global Clusters, you need to declare a compound
 shard key on the collection. The first key must be the ``location`` field.
 
 .. code-block:: ruby
-
+  
   field :location, type: String, default: 'US'
 
 
@@ -101,7 +101,7 @@ In order to maintain fast write operations to the Global Cluster, you should
 declare at least the ``location`` field as a shard key in your model:
 
 .. code-block:: ruby
-
+  
   shard_key :location, :_id
 
 When defined correctly, Mongoid will use these keys when performing all document

--- a/docs/tutorials/sharding.txt
+++ b/docs/tutorials/sharding.txt
@@ -25,11 +25,11 @@ Shard keys can be declared on models using the ``shard_key`` macro:
 
   class Person
     include Mongoid::Document
-    
+
     field :ssn
 
     shard_key ssn: 1
-    
+
     # The collection must also have an index that starts with the shard key.
     index ssn: 1
   end
@@ -48,11 +48,11 @@ collection sharding options:
 .. code-block:: ruby
 
   shard_key ssn: 1
-  
+
   shard_key ssn: 1, country: 1
-  
+
   shard_key ssn: :hashed
-  
+
   shard_key {ssn: :hashed}, unique: true
 
 The alternative is the shorthand syntax, in which only the keys are given.
@@ -62,7 +62,7 @@ be specified:
 .. code-block:: ruby
 
   shard_key :ssn
-  
+
   shard_key :ssn, :country
 
 ``shard_key`` macro can take the name of a ``belongs_to`` association in
@@ -71,41 +71,44 @@ configured in the association as the field name:
 
   class Person
     include Mongoid::Document
-    
+
     belongs_to :country
 
     # Shards by country_id.
     shard_key country: 1
-    
+
     # The collection must also have an index that starts with the shard key.
     index country: 1
   end
+
+When ``reload`` is called on a Mongoid model instance, the method will
+use shard keys defined on the model (if any) to perform the underlying MongoDB query.
+
+.. code-block:: ruby
+
 
 .. _global-clusters:
 
 MongoDB Atlas Global Clusters
 =============================
 
-When working with MongoDB Atlas Global Clusters, you need to declare a compound
-shard key on the collection. The first key must be the ``location`` field.
+On MongoDB Atlast Global Clusters, every document in a collection must include
+the ``location`` field.
 
 .. code-block:: ruby
-  
+
   field :location, type: String, default: 'US'
 
-
-You can read more about `Global Cluster Sharding here
-<https://docs.atlas.mongodb.com/global-cluster-sharding/>`_
-
-In order to maintain fast write operations to the Global Cluster, you should
-declare at least the ``location`` field as a shard key in your model:
+The collection must also be sharded using a compound key where the ``location``
+field is the first key.
 
 .. code-block:: ruby
-  
-  shard_key :location, :_id
 
-When defined correctly, Mongoid will use these keys when performing all document
-writes to the Global Cluster, as well as reloads to the document.
+  shard_key :location, :id
+
+See the `Global Cluster Sharding documentation
+<https://docs.atlas.mongodb.com/global-cluster-sharding/>`_ for more information
+about Atlas Global Clusters.
 
 .. _sharding-management:
 

--- a/lib/mongoid/reloadable.rb
+++ b/lib/mongoid/reloadable.rb
@@ -60,7 +60,7 @@ module Mongoid
     #
     # @since 2.3.2
     def reload_root_document
-      {}.merge(collection.find({ _id: _id }, session: _session).read(mode: :primary).first || {})
+      {}.merge(collection.find(atomic_selector, session: _session).read(mode: :primary).first || {})
     end
 
     # Reload the embedded document.
@@ -73,7 +73,7 @@ module Mongoid
     # @since 2.3.2
     def reload_embedded_document
       extract_embedded_attributes({}.merge(
-        collection(_root).find(_id: _root._id).read(mode: :primary).first
+        collection(_root).find(_root.atomic_selector).read(mode: :primary).first
       ))
     end
 

--- a/spec/mongoid/clients/sessions_spec.rb
+++ b/spec/mongoid/clients/sessions_spec.rb
@@ -20,12 +20,7 @@ describe Mongoid::Clients::Sessions do
 
   let(:subscriber) do
     client = Mongoid::Clients.with_name(:other)
-    monitoring = if client.respond_to?(:monitoring, true)
-      client.send(:monitoring)
-    else
-      # driver 2.5
-      client.instance_variable_get('@monitoring')
-    end
+    monitoring = client.send(:monitoring)
     monitoring.subscribers['Command'].find do |s|
       s.is_a?(EventSubscriber)
     end

--- a/spec/mongoid/reloadable_spec.rb
+++ b/spec/mongoid/reloadable_spec.rb
@@ -367,12 +367,7 @@ describe Mongoid::Reloadable do
 
       let(:subscriber) do
         client = Mongoid::Clients.with_name(:other)
-        monitoring = if client.respond_to?(:monitoring, true)
-          client.send(:monitoring)
-        else
-          # driver 2.5
-          client.instance_variable_get('@monitoring')
-        end
+        monitoring = client.send(:monitoring)
         subscriber = monitoring.subscribers['Command'].find do |s|
           s.is_a?(EventSubscriber)
         end
@@ -394,7 +389,7 @@ describe Mongoid::Reloadable do
         end
 
         before do
-          Profile.with(client: :other) do |_|
+          Profile.with(client: :other) do
             profile.reload
           end
         end
@@ -417,7 +412,7 @@ describe Mongoid::Reloadable do
         end
 
         before do
-          Profile.with(client: :other) do |_|
+          Profile.with(client: :other) do
             profile_image.reload
           end
         end

--- a/spec/support/models/profile.rb
+++ b/spec/support/models/profile.rb
@@ -4,5 +4,15 @@
 class Profile
   include Mongoid::Document
   field :name, type: String
+
+  embeds_one :profile_image
+
   shard_key :name
+end
+
+class ProfileImage
+  include Mongoid::Document
+  field :url, type: String
+
+  embedded_in :profile
 end


### PR DESCRIPTION
https://jira.mongodb.org/browse/MONGOID-4902

I included some extra documentation for sharding with Global Clusters, since I initially thought that the `shard_key` method didn't actually modify the atomic selector for the document. I thought the tutorial was only used for setting up sharding on the cluster itself via rake tasks.