### PR TITLE
MONGOID-5126 Bring Mongoid::Document's === implementation in alignment with Ruby behavior

### DIFF
--- a/docs/release-notes.txt
+++ b/docs/release-notes.txt
@@ -9,6 +9,7 @@ Release Notes
 .. toctree::
   :titlesonly:
 
+  release-notes/mongoid-7.4
   release-notes/mongoid-7.3
   release-notes/mongoid-7.2
   release-notes/mongoid-7.1

--- a/docs/release-notes/mongoid-7.4.txt
+++ b/docs/release-notes/mongoid-7.4.txt
@@ -22,12 +22,12 @@ the complete list of issues fixed in each release, including bug fixes.
 ---------------------------------------
 
 **Breaking change:** In Mongoid 7.4, the ``===`` operator works the same way
-as it does in Ruby, and is equivalent to calling ``is_a?`` on the left hand
-side with the right hand side as the argument:
+as it does in Ruby, and is equivalent to calling ``is_a?`` on the right hand
+side with the left hand side as the argument:
 
 .. code-block:: ruby
 
-  instance === ModelClass
+  ModelClass === instance
   
   # equivalent to:
   instance.is_a?(ModelClass)

--- a/docs/release-notes/mongoid-7.4.txt
+++ b/docs/release-notes/mongoid-7.4.txt
@@ -1,0 +1,90 @@
+***********
+Mongoid 7.4
+***********
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+This page describes significant changes and improvements in Mongoid 7.4.
+The complete list of releases is available `on GitHub
+<https://github.com/mongodb/mongoid/releases>`_ and `in JIRA
+<https://jira.mongodb.org/projects/MONGOID?selectedItem=com.atlassian.jira.jira-projects-plugin:release-page>`_;
+please consult GitHub releases for detailed release notes and JIRA for
+the complete list of issues fixed in each release, including bug fixes.
+
+
+``===`` Operator Matches Ruby Semantics
+---------------------------------------
+
+**Breaking change:** In Mongoid 7.4, the ``===`` operator works the same way
+as it does in Ruby, and is equivalent to calling ``is_a?`` on the left hand
+side with the right hand side as the argument:
+
+.. code-block:: ruby
+
+  instance === ModelClass
+  
+  # equivalent to:
+  instance.is_a?(ModelClass)
+
+Previously, ``===`` returned ``true`` for some cases when the equivalent Ruby
+``===`` implementation returned false.
+
+Mongoid 7.4 behavior:
+
+.. code-block:: ruby
+
+  class Band
+    include Mongoid::Document
+  end
+  
+  class CoverBand < Band
+  end
+  
+  band = Band.new
+  cover_band = CoverBand.new
+  
+  band === Band
+  # => false
+  
+  cover_band === Band
+  # => false
+  
+  Band === Band
+  # => false
+  
+  CoverBand === Band
+  # => false
+  
+Mongoid 7.3 behavior:
+
+.. code-block:: ruby
+
+  band === Band
+  # => true
+
+  cover_band === Band
+  # => true
+  
+  Band === Band
+  # => true
+  
+  CoverBand === Band
+  # => true
+
+The standard invocation of ``===``, that is having the class on the left and
+the instance on the right, works the same in Mongoid 7.4 as it did previously
+and matches the core Ruby behavior:
+
+.. code-block:: ruby
+
+  Band === band
+  # => true
+  
+  Band === cover_band
+  # => true

--- a/lib/mongoid/document.rb
+++ b/lib/mongoid/document.rb
@@ -292,20 +292,6 @@ module Mongoid
 
     module ClassMethods
 
-      # Performs class equality checking.
-      #
-      # @example Compare the classes.
-      #   document === other
-      #
-      # @param [ Document, Object ] other The other object to compare with.
-      #
-      # @return [ true, false ] True if the classes are equal, false if not.
-      #
-      # @since 2.0.0.rc.4
-      def ===(other)
-        other.class == Class ? self <= other : other.is_a?(self)
-      end
-
       # Instantiate a new object, only when loaded from the database or when
       # the attributes have already been typecast.
       #

--- a/lib/mongoid/document.rb
+++ b/lib/mongoid/document.rb
@@ -292,6 +292,20 @@ module Mongoid
 
     module ClassMethods
 
+      # Performs class equality checking.
+      #
+      # @example Compare the classes.
+      #   document === other
+      #
+      # @param [ Document, Object ] other The other object to compare with.
+      #
+      # @return [ true, false ] True if the classes are equal, false if not.
+      #
+      # @since 2.0.0.rc.4
+      def ===(other)
+        other.is_a?(self)
+      end
+
       # Instantiate a new object, only when loaded from the database or when
       # the attributes have already been typecast.
       #

--- a/spec/mongoid/equality_spec.rb
+++ b/spec/mongoid/equality_spec.rb
@@ -106,8 +106,8 @@ describe Mongoid::Equality do
 
     context "when comparable is the same class" do
 
-      it "returns true" do
-        expect(klass === Person).to be true
+      it "returns false" do
+        expect(klass === Person).to be false
       end
     end
 
@@ -156,8 +156,8 @@ describe Mongoid::Equality do
 
       context "when the class is the same" do
 
-        it "returns true" do
-          expect(person === Person).to be true
+        it "returns false" do
+          expect(person === Person).to be false
         end
       end
 
@@ -170,8 +170,8 @@ describe Mongoid::Equality do
 
       context "when the class is a superclass" do
 
-        it "returns true" do
-          expect(Doctor.new === Person).to be true
+        it "returns false" do
+          expect(Doctor.new === Person).to be false
         end
       end
     end


### PR DESCRIPTION
This PR modifies the `===` method override on `Mongoid::Document` classes to just call `is_a?`.

Currently, for a document such as:
```ruby
class User
  include Mongoid::Document
  field :first_name, type: String
end
```
this returns `true`:
```ruby
User === Object
=> true
```
However, the `Object` class is not an instance of `User`, which means it's overriding the expected semantics of `===` for classes (`is_a?`).

This breaks things like `RSpec::Mock`, which uses `===` to determine which class to mock: https://github.com/rspec/rspec-mocks/blob/b1b32716114727a9257e834f0b72015208ca217f/lib/rspec/mocks/space.rb#L108. This causes errors like:
```ruby
allow_any_instance_of(User).to receive(:first_name)
=> RSpec::Mocks::MockExpectationError: Object does not implement: first_name
```

Note this is a breaking change, and may need to be released as a part of a major release. E.g. this will break:
```ruby
case document.class
when User
  # do something
end
```
and needs to be switched to:
```ruby
case document
when User
  # do something
end
```