### PR TITLE
Improve Mongoid::Atomic::Modifiers#push_conflict? regex

### DIFF
--- a/lib/mongoid/atomic/modifiers.rb
+++ b/lib/mongoid/atomic/modifiers.rb
@@ -193,7 +193,7 @@ module Mongoid
       def push_conflict?(field)
         name = field.split(".", 2)[0]
         set_fields.has_key?(name) || pull_fields.has_key?(name) ||
-          (push_fields.keys.count { |item| item =~ /#{name}/ } > 1)
+          (push_fields.keys.count { |item| item =~ /\A#{name}(?:\.|\z)/ } > 1)
       end
 
       # Get the conflicting pull modifications.

--- a/spec/mongoid/atomic/modifiers_spec.rb
+++ b/spec/mongoid/atomic/modifiers_spec.rb
@@ -343,6 +343,35 @@ describe Mongoid::Atomic::Modifiers do
           )
         end
       end
+
+      context "when the modification is a push with a similar name" do
+
+        let(:pushes) do
+          { "addresses.0.locations" => { "street" => "Bond St" } }
+        end
+
+        let(:similar1) do
+          { "dresses" => { "color" => "red" } }
+        end
+
+        let(:similar2) do
+          { "ses.0.foo" => { "baz" => "qux" } }
+        end
+
+        before do
+          modifiers.push(pushes)
+          modifiers.push(similar1)
+          modifiers.push(similar2)
+        end
+
+        it "adds the push all modifiers to the conflicts hash" do
+          expect(modifiers).to eq({ "$push" => {
+                                      "addresses.0.locations" => { '$each' => [{ "street" => "Bond St" }] },
+                                      "dresses" => { '$each' => [{ "color" => "red" }] },
+                                      "ses.0.foo" => { '$each' => [{ "baz" => "qux" }] }
+                                   } })
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Currently, Mongoid::Atomic::Modifiers#push_conflict? has a regex which is too loose. The regex should match exactly the first segment of a key.

addresses <--> addresses.0.street should match
addresses <--> dresses should not match