### PR TITLE
MONGOID-5066: Fix nested symbol operator during Selector.merge!()

### DIFF
--- a/lib/mongoid/criteria/queryable/selector.rb
+++ b/lib/mongoid/criteria/queryable/selector.rb
@@ -22,7 +22,7 @@ module Mongoid
         def merge!(other)
           other.each_pair do |key, value|
             if value.is_a?(Hash) && self[key.to_s].is_a?(Hash)
-              value = self[key.to_s].merge(value) do |_key, old_val, new_val|
+              value = self[key.to_s].transform_keys(&:to_s).merge(value.transform_keys(&:to_s)) do |_key, old_val, new_val|
                 case _key
                 when '$in'
                   new_val & old_val

--- a/spec/mongoid/criteria/queryable/selector_spec.rb
+++ b/spec/mongoid/criteria/queryable/selector_spec.rb
@@ -73,6 +73,42 @@ describe Mongoid::Criteria::Queryable::Selector do
       end
     end
 
+    context "when merging in a new symbol $nin" do
+
+      let(:other) do
+        { "field" => { "$nin" => ["bar"] } }
+      end
+
+      before do
+        selector["field"] = { :$nin => ["foo"] }
+        selector.merge!(other)
+      end
+
+      it "combines the two $nin queries into one" do
+        expect(selector).to eq({
+          "field" => { "$nin" => ["foo", "bar"] }
+        })
+      end
+    end
+
+    context "when merging in a symbol $in with an intersecting value" do
+
+      let(:other) do
+        { "field" => { "$in" => [1,2,3] } }
+      end
+
+      before do
+        selector["field"] = { :$in => [2,3,4] }
+        selector.merge!(other)
+      end
+
+      it "intersects the $in values" do
+        expect(selector).to eq({
+                                    "field" => { "$in" => [2,3] }
+                                })
+      end
+    end
+
     context "when selector contains a $in" do
 
       let(:initial) do


### PR DESCRIPTION
#### Summary

`Selector.merge!()` incorrectly handles nested Hash's containing `$in` and `$nin` operators, where one operator is a String and the other is a Symbol. This PR fixes this issue, along with unit tests that repro the problem behavior in the old code.

This change was originally inspired by a Symbol-String bug manifesting in a chained `Query.where().where()`. A key cause of this bug was in `Selector.merge!()`.

#### Original Repro

`query.where(:f => { :$in => [...] }).where(:f => { "$in" => [...] })`

#### Notes

* The second change which fixes the higher level `Query.where().where()` bug is part of a different module (Storable vs. Selector). I will be submitting that fix + test case(s) in a separate PR.

#### Test Output (No Changes)

```
% rake spec

  1) Mongoid::Criteria::Queryable::Selector merge! when merging in a new symbol $nin combines the two $nin queries into one
     Failure/Error:
       expect(selector).to eq({
         "field" => { "$nin" => ["foo", "bar"] }
       })
     
       expected: {"field"=>{"$nin"=>["foo", "bar"]}}
            got: {"field"=>{:$nin=>["foo"], "$nin"=>["bar"]}}
     
       (compared using ==)
     
       Diff:
       @@ -1 +1 @@
       -"field" => {"$nin"=>["foo", "bar"]},
       +"field" => {:$nin=>["foo"], "$nin"=>["bar"]},
       
     # ./spec/mongoid/criteria/queryable/selector_spec.rb:88:in `block (4 levels) in <top (required)>'

                                                                                                                                                                  
  2) Mongoid::Criteria::Queryable::Selector merge! when merging in a symbol $in with an intersecting value intersects the $in values
     Failure/Error:
       expect(selector).to eq({
                                   "field" => { "$in" => [2,3] }
                               })
     
       expected: {"field"=>{"$in"=>[2, 3]}}
            got: {"field"=>{:$in=>[2, 3, 4], "$in"=>[1, 2, 3]}}
     
       (compared using ==)
     
       Diff:
       @@ -1 +1 @@
       -"field" => {"$in"=>[2, 3]},
       +"field" => {:$in=>[2, 3, 4], "$in"=>[1, 2, 3]},

XYZ examples, 2 failures
```

#### Test Output (Fix Implemented)

```
% rake spec

XYZ examples, 0 failures
```