### PR TITLE
MONGOID-4912 Use a translated message for when an association fails validation during deletion due to dependent documents existing

### DIFF
--- a/lib/config/locales/en.yml
+++ b/lib/config/locales/en.yml
@@ -2,8 +2,6 @@ en:
   mongoid:
     errors:
       messages:
-        restrict_with_error_dependent_destroy:
-          "Cannot delete record because associated objects exist at %{association}."
         blank_in_locale:
           "can't be blank in %{location}"
         message_title: "message"
@@ -45,6 +43,8 @@ en:
           resolution: "Most likely this is caused by passing parameters directly
             through to the find, and the parameter either is not present or the
             key from which it is accessed is incorrect."
+        destroy_restrict_with_error_dependencies_exist:
+          "is not empty and prevents the document from being destroyed"
         document_not_destroyed:
           message: "%{klass} with id %{id} was not destroyed."
           summary: "When calling %{klass}#destroy! and a callback halts the destroy

--- a/lib/config/locales/en.yml
+++ b/lib/config/locales/en.yml
@@ -2,6 +2,8 @@ en:
   mongoid:
     errors:
       messages:
+        restrict_with_error_dependent_destroy:
+          "Cannot delete record because associated objects exist at %{association}."
         blank_in_locale:
           "can't be blank in %{location}"
         message_title: "message"

--- a/lib/mongoid/association/depending.rb
+++ b/lib/mongoid/association/depending.rb
@@ -131,7 +131,9 @@ module Mongoid
 
       def _dependent_restrict_with_error!(association)
         if (relation = send(association.name)) && !relation.blank?
-          errors.add(association.name, RESTRICT_ERROR_MSG)
+          association_name_translated = ::I18n.translate("activerecord.models.#{association.name}", default: association.name.to_s)
+
+          errors.add(:base, :restrict_with_error_dependent_destroy, association: association_name_translated)
           throw(:abort, false)
         end
       end

--- a/lib/mongoid/association/depending.rb
+++ b/lib/mongoid/association/depending.rb
@@ -41,11 +41,6 @@ module Mongoid
           :restrict_with_error
       ]
 
-      # The error message when a strategy cannot delete objects because there are associated objects.
-      #
-      # @since 7.0
-      RESTRICT_ERROR_MSG = 'Cannot delete record because associated objects exist.'.freeze
-
       # Attempt to add the cascading information for the document to know how
       # to handle associated documents on a removal.
       #
@@ -131,9 +126,7 @@ module Mongoid
 
       def _dependent_restrict_with_error!(association)
         if (relation = send(association.name)) && !relation.blank?
-          association_name_translated = ::I18n.translate("activerecord.models.#{association.name}", default: association.name.to_s)
-
-          errors.add(:base, :restrict_with_error_dependent_destroy, association: association_name_translated)
+          errors.add(association.name, :destroy_restrict_with_error_dependencies_exist)
           throw(:abort, false)
         end
       end

--- a/spec/mongoid/association/depending_spec.rb
+++ b/spec/mongoid/association/depending_spec.rb
@@ -850,8 +850,8 @@ describe Mongoid::Association::Depending do
       it 'adds an error to the parent object' do
         expect(person.delete).to be(false)
 
-        key_message = "#{Mongoid::Errors::MongoidError::BASE_KEY}.restrict_with_error_dependent_destroy"
-        expect(person.errors[:base].first).to eq(
+        key_message = "#{Mongoid::Errors::MongoidError::BASE_KEY}.destroy_restrict_with_error_dependencies_exist"
+        expect(person.errors[:restrictable_posts].first).to eq(
           ::I18n.translate(key_message, association: :restrictable_posts)
         )
       end

--- a/spec/mongoid/association/depending_spec.rb
+++ b/spec/mongoid/association/depending_spec.rb
@@ -849,8 +849,11 @@ describe Mongoid::Association::Depending do
 
       it 'adds an error to the parent object' do
         expect(person.delete).to be(false)
-        expect(person.errors[:restrictable_posts].first).to be(
-          Mongoid::Association::Depending::RESTRICT_ERROR_MSG)
+
+        key_message = "#{Mongoid::Errors::MongoidError::BASE_KEY}.restrict_with_error_dependent_destroy"
+        expect(person.errors[:base].first).to eq(
+          ::I18n.translate(key_message, association: :restrictable_posts)
+        )
       end
     end
 

--- a/spec/mongoid/association/depending_spec.rb
+++ b/spec/mongoid/association/depending_spec.rb
@@ -850,10 +850,8 @@ describe Mongoid::Association::Depending do
       it 'adds an error to the parent object' do
         expect(person.delete).to be(false)
 
-        key_message = "#{Mongoid::Errors::MongoidError::BASE_KEY}.destroy_restrict_with_error_dependencies_exist"
-        expect(person.errors[:restrictable_posts].first).to eq(
-          ::I18n.translate(key_message, association: :restrictable_posts)
-        )
+        person.errors[:restrictable_posts].first.should ==
+          "is not empty and prevents the document from being destroyed"
       end
     end
 


### PR DESCRIPTION
https://jira.mongodb.com/browse/MONGOID-4912