### PR TITLE
Preliminary Ruby 3.0 support

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -420,6 +420,10 @@ axes:
         display_name: ruby-2.7
         variables:
            RVM_RUBY: "ruby-2.7"
+      - id: "ruby-3.0"
+        display_name: ruby-3.0
+        variables:
+          RVM_RUBY: "ruby-3.0"
       - id: "ruby-head"
         display_name: ruby-head
         variables:
@@ -528,7 +532,18 @@ axes:
           APP_TESTS: yes
 
 buildvariants:
-- matrix_name: "drivers"
+- matrix_name: "drivers-ruby-3.0"
+  matrix_spec:
+    driver: [current, master, stable]
+    ruby: "ruby-3.0"
+    mongodb-version: "4.4"
+    topology: '*'
+  display_name: "${ruby}, ${driver}, ${mongodb-version}, ${topology}"
+  run_on:
+    - rhel70-small
+  tasks:
+    - name: "test"
+- matrix_name: "drivers-ruby-2.7"
   matrix_spec:
     driver: [current, master, stable]
     ruby: "ruby-2.7"
@@ -539,10 +554,21 @@ buildvariants:
     - rhel70-small
   tasks:
      - name: "test"
-- matrix_name: "topologies"
+- matrix_name: "topologies-ruby-3.0"
   matrix_spec:
     driver: current
-    ruby: "ruby-2.6"
+    ruby: "ruby-3.0"
+    mongodb-version: ['3.6', '4.0', '4.2', '4.4']
+    topology: ["replica-set", "sharded-cluster"]
+  display_name: "${ruby}, ${driver}, ${mongodb-version}, ${topology}"
+  run_on:
+    - ubuntu1604-small
+  tasks:
+    - name: "test"
+- matrix_name: "topologies-ruby-2.7"
+  matrix_spec:
+    driver: current
+    ruby: "ruby-2.7"
     mongodb-version: ['3.6', '4.0', '4.2', '4.4']
     topology: ["replica-set", "sharded-cluster"]
   display_name: "${ruby}, ${driver}, ${mongodb-version}, ${topology}"
@@ -729,7 +755,19 @@ buildvariants:
     - rhel70-small
   tasks:
      - name: "test"
-- matrix_name: "rails-6.0"
+- matrix_name: "rails-6.0-ruby-3.0"
+  matrix_spec:
+    driver: "current"
+    ruby: "ruby-3.0"
+    mongodb-version: "4.4"
+    topology: "standalone"
+    rails: '6.0'
+  display_name: "${rails}, ${driver}, ${mongodb-version}"
+  run_on:
+    - rhel70-small
+  tasks:
+    - name: "test"
+- matrix_name: "rails-6.0-ruby-2.7"
   matrix_spec:
     driver: "current"
     ruby: "ruby-2.7"
@@ -773,7 +811,21 @@ buildvariants:
     - rhel70-small
   tasks:
      - name: "test"
-- matrix_name: app-tests
+- matrix_name: app-tests-ruby-3.0
+  matrix_spec:
+    driver: current
+    ruby: ruby-3.0
+    mongodb-version: '4.4'
+    topology: standalone
+    app-tests: yes
+    # Not currently testing rails master
+    rails: ['6.0', '6.1']
+  display_name: "app tests ${driver}, ${ruby}, ${rails}"
+  run_on:
+    - ubuntu1804-small
+  tasks:
+    - name: "test"
+- matrix_name: app-tests-ruby-2.7
   matrix_spec:
     driver: current
     ruby: ruby-2.7

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -6,7 +6,7 @@ set -o errexit  # Exit the script with error if any of the commands fail
 # Supported/used environment variables:
 #       MONGODB_URI             Set the suggested connection MONGODB_URI (including credentials and topology info)
 #       RVM_RUBY                Define the Ruby version to test with, using its RVM identifier.
-#                               For example: "ruby-2.7" or "jruby-9.2"
+#                               For example: "ruby-3.0" or "jruby-9.2"
 
 . `dirname "$0"`/../spec/shared/shlib/distro.sh
 . `dirname "$0"`/../spec/shared/shlib/set_env.sh

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Compatibility
 
 Mongoid supports and is tested against:
 
-- MRI 2.3-2.7
+- MRI 2.3-3.0
 - JRuby 9.2
 - MongoDB server 2.6-4.4
 

--- a/gemfiles/standard.rb
+++ b/gemfiles/standard.rb
@@ -6,7 +6,7 @@ def standard_dependencies
   end
 
   group :development, :test do
-    gem 'rspec-core', '~> 3.10'
+    gem 'rspec', '~> 3.10'
 
     platform :mri do
       gem 'byebug'
@@ -21,8 +21,6 @@ def standard_dependencies
     gem 'timecop'
     gem 'rspec-retry'
     gem 'benchmark-ips'
-    gem 'rspec-expectations', '>= 3.8.4'
-    gem 'rspec-mocks'
     gem 'fuubar'
     gem 'rfc'
     gem 'childprocess'

