### PR TITLE
MONGOID-4668 Add test for regexp field

### DIFF
--- a/docs/tutorials/mongoid-documents.txt
+++ b/docs/tutorials/mongoid-documents.txt
@@ -609,6 +609,9 @@ If a time zone is specfied, it is respected:
     ticket.opened_at
     # => Sun, 04 Mar 2018 09:00:00 +0000
 
+
+.. _regular-expression-fields:
+
 Regular Expression Fields
 -------------------------
 

--- a/docs/tutorials/mongoid-upgrade.txt
+++ b/docs/tutorials/mongoid-upgrade.txt
@@ -655,6 +655,75 @@ To read more about using the query cache with Mongoid and the limitations
 of the legacy query cache, see :ref:`the query cache documentation <query-cache>`.
 
 
+``Regexp`` Fields Store Assigned Strings As Regular Expressions
+---------------------------------------------------------------
+
+Minor change: when a ``String`` value is written in a ``Regexp`` field,
+Mongoid 7.2 stores that value in MongoDB as a regular expression.
+Subsequently it would be retrieved :ref:`as a BSON::Regexp::Raw instance
+<regular-expression-fields>`.
+Previously the value would be stored as a string and would be retrieved as
+a string.
+
+Example Mongoid 7.2 behavior:
+
+.. code-block:: ruby
+
+  class Offer
+    include Mongoid::Document
+    
+    field :constraint, type: Regexp
+  end
+  
+  offer = Offer.create!(constraint: /foo/)
+  # => #<Offer _id: 6082df412c97a66be6ba9970, constraint: /foo/>
+  
+  Offer.collection.aggregate([
+    {'$match' => {_id: offer.id}},
+    {'$set' => {type: {'$type' => '$constraint'}}},
+  ]).first
+  # => {"_id"=>BSON::ObjectId('6082df412c97a66be6ba9970'),
+  #     "constraint"=>#<BSON::Regexp::Raw:0x000055b4ccdff738 @pattern="foo", @options="m">,
+  #     "type"=>"regex"}
+
+  offer = Offer.create!(constraint: 'foo')
+  # => #<Offer _id: 6082df412c97a66be6ba9971, constraint: /foo/>
+  
+  Offer.collection.aggregate([
+    {'$match' => {_id: offer.id}},
+    {'$set' => {type: {'$type' => '$constraint'}}},
+  ]).first
+  # => {"_id"=>BSON::ObjectId('6082df412c97a66be6ba9971'),
+  #     "constraint"=>#<BSON::Regexp::Raw:0x000055b4cce11320 @pattern="foo", @options="m">,
+  #     "type"=>"regex"}
+
+Mongoid 7.1 behavior with the same model class:
+
+.. code-block:: ruby
+
+  offer = Offer.create!(constraint: /foo/)
+  # => #<Offer _id: 6082e0182c97a66c21e3f721, constraint: /foo/>
+  
+  Offer.collection.aggregate([
+    {'$match' => {_id: offer.id}},
+    {'$set' => {type: {'$type' => '$constraint'}}},
+  ]).first
+  # => {"_id"=>BSON::ObjectId('6082e0182c97a66c21e3f721'),
+  #     "constraint"=>#<BSON::Regexp::Raw:0x000055ecf43f4cb0 @pattern="foo", @options="m">,
+  #     "type"=>"regex"}
+
+  offer = Offer.create!(constraint: 'foo')
+  # => #<Offer _id: 6082e05c2c97a66c21e3f723, constraint: "foo">
+  
+  Offer.collection.aggregate([
+    {'$match' => {_id: offer.id}},
+    {'$set' => {type: {'$type' => '$constraint'}}},
+  ]).first
+  # => {"_id"=>BSON::ObjectId('6082e05c2c97a66c21e3f723'),
+  #     "constraint"=>"foo",
+  #     "type"=>"string"}
+
+
 Upgrading to Mongoid 7.1
 ========================
 

--- a/spec/mongoid/document_fields_spec.rb
+++ b/spec/mongoid/document_fields_spec.rb
@@ -87,13 +87,6 @@ describe Mongoid::Document do
   end
 
   describe 'Regexp field' do
-    class Template
-      include Mongoid::Document
-
-      field :name, type: String
-      field :pattern, type: Regexp
-    end
-
     it 'persists strings as regexp' do
       mop = Mop.create!(regexp_field: 'foo')
       expect(mop.regexp_field).to be_a Regexp

--- a/spec/mongoid/document_fields_spec.rb
+++ b/spec/mongoid/document_fields_spec.rb
@@ -86,17 +86,29 @@ describe Mongoid::Document do
     end
   end
 
-  describe 'Regexp field' do
-    it 'persists strings as regexp' do
-      mop = Mop.create!(regexp_field: 'foo')
-      expect(mop.regexp_field).to be_a Regexp
-      expect(Mop.find(mop.id).regexp_field).to be_a BSON::Regexp::Raw
-      expect(
-        Mop.collection.find(
-          "_id" => mop.id,
-          "regexp_field" => { "$type" => "regex" }
-        ).count
-      ).to be == 1
+  context 'Regexp field' do
+    shared_examples "persists strings as regexp" do |type|
+      it 'persists strings as regexp' do
+        mop = Mop.create!(regexp_field: 'foo')
+        expect(mop.regexp_field).to be_a Regexp
+        expect(Mop.find(mop.id).regexp_field).to be_a BSON::Regexp::Raw
+        expect(
+          Mop.collection.find(
+            "_id" => mop.id,
+            "regexp_field" => { "$type" => type }
+          ).count
+        ).to be == 1
+      end
+    end
+
+    context "< 3.2" do
+      max_server_version("3.1")
+      include_examples "persists strings as regexp", 11
+    end
+
+    context ">= 3.2" do
+      min_server_version("3.2")
+      it_behaves_like "persists strings as regexp", "regex"
     end
   end
 end

--- a/spec/mongoid/document_fields_spec.rb
+++ b/spec/mongoid/document_fields_spec.rb
@@ -91,6 +91,12 @@ describe Mongoid::Document do
       mop = Mop.create!(regexp_field: 'foo')
       expect(mop.regexp_field).to be_a Regexp
       expect(Mop.find(mop.id).regexp_field).to be_a BSON::Regexp::Raw
+      expect(
+        Mop.collection.find(
+          "_id" => mop.id,
+          "regexp_field" => { "$type" => "regex" }
+        ).count
+      ).to be == 1
     end
   end
 end

--- a/spec/mongoid/document_fields_spec.rb
+++ b/spec/mongoid/document_fields_spec.rb
@@ -85,4 +85,19 @@ describe Mongoid::Document do
       end
     end
   end
+
+  describe 'Regexp field' do
+    class Template
+      include Mongoid::Document
+
+      field :name, type: String
+      field :pattern, type: Regexp
+    end
+
+    it 'persists strings as regexp' do
+      mop = Mop.create!(regexp_field: 'foo')
+      expect(mop.regexp_field).to be_a Regexp
+      expect(Mop.find(mop.id).regexp_field).to be_a BSON::Regexp::Raw
+    end
+  end
 end


### PR DESCRIPTION
If a document has a field with type Regexp, it is still possible to assign strings to this field. In this case the field still should be persisted as regexp.