### PR TITLE
MONGOID-4928 implemented custom discriminator key fields

### DIFF
--- a/lib/mongoid/traversable.rb
+++ b/lib/mongoid/traversable.rb
@@ -239,7 +239,7 @@ module Mongoid
 
         # We only need the _type field if inheritance is in play, but need to
         # add to the root class as well for backwards compatibility.
-        unless fields.has_key?("_type")
+        unless fields.has_key?(self.discriminator_key)
           default_proc = lambda { self.class.name }
           field(self.discriminator_key, default: default_proc, type: String)
         end

--- a/lib/mongoid/traversable.rb
+++ b/lib/mongoid/traversable.rb
@@ -37,7 +37,11 @@ module Mongoid
           end
         end 
 
-        unless fields.has_key?(self.discriminator_key) || descendants.length == 0
+        # This condition checks if the new discriminator key would overwrite
+        # an existing field.
+        # This condition also checks if the class has any descendants, because
+        # if it doesn't then it doesn't need a discriminator key. 
+        if !fields.has_key?(self.discriminator_key) && !descendants.empty?
           default_proc = lambda { self.class.name }
           field(self.discriminator_key, default: default_proc, type: String)
         end

--- a/lib/mongoid/traversable.rb
+++ b/lib/mongoid/traversable.rb
@@ -26,7 +26,6 @@ module Mongoid
           raise Errors::InvalidDiscriminatorKeyTarget.new(self, self.superclass)
         end
 
-        
         if value
           super
         else

--- a/lib/mongoid/traversable.rb
+++ b/lib/mongoid/traversable.rb
@@ -26,6 +26,7 @@ module Mongoid
           raise Errors::InvalidDiscriminatorKeyTarget.new(self, self.superclass)
         end
 
+        
         if value
           super
         else
@@ -35,6 +36,11 @@ module Mongoid
           class << self
             delegate :discriminator_key, to: ::Mongoid
           end
+        end 
+
+        unless fields.has_key?(self.discriminator_key) || descendants.length == 0
+          default_proc = lambda { self.class.name }
+          field(self.discriminator_key, default: default_proc, type: String)
         end
       end
     end
@@ -236,7 +242,7 @@ module Mongoid
         # add to the root class as well for backwards compatibility.
         unless fields.has_key?("_type")
           default_proc = lambda { self.class.name }
-          field(:_type, default: default_proc, type: String)
+          field(self.discriminator_key, default: default_proc, type: String)
         end
       end
     end

--- a/spec/mongoid/traversable_spec.rb
+++ b/spec/mongoid/traversable_spec.rb
@@ -425,15 +425,15 @@ describe Mongoid::Traversable do
 
     context ".fields" do 
       context "when the discriminator key is not changed" do 
-        it "parent has _type field" do
+        it "creates a _type field in the parent" do
           expect(Instrument.fields.keys).to include("_type")
         end
   
-        it "child has _type field: Guitar" do
+        it "creates a _type field in the child: Guitar" do
           expect(Guitar.fields.keys).to include("_type")
         end
 
-        it "child has _type field: Piano" do
+        it "creates a _type field in the child: Piano" do
           expect(Piano.fields.keys).to include("_type")
         end
       end
@@ -455,19 +455,19 @@ describe Mongoid::Traversable do
             Mongoid.discriminator_key = "_type"
           end
     
-          it "parent has original global field name value" do 
+          it "creates a field with the old global value in the parent" do 
             expect(GlobalDiscriminiatorParent.fields.keys).to include("_type")
           end
 
-          it "child has original global field name value" do 
+          it "creates a field with the old global value in the child" do 
             expect(GlobalDiscriminiatorChild.fields.keys).to include("_type")
           end
 
-          it "parent does not have global field name value" do 
+          it "does not have the new global value in the parent" do 
             expect(GlobalDiscriminiatorParent.fields.keys).to_not include("test")
           end
 
-          it "child does not have global field name value" do 
+          it "does not have the new global value in the child" do 
             expect(GlobalDiscriminiatorChild.fields.keys).to_not include("test")
           end
           
@@ -491,19 +491,19 @@ describe Mongoid::Traversable do
             Mongoid.discriminator_key = "_type"
           end
 
-          it "parent has new discriminator key" do 
+          it "creates a field with new discriminator key in the parent" do 
             expect(PreGlobalDiscriminiatorParent.fields.keys).to include("test")
           end
 
-          it "child has new discriminator key" do 
+          it "creates a field with new discriminator key in the child" do 
             expect(PreGlobalDiscriminiatorChild.fields.keys).to include("test")
           end
 
