### PR TITLE
Use double splat (**) when sending options toActiveModel::Errors#add method

### DIFF
--- a/lib/mongoid/validatable/associated.rb
+++ b/lib/mongoid/validatable/associated.rb
@@ -43,7 +43,7 @@ module Mongoid
         ensure
           document.exit_validate
         end
-        document.errors.add(attribute, :invalid, options) unless valid
+        document.errors.add(attribute, :invalid, **options) unless valid
       end
     end
   end

--- a/lib/mongoid/validatable/presence.rb
+++ b/lib/mongoid/validatable/presence.rb
@@ -34,15 +34,15 @@ module Mongoid
             document.errors.add(
               attribute,
               :blank_in_locale,
-              options.merge(location: _locale)
+              **options.merge(location: _locale)
             ) if not_present?(_value)
           end
         elsif document.relations.has_key?(attribute.to_s)
           if relation_or_fk_missing?(document, attribute, value)
-            document.errors.add(attribute, :blank, options)
+            document.errors.add(attribute, :blank, **options)
           end
         else
-          document.errors.add(attribute, :blank, options) if not_present?(value)
+          document.errors.add(attribute, :blank, **options) if not_present?(value)
         end
       end
 

--- a/lib/mongoid/validatable/uniqueness.rb
+++ b/lib/mongoid/validatable/uniqueness.rb
@@ -68,7 +68,7 @@ module Mongoid
       # @since 2.4.10
       def add_error(document, attribute, value)
         document.errors.add(
-          attribute, :taken, options.except(:case_sensitive, :scope).merge(value: value)
+          attribute, :taken, **options.except(:case_sensitive, :scope).merge(value: value)
         )
       end
 


### PR DESCRIPTION
Gets rid of a few of these deprecation notices:

```
warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
```