### PR TITLE
MONGOID-4817 use #discriminator_key function instead of _type

### DIFF
--- a/lib/mongoid/association/many.rb
+++ b/lib/mongoid/association/many.rb
@@ -207,7 +207,7 @@ module Mongoid
       #
       # @return [ Document ] A matching document or a new/created one.
       def find_or(method, attrs = {}, type = nil, &block)
-        attrs["_type"] = type.to_s if type
+        attrs[klass.discriminator_key] = type.to_s if type
         where(attrs).first || send(method, attrs, type, &block)
       end
     end

--- a/lib/mongoid/attributes/dynamic.rb
+++ b/lib/mongoid/attributes/dynamic.rb
@@ -116,7 +116,7 @@ module Mongoid
       #
       # @since 4.0.0
       def inspect_dynamic_fields
-        keys = attributes.keys - fields.keys - relations.keys - ["_id", "_type"]
+        keys = attributes.keys - fields.keys - relations.keys - ["_id", self.class.discriminator_key]
         return keys.map do |name|
           "#{name}: #{attributes[name].inspect}"
         end

--- a/lib/mongoid/config.rb
+++ b/lib/mongoid/config.rb
@@ -33,7 +33,7 @@ module Mongoid
     option :belongs_to_required_by_default, default: true
 
     # Set the global discriminator key.
-    option :discriminator_key, default: "_type"
+    option :discriminator_key, default: :_type
 
     # Raise an exception when a field is redefined.
     option :duplicate_fields_exception, default: false

--- a/lib/mongoid/criteria.rb
+++ b/lib/mongoid/criteria.rb
@@ -292,7 +292,7 @@ module Mongoid
         args.unshift(:_id)
       end
       if klass.hereditary?
-        super(*args.push(:_type))
+        super(*args.push(klass.discriminator_key))
       else
         super(*args)
       end
@@ -555,8 +555,7 @@ module Mongoid
     # @since 3.0.3
     def type_selectable?
       klass.hereditary? &&
-        !selector.keys.include?("_type") &&
-        !selector.keys.include?(:_type)
+        !selector.keys.include?(self.discriminator_key)
     end
 
     # Get the selector for type selection.

--- a/lib/mongoid/criteria.rb
+++ b/lib/mongoid/criteria.rb
@@ -169,7 +169,7 @@ module Mongoid
     # @since 2.0.0
     def field_list
       if options[:fields]
-        options[:fields].keys.reject{ |key| key == "_type" }
+        options[:fields].keys.reject{ |key| key == klass.discriminator_key }
       else
         []
       end
@@ -555,7 +555,8 @@ module Mongoid
     # @since 3.0.3
     def type_selectable?
       klass.hereditary? &&
-        !selector.keys.include?(self.discriminator_key)
+        !selector.keys.include?(self.discriminator_key.to_s) &&
+        !selector.keys.include?(self.discriminator_key.to_sym)
     end
 
     # Get the selector for type selection.

--- a/lib/mongoid/document.rb
+++ b/lib/mongoid/document.rb
@@ -233,8 +233,8 @@ module Mongoid
       became.errors.instance_variable_set(:@messages, errors.instance_variable_get(:@messages))
       became.instance_variable_set(:@new_record, new_record?)
       became.instance_variable_set(:@destroyed, destroyed?)
-      became.changed_attributes["_type"] = self.class.to_s
-      became._type = klass.to_s
+      became.changed_attributes[klass.discriminator_key] = self.class.to_s
+      became[klass.discriminator_key] = klass.to_s
 
       # mark embedded docs as persisted
       embedded_relations.each_pair do |name, meta|

--- a/lib/mongoid/factory.rb
+++ b/lib/mongoid/factory.rb
@@ -7,8 +7,6 @@ module Mongoid
   module Factory
     extend self
 
-    TYPE = "_type".freeze
-
     # Builds a new +Document+ from the supplied attributes.
     #
     # @example Build the document.
@@ -20,7 +18,7 @@ module Mongoid
     # @return [ Document ] The instantiated document.
     def build(klass, attributes = nil)
       attributes ||= {}