-          it "parent does not have original discriminator key" do 
+          it "does not have original discriminator key in the parent" do 
             expect(PreGlobalDiscriminiatorParent.fields.keys).to_not include("_type")
           end
 
-          it "child does not have original discriminator key" do 
+          it "does not have original discriminator key in the child" do 
             expect(PreGlobalDiscriminiatorChild.fields.keys).to_not include("_type")
           end
         end
@@ -522,11 +522,11 @@ describe Mongoid::Traversable do
             LocalDiscriminiatorParent.discriminator_key = "test2"
           end
     
-          it "a new field is added" do 
+          it "creates a new field in the parent" do 
             expect(LocalDiscriminiatorParent.fields.keys).to include("test2")
           end
 
-          it "the original field remains" do
+          it "does not remove the original field" do
             expect(LocalDiscriminiatorParent.fields.keys).to include("_type")
           end
 
@@ -534,7 +534,7 @@ describe Mongoid::Traversable do
             expect(LocalDiscriminiatorChild.fields.keys).to include("_type")
           end
 
-          it "new fields are added in the child class" do 
+          it "has the new field in the child class" do 
             expect(LocalDiscriminiatorChild.fields.keys).to include("test2")
           end
         end
@@ -550,15 +550,15 @@ describe Mongoid::Traversable do
             end
           end
     
-          it "new field is added in the parent" do 
+          it "creates a new field in the parent" do 
             expect(PreLocalDiscriminiatorParent.fields.keys).to include("test2")
           end
 
-          it "_type field is not added" do 
+          it "does not create the _type field in the parent" do 
             expect(PreLocalDiscriminiatorParent.fields.keys).to_not include("_type")
           end
 
-          it "new field added in the child class" do 
+          it "creates a new field in the child" do 
             expect(PreLocalDiscriminiatorChild.fields.keys).to include("test2")
           end
         end
@@ -571,11 +571,11 @@ describe Mongoid::Traversable do
             end
           end
     
-          it "_type field is not added" do 
+          it "does not create a _type field" do 
             expect(LocalDiscriminiatorNonParent.fields.keys).to_not include("_type")
           end
 
-          it "new field not added" do 
+          it "does not create a new field" do 
             expect(LocalDiscriminiatorNonParent.fields.keys).to_not include("test2")
           end
         end

--- a/spec/mongoid/traversable_spec.rb
+++ b/spec/mongoid/traversable_spec.rb
@@ -441,11 +441,11 @@ describe Mongoid::Traversable do
       context "when the discriminator key is changed at the base level" do
         context "after class creation" do
           before do
-            class GlobalDiscriminiatorParent
+            class GlobalDiscriminatorParent
               include Mongoid::Document
             end
             
-            class GlobalDiscriminiatorChild < GlobalDiscriminiatorParent
+            class GlobalDiscriminatorChild < GlobalDiscriminatorParent
             end
             
             Mongoid.discriminator_key = "test"
@@ -456,19 +456,19 @@ describe Mongoid::Traversable do
           end
     
           it "creates a field with the old global value in the parent" do 
-            expect(GlobalDiscriminiatorParent.fields.keys).to include("_type")
+            expect(GlobalDiscriminatorParent.fields.keys).to include("_type")
           end
 
           it "creates a field with the old global value in the child" do 
-            expect(GlobalDiscriminiatorChild.fields.keys).to include("_type")
+            expect(GlobalDiscriminatorChild.fields.keys).to include("_type")
           end
 
           it "does not have the new global value in the parent" do 
-            expect(GlobalDiscriminiatorParent.fields.keys).to_not include("test")
+            expect(GlobalDiscriminatorParent.fields.keys).to_not include("test")
           end
 
           it "does not have the new global value in the child" do 
-            expect(GlobalDiscriminiatorChild.fields.keys).to_not include("test")
+            expect(GlobalDiscriminatorChild.fields.keys).to_not include("test")
           end
           
         end
@@ -477,11 +477,11 @@ describe Mongoid::Traversable do
           before do
             Mongoid.discriminator_key = "test"
 
-            class PreGlobalDiscriminiatorParent
+            class PreGlobalDiscriminatorParent
               include Mongoid::Document
             end
             
-            class PreGlobalDiscriminiatorChild < PreGlobalDiscriminiatorParent
+            class PreGlobalDiscriminatorChild < PreGlobalDiscriminatorParent
             end
             
             Mongoid.discriminator_key = "test"
