### PR TITLE
MONGOID-4978 Stop raising error when performing multi-batch query with QueryCache enabled

### DIFF
--- a/lib/mongoid/query_cache.rb
+++ b/lib/mongoid/query_cache.rb
@@ -257,8 +257,12 @@ module Mongoid
             session = client.send(:get_session, @options)
             read_with_retry(session, server_selector) do |server|
               result = send_initial_query(server, session)
-              @cursor = CachedCursor.new(view, result, server, session: session)
-              QueryCache.cache_table[cache_key] = @cursor
+              if result.cursor_id == 0 || result.cursor_id.nil?
+                @cursor = CachedCursor.new(view, result, server, session: session)
+                QueryCache.cache_table[cache_key] = @cursor
+              else
+                @cursor = Mongo::Cursor.new(view, result, server, session: session)
+              end
             end
           end
           if block_given?

--- a/spec/mongoid/query_cache_spec.rb
+++ b/spec/mongoid/query_cache_spec.rb
@@ -460,13 +460,19 @@ describe Mongoid::QueryCache do
 
    context 'when querying colleciton larger than the batch size' do
      before do
-       101.times { Band.create! }
+       Band.destroy_all
+       101.times { |i| Band.create!(_id: i) }
      end
 
      it 'does not raise an exception when querying multiple times' do
        expect do
-         Band.all.to_a
-         Band.all.to_a
+         results1 = Band.all.to_a
+         expect(results1.length).to eq(101)
+         expect(results1.map { |band| band["_id"] }).to eq([*0..100])
+
+         results2 = Band.all.to_a
+         expect(results2.length).to eq(101)
+         expect(results2.map { |band| band["_id"] }).to eq([*0..100])
        end.not_to raise_error
      end
    end

--- a/spec/mongoid/query_cache_spec.rb
+++ b/spec/mongoid/query_cache_spec.rb
@@ -458,6 +458,19 @@ describe Mongoid::QueryCache do
       end
     end
 
+   context 'when querying colleciton larger than the batch size' do
+     before do
+       101.times { Band.create! }
+     end
+ 
+     it 'does not raise an exception when querying multiple times' do
+       expect do
+         Band.all.to_a
+         Band.all.to_a
+       end.not_to raise_error
+     end
+   end
+
     context "when query caching is enabled and the batch_size is set" do
 
       around(:each) do |example|

--- a/spec/mongoid/query_cache_spec.rb
+++ b/spec/mongoid/query_cache_spec.rb
@@ -462,7 +462,7 @@ describe Mongoid::QueryCache do
      before do
        101.times { Band.create! }
      end
- 
+
      it 'does not raise an exception when querying multiple times' do
        expect do
          Band.all.to_a
@@ -624,7 +624,7 @@ describe Mongoid::QueryCache do
       Mongoid::QueryCache.enabled = true
       10.times { Band.create! }
 
-      Band.batch_size(4).all.any?
+      Band.batch_size(4).to_a
     end
 
     it 'does not cache the result' do

--- a/spec/support/session_registry.rb
+++ b/spec/support/session_registry.rb
@@ -39,7 +39,8 @@ class SessionRegistry
 
   def verify_sessions_ended!
     unless @registry.empty?
-      raise "Session registry contains live sessions: #{@registry.join(', ')}"
+      sessions = @registry.map { |_, session| session }
+      raise "Session registry contains live sessions: #{sessions.join(', ')}"
     end
   end
 


### PR DESCRIPTION
This is a backport of RUBY-2338 into Mongoid ([see corresponding driver PR](https://github.com/mongodb/mongo-ruby-driver/pull/2072)).

There was a bug in the query cache implementation where it would cache _all_ queries, not just single batch queries. Thus, when the user tried to perform the same multi-batch query twice, it would attempt to re-iterate the cached query, which isn't allowed in the Ruby driver, and would raise an error.