### PR TITLE
MONGOID-5042 rails g mongoid:config is not working on Rails 6.1

### DIFF
--- a/lib/rails/generators/mongoid/config/config_generator.rb
+++ b/lib/rails/generators/mongoid/config/config_generator.rb
@@ -15,7 +15,7 @@ module Mongoid
       end
 
       def app_name
-        Rails::Application.subclasses.first.parent.to_s.underscore
+        Rails.application.class.module_parent_name.underscore
       end
 
       def create_config_file

--- a/spec/integration/app_spec.rb
+++ b/spec/integration/app_spec.rb
@@ -96,7 +96,7 @@ describe 'Mongoid application tests' do
 
           Dir.chdir(TMP_BASE) do
             FileUtils.rm_rf('mongoid-test')
-            Mrss::ChildProcessHelper.check_call(%w(rails new mongoid-test --skip-spring --skip-active-record), env: clean_env)
+            Mrss::ChildProcessHelper.check_call(%w(rails new mongoid-test --skip-spring --skip-active-record --skip-webpack-install), env: clean_env)
 
             Dir.chdir('mongoid-test') do
               adjust_app_gemfile

--- a/spec/integration/app_spec.rb
+++ b/spec/integration/app_spec.rb
@@ -106,25 +106,14 @@ describe 'Mongoid application tests' do
         end
 
         it 'creates' do
-          Mrss::ChildProcessHelper.check_call(%w(gem uni rails -a --ignore-dependencies))
-          Mrss::ChildProcessHelper.check_call(%w(gem install rails --no-document -v) + [rails_version])
+          Dir.chdir(File.join(TMP_BASE,'mongoid-test')) do
+            Mrss::ChildProcessHelper.check_call(%w(rails g model post), env: clean_env)
+            Mrss::ChildProcessHelper.check_call(%w(rails g model comment post:belongs_to), env: clean_env)
 
-          Dir.chdir(TMP_BASE) do
-            FileUtils.rm_rf('mongoid-test')
-            Mrss::ChildProcessHelper.check_call(%w(rails new mongoid-test --skip-spring --skip-active-record --skip-webpack-install), env: clean_env)
-
-            Dir.chdir('mongoid-test') do
-              adjust_app_gemfile
-              Mrss::ChildProcessHelper.check_call(%w(bundle install), env: clean_env)
-
-              Mrss::ChildProcessHelper.check_call(%w(rails g model post), env: clean_env)
-              Mrss::ChildProcessHelper.check_call(%w(rails g model comment post:belongs_to), env: clean_env)
-
-              # https://jira.mongodb.org/browse/MONGOID-4885
-              comment_text = File.read('app/models/comment.rb')
-              comment_text.should =~ /belongs_to :post/
-              comment_text.should_not =~ /embedded_in :post/
-            end
+            # https://jira.mongodb.org/browse/MONGOID-4885
+            comment_text = File.read('app/models/comment.rb')
+            comment_text.should =~ /belongs_to :post/
+            comment_text.should_not =~ /embedded_in :post/
           end
         end
       end

--- a/spec/integration/app_spec.rb
+++ b/spec/integration/app_spec.rb
@@ -88,7 +88,7 @@ describe 'Mongoid application tests' do
   end
 
   context 'new application - rails' do
-    ['~> 5.1.0', '~> 5.2.0', '~> 6.0.0'].each do |rails_version|
+    ['~> 5.1.0', '~> 5.2.0', '~> 6.0.0', '~> 6.1.0'].each do |rails_version|
       context "with rails #{rails_version}" do
         before(:all) do
           Mrss::ChildProcessHelper.check_call(%w(gem uni rails -a --ignore-dependencies))
@@ -114,6 +114,21 @@ describe 'Mongoid application tests' do
             comment_text = File.read('app/models/comment.rb')
             comment_text.should =~ /belongs_to :post/
             comment_text.should_not =~ /embedded_in :post/
+          end
+        end
+
+        # https://jira.mongodb.org/browse/MONGOID-5042
+        it 'generates config' do
+          Dir.chdir(File.join(TMP_BASE,'mongoid-test')) do
+            mongoid_config_file = File.join(TMP_BASE,'mongoid-test/config/mongoid.yml')
+
+            File.exist?(mongoid_config_file).should be false
+            Mrss::ChildProcessHelper.check_call(%w(rails g mongoid:config), env: clean_env)
+            File.exist?(mongoid_config_file).should be true
+
+            config_text = File.read(mongoid_config_file)
+            config_text.should =~ /mongoid_test_development/
+            config_text.should =~ /mongoid_test_test/
           end
         end
       end

--- a/spec/integration/app_spec.rb
+++ b/spec/integration/app_spec.rb
@@ -91,7 +91,7 @@ describe 'Mongoid application tests' do
     ['~> 5.1.0', '~> 5.2.0', '~> 6.0.0'].each do |rails_version|
       context "with rails #{rails_version}" do
         it 'creates' do
-          Mrss::ChildProcessHelper.check_call(%w(gem uni rails -a))
+          Mrss::ChildProcessHelper.check_call(%w(gem uni rails -a --ignore-dependencies))
           Mrss::ChildProcessHelper.check_call(%w(gem install rails --no-document -v) + [rails_version])
 
           Dir.chdir(TMP_BASE) do

--- a/spec/integration/app_spec.rb
+++ b/spec/integration/app_spec.rb
@@ -90,6 +90,21 @@ describe 'Mongoid application tests' do
   context 'new application - rails' do
     ['~> 5.1.0', '~> 5.2.0', '~> 6.0.0'].each do |rails_version|
       context "with rails #{rails_version}" do
+        before(:all) do
+          Mrss::ChildProcessHelper.check_call(%w(gem uni rails -a --ignore-dependencies))
+          Mrss::ChildProcessHelper.check_call(%w(gem install rails --no-document -v) + [rails_version])
+
+          Dir.chdir(TMP_BASE) do
+            FileUtils.rm_rf('mongoid-test')
+            Mrss::ChildProcessHelper.check_call(%w(rails new mongoid-test --skip-spring --skip-active-record --skip-webpack-install), env: clean_env)
+
+            Dir.chdir('mongoid-test') do
+              adjust_app_gemfile
+              Mrss::ChildProcessHelper.check_call(%w(bundle install), env: clean_env)
+            end
+          end
+        end
+
         it 'creates' do
           Mrss::ChildProcessHelper.check_call(%w(gem uni rails -a --ignore-dependencies))
           Mrss::ChildProcessHelper.check_call(%w(gem install rails --no-document -v) + [rails_version])


### PR DESCRIPTION
> ```
> # lib/rails/generators/mongoid/config/config_generator.rb
> module Mongoid
>   module Generators
>     class ConfigGenerator < Rails::Generators::Base
> 
>       def app_name
>         #
>         # 1A)
>         # https://api.rubyonrails.org/classes/Rails/Generators/NamedBase.html#method-i-application_name
>         #require 'rails/generators/actions'
>         #require 'rails/generators/named_base'
>         #Rails::Generators::NamedBase.new([""]).send(:application_name)
>         #
>         # --OR--
>         #
>         # 1B)
>         #Rails.application.class.name.split("::").first.underscore
>         # 
>         # 2)
>         # https://api.rubyonrails.org/classes/Module.html#method-i-module_parent_name
>         Rails.application.class.module_parent_name.underscore
>       end
> ```
> 
> 
> Ticket: https://jira.mongodb.org/browse/MONGOID-5042
> 
> Alternative PR: #4941
