### PR TITLE
MONGOID-4890 change blank? to use exists and not count

### DIFF
--- a/lib/mongoid/association/many.rb
+++ b/lib/mongoid/association/many.rb
@@ -11,7 +11,7 @@ module Mongoid
       include ::Enumerable
 
       def_delegators :criteria, :avg, :max, :min, :sum
-      def_delegators :_target, :length, :size
+      def_delegators :_target, :length, :size, :any?
 
       # Is the association empty?
       #
@@ -22,7 +22,7 @@ module Mongoid
       #
       # @since 2.1.0
       def blank?
-        size == 0
+        !any?
       end
 
       # Creates a new document on the references many association. This will

--- a/lib/mongoid/association/referenced/has_many/enumerable.rb
+++ b/lib/mongoid/association/referenced/has_many/enumerable.rb
@@ -216,6 +216,21 @@ module Mongoid
               end
             end
 
+            # Does the enumerable have any? Will determine if there exists at least
+            # one element in the enumerable, whether or not it is _loaded.
+            #
+            # @example Doess the enumerable have any?
+            #   enumerable.any?
+            #
+            # @return [ true, false ] If the enumerable has any elements.
+            def any? 
+              if _loaded?
+                in_memory.count > 0
+              else
+                _unloaded.exists? || _added.count > 0
+              end
+            end
+
             # Get the first document in the enumerable. Will check the persisted
             # documents first. Does not load the entire enumerable.
             #

--- a/lib/mongoid/association/referenced/has_many/enumerable.rb
+++ b/lib/mongoid/association/referenced/has_many/enumerable.rb
@@ -223,7 +223,7 @@ module Mongoid
             #   enumerable.any?
             #
             # @return [ true, false ] If the enumerable has any elements.
-            def any? 
+            def any?
               if _loaded?
                 in_memory.count > 0
               else

--- a/spec/mongoid/association/depending_spec.rb
+++ b/spec/mongoid/association/depending_spec.rb
@@ -870,7 +870,7 @@ describe Mongoid::Association::Depending do
       end
 
       context 'when deleted inside a transaction' do
-        require_topology :replica_set
+        require_topology :replica_set, :sharded
         
         before do
           person.restrictable_posts << post
@@ -906,7 +906,7 @@ describe Mongoid::Association::Depending do
       end
 
       context "when inside a transaction" do
-        require_topology :replica_set
+        require_topology :replica_set, :sharded
 
         it 'doesn\'t raise an exception inside a transaction' do
           person.with_session do |session|

--- a/spec/mongoid/association/depending_spec.rb
+++ b/spec/mongoid/association/depending_spec.rb
@@ -868,6 +868,8 @@ describe Mongoid::Association::Depending do
     end
 
     context 'when deleted inside a transaction' do
+      require_topology :replica_set
+      
       before do
         person.restrictable_posts << post
       end

--- a/spec/mongoid/association/depending_spec.rb
+++ b/spec/mongoid/association/depending_spec.rb
@@ -878,9 +878,9 @@ describe Mongoid::Association::Depending do
 
         it 'doesn\'t raise an exception' do
           person.with_session do |session|
-            session.start_transaction
-            expect { person.destroy }.to_not raise_error
-            session.commit_transaction
+            session.with_transaction do 
+              expect { person.destroy }.to_not raise_error
+            end
           end
         end
       end
@@ -910,9 +910,9 @@ describe Mongoid::Association::Depending do
 
         it 'doesn\'t raise an exception inside a transaction' do
           person.with_session do |session|
-            session.start_transaction
-            expect { person.destroy }.to_not raise_error
-            session.commit_transaction
+            session.with_transaction do
+              expect { person.destroy }.to_not raise_error
+            end
           end
         end
       end

--- a/spec/mongoid/association/depending_spec.rb
+++ b/spec/mongoid/association/depending_spec.rb
@@ -870,7 +870,7 @@ describe Mongoid::Association::Depending do
       end
 
       context 'when deleted inside a transaction' do
-        require_topology :replica_set, :sharded
+        require_transaction_support
         
         before do
           person.restrictable_posts << post
@@ -906,8 +906,8 @@ describe Mongoid::Association::Depending do
       end
 
       context "when inside a transaction" do
-        require_topology :replica_set, :sharded
-
+        require_transaction_support
+        
         it 'doesn\'t raise an exception inside a transaction' do
           person.with_session do |session|
             session.with_transaction do

--- a/spec/mongoid/association/depending_spec.rb
+++ b/spec/mongoid/association/depending_spec.rb
@@ -905,11 +905,15 @@ describe Mongoid::Association::Depending do
         expect(person.destroy).to be false
       end
 
