### PR TITLE
use https protocol for spec/shared submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/mongoid/mongoid-test-apps
 [submodule "spec/shared"]
 	path = spec/shared
-	url = git@github.com:mongodb-labs/mongo-ruby-spec-shared
+	url = https://github.com/mongodb-labs/mongo-ruby-spec-shared


### PR DESCRIPTION
fixes inability of users to update submodules when they do not have an SSH key configured for GitHub
