### PR TITLE
MONGOID-4940 included discriminator_value field and added tests

### DIFF
--- a/lib/mongoid/traversable.rb
+++ b/lib/mongoid/traversable.rb
@@ -257,7 +257,7 @@ module Mongoid
         # We only need the _type field if inheritance is in play, but need to
         # add to the root class as well for backwards compatibility.
         unless fields.has_key?(self.discriminator_key)
-          default_proc = lambda { self.class.name }
+          default_proc = lambda { self.class.discriminator_value }
           field(self.discriminator_key, default: default_proc, type: String)
         end
       end

--- a/lib/mongoid/traversable.rb
+++ b/lib/mongoid/traversable.rb
@@ -20,7 +20,8 @@ module Mongoid
     end
 
     # Module used for prepending to the discriminator_key= function
-    #
+    # and the discriminator_value= function
+    # 
     # @api private
     module DiscriminatorAssignment
       def discriminator_key=(value)
@@ -46,7 +47,7 @@ module Mongoid
         # This condition also checks if the class has any descendants, because
         # if it doesn't then it doesn't need a discriminator key. 
         if !fields.has_key?(self.discriminator_key) && !descendants.empty?
-          default_proc = lambda { self.class.name }
+          default_proc = lambda { self.class.discriminator_value }
           field(self.discriminator_key, default: default_proc, type: String)
         end
       end

--- a/spec/mongoid/traversable_spec.rb
+++ b/spec/mongoid/traversable_spec.rb
@@ -1058,6 +1058,26 @@ describe Mongoid::Traversable do
           expect(firefox._type).to eq("Firefox")
         end
       end
+
+      context "when changing the discriminator key" do 
+        before do 
+          Instrument.discriminator_key = "dkey"
+          Guitar.discriminator_value = "string instrument"
+        end
+
+        after do 
+          Instrument.discriminator_key = nil
+          Guitar.discriminator_value = nil
+        end
+
+        let(:guitar) do 
+          Guitar.new
+        end
+
+        it "has the correct discriminator_value for the new discriminator_key" do
+          expect(guitar.dkey).to eq("string instrument")
+        end
+      end
     end
   end
 end

--- a/spec/mongoid/traversable_spec.rb
+++ b/spec/mongoid/traversable_spec.rb
@@ -1077,6 +1077,10 @@ describe Mongoid::Traversable do
         it "has the correct discriminator_value for the new discriminator_key" do
           expect(guitar.dkey).to eq("string instrument")
         end
+
+        it "has the correct discriminator_value for the old discriminator_key" do
+          expect(guitar._type).to eq("string instrument")
+        end
       end
     end
   end

--- a/spec/mongoid/traversable_spec.rb
+++ b/spec/mongoid/traversable_spec.rb
@@ -860,6 +860,23 @@ describe Mongoid::Traversable do
   end
 
   describe "#discriminator_value" do 
+
+    context "when the discriminator value is not set" do 
+
+      it "has the correct discriminator_value" do 
+        expect(Guitar.discriminator_value).to eq("Guitar")
+      end
+
+      it "has the correct discriminator_value" do 
+        expect(Piano.discriminator_value).to eq("Piano")
+      end
+
+      it "has the correct discriminator_value" do 
+        expect(Instrument.discriminator_value).to eq("Instrument")
+      end
+    end
+
+
     context "when the discriminator value is set on the child class" do 
       before do
         Guitar.discriminator_value = "some string instrument"
@@ -884,10 +901,11 @@ describe Mongoid::Traversable do
 
     context "when the discriminator value is set on the parent" do 
       before do
-        begin
-          Instrument.discriminator_value = "musical thingy"
-        rescue
-        end
+        Instrument.discriminator_value = "musical thingy"
+      end
+
+      after do
+        Instrument.discriminator_value = nil
       end
 
       it "is changed in the parent" do 
@@ -929,6 +947,116 @@ describe Mongoid::Traversable do
 
       it "doesn't set the grandchild's discriminator value" do 
         expect(Firefox.discriminator_value).to eq("Firefox")
+      end
+    end
+
+    describe ".fields" do
+
+      let(:guitar) do 
+        Guitar.new
+      end
+
+      let(:piano) do 
+        Piano.new
+      end
+
+      let(:instrument) do 
+        Instrument.new
+      end
+      
+      context "when the discriminator value is not set" do
+        it "has the correct discriminator_value" do 
+          expect(guitar._type).to eq("Guitar")
+        end
+  
+        it "has the correct discriminator_value" do 
+          expect(piano._type).to eq("Piano")
+        end
+  
+        it "has the correct discriminator_value" do 
+          expect(instrument._type).to eq("Instrument")
+        end
+      end
+
+      context "when the discriminator value is set on the child class" do 
+        before do
+          Guitar.discriminator_value = "some string instrument"
+        end
+  
+        after do 
+          Guitar.discriminator_value = nil
+        end
+  
+        it "has the correct discriminator_value" do 
+          expect(guitar._type).to eq("some string instrument")
+        end
+  
+        it "does not change the sibling's discriminator value" do 
+          expect(piano._type).to eq("Piano")
+        end
+  
+        it "does not change the parent's discriminator value" do 
+          expect(instrument._type).to eq("Instrument")
+        end
+      end
+  
+      context "when the discriminator value is set on the parent" do 
+        before do
+          Instrument.discriminator_value = "musical thingy"
+        end
+  
+        after do
+          Instrument.discriminator_value = nil
+        end
+
+        it "is changed in the parent" do 
+          expect(instrument._type).to eq("musical thingy")
+        end
+  
+        it "is not changed in the child: Guitar" do 
+          expect(guitar._type).to eq("Guitar")
+        end
+  
+        it "is not changed in the child: Piano" do 
+          expect(piano._type).to eq("Piano")
+        end
+      end
+  
+      context "when setting the discriminator value to nil" do
+        before do 
+          Guitar.discriminator_value = "some string instrument"
+          Guitar.discriminator_value = nil
+        end
+  
+        it "reverts back to default" do
+          expect(guitar._type).to eq("Guitar")
+        end
+      end
+  
+      context "when setting discriminator value on parent that is also a child" do
+        before do 
+          Browser.discriminator_value = "something"
+        end
+  
+        after do 
+          Browser.discriminator_value = nil
+        end
+
+        let(:browser) do
+          Browser.new
+        end
+
+        let(:firefox) do
+          Firefox.new
+        end
+
+        it "has the correct value in the parent" do 
+          expect(browser._type).to eq("something")
+        end
+  
+        it "doesn't set the grandchild's discriminator value" do 
+          expect(firefox._type).to eq("Firefox")
+        end
       end
     end
   end


### PR DESCRIPTION
On new instance of a class the correct discriminator field is being populated in the _type field.