### PR TITLE
MONGOID-5140 Atomic #unset method should allow Hash args (in addition to current String/Symbol/Array)

### DIFF
--- a/lib/mongoid/contextual/atomic.rb
+++ b/lib/mongoid/contextual/atomic.rb
@@ -182,9 +182,9 @@ module Mongoid
       #
       # @since 3.0.0
       def unset(*args)
-        fields = args.collect { |a| a.is_a?(Hash) ? a.keys : a }
+        fields = args.map { |a| a.is_a?(Hash) ? a.keys : a }
                      .__find_args__
-                     .collect { |f| [database_field_name(f), true] }
+                     .map { |f| [database_field_name(f), true] }
         view.update_many("$unset" => Hash[fields])
       end
 

--- a/lib/mongoid/contextual/atomic.rb
+++ b/lib/mongoid/contextual/atomic.rb
@@ -173,13 +173,16 @@ module Mongoid
       # @example Unset the field on the matches.
       #   context.unset(:name)
       #
-      # @param [ String, Symbol, Array ] args The name of the fields.
+      # @param [ String, Symbol, Array, Hash ] args The name(s) of the field(s) to unset.
+      #   If a Hash is specified, its keys will be used irrespective of its values.
       #
       # @return [ nil ] Nil.
       #
       # @since 3.0.0
       def unset(*args)
-        fields = args.__find_args__.collect { |f| [database_field_name(f), true] }
+        fields = args.collect { |a| a.is_a?(Hash) ? a.keys : a }
+                     .__find_args__
+                     .collect { |f| [database_field_name(f), true] }
         view.update_many("$unset" => Hash[fields])
       end
 

--- a/lib/mongoid/contextual/atomic.rb
+++ b/lib/mongoid/contextual/atomic.rb
@@ -173,8 +173,10 @@ module Mongoid
       # @example Unset the field on the matches.
       #   context.unset(:name)
       #
-      # @param [ String, Symbol, Array, Hash ] args The name(s) of the field(s) to unset.
-      #   If a Hash is specified, its keys will be used irrespective of its values.
+      # @param [ String | Symbol | Array<String|Symbol> | Hash ] args
+      #   The name(s) of the field(s) to unset.
+      #   If a Hash is specified, its keys will be used irrespective of what
+      #   each key's value is, even if the value is nil or false.
       #
       # @return [ nil ] Nil.
       #

--- a/spec/mongoid/contextual/atomic_spec.rb
+++ b/spec/mongoid/contextual/atomic_spec.rb
@@ -830,7 +830,8 @@ describe Mongoid::Contextual::Atomic do
     context "when unsetting multiple fields" do
 
       let!(:new_order) do
-        Band.create(name: "New Order", genres: %w[electro dub], years: 10, likes: 200, rating: 4.3)
+        Band.create(name: "New Order", genres: %w[electro dub], years: 10,
+          likes: 200, rating: 4.3, origin: 'Space')
       end
 
       let(:criteria) do
@@ -876,7 +877,7 @@ describe Mongoid::Contextual::Atomic do
       context "when using Hash arguments" do
 
         before do
-          context.unset({ years: true, likes: "" }, { rating: false })
+          context.unset({ years: true, likes: "" }, { rating: false, origin: nil })
         end
 
         it "unsets the specified fields" do
@@ -886,6 +887,7 @@ describe Mongoid::Contextual::Atomic do
           expect(new_order.years).to be_nil
           expect(new_order.likes).to be_nil
           expect(new_order.rating).to be_nil
+          expect(new_order.origin).to be_nil
         end
       end
 

--- a/spec/mongoid/contextual/atomic_spec.rb
+++ b/spec/mongoid/contextual/atomic_spec.rb
@@ -801,27 +801,28 @@ describe Mongoid::Contextual::Atomic do
           context.unset(:name)
         end
 
-        it "unsets the first existing field" do
-          expect(depeche_mode.reload.name).to be_nil
-        end
-
-        it "unsets the last existing field" do
-          expect(new_order.reload.name).to be_nil
+        it "unsets the fields from all documents" do
+          depeche_mode.reload
+          new_order.reload
+          expect(depeche_mode.name).to be_nil
+          expect(depeche_mode.years).to_not be_nil
+          expect(new_order.name).to be_nil
+          expect(new_order.years).to_not be_nil
         end
       end
 
       context "when the field is aliased" do
