### PR TITLE
MONGOID-5027 Rails 6.1 support

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -552,6 +552,10 @@ axes:
         display_name: "Rails 5.2"
         variables:
            RAILS: "52"
+      - id: "60"
+        display_name: "Rails 6.0"
+        variables:
+           RAILS: "60"
   - id: "i18n"
     display_name: I18n version
     values:
@@ -762,6 +766,18 @@ buildvariants:
     mongodb-version: "4.2"
     topology: "standalone"
     rails: '52'
+  display_name: "${rails}, ${driver}, ${mongodb-version}"
+  run_on:
+    - rhel70-small
+  tasks:
+     - name: "test"
+- matrix_name: "rails-60"
+  matrix_spec:
+    driver: "current"
+    ruby: "ruby-2.7"
+    mongodb-version: "4.4"
+    topology: "standalone"
+    rails: '60'
   display_name: "${rails}, ${driver}, ${mongodb-version}"
   run_on:
     - rhel70-small

--- a/docs/tutorials/mongoid-installation.txt
+++ b/docs/tutorials/mongoid-installation.txt
@@ -227,13 +227,23 @@ are supported by Mongoid.
    :class: compatibility-large no-padding
 
    * - Mongoid
+     - Rails 6.1
      - Rails 6.0
      - Rails 5.2
      - Rails 5.1
      - Rails 5.0
      - Rails 4.2
 
+   * - 7.3
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     -
+     -
+
    * - 7.2
+     - |checkmark| [#rails-6.1]_
      - |checkmark|
      - |checkmark|
      - |checkmark|
@@ -241,6 +251,7 @@ are supported by Mongoid.
      -
 
    * - 7.1
+     - |checkmark| [#rails-6.1]_
      - |checkmark|
      - |checkmark|
      - |checkmark|
@@ -248,6 +259,7 @@ are supported by Mongoid.
      -
 
    * - 7.0
+     - |checkmark| [#rails-6.1]_
      - |checkmark| [#rails-6]_
      - |checkmark|
      - |checkmark|
@@ -256,6 +268,7 @@ are supported by Mongoid.
 
    * - 6.4
      -
+     -
      - |checkmark|
      - |checkmark|
      -
@@ -263,12 +276,14 @@ are supported by Mongoid.
 
    * - 6.3
      -
+     -
      - |checkmark|
      - |checkmark|
      -
      -
 
    * - 6.2
+     -
      -
      - |checkmark|
      - |checkmark|
@@ -304,5 +319,8 @@ are supported by Mongoid.
      - |checkmark|
 
 .. [#rails-6] Rails 6.0 requires Mongoid 7.0.5 or later.
+
+.. [#rails-6.1] Rails 6.1 requires Mongoid 7.0.12, 7.1.7 or 7.2.1 in the
+  respective 7.0, 7.1 and 7.2 stable branches.
 
 .. include:: /includes/unicode-checkmark.rst

--- a/gemfiles/rails_60.gemfile
+++ b/gemfiles/rails_60.gemfile
@@ -1,0 +1,30 @@
+source 'https://rubygems.org'
+
+gem 'rake'
+gem 'actionpack', '~> 6.0.0'
+gem 'activemodel', '~> 6.0.0'
+
+group :development do
+  gem 'yard'
+end
+
+group :development, :test do
+  gem 'rspec-core', '~> 3.7'
+end
+
+group :test do
+  gem 'timecop'
+  gem 'rspec-retry'
+  gem 'benchmark-ips'
+  gem 'rspec-expectations', '~> 3.7', '>= 3.8.4'
+  gem 'rspec-mocks-diag', '~> 3.0'
+  gem 'fuubar'
+  gem 'rfc'
+  gem 'childprocess'
+  platforms :mri do
+    gem 'timeout-interrupt'
+    gem 'byebug'
+  end
+end
+
+gemspec path: '..'

--- a/lib/mongoid/document.rb
+++ b/lib/mongoid/document.rb
@@ -229,8 +229,9 @@ module Mongoid
       became = klass.new(clone_document)
       became._id = _id
       became.instance_variable_set(:@changed_attributes, changed_attributes)
-      became.instance_variable_set(:@errors, ActiveModel::Errors.new(became))
-      became.errors.instance_variable_set(:@messages, errors.instance_variable_get(:@messages))
+      new_errors = ActiveModel::Errors.new(became)
+      new_errors.copy!(errors)
+      became.instance_variable_set(:@errors, new_errors)
       became.instance_variable_set(:@new_record, new_record?)
       became.instance_variable_set(:@destroyed, destroyed?)
       became.changed_attributes[klass.discriminator_key] = self.class.discriminator_value

--- a/lib/mongoid/interceptable.rb
+++ b/lib/mongoid/interceptable.rb
@@ -234,9 +234,11 @@ module Mongoid
     #   document.halted_callback_hook(filter)
     #
     # @param [ Symbol ] filter The callback that halted.
+    # @param [ Symbol ] name The name of the callback that was halted
+    #   (requires Rails 6.1+)
     #
     # @since 3.0.3
-    def halted_callback_hook(filter)
+    def halted_callback_hook(filter, name = nil)
       @before_callback_halted = true
     end
 

--- a/mongoid.gemspec
+++ b/mongoid.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version     = ">= 2.3"
   s.required_rubygems_version = ">= 1.3.6"
 
-  s.add_dependency("activemodel", [">= 5.1", "<=6.1"])
+  s.add_dependency("activemodel", [">= 5.1", "<6.2"])
   s.add_dependency("mongo", ['>=2.10.5', '<3.0.0'])
 
   s.add_development_dependency("bson", ['>=4.9.4', '<5.0.0'])

--- a/mongoid.gemspec
+++ b/mongoid.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version     = ">= 2.3"
   s.required_rubygems_version = ">= 1.3.6"
 
-  s.add_dependency("activemodel", [">= 5.1", "<6.1"])
+  s.add_dependency("activemodel", [">= 5.1", "<=6.1"])
   s.add_dependency("mongo", ['>=2.10.5', '<3.0.0'])
 
   s.add_development_dependency("bson", ['>=4.9.4', '<5.0.0'])

--- a/spec/integration/app_spec.rb
+++ b/spec/integration/app_spec.rb
@@ -150,7 +150,7 @@ describe 'Mongoid application tests' do
                 end
                 index.should be nil
 
-                Mrss::ChildProcessHelper.check_call(%w(rake db:mongoid:create_indexes),
+                Mrss::ChildProcessHelper.check_call(%w(bundle exec rake db:mongoid:create_indexes),
                   cwd: APP_PATH, env: env)
 
                 index = client['posts'].indexes.detect do |index|


### PR DESCRIPTION
Hi,
I use rails 6.1 and mongoid and i get error when i run bundle. So i update the dependency to activemodel <= 6.1 .