### PR TITLE
MONGOID-5078 Fix shard_key_selector_in_db during post-persist callbacks - DRAFT

### DIFF
--- a/lib/mongoid/document.rb
+++ b/lib/mongoid/document.rb
@@ -29,7 +29,7 @@ module Mongoid
     include Mongoid::Touchable::InstanceMethods
 
     attr_accessor :__selected_fields
-    attr_reader :new_record
+    attr_reader :new_record, :during_post_persist_callbacks
 
     included do
       Mongoid.register_model(self)
@@ -116,6 +116,7 @@ module Mongoid
     def initialize(attrs = nil)
       @__parent = nil
       _building do
+        @during_post_persist_callbacks = false
         @new_record = true
         @attributes ||= {}
         apply_pre_processed_defaults
@@ -248,6 +249,14 @@ module Mongoid
       end
 
       became
+    end
+
+    def begin_post_persist_callbacks
+      @during_post_persist_callbacks = true
+    end
+
+    def end_post_persist_callbacks
+      @during_post_persist_callbacks = false
     end
 
     private

--- a/lib/mongoid/persistable/creatable.rb
+++ b/lib/mongoid/persistable/creatable.rb
@@ -120,10 +120,16 @@ module Mongoid
         result = run_callbacks(:save) do
           run_callbacks(:create) do
             yield(self)
+            begin_post_persist_callbacks
             post_process_insert
           end
         end
-        post_process_persist(result, options) and self
+        begin
+          post_process_persist(result, options) and result
+          self
+        ensure
+          end_post_persist_callbacks
+        end
       end
 
       module ClassMethods

--- a/lib/mongoid/persistable/updatable.rb
+++ b/lib/mongoid/persistable/updatable.rb
@@ -112,10 +112,15 @@ module Mongoid
         result = run_callbacks(:save) do
           run_callbacks(:update) do
             yield(self)
+            begin_post_persist_callbacks
             true
           end
         end
-        post_process_persist(result, options) and result
+        begin
+          post_process_persist(result, options) and result
+        ensure
+          end_post_persist_callbacks
+        end
       end
 
       # Update the document in the database.

--- a/lib/mongoid/persistable/upsertable.rb
+++ b/lib/mongoid/persistable/upsertable.rb
@@ -48,10 +48,15 @@ module Mongoid
         return false if performing_validations?(options) && invalid?(:upsert)
         result = run_callbacks(:upsert) do
           yield(self)
+          begin_post_persist_callbacks
           true
         end
-        self.new_record = false
-        post_process_persist(result, options) and result
+        begin
+          self.new_record = false
+          post_process_persist(result, options) and result
+        ensure
+          end_post_persist_callbacks
+        end
       end
     end
   end

--- a/lib/mongoid/shardable.rb
+++ b/lib/mongoid/shardable.rb
@@ -79,7 +79,7 @@ module Mongoid
     def shard_key_selector_in_db
       selector = {}
       shard_key_fields.each do |field|
-        selector[field.to_s] = new_record? ? send(field) : attribute_was(field)
+        selector[field.to_s] = new_record? || during_post_persist_callbacks ? send(field) : attribute_was(field)
       end
       selector
     end


### PR DESCRIPTION
Hi @p  and @comandeo,

The [mongoid#4985](https://github.com/mongodb/mongoid/pull/4985) PR allowed me to tweak my [existing solution](https://github.com/dalton-braze/mongoid/pull/4) draft for [MONGOID-5078](https://jira.mongodb.org/browse/MONGOID-5078) because of `shard_key_selector_in_db` being split out of `shard_key_selector`.

`shard_key_selector_in_db` is defined as:
```
# Returns the selector that would match the existing version of this
# document in the database.
```

This supports the conclusion that `shard_key_selector_in_db` should contain the updated version of a shard key during "post-persist" callbacks (`after_create`, `after_save`, `after_update`, `after_upsert`, etc). The current incorrect behavior is that `shard_key_selector_in_db` returns the old value of a shard key during "post-persist" callbacks which are triggered by updating a shard key.

The potential solution I designed adds a single instance variable, `@during_post_persist_callbacks`, to each `Mongoid::Document`. This instance variable is read by `shard_key_selector_in_db` to determine if it should return a sharded field's internally cached previous value or its current value.

**This PR is intended as a draft (especially the example tests I wrote). I am hoping to use it as a jumping-off point for discussing the solution to this behavior in more detail. I'd love to hear what you think.**

For a much deeper level of detail, check out my original open PR [here](https://github.com/dalton-braze/mongoid/pull/4).