### PR TITLE
fix: Compatibility with keyword arguments in Ruby 3.0.0

### DIFF
--- a/lib/mongoid/errors/mongoid_error.rb
+++ b/lib/mongoid/errors/mongoid_error.rb
@@ -48,7 +48,7 @@ module Mongoid
       #
       # @return [ String ] A localized error message string.
       def translate(key, options)
-        ::I18n.translate("#{BASE_KEY}.#{key}", options)
+        ::I18n.translate("#{BASE_KEY}.#{key}", **options)
       end
 
       # Create the problem.

--- a/lib/mongoid/validatable/associated.rb
+++ b/lib/mongoid/validatable/associated.rb
@@ -43,7 +43,7 @@ module Mongoid
         ensure
           document.exit_validate
         end
-        document.errors.add(attribute, :invalid, options) unless valid
+        document.errors.add(attribute, :invalid, **options) unless valid
       end
     end
   end

--- a/lib/mongoid/validatable/presence.rb
+++ b/lib/mongoid/validatable/presence.rb
@@ -34,15 +34,15 @@ module Mongoid
             document.errors.add(
               attribute,
               :blank_in_locale,
-              options.merge(location: _locale)
+              **options.merge(location: _locale)
             ) if not_present?(_value)
           end
         elsif document.relations.has_key?(attribute.to_s)
           if relation_or_fk_missing?(document, attribute, value)
-            document.errors.add(attribute, :blank, options)
+            document.errors.add(attribute, :blank, **options)
           end
         else
-          document.errors.add(attribute, :blank, options) if not_present?(value)
+          document.errors.add(attribute, :blank, **options) if not_present?(value)
         end
       end
 

--- a/lib/mongoid/validatable/uniqueness.rb
+++ b/lib/mongoid/validatable/uniqueness.rb
@@ -68,7 +68,7 @@ module Mongoid
       # @since 2.4.10
       def add_error(document, attribute, value)
         document.errors.add(
-          attribute, :taken, options.except(:case_sensitive, :scope).merge(value: value)
+          attribute, :taken, **options.except(:case_sensitive, :scope).merge(value: value)
         )
       end
 


### PR DESCRIPTION
In this Pull Request I fixed some incompatibilities with Ruby 3.0.

Reference: https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/