-      type = attributes[TYPE] || attributes[TYPE.to_sym]
+      type = attributes[klass.discriminator_key.to_s] || attributes[klass.discriminator_key.to_sym]
       if type && klass._types.include?(type)
         type.constantize.new(attributes)
       else
@@ -54,7 +52,7 @@ module Mongoid
       if criteria
         selected_fields ||= criteria.options[:fields]
       end
-      type = (attributes || {})[TYPE]
+      type = (attributes || {})[klass.discriminator_key]
       if type.blank?
         obj = klass.instantiate(attributes, selected_fields)
         if criteria && criteria.association && criteria.parent_document

--- a/lib/mongoid/factory.rb
+++ b/lib/mongoid/factory.rb
@@ -7,6 +7,9 @@ module Mongoid
   module Factory
     extend self
 
+    # @deprecated
+    TYPE = "_type".freeze
+
     # Builds a new +Document+ from the supplied attributes.
     #
     # @example Build the document.

--- a/spec/mongoid/criteria_spec.rb
+++ b/spec/mongoid/criteria_spec.rb
@@ -786,12 +786,32 @@ describe Mongoid::Criteria do
 
   describe "#field_list" do
 
-    let(:criteria) do
-      Band.only(:name)
+    context "when using the default discriminator key" do 
+      let(:criteria) do
+        Doctor.only(:_id)
+      end
+
+      it "returns the fields with required _id minus type" do
+        expect(criteria.field_list).to eq([ "_id" ])
+      end
     end
 
-    it "returns the fields with required _id minus type" do
-      expect(criteria.field_list).to eq([ "_id", "name" ])
+    context "when using a custom discriminator key" do 
+      before do 
+        Person.discriminator_key = "dkey"
+      end
+
+      after do 
+        Person.discriminator_key = nil
+      end
+
+      let(:criteria) do
+        Doctor.only(:_id, :_type)
+      end
+
+      it "returns the fields with type without dkey" do
+        expect(criteria.field_list).to eq([ "_id", "_type" ])
+      end
     end
   end
 
@@ -2810,7 +2830,7 @@ describe Mongoid::Criteria do
         end
 
         it "adds _type to the fields" do
-          expect(criteria.options[:fields]["_type"]).to eq(1)
+          expect(criteria.options[:fields]).to include("_type")
         end
       end
 
@@ -2819,6 +2839,10 @@ describe Mongoid::Criteria do
           Person.discriminator_key = "dkey"
         end
 
+        after do 
+          Person.discriminator_key = nil
+        end
+        
         let(:criteria) do
           Doctor.only(:_id)
         end

--- a/spec/mongoid/criteria_spec.rb
+++ b/spec/mongoid/criteria_spec.rb
@@ -2804,13 +2804,32 @@ describe Mongoid::Criteria do
     end
 
     context "when using inheritance" do
+      context "when using the default discriminator key" do 
+        let(:criteria) do
+          Doctor.only(:_id)
+        end
 
-      let(:criteria) do
-        Doctor.only(:_id)
+        it "adds _type to the fields" do
+          expect(criteria.options[:fields]["_type"]).to eq(1)
+        end
       end
 
-      it "adds _type to the fields" do
-        expect(criteria.options[:fields]["_type"]).to eq(1)
+      context "when setting a custom discriminator key" do 
+        before do 
+          Person.discriminator_key = "dkey"
+        end
+
+        let(:criteria) do
+          Doctor.only(:_id)
+        end
+
+        it "adds custom discriminator key to the fields" do
+          expect(criteria.options[:fields]).to include("dkey")
+        end
+
+        it "does not add _type to the fields" do
+          expect(criteria.options[:fields]).to_not include("_type")
+        end
       end
     end
 

--- a/spec/mongoid/document_spec.rb
+++ b/spec/mongoid/document_spec.rb
@@ -881,27 +881,60 @@ describe Mongoid::Document do
       end
 
       context "when no embedded documents are present" do
+        context "when using the default discriminator key" do 
+          let(:person) do
+            manager.becomes(Person)
+          end
 
