### PR TITLE
MONGOID-5061: and() criterion Ruby symbol fix for Mongoid 7.2-stable

### DIFF
--- a/lib/mongoid/criteria/queryable/selectable.rb
+++ b/lib/mongoid/criteria/queryable/selectable.rb
@@ -100,10 +100,10 @@ module Mongoid
                 # Otherwise use $and.
                 if v.is_a?(Hash) &&
                   v.length == 1 &&
-                  (new_k = v.keys.first).start_with?('$') &&
+                  (new_k = v.keys.first).to_s.start_with?('$') &&
                   (existing_kv = c.selector[k]).is_a?(Hash) &&
-                  !existing_kv.key?(new_k) &&
-                  existing_kv.keys.all? { |sub_k| sub_k.start_with?('$') }
+                  !existing_kv.key?(new_k.to_s) &&
+                  existing_kv.keys.all? { |sub_k| sub_k.to_s.start_with?('$') }
                 then
                   merged_v = c.selector[k].merge(v)
                   c.selector.store(k, merged_v)


### PR DESCRIPTION
See https://jira.mongodb.org/browse/MONGOID-5061