### PR TITLE
MONGOID-5125 find: does not return the correct results for has_many relations

### DIFF
--- a/lib/mongoid/association/embedded/embeds_many/proxy.rb
+++ b/lib/mongoid/association/embedded/embeds_many/proxy.rb
@@ -219,8 +219,8 @@ module Mongoid
           # @param [ Array<Object> ] args Various arguments.
           #
           # @return [ Array<Document>, Document ] A single or multiple documents.
-          def find(*args)
-            criteria.find(*args)
+          def find(*args, &block)
+            criteria.find(*args, &block)
           end
 
           # Instantiate a new embeds_many association.

--- a/lib/mongoid/association/embedded/embeds_many/proxy.rb
+++ b/lib/mongoid/association/embedded/embeds_many/proxy.rb
@@ -210,16 +210,27 @@ module Mongoid
           # Finds a document in this association through several different
           # methods.
           #
+          # This method delegates to +Mongoid::Criteria#find+. If this method is
+          # not given a block, it returns one or many documents for the provided
+          # _id values.
+          #
+          # If this method is given a block, it returns the first document
+          # of those found by the current Criteria object for which the block
+          # returns a truthy value.
+          #
           # @example Find a document by its id.
           #   person.addresses.find(BSON::ObjectId.new)
           #
           # @example Find documents for multiple ids.
           #   person.addresses.find([ BSON::ObjectId.new, BSON::ObjectId.new ])
           #
+          # @example Finds the first matching document using a block.
+          #   person.addresses.find { |addr| addr.state == 'CA' }
+          #
           # @param [ Array<Object> ] args Various arguments.
           # @param [ Proc ] block Optional block to pass.
           #
-          # @return [ Array<Document>, Document ] A single or multiple documents.
+          # @return [ Document | Array<Document> | nil ] A document or matching documents.
           def find(*args, &block)
             criteria.find(*args, &block)
           end

--- a/lib/mongoid/association/embedded/embeds_many/proxy.rb
+++ b/lib/mongoid/association/embedded/embeds_many/proxy.rb
@@ -217,6 +217,7 @@ module Mongoid
           #   person.addresses.find([ BSON::ObjectId.new, BSON::ObjectId.new ])
           #
           # @param [ Array<Object> ] args Various arguments.
+          # @param [ Proc ] block Optional block to pass.
           #
           # @return [ Array<Document>, Document ] A single or multiple documents.
           def find(*args, &block)

--- a/lib/mongoid/association/referenced/has_many/proxy.rb
+++ b/lib/mongoid/association/referenced/has_many/proxy.rb
@@ -188,11 +188,22 @@ module Mongoid
           # Find the matching document on the association, either based on id or
           # conditions.
           #
+          # This method delegates to +Mongoid::Criteria#find+. If this method is
+          # not given a block, it returns one or many documents for the provided
+          # _id values.
+          #
+          # If this method is given a block, it returns the first document
+          # of those found by the current Criteria object for which the block
+          # returns a truthy value.
+          #
           # @example Find by an id.
           #   person.posts.find(BSON::ObjectId.new)
           #
           # @example Find by multiple ids.
           #   person.posts.find([ BSON::ObjectId.new, BSON::ObjectId.new ])
+          #
+          # @example Finds the first matching document using a block.
+          #   person.addresses.find { |addr| addr.state == 'CA' }
           #
           # @note This will keep matching documents in memory for iteration
           #   later.
@@ -200,7 +211,7 @@ module Mongoid
           # @param [ BSON::ObjectId, Array<BSON::ObjectId> ] args The ids.
           # @param [ Proc ] block Optional block to pass.
           #
-          # @return [ Document, Criteria ] The matching document(s).
+          # @return [ Document | Array<Document> | nil ] A document or matching documents.
           #
           # @since 2.0.0.beta.1
           def find(*args, &block)

--- a/lib/mongoid/association/referenced/has_many/proxy.rb
+++ b/lib/mongoid/association/referenced/has_many/proxy.rb
@@ -202,8 +202,8 @@ module Mongoid
           # @return [ Document, Criteria ] The matching document(s).
           #
           # @since 2.0.0.beta.1
-          def find(*args)
-            matching = criteria.find(*args)
+          def find(*args, &block)
+            matching = criteria.find(*args, &block)
             Array(matching).each { |doc| _target.push(doc) }
             matching
           end

--- a/lib/mongoid/association/referenced/has_many/proxy.rb
+++ b/lib/mongoid/association/referenced/has_many/proxy.rb
@@ -185,7 +185,7 @@ module Mongoid
             criteria.exists?
           end
 
-          # Find the matchind document on the association, either based on id or
+          # Find the matching document on the association, either based on id or
           # conditions.
           #
           # @example Find by an id.
