### PR TITLE
Replace parent with module_parent_name

### DIFF
--- a/lib/rails/generators/mongoid/config/config_generator.rb
+++ b/lib/rails/generators/mongoid/config/config_generator.rb
@@ -15,7 +15,7 @@ module Mongoid
       end
 
       def app_name
-        Rails::Application.subclasses.first.parent.to_s.underscore
+        Rails::Application.subclasses.first.module_parent.to_s.underscore
       end
 
       def create_config_file


### PR DESCRIPTION
When trying to run `bin/rails g mongoid:config` on a rails 6.1+ app results in the following error

```/usr/local/bundle/gems/railties-6.1.0/lib/rails/railtie.rb:209:in `method_missing': undefined method `parent' for App::Application:Class (NoMethodError)```

Since Rails 6.0 the parent method is replaced with module_parent
https://github.com/rails/rails/pull/34051