### PR TITLE
MONGOID-4968: Proof-of-concept for thread-safe Sessions on driver

### DIFF
--- a/lib/mongoid/threaded.rb
+++ b/lib/mongoid/threaded.rb
@@ -363,43 +363,5 @@ module Mongoid
     def validations_for(klass)
       validations[klass] ||= []
     end
-
-    # Cache a session for this thread.
-    #
-    # @example Save a session for this thread.
-    #   Threaded.set_session(session)
-    #
-    # @param [ Mongo::Session ] session The session to save.
-    #
-    # @since 6.4.0
-    def set_session(session)
-      Thread.current[:session] = session
-    end
-
-    # Get the cached session for this thread.
-    #
-    # @example Get the session for this thread.
-    #   Threaded.get_session
-    #
-    # @return [ Mongo::Session, nil ] The session cached on this thread or nil.
-    #
-    # @since 6.4.0
-    def get_session
-      Thread.current[:session]
-    end
-
-    # Clear the cached session for this thread.
-    #
-    # @example Clear this thread's session.
-    #   Threaded.clear_session
-    #
-    # @return [ nil ]
-    #
-    # @since 6.4.0
-    def clear_session
-      session = get_session
-      session.end_session if session
-      Thread.current[:session] = nil
-    end
   end
 end


### PR DESCRIPTION
This PR demonstrates how the Mongoid code can be simplified (**while retaining backwards compatibility**) if Mongo Ruby driver were to support thread-safe sessions.

See https://github.com/mongodb/mongo-ruby-driver/pull/2060 for work on the Mongo Ruby Driver