### PR TITLE
MONGOID-5127: Add `distance_field` to `Mongoid::Contextual::GeoNear`

### DIFF
--- a/lib/mongoid/contextual/geo_near.rb
+++ b/lib/mongoid/contextual/geo_near.rb
@@ -46,6 +46,22 @@ module Mongoid
         end
       end
 
+      # Projects an output field containing the distance from each document
+      # to the point in the command.
+      #
+      # @example Specify the distance field.
+      #   geo_near.distance_field("dist")
+      #
+      # @param [ String ] value The distance field.
+      #
+      # @return [ GeoNear ] The GeoNear wrapper.
+      #
+      # @since 2.4.0
+      def distance_field(value)
+        command[:distanceField] = value
+        self
+      end
+
       # Provide a distance multiplier to be used for each returned distance.
       #
       # @example Provide the distance multiplier.

--- a/spec/mongoid/contextual/geo_near_spec.rb
+++ b/spec/mongoid/contextual/geo_near_spec.rb
@@ -158,6 +158,27 @@ describe Mongoid::Contextual::GeoNear do
       end
     end
 
+    context "when providing a distance field" do
+
+      let(:criteria) do
+        Bar.all
+      end
+
+      let(:geo_near) do
+        described_class.new(collection, criteria, [ 52, 13 ])
+      end
+
+      let(:results) do
+        geo_near.distance_field("distance").entries
+      end
+
+      it "returns calculated distances" do
+        expect(results.first.distance.calculated).to eq(0.390512483795333)
+        expect(results.last.distance.calculated).to eq(0.460977222864644)
+      end
+
+    end
+
     context "when providing a distance multiplier" do
 
       let(:criteria) do


### PR DESCRIPTION
This PR adds a method for `distance_field` to `Mongoid::Contextual::GeoNear`. This method is [specified in the documentation](https://docs.mongodb.com/v2.4/reference/operator/aggregation/geoNear/#pipe._S_geoNear) for MongoDB from the current version `5.0` all the way back to at least version `2.4.0`, however it's currently not settable via this class, returning the error `NoMethodError: undefined method `distance_field' for #<Mongoid::Contextual::GeoNear:0x0000563a2fc32d18>. Did you mean?  distance_multiplier`.

By adding the `distance_field` method the calculated distances as part of _geoNear_ will be projected in the document results.