@@ -492,19 +492,19 @@ describe Mongoid::Traversable do
           end
 
           it "creates a field with new discriminator key in the parent" do 
-            expect(PreGlobalDiscriminiatorParent.fields.keys).to include("test")
+            expect(PreGlobalDiscriminatorParent.fields.keys).to include("test")
           end
 
           it "creates a field with new discriminator key in the child" do 
-            expect(PreGlobalDiscriminiatorChild.fields.keys).to include("test")
+            expect(PreGlobalDiscriminatorChild.fields.keys).to include("test")
           end
 
           it "does not have the original discriminator key in the parent" do 
-            expect(PreGlobalDiscriminiatorParent.fields.keys).to_not include("_type")
+            expect(PreGlobalDiscriminatorParent.fields.keys).to_not include("_type")
           end
 
           it "does not have the original discriminator key in the child" do 
-            expect(PreGlobalDiscriminiatorChild.fields.keys).to_not include("_type")
+            expect(PreGlobalDiscriminatorChild.fields.keys).to_not include("_type")
           end
         end
       end
@@ -512,71 +512,71 @@ describe Mongoid::Traversable do
       context "when the discriminator key is changed in the parent" do 
         context "after child class creation" do
           before do
-            class LocalDiscriminiatorParent
+            class LocalDiscriminatorParent
               include Mongoid::Document
             end
 
-            class LocalDiscriminiatorChild < LocalDiscriminiatorParent
+            class LocalDiscriminatorChild < LocalDiscriminatorParent
             end
 
-            LocalDiscriminiatorParent.discriminator_key = "test2"
+            LocalDiscriminatorParent.discriminator_key = "test2"
           end
     
           it "creates a new field in the parent" do 
-            expect(LocalDiscriminiatorParent.fields.keys).to include("test2")
+            expect(LocalDiscriminatorParent.fields.keys).to include("test2")
           end
 
           it "does not remove the original field in the parent" do
-            expect(LocalDiscriminiatorParent.fields.keys).to include("_type")
+            expect(LocalDiscriminatorParent.fields.keys).to include("_type")
           end
 
           it "still has _type field in the child" do 
-            expect(LocalDiscriminiatorChild.fields.keys).to include("_type")
+            expect(LocalDiscriminatorChild.fields.keys).to include("_type")
           end
 
           it "has the new field in the child" do 
-            expect(LocalDiscriminiatorChild.fields.keys).to include("test2")
+            expect(LocalDiscriminatorChild.fields.keys).to include("test2")
           end
         end
 
         context "before child class creation" do
           before do
-            class PreLocalDiscriminiatorParent
+            class PreLocalDiscriminatorParent
               include Mongoid::Document
               self.discriminator_key = "test2"
             end
 
-            class PreLocalDiscriminiatorChild < PreLocalDiscriminiatorParent
+            class PreLocalDiscriminatorChild < PreLocalDiscriminatorParent
             end
           end
     
           it "creates a new field in the parent" do 
-            expect(PreLocalDiscriminiatorParent.fields.keys).to include("test2")
+            expect(PreLocalDiscriminatorParent.fields.keys).to include("test2")
           end
 
           it "does not create the _type field in the parent" do 
-            expect(PreLocalDiscriminiatorParent.fields.keys).to_not include("_type")
+            expect(PreLocalDiscriminatorParent.fields.keys).to_not include("_type")
           end
 
           it "creates a new field in the child" do 
-            expect(PreLocalDiscriminiatorChild.fields.keys).to include("test2")
+            expect(PreLocalDiscriminatorChild.fields.keys).to include("test2")
           end
         end
 
         context "when there's no child class" do
           before do
-            class LocalDiscriminiatorNonParent
+            class LocalDiscriminatorNonParent
               include Mongoid::Document
               self.discriminator_key = "test2"
             end
           end
     
           it "does not create a _type field" do 
-            expect(LocalDiscriminiatorNonParent.fields.keys).to_not include("_type")
+            expect(LocalDiscriminatorNonParent.fields.keys).to_not include("_type")
           end
 
           it "does not create a new field" do 
-            expect(LocalDiscriminiatorNonParent.fields.keys).to_not include("test2")
+            expect(LocalDiscriminatorNonParent.fields.keys).to_not include("test2")
           end
         end
       end

--- a/spec/mongoid/traversable_spec.rb
+++ b/spec/mongoid/traversable_spec.rb
@@ -499,11 +499,11 @@ describe Mongoid::Traversable do
             expect(PreGlobalDiscriminiatorChild.fields.keys).to include("test")
           end
 