-
         before do
           context.unset(:years)
         end
 
-        it "unsets the first existing field" do
-          expect(depeche_mode.reload.years).to be_nil
-        end
-
-        it "unsets the last existing field" do
-          expect(new_order.reload.years).to be_nil
+        it "unsets the fields from all documents" do
+          depeche_mode.reload
+          new_order.reload
+          expect(depeche_mode.name).to_not be_nil
+          expect(depeche_mode.years).to be_nil
+          expect(new_order.name).to_not be_nil
+          expect(new_order.years).to be_nil
         end
       end
     end
@@ -829,7 +830,7 @@ describe Mongoid::Contextual::Atomic do
     context "when unsetting multiple fields" do
 
       let!(:new_order) do
-        Band.create(name: "New Order", genres: [ "electro", "dub" ], years: 10)
+        Band.create(name: "New Order", genres: %w[electro dub], years: 10, likes: 200, rating: 4.3)
       end
 
       let(:criteria) do
@@ -846,12 +847,13 @@ describe Mongoid::Contextual::Atomic do
           context.unset(:name, :genres)
         end
 
-        it "unsets name field" do
-          expect(new_order.reload.name).to be_nil
-        end
-
-        it "unsets genres field" do
-          expect(new_order.reload.genres).to be_nil
+        it "unsets the specified fields" do
+          new_order.reload
+          expect(new_order.name).to be_nil
+          expect(new_order.genres).to be_nil
+          expect(new_order.years).to_not be_nil
+          expect(new_order.likes).to_not be_nil
+          expect(new_order.rating).to_not be_nil
         end
       end
 
@@ -861,12 +863,45 @@ describe Mongoid::Contextual::Atomic do
           context.unset(:name, :years)
         end
 
-        it "unsets the unaliased field" do
-          expect(new_order.reload.name).to be_nil
+        it "unsets the specified fields" do
+          new_order.reload
+          expect(new_order.name).to be_nil
+          expect(new_order.genres).to_not be_nil
+          expect(new_order.years).to be_nil
+          expect(new_order.likes).to_not be_nil
+          expect(new_order.rating).to_not be_nil
+        end
+      end
+
+      context "when using Hash arguments" do
+
+        before do
+          context.unset({ years: true, likes: "" }, { rating: false })
         end
 
-        it "unsets the aliased field" do
-          expect(new_order.reload.years).to be_nil
+        it "unsets the specified fields" do
+          new_order.reload
+          expect(new_order.name).to_not be_nil
+          expect(new_order.genres).to_not be_nil
+          expect(new_order.years).to be_nil
+          expect(new_order.likes).to be_nil
+          expect(new_order.rating).to be_nil
+        end
+      end
+
+      context "when mixing argument types" do
+
+        before do
+          context.unset(:name, [:years], { likes: "" }, { rating: false })
+        end
+
+        it "unsets the specified fields" do
+          new_order.reload
+          expect(new_order.name).to be_nil
+          expect(new_order.genres).to_not be_nil
+          expect(new_order.years).to be_nil
+          expect(new_order.likes).to be_nil
+          expect(new_order.rating).to be_nil
         end
       end
     end
@@ -895,7 +930,9 @@ describe Mongoid::Contextual::Atomic do
       end
 
       it "unsets the unaliased field" do
-        expect(depeche_mode.reload.name).to be_nil
+        depeche_mode.reload
+        expect(depeche_mode.name).to be_nil
+        expect(depeche_mode.years).to_not be_nil
       end
     end
   end


### PR DESCRIPTION
Fixes MONGOID-5140

The native MongoDB interface for $unset uses a Hash object rather than an array. Therefore, for consistency, Mongoid should allow a Hash to be the argument to `.unset` in addition to the currently allowed types (String/Symbol/Array)

```
{ $unset: { <field1>: "", ... } }
```

According to [MongoDB's docs](https://docs.mongodb.com/manual/reference/operator/update/unset/):

> The specified value in the $unset expression (i.e. "") does not impact the operation.

So I'm simply taking the Hash keys, even if the value is nil or false.