### PR TITLE
MONGOID-5040 Revert Document#to_ary to be a private method

### DIFF
--- a/lib/mongoid/document.rb
+++ b/lib/mongoid/document.rb
@@ -250,6 +250,8 @@ module Mongoid
       became
     end
 
+    private
+
     # Implement this for calls to flatten on array.
     #
     # @example Get the document as an array.
@@ -258,12 +260,9 @@ module Mongoid
     # @return [ nil ] Always nil.
     #
     # @since 2.1.0
-    # @api private
     def to_ary
       nil
     end
-
-    private
 
     # Returns the logger
     #
@@ -285,8 +284,6 @@ module Mongoid
     def model_key
       @model_cache_key ||= self.class.model_name.cache_key
     end
-
-    private
 
     def as_attributes
       return attributes if frozen?

--- a/spec/mongoid/document_spec.rb
+++ b/spec/mongoid/document_spec.rb
@@ -1323,6 +1323,17 @@ describe Mongoid::Document do
     end
   end
 
+  describe "#to_ary" do
+
+    it "does not publicly respond to #to_ary" do
+      expect(Person.new.respond_to?(:to_ary)).to eq false
+    end
+
+    it "does private respond to #to_ary" do
+      expect(Person.new.send(:to_ary)).to eq nil
+    end
+  end
+
   context "when marshalling the document" do
 
     let(:agency) do


### PR DESCRIPTION
Fixes https://jira.mongodb.org/browse/MONGOID-5040