### PR TITLE
MONGOID-5063 Support numeric path components when traversing hashes with dot notation in extract_attribute

### DIFF
--- a/lib/mongoid/matcher.rb
+++ b/lib/mongoid/matcher.rb
@@ -49,8 +49,12 @@ module Mongoid
 
       key.to_s.split('.').each do |field|
         if (index = field.to_i).to_s == field
-          # Array indexing
-          if Array === src
+          case src
+          when Hash
+            exists = src.key?(field)
+            src = src[field]
+          when Array
+            # Array indexing
             exists = index < src.length
             src = src[index]
           else

--- a/spec/mongoid/matcher/extract_attribute_data/traversal.yml
+++ b/spec/mongoid/matcher/extract_attribute_data/traversal.yml
@@ -109,6 +109,17 @@
   value: ~
   expanded: false
 
+- name: numeric path component when traversing hash
+  document:
+    foo:
+      "10":
+        42
+  key: "foo.10"
+
+  exists: true
+  value: 42
+  expanded: false
+
 - name: array index - hash leaf
   document: &foo-one-two
     foo:
@@ -256,15 +267,4 @@
     
   exists: false
   value: ~
-  expanded: false
-
-- name: numeric hash key matching the split position
-  document:
-    foo:
-      "10":
-        true
-  key: "foo.10"
-
-  exists: true
-  value: true
   expanded: false

--- a/spec/mongoid/matcher/extract_attribute_data/traversal.yml
+++ b/spec/mongoid/matcher/extract_attribute_data/traversal.yml
@@ -257,3 +257,14 @@
   exists: false
   value: ~
   expanded: false
+
+- name: numeric hash key matching the split position
+  document:
+    foo:
+      "10":
+        true
+  key: "foo.10"
+
+  exists: true
+  value: true
+  expanded: false


### PR DESCRIPTION
extract_attribute() fails to correctly handle cases with a numeric hash key. When the current code finds a numeric hash key, but sees that 'src' is NOT an array, it returns that the field does not exist.

This PR adds a test case that fails for the old code, and then passes with the new code.

#### Test Output (Old Code)

```
1) Matcher.extract_attribute traversal.yml numeric hash key matching the split position has the expected exists flag
     Failure/Error: actual[0].should == expected_exists
     
       expected: true
            got: false (using ==)
       Diff:
       @@ -1 +1 @@
       -true
       +false
       
     # ./spec/mongoid/matcher/extract_attribute_spec.rb:33:in `block (6 levels) in <top (required)>'

                                                                                                                                                                                
  2) Matcher.extract_attribute traversal.yml numeric hash key matching the split position has the expected value
     Failure/Error: actual[1].should == expected_value
     
       expected: true
            got: nil (using ==)
     # ./spec/mongoid/matcher/extract_attribute_spec.rb:37:in `block (6 levels) in <top (required)>'

XYZ examples, 2 failures
```

#### Test Output (New Code)

```
XYZ examples, 0 failures
```