-        let(:person) do
-          manager.becomes(Person)
+          it "copies attributes" do
+            expect(person.title).to eq('Sir')
+          end
+
+          it "keeps the same object id" do
+            expect(person.id).to eq(manager.id)
+          end
+
+          it "sets the class type" do
+            expect(person._type).to eq("Person")
+          end
+
+          it "raises an error when inappropriate class is provided" do
+            expect {
+              manager.becomes(String)
+            }.to raise_error(ArgumentError)
+          end
         end
 
-        it "copies attributes" do
-          expect(person.title).to eq('Sir')
-        end
+        context "when using a custom discriminator key" do 
+          before do 
+            Person.discriminator_key = "dkey"
+          end
 
-        it "keeps the same object id" do
-          expect(person.id).to eq(manager.id)
-        end
+          after do 
+            Person.discriminator_key = nil
+          end
 
-        it "sets the class type" do
-          expect(person._type).to eq("Person")
-        end
+          let(:person) do
+            manager.becomes(Person)
+          end
 
-        it "raises an error when inappropriate class is provided" do
-          expect {
-            manager.becomes(String)
-          }.to raise_error(ArgumentError)
+          it "copies attributes" do
+            expect(person.title).to eq('Sir')
+          end
+
+          it "keeps the same object id" do
+            expect(person.id).to eq(manager.id)
+          end
+
+          it "sets the class type with new discriminator key" do
+            expect(person.dkey).to eq("Person")
+          end
+
+          it "raises an error when inappropriate class is provided" do
+            expect {
+              manager.becomes(String)
+            }.to raise_error(ArgumentError)
+          end
         end
       end
 

--- a/spec/mongoid/document_spec.rb
+++ b/spec/mongoid/document_spec.rb
@@ -901,7 +901,7 @@ describe Mongoid::Document do
           it "raises an error when inappropriate class is provided" do
             expect {
               manager.becomes(String)
-            }.to raise_error(ArgumentError)
+            }.to raise_error(ArgumentError, /A class which includes Mongoid::Document is expected/)
           end
         end
 
@@ -914,26 +914,8 @@ describe Mongoid::Document do
             Person.discriminator_key = nil
           end
 
-          let(:person) do
-            manager.becomes(Person)
-          end
-
-          it "copies attributes" do
-            expect(person.title).to eq('Sir')
-          end
-
-          it "keeps the same object id" do
-            expect(person.id).to eq(manager.id)
-          end
-
           it "sets the class type with new discriminator key" do
             expect(person.dkey).to eq("Person")
-          end
-
-          it "raises an error when inappropriate class is provided" do
-            expect {
-              manager.becomes(String)
-            }.to raise_error(ArgumentError)
           end
         end
       end

--- a/spec/mongoid/factory_spec.rb
+++ b/spec/mongoid/factory_spec.rb
@@ -78,28 +78,62 @@ describe Mongoid::Factory do
     end
 
     context "when type is not preset" do
+      context "when using the default discriminator key" do 
+        let(:attributes) do
+          { "title" => "Sir" }
+        end
 
-      let(:attributes) do
-        { "title" => "Sir" }
+        let(:person) do
+          described_class.build(Person, attributes)
+        end
+
+        it "instantiates based on the provided class" do
+          expect(person.title).to eq("Sir")
+        end
+
+        context "when the type is a symbol" do
+
+          let(:person) do
+            described_class.build(Person, { :_type => "Doctor" })
+          end
+
+          it "instantiates the subclass" do
+            expect(person.class).to eq(Doctor)
+          end
+        end
       end
 
-      let(:person) do
-        described_class.build(Person, attributes)
-      end
+      context "when using a custom discriminator key" do 
+        before do 
+          Person.discriminator_key = "dkey"
+        end
 
-      it "instantiates based on the provided class" do
-        expect(person.title).to eq("Sir")
-      end
-    end
+        after do 
+          Person.discriminator_key = nil
+        end
 
-    context "when the type is a symbol" do
+        let(:attributes) do
+          { "title" => "Sir" }
+        end
 
-      let(:person) do
-        described_class.build(Person, { :_type => "Doctor" })
-      end
+        let(:person) do
+          described_class.build(Person, attributes)
+        end
 