--- a/gemfiles/standard.rb
+++ b/gemfiles/standard.rb
@@ -6,7 +6,7 @@ def standard_dependencies
   end
 
   group :development, :test do
-    gem 'rspec-core', '~> 3.7'
+    gem 'rspec-core', '~> 3.10'
 
     platform :mri do
       gem 'byebug'
@@ -21,8 +21,8 @@ def standard_dependencies
     gem 'timecop'
     gem 'rspec-retry'
     gem 'benchmark-ips'
-    gem 'rspec-expectations', '~> 3.7', '>= 3.8.4'
-    gem 'rspec-mocks-diag', '~> 3.0'
+    gem 'rspec-expectations', '>= 3.8.4'
+    gem 'rspec-mocks'
     gem 'fuubar'
     gem 'rfc'
     gem 'childprocess'

--- a/lib/mongoid/errors/mongoid_error.rb
+++ b/lib/mongoid/errors/mongoid_error.rb
@@ -48,7 +48,7 @@ module Mongoid
       #
       # @return [ String ] A localized error message string.
       def translate(key, options)
-        ::I18n.translate("#{BASE_KEY}.#{key}", options)
+        ::I18n.translate("#{BASE_KEY}.#{key}", **options)
       end
 
       # Create the problem.

--- a/lib/mongoid/validatable/associated.rb
+++ b/lib/mongoid/validatable/associated.rb
@@ -43,7 +43,7 @@ module Mongoid
         ensure
           document.exit_validate
         end
-        document.errors.add(attribute, :invalid, options) unless valid
+        document.errors.add(attribute, :invalid, **options) unless valid
       end
     end
   end

--- a/lib/mongoid/validatable/presence.rb
+++ b/lib/mongoid/validatable/presence.rb
@@ -34,15 +34,15 @@ module Mongoid
             document.errors.add(
               attribute,
               :blank_in_locale,
-              options.merge(location: _locale)
+              **options.merge(location: _locale)
             ) if not_present?(_value)
           end
         elsif document.relations.has_key?(attribute.to_s)
           if relation_or_fk_missing?(document, attribute, value)
-            document.errors.add(attribute, :blank, options)
+            document.errors.add(attribute, :blank, **options)
           end
         else
-          document.errors.add(attribute, :blank, options) if not_present?(value)
+          document.errors.add(attribute, :blank, **options) if not_present?(value)
         end
       end
 

--- a/lib/mongoid/validatable/uniqueness.rb
+++ b/lib/mongoid/validatable/uniqueness.rb
@@ -68,7 +68,7 @@ module Mongoid
       # @since 2.4.10
       def add_error(document, attribute, value)
         document.errors.add(
-          attribute, :taken, options.except(:case_sensitive, :scope).merge(value: value)
+          attribute, :taken, **options.except(:case_sensitive, :scope).merge(value: value)
         )
       end
 

--- a/spec/mongoid/errors/mongoid_error_spec.rb
+++ b/spec/mongoid/errors/mongoid_error_spec.rb
@@ -11,12 +11,12 @@ describe Mongoid::Errors::MongoidError do
 
   before do
     {"message_title" => "message", "summary_title" => "summary", "resolution_title" => "resolution"}.each do |key, name|
-      expect(::I18n).to receive(:translate).with("mongoid.errors.messages.#{key}", {}).and_return(name)
+      expect(::I18n).to receive(:translate).with("mongoid.errors.messages.#{key}", **{}).and_return(name)
     end
 
     ["message", "summary", "resolution"].each do |name|
       expect(::I18n).to receive(:translate).
-        with("mongoid.errors.messages.#{key}.#{name}", {}).
+        with("mongoid.errors.messages.#{key}.#{name}", **{}).
       and_return(name)
     end
 

--- a/spec/mongoid/persistable_spec.rb
+++ b/spec/mongoid/persistable_spec.rb
@@ -178,8 +178,8 @@ describe Mongoid::Persistable do
 
         before do
           class Band
-            def my_updates(*args)
-              atomically(*args) do |d|
+            def my_updates(**args)
+              atomically(**args) do |d|
                 d.set(name: "Placebo")
                 d.unset(:origin)
               end


### PR DESCRIPTION
Fixes MONGOID-5048, MONGOID-4974, MONGOID-5041, MONGOID-4833, MONGOID-5044

Summary:
- Allow Ruby 3.0 in tests
- I18n.translate should use double-splat keyword arguments
- Upgrade Rspec to 3.10+ for Ruby 3.0 support (tests fail otherwise)
- Remove `rspec-mocks-diag` gem and switch back to standard `rspec-mocks` (reverts https://github.com/mongodb/mongoid/pull/4690)

Specs seem to be running fine on my local machine with Ruby 3.0 (* test run still in progress but no failures yet). I am not familiar with Evergreen CI and I need some help to get it to run. 