### PR TITLE
MONGOID-5149 Skip inverse detection when inverse_of: nil is set

### DIFF
--- a/lib/mongoid/association/relatable.rb
+++ b/lib/mongoid/association/relatable.rb
@@ -122,6 +122,8 @@ module Mongoid
       # @since 7.0
       def inverses(other = nil)
         return [ inverse_of ] if inverse_of
+        return [] if @options.key?(:inverse_of) && !inverse_of
+
         if polymorphic?
           polymorphic_inverses(other)
         else

--- a/spec/mongoid/association/referenced/belongs_to_query_spec.rb
+++ b/spec/mongoid/association/referenced/belongs_to_query_spec.rb
@@ -7,15 +7,28 @@ require_relative './has_many_models'
 describe Mongoid::Association::Referenced::BelongsTo do
   context 'when projecting with #only' do
     before do
+      academy1 = HmmAcademy.create!(name: 'Test Academy 1')
+      academy2 = HmmAcademy.create!(name: 'Test Academy 2')
+
       school = HmmSchool.create!(district: 'foo', team: 'Bulldogs')
-      HmmStudent.create!(school: school, name: 'Dave', grade: 10)
+
+      HmmStudent.create!(
+        school: school,
+        name: 'Dave',
+        grade: 10,
+        current_academy: academy1,
+        previous_academy: academy2)
     end
 
     let(:student) do
-      HmmStudent.where(name: 'Dave').only(:school_id, 'school._id', 'school.district').first
+      HmmStudent
+        .where(name: 'Dave')
+        .only(:school_id, :previous_academy_id, 'previous_academy.name', 'school._id', 'school.district')
+        .first
     end
 
     let(:school) { student.school }
+    let(:previous_academy) { student.previous_academy }
 
     it 'populates specified fields only' do
       pending 'https://jira.mongodb.org/browse/MONGOID-4704'
@@ -33,6 +46,7 @@ describe Mongoid::Association::Referenced::BelongsTo do
     it 'fetches all fields' do
       expect(school.district).to eq('foo')
       expect(school.team).to eq('Bulldogs')
+      expect(previous_academy.name).to eq('Test Academy 2')
     end
   end
 end

--- a/spec/mongoid/association/referenced/has_many_models.rb
+++ b/spec/mongoid/association/referenced/has_many_models.rb
@@ -24,6 +24,14 @@ class HmmAddress
   belongs_to :company, class_name: 'HmmCompany'
 end
 
+class HmmAcademy
+  include Mongoid::Document
+
+  has_many :students, class_name: 'HmmStudent', inverse_of: :current_academy
+
+  field :name, type: String
+end
+
 class HmmSchool
   include Mongoid::Document
 
@@ -35,6 +43,9 @@ end
 
 class HmmStudent
   include Mongoid::Document
+
+  belongs_to :current_academy, class_name: 'HmmAcademy', inverse_of: :students, optional: true
+  belongs_to :previous_academy, class_name: 'HmmAcademy', inverse_of: nil, optional: true
 
   belongs_to :school, class_name: 'HmmSchool'
 

--- a/spec/mongoid/association/referenced/has_many_models.rb
+++ b/spec/mongoid/association/referenced/has_many_models.rb
@@ -24,10 +24,19 @@ class HmmAddress
   belongs_to :company, class_name: 'HmmCompany'
 end
 
-class HmmAcademy
+class HmmOwner
   include Mongoid::Document
 
-  has_many :students, class_name: 'HmmStudent', inverse_of: :current_academy
+  has_many :pets, class_name: 'HmmPet', inverse_of: :current_owner
+
+  field :name, type: String
+end
+
+class HmmPet
+  include Mongoid::Document
+
+  belongs_to :current_owner, class_name: 'HmmOwner', inverse_of: :pets, optional: true
+  belongs_to :previous_owner, class_name: 'HmmOwner', inverse_of: nil, optional: true
 
   field :name, type: String
 end
@@ -43,9 +52,6 @@ end
 
 class HmmStudent
   include Mongoid::Document
-
-  belongs_to :current_academy, class_name: 'HmmAcademy', inverse_of: :students, optional: true
-  belongs_to :previous_academy, class_name: 'HmmAcademy', inverse_of: nil, optional: true
 
   belongs_to :school, class_name: 'HmmSchool'
 


### PR DESCRIPTION
When an association is defined with the `inverse_of: nil` option, I believe its inverse should not be looked up in any case.

This PR fixes that by skipping the lookup when the option is explicitly defined and set to `nil` but will still let the lookup happen if the option was not specified and is thus `nil`.

I didn't push as to create a `inverse_of_set?` method in the `Options` module as it would not be defined for any other option but I suppose it could make sense.

## Why this PR

We actually got a bug while migrating to mongoid 7 where we have the kind of relationship I defined in the spec and due to the way inverse are looked up, trying to get the inverse of `previous_academy` here would return the inverse of `current_academy` and that would in the end cause this error:

```
ActiveModel::MissingAttributeError:
  Missing attribute: 'current_academy_id'
```

Which doesn't really make sense.