-          it "does not have original discriminator key in the parent" do 
+          it "does not have the original discriminator key in the parent" do 
             expect(PreGlobalDiscriminiatorParent.fields.keys).to_not include("_type")
           end
 
-          it "does not have original discriminator key in the child" do 
+          it "does not have the original discriminator key in the child" do 
             expect(PreGlobalDiscriminiatorChild.fields.keys).to_not include("_type")
           end
         end
@@ -526,15 +526,15 @@ describe Mongoid::Traversable do
             expect(LocalDiscriminiatorParent.fields.keys).to include("test2")
           end
 
-          it "does not remove the original field" do
+          it "does not remove the original field in the parent" do
             expect(LocalDiscriminiatorParent.fields.keys).to include("_type")
           end
 
-          it "still has _type field" do 
+          it "still has _type field in the child" do 
             expect(LocalDiscriminiatorChild.fields.keys).to include("_type")
           end
 
-          it "has the new field in the child class" do 
+          it "has the new field in the child" do 
             expect(LocalDiscriminiatorChild.fields.keys).to include("test2")
           end
         end

--- a/spec/mongoid/traversable_spec.rb
+++ b/spec/mongoid/traversable_spec.rb
@@ -425,15 +425,15 @@ describe Mongoid::Traversable do
 
     context ".fields" do 
       context "when the discriminator key is not changed" do 
-        it "equals _type" do
-          expect(Instrument.discriminator_key).to eq("_type")
+        it "parent has _type field" do
+          expect(Instrument.fields.keys).to include("_type")
         end
   
-        it "child's discriminator key equals _type: Guitar" do
+        it "child has _type field: Guitar" do
           expect(Guitar.fields.keys).to include("_type")
         end
 
-        it "child's discriminator key equals _type: Piano" do
+        it "child has _type field: Piano" do
           expect(Piano.fields.keys).to include("_type")
         end
       end
@@ -455,19 +455,19 @@ describe Mongoid::Traversable do
             Mongoid.discriminator_key = "_type"
           end
     
-          it "parent uses original global value" do 
+          it "parent has original global field name value" do 
             expect(GlobalDiscriminiatorParent.fields.keys).to include("_type")
           end
 
-          it "child uses original global value" do 
+          it "child has original global field name value" do 
             expect(GlobalDiscriminiatorChild.fields.keys).to include("_type")
           end
 
-          it "parent does not use global value" do 
+          it "parent does not have global field name value" do 
             expect(GlobalDiscriminiatorParent.fields.keys).to_not include("test")
           end
 
-          it "child does not use global value" do 
+          it "child does not have global field name value" do 
             expect(GlobalDiscriminiatorChild.fields.keys).to_not include("test")
           end
           
@@ -522,12 +522,11 @@ describe Mongoid::Traversable do
             LocalDiscriminiatorParent.discriminator_key = "test2"
           end
     
-          after do 
-            LocalDiscriminiatorParent.discriminator_key = "_type"
-          end
-    
           it "a new field is added" do 
             expect(LocalDiscriminiatorParent.fields.keys).to include("test2")
+          end
+
+          it "the original field remains" do
             expect(LocalDiscriminiatorParent.fields.keys).to include("_type")
           end
 
@@ -535,7 +534,7 @@ describe Mongoid::Traversable do
             expect(LocalDiscriminiatorChild.fields.keys).to include("_type")
           end
 
-          it "new fields are added in the child classes" do 
+          it "new fields are added in the child class" do 
             expect(LocalDiscriminiatorChild.fields.keys).to include("test2")
           end
         end
@@ -551,12 +550,11 @@ describe Mongoid::Traversable do
             end
           end
     
-          after do 
-            PreLocalDiscriminiatorParent.discriminator_key = "_type"
+          it "new field is added in the parent" do 
+            expect(PreLocalDiscriminiatorParent.fields.keys).to include("test2")
           end
-    
+
           it "_type field is not added" do 
-            expect(PreLocalDiscriminiatorParent.fields.keys).to_not include("_type")
             expect(PreLocalDiscriminiatorParent.fields.keys).to_not include("_type")
           end
 
@@ -571,10 +569,6 @@ describe Mongoid::Traversable do
               include Mongoid::Document
               self.discriminator_key = "test2"
             end
-          end
-    
-          after do 
-            LocalDiscriminiatorNonParent.discriminator_key = "_type"
           end
     
           it "_type field is not added" do 


### PR DESCRIPTION
If the discriminator key changes before the class is created then it is created with the correct field, otherwise a second field is added in addition to type.