### PR TITLE
Fix MONGOID-5116 Using 'without' breaks access to attributes of embedded documents

### DIFF
--- a/lib/mongoid/association/accessors.rb
+++ b/lib/mongoid/association/accessors.rb
@@ -121,6 +121,9 @@ module Mongoid
       # (embedded) association with the given key, or nil if no projection
       # is to be performed.
       #
+      # Also returns nil if exclusionary projection was requested but it does
+      # not exclude the field of the association.
+      #
       # For example, if __selected_fields is {'a' => 1, 'b.c' => 2, 'b.c.f' => 3},
       # and assoc_key is 'b', return value would be {'c' => 2, 'c.f' => 3}.
       #
@@ -135,8 +138,11 @@ module Mongoid
         # If the list of fields was specified using #without instead of #only
         # and the provided list does not include the association, any of its
         # fields should be allowed.
-        return nil if __selected_fields.values.all?(0) &&
-          __selected_fields.keys.none? { |k| k.start_with?(assoc_key) }
+        if __selected_fields.values.all? { |v| v == 0 } &&
+          __selected_fields.keys.none? { |k| k.split('.', 2).first == assoc_key }
+        then
+          return nil
+        end
 
         projecting_assoc = false
 

--- a/lib/mongoid/association/accessors.rb
+++ b/lib/mongoid/association/accessors.rb
@@ -132,6 +132,12 @@ module Mongoid
       def _mongoid_filter_selected_fields(assoc_key)
         return nil unless __selected_fields
 
+        # If the list of fields was specified using #without instead of #only
+        # and the provided list does not include the association, any of its
+        # fields should be allowed.
+        return nil if __selected_fields.values.all?(0) &&
+          __selected_fields.keys.none? { |k| k.start_with?(assoc_key) }
+
         projecting_assoc = false
 
         filtered = {}

--- a/spec/mongoid/document_query_spec.rb
+++ b/spec/mongoid/document_query_spec.rb
@@ -45,8 +45,26 @@ describe Mongoid::Document do
 
     let(:person) { Person.where(username: 'Dev').without(:title).first }
 
-    it 'allows access to embed fields' do
+    it 'allows access to attributes of embedded documents' do
       expect(person.pet.name).to eq 'Duck'
+    end
+
+    context 'when exclusion starts with association name but is not the association' do
+
+      let(:person) { Person.where(username: 'Dev').without(:pet_).first }
+
+      it 'allows access to attributes of embedded documents' do
+        expect(person.pet.name).to eq 'Duck'
+      end
+    end
+
+    context 'when exclusion starts with prefix of association name' do
+
+      let(:person) { Person.where(username: 'Dev').without(:pe).first }
+
+      it 'allows access to attributes of embedded documents' do
+        expect(person.pet.name).to eq 'Duck'
+      end
     end
   end
 end

--- a/spec/mongoid/document_query_spec.rb
+++ b/spec/mongoid/document_query_spec.rb
@@ -45,7 +45,7 @@ describe Mongoid::Document do
 
     let(:person) { Person.where(username: 'Dev').without(:title).first }
 
-    it 'allows access to attributes of embedded documents' do
+      it 'allows access to attribute of embedded document' do
       expect(person.pet.name).to eq 'Duck'
     end
 
@@ -53,7 +53,7 @@ describe Mongoid::Document do
 
       let(:person) { Person.where(username: 'Dev').without(:pet_).first }
 
-      it 'allows access to attributes of embedded documents' do
+      it 'allows access to attribute of embedded document' do
         expect(person.pet.name).to eq 'Duck'
       end
     end
@@ -62,8 +62,28 @@ describe Mongoid::Document do
 
       let(:person) { Person.where(username: 'Dev').without(:pe).first }
 
-      it 'allows access to attributes of embedded documents' do
+      it 'allows access to attribute of embedded document' do
         expect(person.pet.name).to eq 'Duck'
+      end
+    end
+
+    context 'when another attribute of the association is excluded' do
+
+      let(:person) { Person.where(username: 'Dev').without('pet.weight').first }
+
+      it 'allows access to non-excluded attribute of embedded document' do
+        expect(person.pet.name).to eq 'Duck'
+      end
+    end
+
+    context 'when the excluded attribute of the association is retrieved' do
+
+      let(:person) { Person.where(username: 'Dev').without('pet.name').first }
+
+      it 'prohibits the retrieval' do
+        lambda do
+          person.pet.name
+        end.should raise_error(ActiveModel::MissingAttributeError)
       end
     end
   end

--- a/spec/mongoid/document_query_spec.rb
+++ b/spec/mongoid/document_query_spec.rb
@@ -36,4 +36,17 @@ describe Mongoid::Document do
       expect(_person.age).to be 42
     end
   end
+
+  context 'when projecting with #without' do
+    before do
+      duck = Pet.new(name: 'Duck')
+      Person.create!(username: 'Dev', title: 'CEO', pet: duck)
+    end
+
+    let(:person) { Person.where(username: 'Dev').without(:title).first }
+
+    it 'allows access to embed fields' do
+      expect(person.pet.name).to eq 'Duck'
+    end
+  end
 end


### PR DESCRIPTION
As reported in https://jira.mongodb.org/browse/MONGOID-5116, there's an issue when a record was loaded by a query that was built using `without` and we then try to access a field on one of its embeds.

```ruby
duck = Pet.new(name: 'Duck')
Person.create!(username: 'Dev', title: 'CEO', pet: duck)

person = Person.where(username: 'Dev').without(:title).first

person.pet.name
#! ActiveModel::MissingAttributeError:
#!  Missing attribute: 'name'
```

This is due to the way fields filtering happens as it only accounts for cases where `only` was used.

This PR is a fix that will ignore fields selection if it's only rejecting fields that don't involve the association.