### PR TITLE
Fix MONGOID-5068 ElemMatch matcher operates on pre-stringified keys in condition verification path against impossible values

### DIFF
--- a/lib/mongoid/matcher/elem_match.rb
+++ b/lib/mongoid/matcher/elem_match.rb
@@ -15,7 +15,8 @@ module Mongoid
           # Validate the condition is valid, even though we will never attempt
           # matching it.
           condition.each do |k, v|
-            if k.to_s.start_with?('$')
+            k = k.to_s
+            if k.start_with?('$')
               begin
                 ExpressionOperator.get(k)
               rescue Mongoid::Errors::InvalidExpressionOperator

--- a/spec/integration/matcher_operator_data/elem_match.yml
+++ b/spec/integration/matcher_operator_data/elem_match.yml
@@ -361,3 +361,49 @@
   # https://jira.mongodb.org/browse/MONGOID-4908
   matches: false
   error: [matcher, driver]
+
+- name: $elemMatch given as symbol
+  document:
+    tags:
+      - intelligent
+  query:
+    tags:
+      :$elemMatch:
+        $eq: intelligent
+  matches: true
+
+- name: $elemMatch given as symbol - document does not contain the matched field
+  document:
+  query:
+    tags:
+      :$elemMatch:
+        $eq: intelligent
+  matches: false
+
+- name: $elemMatch argument operator given as symbol - matches
+  document:
+    tags:
+      - intelligent
+  query:
+    tags:
+      $elemMatch:
+        :$eq: intelligent
+  matches: true
+
+- name: $elemMatch argument operator given as symbol - does not match
+  document:
+    tags:
+      - intelligent
+  query:
+    tags:
+      $elemMatch:
+        :$eq: intelli
+  matches: false
+
+- name: $elemMatch argument operator given as symbol - document does not contain the matched field
+  document:
+  query:
+    tags:
+      $elemMatch:
+        :$eq: intelli
+  matches: false


### PR DESCRIPTION
`Mongoid::Matcher::ElemMatch.matches?()` didn't consistently convert input keys within its condition to Strings. This PR doesn't include a new unit test verifying this behavior because `ElemMatch` is clearly out of sync with the `k = k.to_s` pattern used in other `lib/Mongoid/matcher/*.rb` files. Existing examples of correctly using `k = k.to_s` in other of these Matcher sub-modules are:
* [expression.rb](https://github.com/mongodb/mongoid/blob/master/lib/mongoid/matcher/expression.rb)
* [field_expression.rb](https://github.com/mongodb/mongoid/blob/master/lib/mongoid/matcher/field_expression.rb)
* [not.rb](https://github.com/mongodb/mongoid/blob/master/lib/mongoid/matcher/not.rb)