### PR TITLE
MONGOID-5067: Fix Storable.add_field_expression() when adding a nested String operator equivalent to an existing nested Symbol operator

### DIFF
--- a/lib/mongoid/criteria/queryable/storable.rb
+++ b/lib/mongoid/criteria/queryable/storable.rb
@@ -46,9 +46,9 @@ module Mongoid
             # We already have a restriction by the field we are trying
             # to restrict, combine the restrictions.
             if value.is_a?(Hash) && selector[field].is_a?(Hash) &&
-              value.keys.all? { |key|
-                key_s = key.to_s
-                key_s[0] == ?$ && !selector[field].key?(key_s)
+              (selector_keys = selector[field].transform_keys(&:to_s)) &&
+              value.transform_keys(&:to_s).keys.all? { |k|
+                k[0] == ?$ && !selector_keys.key?(k)
               }
             then
               # Multiple operators can be combined on the same field by

--- a/spec/mongoid/criteria/queryable/storable_spec.rb
+++ b/spec/mongoid/criteria/queryable/storable_spec.rb
@@ -129,6 +129,28 @@ describe Mongoid::Criteria::Queryable::Storable do
       end
     end
 
+    context 'when a String equivalent of an existing Symbol operator is added' do
+      let(:modified) do
+        query.add_field_expression('foo', {:$in=>[1,2]})
+        query.add_field_expression('foo', {"$in"=>[2,3]})
+      end
+
+      it 'connects the equivalent operators with $and' do
+        modified.selector.should == {
+          '$and' => [
+            {
+              "foo"=> {
+                "$in"=>[2, 3]
+              }
+            }
+          ],
+          "foo"=> {
+            :$in=> [1, 2]
+          }
+        }
+      end
+    end
+
     context 'an operator write' do
       let(:modified) do
         query.add_field_expression('$eq', {'foo' => 'bar'})


### PR DESCRIPTION
#### Summary

`Storable.add_field_expression()` doesn't correctly handle adding a nested String operator that is equivalent to an existing nested Symbol operator. This PR includes both the fix and a test reproducing the bug in the old code.

This is the second piece of a Symbol-String bug manifesting in a chained `Query.where().where()`. The first piece is addressed in [MONGOID-5066](https://jira.mongodb.org/browse/MONGOID-5066) and its accompanying [PR](https://github.com/mongodb/mongoid/pull/4965). 

#### Original Repro
`query.where(:f => { :$in => [...] }).where(:f => { "$in" => [...] })`

#### Test Output (No Changes)

```
% rake spec

  1) Mongoid::Criteria::Queryable::Storable#add_field_expression when a String equivalent of an existing Symbol operator is added connects the equivalent operators with $and
     Failure/Error:
       modified.selector.should == {
         '$and' => [
           {
             "foo"=> {
               "$in"=>[2, 3]
             }
           }
         ],
         "foo"=> {
           :$in=> [1, 2]
     
       expected: {"$and"=>[{"foo"=>{"$in"=>[2, 3]}}], "foo"=>{:$in=>[1, 2]}}
            got: {"foo"=>{:$in=>[1, 2], "$in"=>[2, 3]}} (using ==)
       Diff:
       @@ -1,3 +1,2 @@
       -"$and" => [{"foo"=>{"$in"=>[2, 3]}}],
       -"foo" => {:$in=>[1, 2]},
       +"foo" => {:$in=>[1, 2], "$in"=>[2, 3]},

XYZ examples, 1 failure
```

#### Test Output (Fix Implemented)

```
% rake spec

XYZ examples, 0 failures
```