### PR TITLE
Fix method visibility via `Mongoid::Association::Proxy`

### DIFF
--- a/lib/mongoid/association/proxy.rb
+++ b/lib/mongoid/association/proxy.rb
@@ -137,6 +137,10 @@ module Mongoid
         _target.public_send(name, *args, &block)
       end
 
+      def respond_to_missing?(name, *args)
+        _target.respond_to?(name)
+      end
+
       # When the base document illegally references an embedded document this
       # error will get raised.
       #

--- a/lib/mongoid/association/proxy.rb
+++ b/lib/mongoid/association/proxy.rb
@@ -134,7 +134,7 @@ module Mongoid
       # @param [ Array ] args The arguments passed to the method.
       #
       def method_missing(name, *args, &block)
-        _target.send(name, *args, &block)
+        _target.public_send(name, *args, &block)
       end
 
       # When the base document illegally references an embedded document this

--- a/spec/app/models/person.rb
+++ b/spec/app/models/person.rb
@@ -208,6 +208,12 @@ class Person
   reset_callbacks(:create)
   reset_callbacks(:save)
   reset_callbacks(:destroy)
+
+  private
+
+  def secret_name
+    "secret"
+  end
 end
 
 require "app/models/doctor"

--- a/spec/mongoid/association/referenced/belongs_to/proxy_spec.rb
+++ b/spec/mongoid/association/referenced/belongs_to/proxy_spec.rb
@@ -131,6 +131,11 @@ describe Mongoid::Association::Referenced::BelongsTo::Proxy do
           it "does not expose private methods" do
             expect { game.person.secret_name }.to raise_error(NoMethodError)
           end
+
+          it "properly exposes delegated methods visibility" do
+            expect(defined?(game.person.id)).to eq("method")
+            expect(defined?(game.person.secret_name)).to be_nil
+          end
         end
 
         context "when the child is not a new record" do

--- a/spec/mongoid/association/referenced/belongs_to/proxy_spec.rb
+++ b/spec/mongoid/association/referenced/belongs_to/proxy_spec.rb
@@ -127,6 +127,10 @@ describe Mongoid::Association::Referenced::BelongsTo::Proxy do
           it "does not save the target" do
             expect(person).to_not be_persisted
           end
+
+          it "does not expose private methods" do
+            expect { game.person.secret_name }.to raise_error(NoMethodError)
+          end
         end
 
         context "when the child is not a new record" do


### PR DESCRIPTION
See https://jira.mongodb.org/projects/MONGOID/issues/MONGOID-5009

When defining belongs_to/has_one associations, the methods in the associated object change visibilty and ruby's `defined?` doesn't detect them.
When doing `parent.child = child`, the associated object is cloned (object_id changes) and while the class, ancestors, and everything looks and feels the same, something happens where the private methods are made public, and public methods are there but not recognized by ruby's `defined?`.
Same happens when doing `child.parent = parent`

After looking for a bit, found the root cause in `Mongoid::Association::Proxy`. It undefines all methods to then send them to `_target` via `method_missing`
https://github.com/mongodb/mongoid/blob/v7.1.4/lib/mongoid/association/proxy.rb#L16-L20
https://github.com/mongodb/mongoid/blob/v7.1.4/lib/mongoid/association/proxy.rb#L130-L138

In there, it's using `send` to call the method in target, that makes it delegate _any_ method to it, including private ones. It should be using `public_send`. That solves the "private_methods_stay_private" case.

In addition to that, when overriding `method_missing` it should override `respond_to_missing?` as well, so ruby knows to find those methods. See https://thoughtbot.com/blog/always-define-respond-to-missing-when-overriding.

Opening this against `7.1-stable` since I was having trouble running tests in master.