@@ -198,6 +198,7 @@ module Mongoid
           #   later.
           #
           # @param [ BSON::ObjectId, Array<BSON::ObjectId> ] args The ids.
+          # @param [ Proc ] block Optional block to pass.
           #
           # @return [ Document, Criteria ] The matching document(s).
           #

--- a/spec/mongoid/association/embedded/embeds_many/proxy_spec.rb
+++ b/spec/mongoid/association/embedded/embeds_many/proxy_spec.rb
@@ -1417,12 +1417,12 @@ describe Mongoid::Association::Embedded::EmbedsMany::Proxy do
         expect(person.addresses.any?).to be true
       end
     end
-    
+
     context "when documents are not persisted" do
       before do
         person.addresses.build(street: "Bond")
       end
-      
+
       it "returns true" do
         expect(person.addresses.any?).to be true
       end
@@ -2146,6 +2146,44 @@ describe Mongoid::Association::Embedded::EmbedsMany::Proxy do
             expect(addresses).to be_empty
           end
         end
+      end
+    end
+
+    context "with block" do
+      let!(:author) do
+        Person.create!(title: 'Person')
+      end
+
+      let!(:video_one) do
+        author.videos.create!(title: 'video one')
+      end
+
+      let!(:video_two) do
+        author.videos.create!(title: 'video two')
+      end
+
+      it "finds one" do
+        expect(
+          author.videos.find do |video|
+            video.title == 'video one'
+          end
+        ).to eq(video_one)
+      end
+
+      it "finds multiple" do
+        expect(
+          author.videos.find do |video|
+            ['video one', 'video two'].include?(video.title)
+          end
+        ).to eq(video_one)
+      end
+
+      it "returns nil when not found" do
+        expect(
+          author.videos.find do |video|
+            video.title == 'non exiting one'
+          end
+        ).to be_nil
       end
     end
   end

--- a/spec/mongoid/association/embedded/embeds_many/proxy_spec.rb
+++ b/spec/mongoid/association/embedded/embeds_many/proxy_spec.rb
@@ -2170,12 +2170,12 @@ describe Mongoid::Association::Embedded::EmbedsMany::Proxy do
         ).to eq(video_one)
       end
 
-      it "finds multiple" do
+      it "returns first match of multiple" do
         expect(
           author.videos.find do |video|
             ['video one', 'video two'].include?(video.title)
           end
-        ).to eq(video_one)
+        ).to be_a(Video)
       end
 
       it "returns nil when not found" do

--- a/spec/mongoid/association/referenced/has_many/proxy_spec.rb
+++ b/spec/mongoid/association/referenced/has_many/proxy_spec.rb
@@ -2728,10 +2728,10 @@ describe Mongoid::Association::Referenced::HasMany::Proxy do
           author.posts.find do |post|
             post.title == 'post one'
           end
-        ).to eq(post_one)
+        ).to be_a(Post)
       end
 
-      it "finds multiple" do
+      it "returns first match of multiple" do
         expect(
           author.posts.find do |post|
             ['post one', 'post two'].include?(post.title)

--- a/spec/mongoid/association/referenced/has_many/proxy_spec.rb
+++ b/spec/mongoid/association/referenced/has_many/proxy_spec.rb
@@ -2709,6 +2709,44 @@ describe Mongoid::Association::Referenced::HasMany::Proxy do
         end
       end
     end
+
+    context "with block" do
+      let!(:author) do
+        Person.create!(title: 'Person')
+      end
+
+      let!(:post_one) do
+        author.posts.create!(title: 'post one')
+      end
+
+      let!(:post_two) do
+        author.posts.create!(title: 'post two')
+      end
+
+      it "finds one" do
+        expect(
+          author.posts.find do |post|
+            post.title == 'post one'
+          end
+        ).to eq(post_one)
+      end
+
+      it "finds multiple" do
+        expect(
+          author.posts.find do |post|
+            ['post one', 'post two'].include?(post.title)
+          end
+        ).to eq(post_one)
+      end
+
+      it "returns nil when not found" do
+        expect(
+          author.posts.find do |post|
+            post.title == 'non exiting one'
+          end
+        ).to be_nil
+      end
+    end
   end
 
   describe "#find_or_create_by" do


### PR DESCRIPTION
See: https://jira.mongodb.org/projects/MONGOID/issues/MONGOID-5125

Since #4817 `find` can take a block, however this is not used when a has many relation proxy is used. This is a simple change to allow the block to be passed through to the criteria.

Example:

```
class Widget 
  include Mongoid::Document

  has_many :screws

  def find_flat_screw 
    screws.find { |screw| screw.head == 'flat' }
  end
end
```

The find method above will currently return an empty set incorrectly, instead of the first item in the has_many collection