-      it 'doesn\'t raise an exception' do
-        person.with_session do |session|
-          session.start_transaction
-          expect { person.destroy }.to_not raise_error
-          session.commit_transaction
+      context "when inside a transaction" do
+        require_topology :replica_set
+
+        it 'doesn\'t raise an exception inside a transaction' do
+          person.with_session do |session|
+            session.start_transaction
+            expect { person.destroy }.to_not raise_error
+            session.commit_transaction
+          end
         end
       end
     end

--- a/spec/mongoid/association/depending_spec.rb
+++ b/spec/mongoid/association/depending_spec.rb
@@ -489,7 +489,7 @@ describe Mongoid::Association::Depending do
           end
         end
 
-        context "when dependent is restrict_with_error" do
+        context "when dependent is restrict_with_exception" do
 
           context "when restricting a references many" do
 
@@ -864,6 +864,20 @@ describe Mongoid::Association::Depending do
 
       it 'deletes the object and leaves the other one intact' do
         expect(person.delete).to be(true)
+      end
+    end
+
+    context 'when deleted inside a transaction' do
+      before do
+        person.restrictable_posts << post
+      end
+
+      it 'doesn\'t raise an exception' do
+        person.with_session do |session|
+          session.start_transaction
+          person.destroy
+          session.commit_transaction
+        end
       end
     end
   end

--- a/spec/mongoid/association/embedded/embeds_many/proxy_spec.rb
+++ b/spec/mongoid/association/embedded/embeds_many/proxy_spec.rb
@@ -1411,7 +1411,6 @@ describe Mongoid::Association::Embedded::EmbedsMany::Proxy do
     context "when documents are persisted" do
       before do
         person.addresses.create(street: "Upper")
-        person.addresses.build(street: "Bond")
       end
 
       it "returns true" do

--- a/spec/mongoid/association/embedded/embeds_many/proxy_spec.rb
+++ b/spec/mongoid/association/embedded/embeds_many/proxy_spec.rb
@@ -1402,6 +1402,40 @@ describe Mongoid::Association::Embedded::EmbedsMany::Proxy do
     end
   end
 
+  describe "#any?" do
+
+    let(:person) do
+      Person.create
+    end
+
+    context "when documents are persisted" do
+      before do
+        person.addresses.create(street: "Upper")
+        person.addresses.build(street: "Bond")
+      end
+
+      it "returns true" do
+        expect(person.addresses.any?).to be true
+      end
+    end
+    
+    context "when documents are not persisted" do
+      before do
+        person.addresses.build(street: "Bond")
+      end
+      
+      it "returns true" do
+        expect(person.addresses.any?).to be true
+      end
+    end
+
+    context "when documents are not created" do
+      it "returns false" do
+        expect(person.addresses.any?).to be false
+      end
+    end
+  end
+
   describe "#create" do
 
     context "when providing multiple attributes" do

--- a/spec/mongoid/association/referenced/has_and_belongs_to_many/proxy_spec.rb
+++ b/spec/mongoid/association/referenced/has_and_belongs_to_many/proxy_spec.rb
@@ -1757,75 +1757,6 @@ describe Mongoid::Association::Referenced::HasAndBelongsToMany::Proxy do
       end
     end
 
-    describe "#any?" do
-
-      let(:person) do
-        Person.create
-      end
-  
-      context "when nothing exists on the relation" do
-        
-        context "when no document is added" do
-
-          let!(:sandwich) do
-            Sandwich.create!
-          end
-
-          it "returns false" do
-            expect(sandwich.meats.any?).to be false
-          end
-        end
-
-        context "when the document is destroyed" do
-  
-          before do
-            Meat.create!
-          end
-  
-          let!(:sandwich) do
-            Sandwich.create!
-          end
-  
-          it "returns false" do
-            sandwich.destroy
-            expect(sandwich.meats.any?).to be false
-          end
-        end
-      end
-
-      context "when appending to a relation and _loaded/_unloaded are empty" do
-  
-        let!(:sandwich) do
-          Sandwich.create!
-        end
-
-        before do
-          sandwich.meats << Meat.new
-        end
-  
-        it "returns true" do
-          expect(sandwich.meats.any?).to be true
-        end
-      end
-
-      context "when appending to a relation in a transaction" do
-        require_topology :replica_set
-        
-        let!(:sandwich) do
-          Sandwich.create!
-        end
-
-        it "returns true" do
-          sandwich.with_session do |session|
-            session.start_transaction
-            expect { sandwich.meats << Meat.new }.to_not raise_error
-            expect(sandwich.meats.any?).to be true
-            session.commit_transaction
-          end
-        end
-      end
-    end
-
     context "when documents have been persisted" do
 
       let!(:preference) do
