### PR TITLE
MONGOID-4977 (backport): Use recent driver APIs in Mongoid QueryCache for compatibility with sessions & modern retryable reads

### DIFF
--- a/lib/mongoid/query_cache.rb
+++ b/lib/mongoid/query_cache.rb
@@ -233,13 +233,13 @@ module Mongoid
               session = client.send(:get_session, @options)
               read_with_retry(session, server_selector) do |server|
                 result = send_initial_query(server, session)
-                @cursor = cursor(result, server, session)
+                @cursor = get_cursor(result, server, session)
               end
             else
               read_with_retry do
                 server = server_selector.select_server(cluster)
                 result = send_initial_query(server)
-                @cursor = cursor(result, server)
+                @cursor = get_cursor(result, server)
               end
             end
           end
@@ -270,7 +270,7 @@ module Mongoid
         cursor || QueryCache.cache_table[cache_key]
       end
 
-      def cursor(result, server, session = nil)
+      def get_cursor(result, server, session = nil)
         if result.cursor_id == 0 || result.cursor_id.nil?
           cursor = if session
             CachedCursor.new(view, result, server, session: session)

--- a/spec/lite_spec_helper.rb
+++ b/spec/lite_spec_helper.rb
@@ -16,6 +16,7 @@ require 'pp'
 
 require 'support/spec_config'
 require 'support/lite_constraints'
+require "support/session_registry"
 
 unless SpecConfig.instance.ci?
   begin

--- a/spec/mongoid/query_cache_spec.rb
+++ b/spec/mongoid/query_cache_spec.rb
@@ -557,7 +557,7 @@ describe Mongoid::QueryCache do
       Mongoid::QueryCache.enabled = true
       10.times { Band.create! }
 
-      Band.batch_size(4).all
+      Band.batch_size(4).all.to_a
     end
 
     it 'does not cache the result' do

--- a/spec/mongoid/query_cache_spec.rb
+++ b/spec/mongoid/query_cache_spec.rb
@@ -10,6 +10,20 @@ describe Mongoid::QueryCache do
     Mongoid::QueryCache.cache { spec.run }
   end
 
+  before(:all) do
+    # It is likely that there are other session leaks in the driver
+    # and/or Mongoid that are unrelated to the query cache. Clear the
+    # SessionRegistry at the start of these tests in order to detect leaks that
+    # occur only within the scope of these tests.
+    #
+    # Other session leaks will be detected and addressed as part of RUBY-2391.
+    SessionRegistry.instance.clear_registry
+  end
+
+  after do
+    SessionRegistry.instance.verify_sessions_ended!
+  end
+
   context 'when iterating over objects sharing the same base' do
 
     let(:server) do
@@ -543,7 +557,7 @@ describe Mongoid::QueryCache do
       Mongoid::QueryCache.enabled = true
       10.times { Band.create! }
 
-      Band.batch_size(4).all.any?
+      Band.batch_size(4).all
     end
 
     it 'does not cache the result' do

--- a/spec/support/session_registry.rb
+++ b/spec/support/session_registry.rb
@@ -1,0 +1,50 @@
+require 'singleton'
+
+module Mongo
+  class Client
+    alias :get_session_without_tracking :get_session
+
+    def get_session(options = {})
+      get_session_without_tracking(options).tap do |session|
+        SessionRegistry.instance.register(session)
+      end
+    end
+  end
+
+  class Session
+    alias :end_session_without_tracking :end_session
+
+    def end_session
+      SessionRegistry.instance.unregister(self)
+      end_session_without_tracking
+    end
+  end
+end
+
+
+class SessionRegistry
+  include Singleton
+
+  def initialize
+    @registry = {}
+  end
+
+  def register(session)
+    @registry[session.session_id] = session if session
+  end
+
+  def unregister(session)
+    @registry.delete(session.session_id)
+  end
+
+  def verify_sessions_ended!
+    unless @registry.empty?
+      sessions = @registry.map { |_, session| session }
+      raise "Session registry contains live sessions: #{sessions.join(', ')}"
+    end
+  end
+
+  def clear_registry
+    @registry = {}
+  end
+end


### PR DESCRIPTION
You can see the tests running in this patch: [https://spruce.mongodb.com/version/5f91d81c0ae606431f650bc7/tasks](https://spruce.mongodb.com/version/5f91d81c0ae606431f650bc7/tasks)