### PR TITLE
allows ActionController::Parameters to be passed as nested attributes

### DIFF
--- a/lib/mongoid/association/nested/many.rb
+++ b/lib/mongoid/association/nested/many.rb
@@ -1,4 +1,3 @@
-require 'pry'
 # frozen_string_literal: true
 # encoding: utf-8
 
@@ -28,7 +27,7 @@ module Mongoid
             raise Errors::TooManyNestedAttributeRecords.new(existing, options[:limit])
           end
           attributes.each do |attrs|
-            if attrs.is_a?(Hash)
+            if attrs.is_a?(::Hash)
               process_attributes(parent, attrs.with_indifferent_access)
             else
               process_attributes(parent, attrs[1].with_indifferent_access)

--- a/lib/mongoid/association/nested/many.rb
+++ b/lib/mongoid/association/nested/many.rb
@@ -1,3 +1,4 @@
+require 'pry'
 # frozen_string_literal: true
 # encoding: utf-8
 
@@ -27,7 +28,7 @@ module Mongoid
             raise Errors::TooManyNestedAttributeRecords.new(existing, options[:limit])
           end
           attributes.each do |attrs|
-            if attrs.is_a?(::Hash)
+            if attrs.is_a?(Hash)
               process_attributes(parent, attrs.with_indifferent_access)
             else
               process_attributes(parent, attrs[1].with_indifferent_access)
@@ -45,6 +46,7 @@ module Mongoid
         # @param [ Hash ] attributes The attributes hash to attempt to set.
         # @param [ Hash ] options The options defined.
         def initialize(association, attributes, options = {})
+          attributes = attributes&.to_h if attributes.respond_to?(:keys)
           if attributes.respond_to?(:with_indifferent_access)
             @attributes = attributes.with_indifferent_access.sort do |a, b|
               a[0].to_i <=> b[0].to_i

--- a/spec/mongoid/association/nested/many_spec.rb
+++ b/spec/mongoid/association/nested/many_spec.rb
@@ -142,6 +142,26 @@ describe Mongoid::Association::Nested::Many do
         expect(person.addresses.first.street).to eq("Maybachufer")
       end
     end
+
+    context "copes with ActionController::Parameters" do
+
+      let(:attributes) do
+        ActionController::Parameters.new(super()).permit!
+      end
+
+      let(:builder) do
+        described_class.new(association, attributes)
+      end
+
+      before do
+        builder.build(person)
+      end
+
+      it "adds new documents" do
+        expect(person.addresses.first.street).to eq("Maybachufer")
+      end
+
+    end
   end
 
   describe "#initialize" do


### PR DESCRIPTION
Whilst upgrading to Rails 5 we found that ActionController::Parameters doesn't respond to .with_indifferent_access. So this caused problems here in Nested Many because this assumes that the attributes are either passed as an array or a hash and ActionController::Parameters is assumed to be an Array.