### PR TITLE
Fix for MONGOID-4957

### DIFF
--- a/lib/mongoid/persistable/updatable.rb
+++ b/lib/mongoid/persistable/updatable.rb
@@ -137,11 +137,13 @@ module Mongoid
             coll = collection(_root)
             selector = atomic_selector
             coll.find(selector).update_one(positionally(selector, updates), session: _session)
+
+            # This causes the issue
             conflicts.each_pair do |key, value|
               coll.find(selector).update_one(positionally(selector, { key => value }), session: _session)
             end
 
-            # This code will fix the issue
+            # This code will fix the issue (replace above)
             # conflicts.each_pair do |modifier, values|
             #   inner_conflicts = values.group_by {|key, _| key.split(".", 2)[0] }.values
             #   while batch = inner_conflicts.map(&:pop).compact.to_h.presence

--- a/lib/mongoid/persistable/updatable.rb
+++ b/lib/mongoid/persistable/updatable.rb
@@ -140,6 +140,14 @@ module Mongoid
             conflicts.each_pair do |key, value|
               coll.find(selector).update_one(positionally(selector, { key => value }), session: _session)
             end
+
+            # This code will fix the issue
+            # conflicts.each_pair do |modifier, values|
+            #   inner_conflicts = values.group_by {|key, _| key.split(".", 2)[0] }.values
+            #   while batch = inner_conflicts.map(&:pop).compact.to_h.presence
+            #     coll.find(selector).update_one(positionally(selector, { modifier => batch }), session: _session)
+            #   end
+            # end
           end
         end
       end

--- a/spec/mongoid/persistable/savable_spec.rb
+++ b/spec/mongoid/persistable/savable_spec.rb
@@ -263,37 +263,8 @@ describe Mongoid::Persistable::Savable do
         let!(:crate) { truck.crates.create!(volume: 0.4) }
 
         it 'persists the new documents' do
-          expect(truck.crates.size).to eq 1
-          expect(truck.crates[0].volume).to eq 0.4
-          expect(truck.crates[0].toys.size).to eq 0
-
           truck.crates.first.toys.build(name: "Teddy bear")
           truck.crates.build(volume: 0.8)
-
-          # The following is equivalent to the two lines above:
-          #
-          # truck.crates_attributes = {
-          #   '0' => {
-          #     "toys_attributes" => {
-          #       "0" => {
-          #         "name" => "Teddy bear"
-          #       }
-          #     },
-          #     "id" => crate.id.to_s
-          #   },
-          #   "1" => {
-          #     "volume" => 0.8
-          #   }
-          # }
-
-          expect(truck.crates.size).to eq 2
-          expect(truck.crates[0].volume).to eq 0.4
-          expect(truck.crates[0].toys.size).to eq 1
-          expect(truck.crates[0].toys[0].name).to eq "Teddy bear"
-          expect(truck.crates[1].volume).to eq 0.8
-          expect(truck.crates[1].toys.size).to eq 0
-
-          #expect(truck.atomic_updates[:conflicts]).to eq nil
 
           expect { truck.save! }.not_to raise_error
 

--- a/spec/support/models/crate.rb
+++ b/spec/support/models/crate.rb
@@ -3,6 +3,7 @@
 
 class Crate
   include Mongoid::Document
+  include Mongoid::Timestamps::Short
 
   embedded_in :vehicle
   embeds_many :toys

--- a/spec/support/models/vehicle.rb
+++ b/spec/support/models/vehicle.rb
@@ -7,7 +7,7 @@ class Vehicle
   belongs_to :shipping_container
   belongs_to :driver
 
-  embeds_many :crates
+  embeds_many :crates, cascade_callbacks: true
 
   accepts_nested_attributes_for :driver
   accepts_nested_attributes_for :shipping_container


### PR DESCRIPTION
After further investigation, the problem with MONGOID-4957 is how conflicts are handled.

Currently, **conflicts can occur within conflicts**. The test case demonstrates this failure.

In order to fix this, we need to add de-confliction logic within the conflict resolution logic. The logic I've added does this in a reasonably minimal number of queries.