-      it "instantiates the subclass" do
-        expect(person.class).to eq(Doctor)
+        it "instantiates based on the provided class" do
+          expect(person.title).to eq("Sir")
+        end
+        
+        context "when the type is a symbol" do
+          
+          let(:person) do
+            described_class.build(Person, { :dkey => "Doctor" })
+          end
+          
+          it "instantiates the subclass" do
+            expect(person.class).to eq(Doctor)
+          end
+        end
       end
     end
   end
@@ -179,20 +213,48 @@ describe Mongoid::Factory do
 
     context "when a type is not in the attributes" do
 
-      let(:attributes) do
-        { "title" => "Sir" }
+      context "when using the default discriminator key" do
+        let(:attributes) do
+          { "title" => "Sir" }
+        end
+
+        let(:document) do
+          described_class.from_db(Person, attributes)
+        end
+
+        it "generates based on the provided class" do
+          expect(document).to be_a(Person)
+        end
+
+        it "sets the attributes" do
+          expect(document.title).to eq("Sir")
+        end
       end
 
-      let(:document) do
-        described_class.from_db(Person, attributes)
-      end
+      context "when using a custom discriminator key" do
+        before do 
+          Person.discriminator_key = "dkey"
+        end
 
-      it "generates based on the provided class" do
-        expect(document).to be_a(Person)
-      end
+        after do 
+          Person.discriminator_key = nil
+        end
 
-      it "sets the attributes" do
-        expect(document.title).to eq("Sir")
+        let(:attributes) do
+          { "title" => "Sir" }
+        end
+
+        let(:document) do
+          described_class.from_db(Person, attributes)
+        end
+
+        it "generates based on the provided class" do
+          expect(document).to be_a(Person)
+        end
+
+        it "sets the attributes" do
+          expect(document.title).to eq("Sir")
+        end
       end
     end
 

--- a/spec/mongoid/inspectable_spec.rb
+++ b/spec/mongoid/inspectable_spec.rb
@@ -32,6 +32,33 @@ describe Mongoid::Inspectable do
       it "displays field aliases" do
         expect(inspected).to include("t(test):")
       end
+
+      it "displays the default discriminator key" do 
+        expect(inspected).to include("_type: \"Person\"")
+      end
+    end
+
+    context "when using a custom discriminator key" do
+
+      before do 
+        Person.discriminator_key = "dkey"
+      end
+
+      after do 
+        Person.discriminator_key = nil
+      end
+
+      let(:person) do
+        Person.new(title: "CEO")
+      end
+
+      let(:inspected) do
+        person.inspect
+      end
+
+      it "displays the new discriminator key" do 
+        expect(inspected).to include("dkey: \"Person\"")
+      end
     end
 
     context "when allowing dynamic fields" do

--- a/spec/mongoid/inspectable_spec.rb
+++ b/spec/mongoid/inspectable_spec.rb
@@ -26,7 +26,7 @@ describe Mongoid::Inspectable do
       end
 
       it "displays defined fields" do
-        expect(inspected).to include("title: \"CEO\"")
+        expect(inspected).to include(%q,title: "CEO",)
       end
 
       it "displays field aliases" do
@@ -34,7 +34,7 @@ describe Mongoid::Inspectable do
       end
 
       it "displays the default discriminator key" do 
-        expect(inspected).to include("_type: \"Person\"")
+        expect(inspected).to include(%q,_type: "Person",)
       end
     end
 
@@ -57,7 +57,7 @@ describe Mongoid::Inspectable do
       end
 
       it "displays the new discriminator key" do 
-        expect(inspected).to include("dkey: \"Person\"")
+        expect(inspected).to include(%q,dkey: "Person",)
       end
     end
 
@@ -72,7 +72,7 @@ describe Mongoid::Inspectable do
       end
 
       it "includes dynamic attributes" do
-        expect(inspected).to include("some_attribute: \"foo\"")
+        expect(inspected).to include(%q,some_attribute: "foo",)
       end
     end
   end


### PR DESCRIPTION
So far I have changed criteria.rb to no longer hard-code _type.