@@ -1911,6 +1842,107 @@ describe Mongoid::Association::Referenced::HasAndBelongsToMany::Proxy do
         it "returns 0" do
           expect(person.preferences.count).to eq(0)
         end
+      end
+    end
+  end
+
+  describe "#any?" do
+
+    let(:sandwich) do
+      Sandwich.create
+    end
+
+    context "when nothing exists on the relation" do
+      
+      context "when no document is added" do
+
+        let!(:sandwich) do
+          Sandwich.create!
+        end
+
+        it "returns false" do
+          expect(sandwich.meats.any?).to be false
+        end
+      end
+
+      context "when the document is destroyed" do
+
+        before do
+          Meat.create!
+        end
+
+        let!(:sandwich) do
+          Sandwich.create!
+        end
+
+        it "returns false" do
+          sandwich.destroy
+          expect(sandwich.meats.any?).to be false
+        end
+      end
+    end
+
+    context "when appending to a relation and _loaded/_unloaded are empty" do
+
+      let!(:sandwich) do
+        Sandwich.create!
+      end
+
+      before do
+        sandwich.meats << Meat.new
+      end
+
+      it "returns true" do
+        expect(sandwich.meats.any?).to be true
+      end
+    end
+
+    context "when appending to a relation in a transaction" do
+      require_topology :replica_set, :sharded
+      
+      let!(:sandwich) do
+        Sandwich.create!
+      end
+
+      it "returns true" do
+        sandwich.with_session do |session|
+          session.start_transaction
+          expect { sandwich.meats << Meat.new }.to_not raise_error
+          expect(sandwich.meats.any?).to be true
+          session.commit_transaction
+        end
+      end
+    end
+
+    context "when documents have been persisted" do
+
+      let!(:meat) do
+        sandwich.meats.create
+      end
+
+      it "returns true" do
+        expect(sandwich.meats.any?).to be true
+      end
+    end
+
+    context "when documents have not been persisted" do
+
+      let!(:meat) do
+        sandwich.meats.build
+      end
+
+      it "returns false" do
+        expect(sandwich.meats.any?).to be true
+      end
+    end
+
+    context "when new documents exist in the database" do
+      before do
+        Meat.create(sandwiches: [sandwich])
+      end
+
+      it "returns true" do
+        expect(sandwich.meats.any?).to be true
       end
     end
   end

--- a/spec/mongoid/association/referenced/has_and_belongs_to_many/proxy_spec.rb
+++ b/spec/mongoid/association/referenced/has_and_belongs_to_many/proxy_spec.rb
@@ -1935,7 +1935,7 @@ describe Mongoid::Association::Referenced::HasAndBelongsToMany::Proxy do
     end
 
     context "when appending to a relation in a transaction" do
-      require_topology :replica_set, :sharded
+      require_transaction_support
       
       let!(:sandwich) do
         Sandwich.create!

--- a/spec/mongoid/association/referenced/has_and_belongs_to_many/proxy_spec.rb
+++ b/spec/mongoid/association/referenced/has_and_belongs_to_many/proxy_spec.rb
@@ -1757,6 +1757,43 @@ describe Mongoid::Association::Referenced::HasAndBelongsToMany::Proxy do
       end
     end
 
+    describe "#any?" do
+
+      let(:person) do
+        Person.create
+      end
+  
+      context "when nothing exists on the relation" do
+        
+        context "when no document is added" do
+
+          let!(:sandwich) do
+            Sandwich.create!
+          end
+
+          it "returns false" do
+            expect(sandwich.meats.any?).to be false
+          end
+        end
+
+        context "when the document is destroyed" do
+  
+          before do
+            Meat.create!
+          end
+  
+          let!(:sandwich) do
+            Sandwich.create!
+          end
+  
+          it "returns false" do
+            sandwich.destroy
+            expect(sandwich.meats.any?).to be false
+          end
+        end
+      end
+    end
+
     context "when documents have been persisted" do
 
       let!(:preference) do

--- a/spec/mongoid/association/referenced/has_and_belongs_to_many/proxy_spec.rb
+++ b/spec/mongoid/association/referenced/has_and_belongs_to_many/proxy_spec.rb
@@ -1792,6 +1792,38 @@ describe Mongoid::Association::Referenced::HasAndBelongsToMany::Proxy do
           end
         end
       end
+
+      context "when appending to a relation and _loaded/_unloaded are empty" do
+  
+        let!(:sandwich) do
+          Sandwich.create!
+        end
+
+        before do
+          sandwich.meats << Meat.new
+        end
+  
+        it "returns true" do
+          expect(sandwich.meats.any?).to be true
+        end
+      end
+
+      context "when appending to a relation in a transaction" do
+        require_topology :replica_set
+        
+        let!(:sandwich) do
+          Sandwich.create!
+        end
+
+        it "returns true" do
+          sandwich.with_session do |session|
+            session.start_transaction
+            expect { sandwich.meats << Meat.new }.to_not raise_error
+            expect(sandwich.meats.any?).to be true
+            session.commit_transaction
+          end
+        end
+      end
     end
 
     context "when documents have been persisted" do

