### PR TITLE
MONGOID-4944 Test that query cache properly uses limits

### DIFF
--- a/lib/mongoid/query_cache.rb
+++ b/lib/mongoid/query_cache.rb
@@ -287,9 +287,6 @@ module Mongoid
         if limit
           key = [ collection.namespace, selector, nil, skip, sort, projection, collation  ]
           cursor = QueryCache.cache_table[key]
-          if cursor
-            cursor.to_a[0...limit.abs]
-          end
         end
         cursor || QueryCache.cache_table[cache_key]
       end

--- a/lib/mongoid/query_cache.rb
+++ b/lib/mongoid/query_cache.rb
@@ -266,8 +266,14 @@ module Mongoid
             end
           end
           if block_given?
-            @cursor.each do |doc|
-              yield doc
+            if limit
+              @cursor.to_a[0...limit].each do |doc|
+                yield doc
+              end
+            else
+              @cursor.each do |doc|
+                yield doc
+              end
             end
           else
             @cursor.to_enum

--- a/spec/mongoid/query_cache_spec.rb
+++ b/spec/mongoid/query_cache_spec.rb
@@ -410,6 +410,9 @@ describe Mongoid::QueryCache do
         end
 
         context "when the next query has a limit" do
+          # Server versions older than 3.2 also perform a killCursors operation,
+          # which causes this test to fail.
+          min_server_version '3.2'
 
           it "queries again" do
             expect_query(1) do


### PR DESCRIPTION
Limit functionality is broken on the Mongoid query cache because the tests don't actually check that the query results are correct. This PR fixes this issue and modifies the tests to check for it. It will be backported to 7.1 and 7.0.