### PR TITLE
MONGOID-4977 Use recent driver APIs in Mongoid QueryCache for compatibility with sessions & modern retryable reads

### DIFF
--- a/lib/mongoid/query_cache.rb
+++ b/lib/mongoid/query_cache.rb
@@ -253,8 +253,8 @@ module Mongoid
           super
         else
           @cursor = nil
-          session = client.send(:get_session, @options)
           unless @cursor = cached_cursor
+            session = client.send(:get_session, @options)
             read_with_retry(session, server_selector) do |server|
               result = send_initial_query(server, session)
               @cursor = CachedCursor.new(view, result, server, session: session)

--- a/lib/mongoid/query_cache.rb
+++ b/lib/mongoid/query_cache.rb
@@ -191,10 +191,7 @@ module Mongoid
       private
 
       def process(result)
-        @remaining -= result.returned_count if limited?
-        @cursor_id = result.cursor_id
-        @coll_name ||= result.namespace.sub("#{database.name}.", '') if result.namespace
-        documents = result.documents
+        documents = super
         if @cursor_id.zero? && !@after_first_batch
           @cached_documents ||= []
           @cached_documents.concat(documents)

--- a/spec/lite_spec_helper.rb
+++ b/spec/lite_spec_helper.rb
@@ -16,7 +16,7 @@ require 'pp'
 
 require 'support/spec_config'
 require 'support/lite_constraints'
-require 'support/session_registry'
+require "support/session_registry" 
 
 unless SpecConfig.instance.ci?
   begin

--- a/spec/lite_spec_helper.rb
+++ b/spec/lite_spec_helper.rb
@@ -16,6 +16,7 @@ require 'pp'
 
 require 'support/spec_config'
 require 'support/lite_constraints'
+require 'support/session_registry'
 
 unless SpecConfig.instance.ci?
   begin

--- a/spec/mongoid/query_cache_spec.rb
+++ b/spec/mongoid/query_cache_spec.rb
@@ -2,6 +2,7 @@
 # encoding: utf-8
 
 require "spec_helper"
+require "support/session_registry" 
 
 describe Mongoid::QueryCache do
 

--- a/spec/mongoid/query_cache_spec.rb
+++ b/spec/mongoid/query_cache_spec.rb
@@ -10,6 +10,16 @@ describe Mongoid::QueryCache do
     Mongoid::QueryCache.cache { spec.run }
   end
 
+  before(:all) do
+    # It is likely that there are other session leaks in the driver
+    # and/or Mongoid that are unrelated to the query cache. Clear the
+    # SessionRegistry at the start of these tests in order to detect leaks that
+    # occur only within the scope of these tests.
+    #
+    # Other session leaks will be detected and addressed as part of RUBY-2391.
+    SessionRegistry.instance.clear_registry
+  end
+
   before do
     SessionRegistry.instance.verify_sessions_ended!
   end

--- a/spec/mongoid/query_cache_spec.rb
+++ b/spec/mongoid/query_cache_spec.rb
@@ -2,7 +2,6 @@
 # encoding: utf-8
 
 require "spec_helper"
-require "support/session_registry" 
 
 describe Mongoid::QueryCache do
 
@@ -21,7 +20,7 @@ describe Mongoid::QueryCache do
     SessionRegistry.instance.clear_registry
   end
 
-  before do
+  after do
     SessionRegistry.instance.verify_sessions_ended!
   end
 

--- a/spec/mongoid/query_cache_spec.rb
+++ b/spec/mongoid/query_cache_spec.rb
@@ -10,6 +10,10 @@ describe Mongoid::QueryCache do
     Mongoid::QueryCache.cache { spec.run }
   end
 
+  before do
+    SessionRegistry.instance.verify_sessions_ended!
+  end
+
   context 'when iterating over objects sharing the same base' do
 
     let(:server) do

--- a/spec/support/session_registry.rb
+++ b/spec/support/session_registry.rb
@@ -1,0 +1,36 @@
+require 'singleton'
+
+module Mongo
+  class Client
+    alias :get_session_without_tracking! :get_session!
+
+    def get_session!(options = {})
+      get_session_without_tracking!(options).tap do |session|
+        SessionRegistry.instance.register(session)
+      end
+    end
+  end
+end
+
+class SessionRegistry
+  include Singleton
+
+  def initialize
+    @registry = []
+  end
+
+  def register(session)
+    @registry << session
+  end
+
+  def verify_sessions_ended!
+    unless @registry.all? { |session| session.ended? }
+      unended_sessions = @registry.select { |session| !session.ended? }
+      raise "Session registry contains live sessions: #{unended_sessions.join(',')}"
+    end
+  end
+
+  def clear_registry
+    @registry = []
+  end
+end

--- a/spec/support/session_registry.rb
+++ b/spec/support/session_registry.rb
@@ -24,9 +24,10 @@ class SessionRegistry
   end
 
   def verify_sessions_ended!
-    unless @registry.all? { |session| session.ended? }
-      unended_sessions = @registry.select { |session| !session.ended? }
-      raise "Session registry contains live sessions: #{unended_sessions.join(',')}"
+    @registry.reject! { |session| session.ended? }
+
+    unless @registry.empty?
+      raise "Session registry contains live sessions: #{@registry.join(', ')}"
     end
   end
 

--- a/spec/support/session_registry.rb
+++ b/spec/support/session_registry.rb
@@ -20,7 +20,7 @@ class SessionRegistry
   end
 
   def register(session)
-    @registry << session
+    @registry << session if session
   end
 
   def verify_sessions_ended!

--- a/spec/support/session_registry.rb
+++ b/spec/support/session_registry.rb
@@ -2,10 +2,10 @@ require 'singleton'
 
 module Mongo
   class Client
-    alias :get_session_without_tracking! :get_session!
+    alias :get_session_without_tracking :get_session
 
-    def get_session!(options = {})
-      get_session_without_tracking!(options).tap do |session|
+    def get_session(options = {})
+      get_session_without_tracking(options).tap do |session|
         SessionRegistry.instance.register(session)
       end
     end


### PR DESCRIPTION
https://jira.mongodb.org/browse/MONGOID-4977

The current `Mongoid::QueryCache::View.each` method is in sync with `Mongo::Collection::View::Iterable` from [5 years ago](https://github.com/mongodb/mongo-ruby-driver/commit/2df954f609d0d29b517a27784e0408894e39466b).

Since then, `Iterable` has been updated with a number of new features:
 - `close_query` [support](https://github.com/mongodb/mongo-ruby-driver/commit/e7dce35c2e66a24a954659de433db560abf23e6b)
 - `sessions` [support](https://github.com/mongodb/mongo-ruby-driver/commit/9769cbeea128c5d77e243486306f255cfa543aa7)
 - [support](https://github.com/mongodb/mongo-ruby-driver/commit/fc8d2e9af4907d0a6786d096bf9df3bcf7a7da38) for `write?` or `out?` queries

The primary issue with this is that any queries through the query cache don't utilize sessions. This PR is designed to update the query cache implementation to match the current implementation of `Mongo::Collection::View::Iterable` (see https://github.com/mongodb/mongo-ruby-driver/blob/v2.12.1/lib/mongo/collection/view/iterable.rb#L37-L56).

It adds support for:
 - the `write?` check (skips the query cache)
 - storing the cursor in `@cursor` for `close_query` support
 - calling `client.get_session` and passing the session to `read_with_retry`, `send_initial_query`, and the `CachedCursor` object

Secondly, `Mongoid::QueryCache::CachedCursor.process` has been changed to delegate to the super method in `Mongo::Cursor.process`, which picks up a bunch of changes, most importantly ending the implicit session.