### PR TITLE
Fix nil preventing fallbacks on localized fields

### DIFF
--- a/lib/mongoid/fields/localized.rb
+++ b/lib/mongoid/fields/localized.rb
@@ -87,7 +87,7 @@ module Mongoid
         end
         return value unless value.nil?
         if fallbacks? && ::I18n.respond_to?(:fallbacks)
-          object[::I18n.fallbacks[locale].map(&:to_s).find{ |loc| object.has_key?(loc) }]
+          object[::I18n.fallbacks[locale].map(&:to_s).find{ |loc| !object[loc].nil? }]
         end
       end
     end

--- a/spec/mongoid/fields/localized_spec.rb
+++ b/spec/mongoid/fields/localized_spec.rb
@@ -151,6 +151,17 @@ describe Mongoid::Fields::Localized do
                 end
               end
 
+              context "when the value for the current locale is nil" do
+
+                let(:value) do
+                  field.demongoize({ "de" => nil, "en" => "pruebas" })
+                end
+
+                it "returns the fallback translation" do
+                  expect(value).to eq("pruebas")
+                end
+              end
+
               context "when the fallback translation does not exist" do
 
                 let(:value) do


### PR DESCRIPTION
In #3490, a fix to prevent falling back to another locale when the current locale's value was `false` introduced a regression where the value `nil`, which was previously treated as a missing translation, became accepted as a translated value too.

This PR assumes that was an unwanted change, fixes it, and introduces a regression test.