### PR TITLE
MONGOID-4984 fix _matches?() returns incorrect values for numeric selectors and arrays containing hashes for 6.4

### DIFF
--- a/lib/mongoid/matchable.rb
+++ b/lib/mongoid/matchable.rb
@@ -151,8 +151,12 @@ module Mongoid
         if (key_string = key.to_s) =~ /.+\..+/
           key_string.split('.').inject(document.send(:as_attributes)) do |_attribs, _key|
             if _attribs.is_a?(::Array)
-              if _key =~ /\A\d+\z/ && _attribs.none? {|doc| doc.is_a?(Hash)}
+              no_hash_key_matches = _attribs.none? {|doc| doc.is_a?(Hash) && doc.has_key?(_key)}
+
+              if _key =~ /\A\d+\z/ && no_hash_key_matches
                 _attribs.try(:[], _key.to_i)
+              elsif no_hash_key_matches
+                nil
               else
                 _attribs.map { |doc| doc.try(:[], _key) }
               end

--- a/spec/mongoid/matchable_spec.rb
+++ b/spec/mongoid/matchable_spec.rb
@@ -102,6 +102,40 @@ describe Mongoid::Matchable do
             expect(document.locations.first._matches?(selector)).to be false
           end
         end
+
+        context "when the array contains hashes" do
+          let(:tim) { { "name" => "Tim", "age" => 20 } }
+          let(:logan) { { "name" => "Logan", "age" => 188 } }
+          let(:occupants) { [tim, logan] }
+
+          context "when the contents match" do
+            it "returns true for the first hash" do
+              expect(document.locations.first._matches?({ "occupants.name" => "Tim" })).to be true
+            end
+
+            it "returns true for the second hash" do
+              expect(document.locations.first._matches?({ "occupants.name" => "Logan" })).to be true
+            end
+          end
+
+          context "using $exists" do
+            it "returns true for the 0 index" do
+              expect(document.locations.first._matches?({ "occupants.0" => { "$exists" => true} })).to be true
+            end
+
+            it "returns true for the 1 index" do
+              expect(document.locations.first._matches?({ "occupants.1" => { "$exists" => true} })).to be true
+            end
+
+            it "returns false for the 2 index" do
+              expect(document.locations.first._matches?({ "occupants.2" => { "$exists" => false} })).to be true
+            end
+
+            it "returns false for a non-existent key" do
+              expect(document.locations.first._matches?({ "occupants.nonexistent" => { "$exists" => false} })).to be true
+            end
+          end
+        end
       end
 
       context "when matching values of multiple embedded hashes" do


### PR DESCRIPTION
https://jira.mongodb.org/browse/MONGOID-4984

_matches?() gives incorrect results when an array contains hash objects

```ruby
document: {"occupants" => [{"name" => "Tim"},{"name" => "Logan"}]}

selector: {"occupants.2" => {"$exists" => true}
document._matches?(selector) # returns true, but should be false

selector: {"occupants.non_numeric_key" => {"$exists" => true}
document._matches?(selector) # returns true, but should be false
```