### PR TITLE
MONGOID-4898 changed to count_documents and added estimated_count [WIP]

### DIFF
--- a/lib/mongoid/contextual/mongo.rb
+++ b/lib/mongoid/contextual/mongo.rb
@@ -71,7 +71,31 @@ module Mongoid
       # @since 3.0.0
       def count(options = {}, &block)
         return super(&block) if block_given?
-        try_cache(:count) { view.count(options) }
+        try_cache(:count) { view.count_documents(options) }
+      end
+
+      # Get the estimated number of documents matching the query.
+      #
+      # @example Get the estimated number of matching documents.
+      #   context.estimated_count
+      #
+      # @example Get the count of documents with the provided options.
+      #   context.estimated_count(limit: 1)
+      #
+      # @example Get the count for where the provided block is true.
+      #   context.estimated_count do |doc|
+      #     doc.likes > 1
+      #   end
+      #
+      # @param [ Hash ] options The options, such as skip and limit to be factored
+      #   into the count.
+      #
+      # @return [ Integer ] The number of matches.
+      #
+      # @since 3.0.0
+      def estimated_count(options = {}, &block)
+        return super(&block) if block_given?
+        try_cache(:count) { view.estimated_document_count(options) }
       end
 
       # Delete all documents in the database that match the selector.

--- a/lib/mongoid/findable.rb
+++ b/lib/mongoid/findable.rb
@@ -60,6 +60,18 @@ module Mongoid
       with_default_scope.count
     end
 
+    # Returns an estimated count of records in the database.
+    # If you want to specify conditions use where.
+    #
+    # @example Get the count of matching documents.
+    #   Person.estimated_count
+    #   Person.where(title: "Sir").estimated_count
+    #
+    # @return [ Integer ] The number of matching documents.
+    def estimated_count
+      with_default_scope.estimated_count
+    end
+
     # Returns true if count is zero
     #
     # @example Are there no saved documents for this model?

--- a/spec/mongoid/contextual/mongo_spec.rb
+++ b/spec/mongoid/contextual/mongo_spec.rb
@@ -110,7 +110,7 @@ describe Mongoid::Contextual::Mongo do
       end
 
       before do
-        expect(context.view).to receive(:count).once.and_return(1)
+        expect(context.view).to receive(:count_documents).once.and_return(1)
       end
 
       it "returns the count cached value after first call" do
@@ -1401,7 +1401,7 @@ describe Mongoid::Contextual::Mongo do
         context "when calling more than once" do
 
           before do
-            expect(context.view).to receive(:count).once.and_return(2)
+            expect(context.view).to receive(:count_documents).once.and_return(2)
           end
 
           it "returns the cached value for subsequent calls" do
@@ -1413,7 +1413,7 @@ describe Mongoid::Contextual::Mongo do
 
           before do
             context.entries
-            expect(context.view).to receive(:count).once.and_return(2)
+            expect(context.view).to receive(:count_documents).once.and_return(2)
           end
 
           it "returns the cached value for all calls" do
@@ -1450,7 +1450,7 @@ describe Mongoid::Contextual::Mongo do
         context "when calling more than once" do
 
           before do
-            expect(context.view).to receive(:count).once.and_return(1)
+            expect(context.view).to receive(:count_documents).once.and_return(1)
           end
 
           it "returns the cached value for subsequent calls" do
@@ -1462,7 +1462,7 @@ describe Mongoid::Contextual::Mongo do
 
           before do
             context.entries
-            expect(context.view).to receive(:count).once.and_return(1)
+            expect(context.view).to receive(:count_documents).once.and_return(1)
           end
 
           it "returns the cached value for all calls" do

--- a/spec/mongoid/findable_spec.rb
+++ b/spec/mongoid/findable_spec.rb
@@ -479,6 +479,32 @@ describe Mongoid::Findable do
     end
   end
 
+  describe '.count' do 
+    context 'when the collection is not empty' do 
+      before do
+        Band.create(name: "Tool")
+        Band.create(name: "Photek")
+      end
+
+      it 'returns the currect count' do 
+        expect(Band.count).to eq(2)
+      end
+    end
+  end
+
+  describe '.estimated_count' do 
+    context 'when the collection is not empty' do 
+      before do
+        Band.create(name: "Tool")
+        Band.create(name: "Photek")
+      end
+
+      it 'returns the currect count' do 
+        expect(Band.estimated_count).to eq(2)
+      end
+    end
+  end
+  
   Mongoid::Criteria::Queryable::Selectable.forwardables.each do |method|
 
     describe "##{method}" do


### PR DESCRIPTION
This PR has failing tests in the current driver version. The count_documents method does not accurately count object with collation, because it doesn't pass along the options to the count_documents method. The fix in driver was merged into master, I am just waiting for it to be released.