--- a/spec/mongoid/association/referenced/has_and_belongs_to_many/proxy_spec.rb
+++ b/spec/mongoid/association/referenced/has_and_belongs_to_many/proxy_spec.rb
@@ -1906,10 +1906,10 @@ describe Mongoid::Association::Referenced::HasAndBelongsToMany::Proxy do
 
       it "returns true" do
         sandwich.with_session do |session|
-          session.start_transaction
-          expect { sandwich.meats << Meat.new }.to_not raise_error
-          expect(sandwich.meats.any?).to be true
-          session.commit_transaction
+          session.with_transaction do 
+            expect{ sandwich.meats << Meat.new }.to_not raise_error
+            expect(sandwich.meats.any?).to be true
+          end
         end
       end
     end

--- a/spec/mongoid/association/referenced/has_many/proxy_spec.rb
+++ b/spec/mongoid/association/referenced/has_many/proxy_spec.rb
@@ -1488,7 +1488,7 @@ describe Mongoid::Association::Referenced::HasMany::Proxy do
         movie.ratings.build(value: 1)
       end
 
-      it "returns false" do 
+      it "returns false" do
         expect(movie.ratings.any?).to be true
       end
     end

--- a/spec/mongoid/association/referenced/has_many/proxy_spec.rb
+++ b/spec/mongoid/association/referenced/has_many/proxy_spec.rb
@@ -1517,7 +1517,7 @@ describe Mongoid::Association::Referenced::HasMany::Proxy do
     end
 
     context "when appending to a relation in a transaction" do
-      require_topology :replica_set, :sharded
+      require_transaction_support
       
       let!(:movie) do
         Movie.create!

--- a/spec/mongoid/association/referenced/has_many/proxy_spec.rb
+++ b/spec/mongoid/association/referenced/has_many/proxy_spec.rb
@@ -1431,6 +1431,13 @@ describe Mongoid::Association::Referenced::HasMany::Proxy do
         expect(movie.ratings.count).to eq(0)
       end
     end
+    
+    context "when no document is added" do
+
+      it "returns false" do
+        expect(movie.ratings.any?).to be false
+      end
+    end
 
     context "when new documents exist in the database" do
 
@@ -1453,6 +1460,60 @@ describe Mongoid::Association::Referenced::HasMany::Proxy do
 
         it "returns the count from the db" do
           expect(movie.ratings.count).to eq(0)
+        end
+      end
+    end
+  end
+
+  describe "#any?" do
+
+    let(:movie) do
+      Movie.create
+    end
+
+    context "when documents have been persisted" do
+
+      let!(:rating) do
+        movie.ratings.create(value: 1)
+      end
+
+      it "returns true" do
+        expect(movie.ratings.any?).to be true
+      end
+    end
+
+    context "when documents have not been persisted" do
+
+      let!(:rating) do
+        movie.ratings.build(value: 1)
+      end
+
+      it "returns false" do 
+        expect(movie.ratings.any?).to be true
+      end
+    end
+
+    context "when new documents exist in the database" do
+
+      context "when the documents are part of the relation" do
+
+        before do
+          Rating.create(ratable: movie)
+        end
+
+        it "returns true" do
+          expect(movie.ratings.any?).to be true
+        end
+      end
+
+      context "when the documents are not part of the relation" do
+
+        before do
+          Rating.create
+        end
+
+        it "returns false" do
+          expect(movie.ratings.any?).to be false
         end
       end
     end

--- a/spec/mongoid/association/referenced/has_many/proxy_spec.rb
+++ b/spec/mongoid/association/referenced/has_many/proxy_spec.rb
@@ -1525,10 +1525,10 @@ describe Mongoid::Association::Referenced::HasMany::Proxy do
 
       it "returns true" do
         movie.with_session do |session|
-          session.start_transaction
-          expect { movie.ratings << Rating.new }.to_not raise_error
-          expect(movie.ratings.any?).to be true
-          session.commit_transaction
+          session.with_transaction do 
+            expect{ movie.ratings << Rating.new }.to_not raise_error
+            expect(movie.ratings.any?).to be true
+          end
         end
       end
     end


### PR DESCRIPTION
This is a pretty weird fix... Since _target can be either an enumerable or an array I had to make a method in enumerable that was already defined on arrays. This method turned out to be any?, which returns a boolean based on whether there is an element in the array.

Also note that `in_memory` and `_added` are both hashes in the any? function.