### PR TITLE
::I18n.translate takes keyword arguments

### DIFF
--- a/lib/mongoid/errors/mongoid_error.rb
+++ b/lib/mongoid/errors/mongoid_error.rb
@@ -48,7 +48,7 @@ module Mongoid
       #
       # @return [ String ] A localized error message string.
       def translate(key, options)
-        ::I18n.translate("#{BASE_KEY}.#{key}", options)
+        ::I18n.translate("#{BASE_KEY}.#{key}", **options)
       end
 
       # Create the problem.

--- a/lib/mongoid/validatable/associated.rb
+++ b/lib/mongoid/validatable/associated.rb
@@ -43,7 +43,7 @@ module Mongoid
         ensure
           document.exit_validate
         end
-        document.errors.add(attribute, :invalid, options) unless valid
+        document.errors.add(attribute, :invalid, **options) unless valid
       end
     end
   end

--- a/lib/mongoid/validatable/presence.rb
+++ b/lib/mongoid/validatable/presence.rb
@@ -34,15 +34,15 @@ module Mongoid
             document.errors.add(
               attribute,
               :blank_in_locale,
-              options.merge(location: _locale)
+              **options.merge(location: _locale)
             ) if not_present?(_value)
           end
         elsif document.relations.has_key?(attribute.to_s)
           if relation_or_fk_missing?(document, attribute, value)
-            document.errors.add(attribute, :blank, options)
+            document.errors.add(attribute, :blank, **options)
           end
         else
-          document.errors.add(attribute, :blank, options) if not_present?(value)
+          document.errors.add(attribute, :blank, **options) if not_present?(value)
         end
       end
 

--- a/lib/mongoid/validatable/uniqueness.rb
+++ b/lib/mongoid/validatable/uniqueness.rb
@@ -68,7 +68,7 @@ module Mongoid
       # @since 2.4.10
       def add_error(document, attribute, value)
         document.errors.add(
-          attribute, :taken, options.except(:case_sensitive, :scope).merge(value: value)
+          attribute, :taken, **options.except(:case_sensitive, :scope).merge(value: value)
         )
       end
 


### PR DESCRIPTION
Ruby v3 is failing with the following exception since :I18n.translate takes the options as keyword arguments and not a hash:
~~~
ArgumentError: wrong number of arguments (given 2, expected 0..1)
            /Users/rmorrison/.rvm/gems/ruby-3.0.0/gems/i18n-1.8.7/lib/i18n.rb:195:in `translate'
            /Users/rmorrison/.rvm/gems/ruby-3.0.0/gems/mongoid-7.2.0/lib/mongoid/errors/mongoid_error.rb:51:in `translate'
            /Users/rmorrison/.rvm/gems/ruby-3.0.0/gems/mongoid-7.2.0/lib/mongoid/errors/mongoid_error.rb:66:in `translate_problem'
            /Users/rmorrison/.rvm/gems/ruby-3.0.0/gems/mongoid-7.2.0/lib/mongoid/errors/mongoid_error.rb:25:in `compose_message'
            /Users/rmorrison/.rvm/gems/ruby-3.0.0/gems/mongoid-7.2.0/lib/mongoid/errors/document_not_found.rb:32:in `initialize'
            /Users/rmorrison/.rvm/gems/ruby-3.0.0/gems/mongoid-7.2.0/lib/mongoid/reloadable.rb:26:in `new'
            /Users/rmorrison/.rvm/gems/ruby-3.0.0/gems/mongoid-7.2.0/lib/mongoid/reloadable.rb:26:in `reload'
~~~