### PR TITLE
MONGOID-5042 rails g mongoid:config is not working on Rails 6.1 

### DIFF
--- a/lib/rails/generators/mongoid/config/config_generator.rb
+++ b/lib/rails/generators/mongoid/config/config_generator.rb
@@ -15,7 +15,7 @@ module Mongoid
       end
 
       def app_name
-        Rails::Application.subclasses.first.parent.to_s.underscore
+        Rails.application.class.module_parent_name.underscore
       end
 
       def create_config_file


### PR DESCRIPTION
```
# lib/rails/generators/mongoid/config/config_generator.rb
module Mongoid
  module Generators
    class ConfigGenerator < Rails::Generators::Base

      def app_name
        #
        # 1A)
        # https://api.rubyonrails.org/classes/Rails/Generators/NamedBase.html#method-i-application_name
        #require 'rails/generators/actions'
        #require 'rails/generators/named_base'
        #Rails::Generators::NamedBase.new([""]).send(:application_name)
        #
        # --OR--
        #
        # 1B)
        #Rails.application.class.name.split("::").first.underscore
        # 
        # 2)
        # https://api.rubyonrails.org/classes/Module.html#method-i-module_parent_name
        Rails.application.class.module_parent_name.underscore
      end
```



Ticket: https://jira.mongodb.org/browse/MONGOID-5042
Alternative PR: https://github.com/mongodb/mongoid/pull/4941
