### PR TITLE
MONGOID-5141 [Code Comments Only] Remove all @since comments

### DIFF
--- a/lib/mongoid.rb
+++ b/lib/mongoid.rb
@@ -42,8 +42,6 @@ module Mongoid
   extend self
 
   # A string added to the platform details of Ruby driver client handshake documents.
-  #
-  # @since 6.1.0
   PLATFORM_DETAILS = "mongoid-#{VERSION}".freeze
 
   # The minimum MongoDB version supported.
@@ -62,8 +60,6 @@ module Mongoid
   #   end
   #
   # @return [ Config ] The configuration object.
-  #
-  # @since 1.0.0
   def configure
     block_given? ? yield(Config) : Config
   end
@@ -74,8 +70,6 @@ module Mongoid
   #   Mongoid.default_client
   #
   # @return [ Mongo::Client ] The default client.
-  #
-  # @since 5.0.0
   def default_client
     Clients.default
   end
@@ -86,8 +80,6 @@ module Mongoid
   #   Mongoid.disconnect_clients
   #
   # @return [ true ] True.
-  #
-  # @since 5.0.0
   def disconnect_clients
     Clients.disconnect
   end
@@ -98,8 +90,6 @@ module Mongoid
   #   Mongoid.client(:default)
   #
   # @return [ Mongo::Client ] The named client.
-  #
-  # @since 5.0.0
   def client(name)
     Clients.with_name(name)
   end
@@ -109,8 +99,6 @@ module Mongoid
   #
   # @example Delegate the configuration methods.
   #   Mongoid.database = Mongo::Connection.new.db("test")
-  #
-  # @since 1.0.0
   def_delegators Config, *(Config.public_instance_methods(false) - [ :logger=, :logger ])
 
 

--- a/lib/mongoid/association.rb
+++ b/lib/mongoid/association.rb
@@ -34,8 +34,6 @@ module Mongoid
     # Map the macros to their corresponding Association classes.
     #
     # @return [ Hash ] The mapping from macros to their Association class.
-    #
-    # @since 7.0
     MACRO_MAPPING = {
         embeds_one: Association::Embedded::EmbedsOne,
         embeds_many: Association::Embedded::EmbedsMany,
@@ -60,8 +58,6 @@ module Mongoid
     #   address.embedded?
     #
     # @return [ true, false ] True if the document has a parent document.
-    #
-    # @since 2.0.0.rc.1
     def embedded?
       @embedded ||= (cyclic ? _parent.present? : self.class.embedded?)
     end
@@ -72,8 +68,6 @@ module Mongoid
     #   address.embedded_many?
     #
     # @return [ true, false ] True if in an embeds many.
-    #
-    # @since 2.0.0.rc.1
     def embedded_many?
       _association && _association.is_a?(Association::Embedded::EmbedsMany)
     end
@@ -84,8 +78,6 @@ module Mongoid
     #   address.embedded_one?
     #
     # @return [ true, false ] True if in an embeds one.
-    #
-    # @since 2.0.0.rc.1
     def embedded_one?
       _association && _association.is_a?(Association::Embedded::EmbedsOne)
     end
@@ -99,8 +91,6 @@ module Mongoid
     # @raise [ Errors::NoMetadata ] If no association metadata is present.
     #
     # @return [ Symbol ] The association name.
-    #
-    # @since 3.0.0
     def association_name
       raise Errors::NoMetadata.new(self.class.name) unless _association
       _association.name
@@ -112,8 +102,6 @@ module Mongoid
     #   post.referenced_many?
     #
     # @return [ true, false ] True if in a references many.
-    #
-    # @since 2.0.0.rc.1
     def referenced_many?
       _association && _association.is_a?(Association::Referenced::HasMany)
     end
@@ -124,8 +112,6 @@ module Mongoid
     #   address.referenced_one?
     #
     # @return [ true, false ] True if in a references one.
-    #
-    # @since 2.0.0.rc.1
     def referenced_one?
       _association && _association.is_a?(Association::Referenced::HasOne)
     end
@@ -137,8 +123,6 @@ module Mongoid
     #   document.reload_relations
     #
     # @return [ Hash ] The association metadata.
-    #
-    # @since 2.1.6
     def reload_relations
       relations.each_pair do |name, meta|
         if instance_variable_defined?("@_#{name}")

--- a/lib/mongoid/association/accessors.rb
+++ b/lib/mongoid/association/accessors.rb
@@ -24,8 +24,6 @@ module Mongoid
       #   accessible in the built document.
       #
       # @return [ Proxy ] The association.
-      #
-      # @since 2.0.0.rc.1
       def __build__(name, object, association, selected_fields = nil)
         relation = create_relation(object, association, selected_fields)
         set_relation(name, relation)
@@ -43,8 +41,6 @@ module Mongoid
       #   accessible in the created association document.
       #
       # @return [ Proxy ] The association.
-      #
-      # @since 2.0.0.rc.1
       def create_relation(object, association, selected_fields = nil)
         type = @attributes[association.inverse_type]
         target = association.build(self, object, type, selected_fields)
@@ -58,8 +54,6 @@ module Mongoid
       #   person.reset_relation_criteria(:preferences)
       #
       # @param [ Symbol ] name The name of the association.
-      #
-      # @since 3.0.14
       def reset_relation_criteria(name)
         if instance_variable_defined?("@_#{name}")
           send(name).reset_unloaded
@@ -76,8 +70,6 @@ module Mongoid
       # @param [ Proxy ] relation The association to set.
       #
       # @return [ Proxy ] The association.
-      #
-      # @since 2.0.0.rc.1
       def set_relation(name, relation)
         instance_variable_set("@_#{name}", relation)
       end
@@ -98,8 +90,6 @@ module Mongoid
       # @param [ true, false ] reload If the association is to be reloaded.
       #
       # @return [ Proxy ] The association.
-      #
-      # @since 3.0.16
       def get_relation(name, association, object, reload = false)
         if !reload && (value = ivar(name)) != false
           value
@@ -209,8 +199,6 @@ module Mongoid
       #   document.without_autobuild?
       #
       # @return [ true, false ] If autobuild is disabled.
-      #
-      # @since 3.0.0
       def without_autobuild?
         Threaded.executing?(:without_autobuild)
       end
@@ -223,8 +211,6 @@ module Mongoid
       #   end
       #
       # @return [ Object ] The result of the yield.
-      #
-      # @since 3.0.0
       def without_autobuild
         Threaded.begin_execution("without_autobuild")
         yield
@@ -241,8 +227,6 @@ module Mongoid
       # @param [ Array ] args The arguments.
       #
       # @return [ Array<Hash> ] The attributes and options.
-      #
-      # @since 2.3.4
       def parse_args(*args)
         [args.first || {}, args.size > 1 ? args[1] : {}]
       end
@@ -260,8 +244,6 @@ module Mongoid
       # @param [ Association ] association The association.
       #
       # @return [ Class ] The model being set up.
-      #
-      # @since 3.0.0
       def self.define_existence_check!(association)
         name = association.name
         association.inverse_class.tap do |klass|
@@ -284,8 +266,6 @@ module Mongoid
       # @param [ Association ] association The association metadata for the association.
       #
       # @return [ Class ] The class being set up.
-      #
-      # @since 2.0.0.rc.1
       def self.define_getter!(association)
         name = association.name
         association.inverse_class.tap do |klass|
@@ -328,8 +308,6 @@ module Mongoid
       # @param [ Association ] association The association metadata for the association.
       #
       # @return [ Class ] The class being set up.
-      #
-      # @since 2.0.0.rc.1
       def self.define_setter!(association)
         name = association.name
         association.inverse_class.tap do |klass|
@@ -380,8 +358,6 @@ module Mongoid
       # @param [ Association ] association The association for the association.
       #
       # @return [ Class ] The class being set up.
-      #
-      # @since 2.0.0.rc.1
       def self.define_builder!(association)
         name = association.name
         association.inverse_class.tap do |klass|
@@ -407,8 +383,6 @@ module Mongoid
       # @param [ Association ] association The association for the association.
       #
       # @return [ Class ] The class being set up.
-      #
-      # @since 2.0.0.rc.1
       def self.define_creator!(association)
         name = association.name
         association.inverse_class.tap do |klass|

--- a/lib/mongoid/association/bindable.rb
+++ b/lib/mongoid/association/bindable.rb
@@ -18,8 +18,6 @@ module Mongoid
       # @param [ Document ] base The base of the binding.
       # @param [ Document, Array<Document> ] target The target of the binding.
       # @param [ Association ] association The association metadata.
-      #
-      # @since 2.0.0.rc.1
       def initialize(base, target, association)
         @_base, @_target, @_association = base, target, association
       end
@@ -32,8 +30,6 @@ module Mongoid
       #   end
       #
       # @return [ Object ] The result of the yield.
-      #
-      # @since 3.0.0
       def binding
         unless _binding?
           _binding do
@@ -54,8 +50,6 @@ module Mongoid
       # @param [ Document ] doc The document getting bound.
       #
       # @raise [ Errors::InverseNotFound ] If no inverse found.
-      #
-      # @since 3.0.0
       def check_inverse!(doc)
         unless _association.bindable?(doc)
           raise Errors::InverseNotFound.new(
@@ -77,8 +71,6 @@ module Mongoid
       #
       # @param [ Document ] keyed The document that stores the foreign key.
       # @param [ Object ] id The id of the bound document.
-      #
-      # @since 3.0.0
       def bind_foreign_key(keyed, id)
         unless keyed.frozen?
           keyed.you_must(_association.foreign_key_setter, id)
@@ -95,8 +87,6 @@ module Mongoid
       #
       # @param [ Document ] typed The document that stores the type field.
       # @param [ String ] name The name of the model.
-      #
-      # @since 3.0.0
       def bind_polymorphic_type(typed, name)
         if _association.type
           typed.you_must(_association.type_setter, name)
@@ -113,8 +103,6 @@ module Mongoid
       #
       # @param [ Document ] typed The document that stores the type field.
       # @param [ String ] name The name of the model.
-      #
-      # @since 3.0.0
       def bind_polymorphic_inverse_type(typed, name)
         if _association.inverse_type
           typed.you_must(_association.inverse_type_setter, name)
@@ -131,8 +119,6 @@ module Mongoid
       #
       # @param [ Document ] doc The base document.
       # @param [ Document ] inverse The inverse document.
-      #
-      # @since 3.0.0
       def bind_inverse(doc, inverse)
         if doc.respond_to?(_association.inverse_setter)
           doc.you_must(_association.inverse_setter, inverse)
@@ -147,8 +133,6 @@ module Mongoid
       #   binding.bind_from_relational_parent(doc)
       #
       # @param [ Document ] doc The document to bind.
-      #
-      # @since 3.0.0
       def bind_from_relational_parent(doc)
         check_inverse!(doc)
         bind_foreign_key(doc, record_id(_base))
@@ -170,8 +154,6 @@ module Mongoid
       #   binding.set_base_association
       #
       # @return [ true, false ] If the association changed.
-      #
-      # @since 2.4.4
       def set_base_association
         inverse_association = _association.inverse_association(_target)
         if inverse_association != _association && !inverse_association.nil?
@@ -187,8 +169,6 @@ module Mongoid
       #   unbinding.unbind_from_relational_parent(doc)
       #
       # @param [ Document ] doc The document to unbind.
-      #
-      # @since 3.0.0
       def unbind_from_relational_parent(doc)
         check_inverse!(doc)
         bind_foreign_key(doc, nil)

--- a/lib/mongoid/association/builders.rb
+++ b/lib/mongoid/association/builders.rb
@@ -17,8 +17,6 @@ module Mongoid
     #   # The following methods get created:
     #   person.build_name({ :first_name => "Durran" })
     #   person.create_name({ :first_name => "Durran" })
-    #
-    # @since 2.0.0.rc.1
     module Builders
       extend ActiveSupport::Concern
 
@@ -33,8 +31,6 @@ module Mongoid
       # @param [ Array ] args The arguments.
       #
       # @return [ Array<Hash> ] The attributes and options.
-      #
-      # @since 2.3.4
       def parse_args(*args)
         [ args.first || {}, args.size > 1 ? args[1] : {} ]
       end
@@ -47,8 +43,6 @@ module Mongoid
       # @param [ Association ] association The association metadata for the association.
       #
       # @return [ Class ] The class being set up.
-      #
-      # @since 2.0.0.rc.1
       def self.define_builder!(association)
         association.inverse_class.tap do |klass|
           klass.re_define_method("build_#{association.name}") do |*args|
@@ -72,8 +66,6 @@ module Mongoid
       # @param [ Association ] association The association metadata for the association.
       #
       # @return [ Class ] The class being set up.
-      #
-      # @since 2.0.0.rc.1
       def self.define_creator!(association)
         association.inverse_class.tap do |klass|
           klass.re_define_method("create_#{association.name}") do |*args|

--- a/lib/mongoid/association/constrainable.rb
+++ b/lib/mongoid/association/constrainable.rb
@@ -18,8 +18,6 @@ module Mongoid
       # @param [ Object ] object The object to convert.
       #
       # @return [ Object ] The object cast to the correct type.
-      #
-      # @since 2.0.0.rc.7
       def convert_to_foreign_key(object)
         return convert_polymorphic(object) if polymorphic?
         field = relation_class.fields["_id"]

--- a/lib/mongoid/association/depending.rb
+++ b/lib/mongoid/association/depending.rb
@@ -31,8 +31,6 @@ module Mongoid
       end
 
       # The valid dependent strategies.
-      #
-      # @since 7.0
       STRATEGIES = [
           :delete_all,
           :destroy,
@@ -50,8 +48,6 @@ module Mongoid
       # @param [ Association ] association The association metadata.
       #
       # @return [ Class ] The class of the document.
-      #
-      # @since 2.0.0.rc.1
       def self.define_dependency!(association)
         validate!(association)
         association.inverse_class.tap do |klass|
@@ -79,8 +75,6 @@ module Mongoid
       #
       # @example Execute cascades.
       #   document.apply_destroy_dependencies!
-      #
-      # @since 2.0.0.rc.1
       def apply_destroy_dependencies!
         self.class._all_dependents.each do |association|
           if dependent = association.try(:dependent)

--- a/lib/mongoid/association/eager_loadable.rb
+++ b/lib/mongoid/association/eager_loadable.rb
@@ -7,8 +7,6 @@ module Mongoid
   module Association
 
     # This module defines the eager loading behavior for criteria.
-    #
-    # @since 7.0
     module EagerLoadable
 
       def eager_loadable?

--- a/lib/mongoid/association/embedded/batchable.rb
+++ b/lib/mongoid/association/embedded/batchable.rb
@@ -20,8 +20,6 @@ module Mongoid
         # @param [ Array<Document> ] docs The docs to add.
         #
         # @return [ Array<Hash> ] The inserts.
-        #
-        # @since 3.0.0
         def batch_insert(docs)
           execute_batch_push(docs)
         end
@@ -34,8 +32,6 @@ module Mongoid
         # @param [ Array<Document> ] docs The docs to clear.
         #
         # @return [ Array ] The empty array.
-        #
-        # @since 3.0.0
         def batch_clear(docs)
           pre_process_batch_remove(docs, :delete)
           unless docs.empty?
@@ -55,8 +51,6 @@ module Mongoid
         #
         # @param [ Array<Document> ] docs The docs to remove.
         # @param [ Symbol ] method Delete or destroy.
-        #
-        # @since 3.0.0
         def batch_remove(docs, method = :delete)
           removals = pre_process_batch_remove(docs, method)
           if !docs.empty?
@@ -77,8 +71,6 @@ module Mongoid
         # @param [ Array<Document> ] docs The docs to replace with.
         #
         # @return [ Array<Hash> ] The inserts.
-        #
-        # @since 3.0.0
         def batch_replace(docs)
           if docs.blank?
             if _assigning? && !empty?
@@ -108,8 +100,6 @@ module Mongoid
         #   batchable.add_atomic_sets([{ field: value }])
         #
         # @param [ Array<Hash> ] sets The atomic sets.
-        #
-        # @since 3.0.0
         def add_atomic_sets(sets)
           if _assigning?
             _base.delayed_atomic_sets[path].try(:clear)
@@ -130,8 +120,6 @@ module Mongoid
         # @param [ Array<Document> ] docs The docs to persist.
         #
         # @return [ Array<Hash> ] The inserts.
-        #
-        # @since 7.0.0
         def execute_batch_set(docs)
           self.inserts_valid = true
           inserts = pre_process_batch_insert(docs)
@@ -155,8 +143,6 @@ module Mongoid
         # @param [ Array<Document> ] docs The docs to persist.
         #
         # @return [ Array<Hash> ] The inserts.
-        #
-        # @since 7.0.0
         def execute_batch_push(docs)
           self.inserts_valid = true
           pushes = pre_process_batch_insert(docs)
@@ -178,8 +164,6 @@ module Mongoid
         #   batchable.insertable?
         #
         # @return [ true, false ] If inserts can be performed.
-        #
-        # @since 3.0.0
         def insertable?
           persistable? && !_assigning? && inserts_valid
         end
@@ -192,8 +176,6 @@ module Mongoid
         #   batchable.inserts_valid
         #
         # @return [ true, false ] If inserts are currently valid.
-        #
-        # @since 3.0.0
         def inserts_valid
           @inserts_valid
         end
@@ -208,8 +190,6 @@ module Mongoid
         # @param [ true, false ] value The flag.
         #
         # @return [ true, false ] The flag.
-        #
-        # @since 3.0.0
         def inserts_valid=(value)
           @inserts_valid = value
         end
@@ -225,8 +205,6 @@ module Mongoid
         # @param [ Array<Hash, Document> ] docs The docs to normalize.
         #
         # @return [ Array<Document> ] The docs.
-        #
-        # @since 3.0.0
         def normalize_docs(docs)
           if docs.first.is_a?(::Hash)
             docs.map do |doc|
@@ -247,8 +225,6 @@ module Mongoid
         #   batchable.path
         #
         # @return [ String ] The atomic path.
-        #
-        # @since 3.0.0
         def path
           @path ||= _unscoped.first.atomic_path
         end
@@ -263,8 +239,6 @@ module Mongoid
         # @param [ String ] value The path.
         #
         # @return [ String ] The path.
-        #
-        # @since 3.0.0
         def path=(value)
           @path = value
         end
@@ -277,8 +251,6 @@ module Mongoid
         #   batchable.selector
         #
         # @return [ Hash ] The atomic selector.
-        #
-        # @since 3.0.0
         def selector
           @selector ||= _base.atomic_selector
         end
@@ -293,8 +265,6 @@ module Mongoid
         # @param [ Array<Document> ] docs The documents.
         #
         # @return [ Array<Hash> ] The documents as an array of hashes.
-        #
-        # @since 3.0.0
         def pre_process_batch_insert(docs)
           docs.map do |doc|
             next unless doc
@@ -322,8 +292,6 @@ module Mongoid
         # @param [ Symbol ] method Delete or destroy.
         #
         # @return [ Array<Hash> ] The documents as hashes.
-        #
-        # @since 3.0.0
         def pre_process_batch_remove(docs, method)
           docs.map do |doc|
             self.path = doc.atomic_path unless path
@@ -350,8 +318,6 @@ module Mongoid
         # @param [ Array<Documents> ] docs The inserted docs.
         #
         # @return [ Enumerable ] The document enum.
-        #
-        # @since 3.0.0
         def post_process_batch_insert(docs)
           docs.each do |doc|
             doc.new_record = false
@@ -371,8 +337,6 @@ module Mongoid
         # @param [ Symbol ] method Delete or destroy.
         #
         # @return [ Array<Document> ] The documents.
-        #
-        # @since 3.0.0
         def post_process_batch_remove(docs, method)
           docs.each do |doc|
             doc.run_after_callbacks(:destroy) if method == :destroy

--- a/lib/mongoid/association/embedded/cyclic.rb
+++ b/lib/mongoid/association/embedded/cyclic.rb
@@ -36,8 +36,6 @@ module Mongoid
           #
           # This provides the default nomenclature for accessing a parent document
           # or its children.
-          #
-          # @since 2.0.0.rc.1
           def recursively_embeds_many(options = {})
             embeds_many(
                 cyclic_child_name,
@@ -66,8 +64,6 @@ module Mongoid
           #
           # This provides the default nomenclature for accessing a parent document
           # or its children.
-          #
-          # @since 2.0.0.rc.1
           def recursively_embeds_one(options = {})
             embeds_one(
                 cyclic_child_name(false),
@@ -84,8 +80,6 @@ module Mongoid
           #   Role.cyclic_parent_name
           #
           # @return [ String ] "parent_" plus the class name underscored.
-          #
-          # @since 2.0.0.rc.1
           def cyclic_parent_name
             ("parent_#{self.name.demodulize.underscore.singularize}").to_sym
           end
@@ -99,8 +93,6 @@ module Mongoid
           #
           # @return [ String ] "child_" plus the class name underscored in
           #   singular or plural form.
-          #
-          # @since 2.0.0.rc.1
           def cyclic_child_name(many = true)
             ("child_#{self.name.demodulize.underscore.send(many ? :pluralize : :singularize)}").to_sym
           end

--- a/lib/mongoid/association/embedded/embedded_in.rb
+++ b/lib/mongoid/association/embedded/embedded_in.rb
@@ -10,8 +10,6 @@ module Mongoid
     module Embedded
 
       # The EmbeddedIn type association.
-      #
-      # @since 7.0
       class EmbeddedIn
         include Relatable
         include Buildable
@@ -20,8 +18,6 @@ module Mongoid
         # common ones.
         #
         # @return [ Array<Symbol> ] The extra valid options.
-        #
-        # @since 7.0
         ASSOCIATION_OPTIONS = [
             :autobuild,
             :cyclic,
@@ -33,15 +29,11 @@ module Mongoid
         # the shared ones.
         #
         # @return [ Array<Symbol> ] The valid options.
-        #
-        # @since 7.0
         VALID_OPTIONS = (ASSOCIATION_OPTIONS + SHARED_OPTIONS).freeze
 
         # Setup the instance methods, fields, etc. on the association owning class.
         #
         # @return [ self ]
-        #
-        # @since 7.0
         def setup!
           setup_instance_methods!
           @owner_class.embedded = true
@@ -51,8 +43,6 @@ module Mongoid
         # Is this association type embedded?
         #
         # @return [ true ] Always true.
-        #
-        # @since 7.0
         def embedded?; true; end
 
         # The primary key
@@ -63,22 +53,16 @@ module Mongoid
         # Does this association type store the foreign key?
         #
         # @return [ false ] Always false.
-        #
-        # @since 7.0
         def stores_foreign_key?; false; end
 
         # The default for validating the association object.
         #
         # @return [ false ] Always false.
-        #
-        # @since 7.0
         def validation_default; false; end
 
         # The key that is used to get the attributes for the associated object.
         #
         # @return [ String ] The name of the association.
-        #
-        # @since 7.0
         def key
           @key ||= name.to_s
         end
@@ -86,8 +70,6 @@ module Mongoid
         # Get the association proxy class for this association type.
         #
         # @return [ Association::Embedded::EmbeddedIn::Proxy ] The proxy class.
-        #
-        # @since 7.0
         def relation
           Proxy
         end
@@ -95,8 +77,6 @@ module Mongoid
         # Is this association polymorphic?
         #
         # @return [ true, false ] Whether this association is polymorphic.
-        #
-        # @since 7.0
         def polymorphic?
           !!@options[:polymorphic]
         end
@@ -107,8 +87,6 @@ module Mongoid
         # @param [ Hash ] options The options for the association.
         #
         # @return [ Association::Nested::One ] The Nested Builder object.
-        #
-        # @since 7.0
         def nested_builder(attributes, options)
           Nested::One.new(self, attributes, options)
         end

--- a/lib/mongoid/association/embedded/embedded_in/binding.rb
+++ b/lib/mongoid/association/embedded/embedded_in/binding.rb
@@ -7,8 +7,6 @@ module Mongoid
       class EmbeddedIn
 
         # The Binding object for embedded_in associations.
-        #
-        # @since 7.0
         class Binding
           include Bindable
 
@@ -21,8 +19,6 @@ module Mongoid
           # @example Bind the documents.
           #   name.person.bind(:continue => true)
           #   name.person = Person.new
-          #
-          # @since 2.0.0.rc.1
           def bind_one
             _base._association = _association.inverse_association(_target) unless _base._association
             _base.parentize(_target)
@@ -41,8 +37,6 @@ module Mongoid
           # @example Unbind the document.
           #   name.person.unbind(:continue => true)
           #   name.person = nil
-          #
-          # @since 2.0.0.rc.1
           def unbind_one
             binding do
               if _base.embedded_many?

--- a/lib/mongoid/association/embedded/embedded_in/buildable.rb
+++ b/lib/mongoid/association/embedded/embedded_in/buildable.rb
@@ -7,8 +7,6 @@ module Mongoid
       class EmbeddedIn
 
         # The Builder behavior for embedded_in associations.
-        #
-        # @since 7.0
         module Buildable
           include Threaded::Lifecycle
 

--- a/lib/mongoid/association/embedded/embedded_in/proxy.rb
+++ b/lib/mongoid/association/embedded/embedded_in/proxy.rb
@@ -34,8 +34,6 @@ module Mongoid
           # @param [ Document ] replacement A document to replace the target.
           #
           # @return [ Document, nil ] The association or nil.
-          #
-          # @since 2.0.0.rc.1
           def substitute(replacement)
             unbind_one
             unless replacement
@@ -56,8 +54,6 @@ module Mongoid
           #   binding([ address ])
           #
           # @return [ Binding ] A binding object.
-          #
-          # @since 2.0.0.rc.1
           def binding
             Binding.new(_base, _target, _association)
           end
@@ -68,8 +64,6 @@ module Mongoid
           #   object.characterize_one(document)
           #
           # @param [ Document ] document The document to set the association metadata on.
-          #
-          # @since 2.1.0
           def characterize_one(document)
             unless _base._association
               _base._association = _association.inverse_association(document)
@@ -82,8 +76,6 @@ module Mongoid
           #   relation.persistable?
           #
           # @return [ true, false ] If the association is persistable.
-          #
-          # @since 2.1.0
           def persistable?
             _target.persisted? && !_binding? && !_building?
           end
@@ -97,8 +89,6 @@ module Mongoid
             #   Association::Embedded::EmbeddedIn.embedded?
             #
             # @return [ true ] true.
-            #
-            # @since 2.0.0.rc.1
             def embedded?
               true
             end
@@ -111,8 +101,6 @@ module Mongoid
             # @param [ Document ] document The document to calculate on.
             #
             # @return [ Root ] The root atomic path calculator.
-            #
-            # @since 2.1.0
             def path(document)
               Mongoid::Atomic::Paths::Root.new(document)
             end

--- a/lib/mongoid/association/embedded/embeds_many.rb
+++ b/lib/mongoid/association/embedded/embeds_many.rb
@@ -10,8 +10,6 @@ module Mongoid
     module Embedded
 
       # The EmbedsMany type association.
-      #
-      # @since 7.0
       class EmbedsMany
         include Relatable
         include Buildable
@@ -20,8 +18,6 @@ module Mongoid
         # common ones.
         #
         # @return [ Array<Symbol> ] The extra valid options.
-        #
-        # @since 7.0
         ASSOCIATION_OPTIONS = [
             :as,
             :cascade_callbacks,
@@ -38,15 +34,11 @@ module Mongoid
         # the shared ones.
         #
         # @return [ Array<Symbol> ] The valid options.
-        #
-        # @since 7.0
         VALID_OPTIONS = (ASSOCIATION_OPTIONS + SHARED_OPTIONS).freeze
 
         # Setup the instance methods, fields, etc. on the association owning class.
         #
         # @return [ self ]
-        #
-        # @since 7.0
         def setup!
           setup_instance_methods!
           @owner_class.embedded_relations = @owner_class.embedded_relations.merge(name => self)
@@ -57,8 +49,6 @@ module Mongoid
         # The field key used to store the list of association objects.
         #
         # @return [ String ] The field name.
-        #
-        # @since 7.0
         def store_as
           @store_as ||= (@options[:store_as].try(:to_s) || name.to_s)
         end
@@ -66,8 +56,6 @@ module Mongoid
         # The key that is used to get the attributes for the associated object.
         #
         # @return [ String ] The name of the field used to store the association.
-        #
-        # @since 7.0
         def key
           store_as.to_s
         end
@@ -75,8 +63,6 @@ module Mongoid
         # Is this association type embedded?
         #
         # @return [ true ] Always true.
-        #
-        # @since 7.0
         def embedded?; true; end
 
         # Get the default validation setting for the association. Determines if
@@ -86,15 +72,11 @@ module Mongoid
         #   Proxy.validation_default
         #
         # @return [ true ] Always true.
-        #
-        # @since 2.1.9
         def validation_default; true; end
 
         # Does this association type store the foreign key?
         #
         # @return [ false ] Always false.
-        #
-        # @since 7.0
         def stores_foreign_key?; false; end
 
         # The primary key
@@ -105,8 +87,6 @@ module Mongoid
         # Get the association proxy class for this association type.
         #
         # @return [ Association::Embedded::EmbedsMany::Proxy ] The proxy class.
-        #
-        # @since 7.0
         def relation
           Proxy
         end
@@ -114,8 +94,6 @@ module Mongoid
         # Is this association polymorphic?
         #
         # @return [ true, false ] Whether this association is polymorphic.
-        #
-        # @since 7.0
         def polymorphic?
           @polymorphic ||= !!@options[:as]
         end
@@ -125,8 +103,6 @@ module Mongoid
         # @note Only relevant if the association is polymorphic.
         #
         # @return [ String, nil ] The field for storing the associated object's type.
-        #
-        # @since 7.0
         def type
           @type ||= "#{as}_type" if polymorphic?
         end
@@ -137,8 +113,6 @@ module Mongoid
         # @param [ Hash ] options The options for the association.
         #
         # @return [ Association::Nested::Many ] The Nested Builder object.
-        #
-        # @since 7.0
         def nested_builder(attributes, options)
           Nested::Many.new(self, attributes, options)
         end
@@ -152,8 +126,6 @@ module Mongoid
         #
         # @return [ Mongoid::Atomic::Paths::Embedded::Many ]
         #   The embedded many atomic path calculator.
-        #
-        # @since 2.1.0
         def path(document)
           Mongoid::Atomic::Paths::Embedded::Many.new(document)
         end
@@ -162,8 +134,6 @@ module Mongoid
         #
         # @param [ Document ] base The base document.
         # @param [ Document ] target The children documents.
-        #
-        # @since 7.0
         def criteria(base, target)
           criterion = klass.scoped
           criterion.embedded = true

--- a/lib/mongoid/association/embedded/embeds_many/binding.rb
+++ b/lib/mongoid/association/embedded/embeds_many/binding.rb
@@ -7,8 +7,6 @@ module Mongoid
       class EmbedsMany
 
         # Binding class for all embeds_many associations.
-        #
-        # @since 7.0
         class Binding
           include Bindable
 
@@ -19,8 +17,6 @@ module Mongoid
           #   person.addresses.bind_one(address)
           #
           # @param [ Document ] doc The single document to bind.
-          #
-          # @since 2.0.0.rc.1
           def bind_one(doc)
             doc.parentize(_base)
             binding do
@@ -34,8 +30,6 @@ module Mongoid
           #   person.addresses.unbind_one(document)
           #
           # @param [ Document ] doc The single document to unbind.
-          #
-          # @since 2.0.0.rc.1
           def unbind_one(doc)
             binding do
               doc.do_or_do_not(_association.inverse_setter(_target), nil)

--- a/lib/mongoid/association/embedded/embeds_many/buildable.rb
+++ b/lib/mongoid/association/embedded/embeds_many/buildable.rb
@@ -7,8 +7,6 @@ module Mongoid
       class EmbedsMany
 
         # Builder class for embeds_many associations.
-        #
-        # @since 7.0
         module Buildable
           include Threaded::Lifecycle
 

--- a/lib/mongoid/association/embedded/embeds_many/proxy.rb
+++ b/lib/mongoid/association/embedded/embeds_many/proxy.rb
@@ -39,8 +39,6 @@ module Mongoid
           #   person.addresses.as_document
           #
           # @return [ Array<Hash> ] The association as stored in the db.
-          #
-          # @since 2.0.0.rc.1
           def as_document
             as_attributes.collect { |attrs| BSON::Document.new(attrs) }
           end
@@ -54,8 +52,6 @@ module Mongoid
           # @param [ Array<Document> ] docs The docs to add.
           #
           # @return [ Array<Document> ] The documents.
-          #
-          # @since 2.4.0
           def concat(docs)
             batch_insert(docs) unless docs.empty?
             self
@@ -125,8 +121,6 @@ module Mongoid
           # @param [ Document ] document The document to be deleted.
           #
           # @return [ Document, nil ] The deleted document or nil if nothing deleted.
-          #
-          # @since 2.0.0.rc.1
           def delete(document)
             execute_callback :before_remove, document
             doc = _target.delete_one(document)
@@ -168,8 +162,6 @@ module Mongoid
           #
           # @return [ Many, Enumerator ] The association or an enumerator if no
           #   block was provided.
-          #
-          # @since 3.1.0
           def delete_if
             if block_given?
               dup_target = _target.dup
@@ -262,8 +254,6 @@ module Mongoid
           #   relation.in_memory
           #
           # @return [ Array<Document> ] The documents in memory.
-          #
-          # @since 2.1.0
           def in_memory
             _target
           end
@@ -281,8 +271,6 @@ module Mongoid
           #   provided.
           #
           # @return [ Document, Array<Document> ] The popped document(s).
-          #
-          # @since 3.0.0
           def pop(count = nil)
             if count
               if docs = _target[_target.size - count, _target.size]
@@ -325,8 +313,6 @@ module Mongoid
           # @param [ Array<Document> ] docs The replacement docs.
           #
           # @return [ Many ] The proxied association.
-          #
-          # @since 2.0.0.rc.1
           def substitute(docs)
             batch_replace(docs)
             self
@@ -339,8 +325,6 @@ module Mongoid
           #   person.addresses.unscoped
           #
           # @return [ Criteria ] The unscoped association.
-          #
-          # @since 2.4.0
           def unscoped
             criterion = klass.unscoped
             criterion.embedded = true
@@ -361,8 +345,6 @@ module Mongoid
           #   relation.append(document)
           #
           # @param [ Document ] document The document to append to the target.
-          #
-          # @since 2.0.0.rc.1
           def append(document)
             execute_callback :before_add, document
             unless object_already_related?(document)
@@ -380,8 +362,6 @@ module Mongoid
           #   relation.binding([ address ])
           #
           # @return [ Binding ] The many binding.
-          #
-          # @since 2.0.0.rc.1
           def binding
             Binding.new(_base, _target, _association)
           end
@@ -402,8 +382,6 @@ module Mongoid
           #   relation.delete_one(doc)
           #
           # @param [ Document ] document The document to delete.
-          #
-          # @since 2.4.7
           def delete_one(document)
             _target.delete_one(document)
             _unscoped.delete_one(document)
@@ -417,8 +395,6 @@ module Mongoid
           #   relation.integrate(document)
           #
           # @param [ Document ] document The document to integrate.
-          #
-          # @since 2.1.0
           def integrate(document)
             characterize_one(document)
             bind_one(document)
@@ -447,8 +423,6 @@ module Mongoid
           #   relation.persistable?
           #
           # @return [ true, false ] If the association is persistable.
-          #
-          # @since 2.1.0
           def persistable?
             _base.persisted? && !_binding?
           end
@@ -459,8 +433,6 @@ module Mongoid
           #
           # @example Reindex the association.
           #   person.addresses.reindex
-          #
-          # @since 2.0.0.rc.1
           def reindex
             _unscoped.each_with_index do |doc, index|
               doc._index = index
@@ -476,8 +448,6 @@ module Mongoid
           # @param [ Array<Document> ] docs The documents to scope.
           #
           # @return [ Array<Document> ] The scoped docs.
-          #
-          # @since 2.4.0
           def scope(docs)
             unless _association.order || _association.klass.default_scoping?
               return docs
@@ -512,8 +482,6 @@ module Mongoid
           #   relation._unscoped
           #
           # @return [ Array<Document> ] The unscoped documents.
-          #
-          # @since 2.4.0
           def _unscoped
             @_unscoped ||= []
           end
@@ -526,8 +494,6 @@ module Mongoid
           # @param [ Array<Document> ] docs The documents.
           #
           # @return [ Array<Document ] The unscoped docs.
-          #
-          # @since 2.4.0
           def _unscoped=(docs)
             @_unscoped = docs
           end
@@ -549,8 +515,6 @@ module Mongoid
             #   Association::Embedded::EmbedsMany.embedded?
             #
             # @return [ true ] true.
-            #
-            # @since 2.0.0.rc.1
             def embedded?
               true
             end
@@ -561,8 +525,6 @@ module Mongoid
             #   Association::Embedded::EmbedsMany.foreign_key_suffix
             #
             # @return [ nil ] nil.
-            #
-            # @since 3.0.0
             def foreign_key_suffix
               nil
             end

--- a/lib/mongoid/association/embedded/embeds_one.rb
+++ b/lib/mongoid/association/embedded/embeds_one.rb
@@ -10,8 +10,6 @@ module Mongoid
     module Embedded
 
       # The EmbedsOne type association.
-      #
-      # @since 7.0
       class EmbedsOne
         include Relatable
         include Buildable
@@ -20,8 +18,6 @@ module Mongoid
         # common ones.
         #
         # @return [ Array<Symbol> ] The extra valid options.
-        #
-        # @since 7.0
         ASSOCIATION_OPTIONS = [
             :autobuild,
             :as,
@@ -34,15 +30,11 @@ module Mongoid
         # the shared ones.
         #
         # @return [ Array<Symbol> ] The valid options.
-        #
-        # @since 7.0
         VALID_OPTIONS = (ASSOCIATION_OPTIONS + SHARED_OPTIONS).freeze
 
         # Setup the instance methods, fields, etc. on the association owning class.
         #
         # @return [ self ]
-        #
-        # @since 7.0
         def setup!
           setup_instance_methods!
           @owner_class.embedded_relations = @owner_class.embedded_relations.merge(name => self)
@@ -53,8 +45,6 @@ module Mongoid
         # The field key used to store the association object.
         #
         # @return [ String ] The field name.
-        #
-        # @since 7.0
         def store_as
           @store_as ||= (@options[:store_as].try(:to_s) || name.to_s)
         end
@@ -62,8 +52,6 @@ module Mongoid
         # The key that is used to get the attributes for the associated object.
         #
         # @return [ String ] The name of the field used to store the association.
-        #
-        # @since 7.0
         def key
           store_as.to_s
         end
@@ -71,8 +59,6 @@ module Mongoid
         # Is this association type embedded?
         #
         # @return [ true ] Always true.
-        #
-        # @since 7.0
         def embedded?; true; end
 
         # Get the default validation setting for the association. Determines if
@@ -82,15 +68,11 @@ module Mongoid
         #   Proxy.validation_default
         #
         # @return [ true, false ] The validation default.
-        #
-        # @since 2.1.9
         def validation_default; true; end
 
         # Does this association type store the foreign key?
         #
         # @return [ false ] Always false.
-        #
-        # @since 7.0
         def stores_foreign_key?; false; end
 
         # The primary key
@@ -101,8 +83,6 @@ module Mongoid
         # Get the association proxy class for this association type.
         #
         # @return [ Association::Embedded::EmbedsMany::Proxy ] The proxy class.
-        #
-        # @since 7.0
         def relation
           Proxy
         end
@@ -110,8 +90,6 @@ module Mongoid
         # Is this association polymorphic?
         #
         # @return [ true, false ] Whether this association is polymorphic.
-        #
-        # @since 7.0
         def polymorphic?
           @polymorphic ||= !!@options[:as]
         end
@@ -121,8 +99,6 @@ module Mongoid
         # @note Only relevant if the association is polymorphic.
         #
         # @return [ String, nil ] The field for storing the associated object's type.
-        #
-        # @since 7.0
         def type
           @type ||= "#{as}_type" if polymorphic?
         end
@@ -133,8 +109,6 @@ module Mongoid
         # @param [ Hash ] options The options for the association.
         #
         # @return [ Association::Nested::One ] The Nested Builder object.
-        #
-        # @since 7.0
         def nested_builder(attributes, options)
           Nested::One.new(self, attributes, options)
         end

--- a/lib/mongoid/association/embedded/embeds_one/binding.rb
+++ b/lib/mongoid/association/embedded/embeds_one/binding.rb
@@ -7,8 +7,6 @@ module Mongoid
       class EmbedsOne
 
         # Binding class for all embeds_one associations.
-        #
-        # @since 7.0
         class Binding
           include Bindable
 
@@ -21,8 +19,6 @@ module Mongoid
           # @example Bind the document.
           #   person.name.bind(:continue => true)
           #   person.name = Name.new
-          #
-          # @since 2.0.0.rc.1
           def bind_one
             _target.parentize(_base)
             binding do
@@ -36,8 +32,6 @@ module Mongoid
           # @example Unbind the document.
           #   person.name.unbind(:continue => true)
           #   person.name = nil
-          #
-          # @since 2.0.0.rc.1
           def unbind_one
             binding do
               _target.do_or_do_not(_association.inverse_setter(_target), nil)

--- a/lib/mongoid/association/embedded/embeds_one/buildable.rb
+++ b/lib/mongoid/association/embedded/embeds_one/buildable.rb
@@ -7,8 +7,6 @@ module Mongoid
       class EmbedsOne
 
         # Builder class for embeds_one associations.
-        #
-        # @since 7.0
         module Buildable
           include Threaded::Lifecycle
 

--- a/lib/mongoid/association/embedded/embeds_one/proxy.rb
+++ b/lib/mongoid/association/embedded/embeds_one/proxy.rb
@@ -11,8 +11,6 @@ module Mongoid
           # The valid options when defining this association.
           #
           # @return [ Array<Symbol> ] The allowed options when defining this association.
-          #
-          # @since 7.0
           VALID_OPTIONS = [
               :autobuild,
               :as,
@@ -48,8 +46,6 @@ module Mongoid
           # @param [ Document ] replacement A document to replace the target.
           #
           # @return [ Document, nil ] The association or nil.
-          #
-          # @since 2.0.0.rc.1
           def substitute(replacement)
             if replacement != self
               if _assigning?
@@ -78,8 +74,6 @@ module Mongoid
           #   relation.binding([ address ])
           #
           # @return [ Binding ] The association's binding.
-          #
-          # @since 2.0.0.rc.1
           def binding
             Binding.new(_base, _target, _association)
           end
@@ -90,8 +84,6 @@ module Mongoid
           #   relation.persistable?
           #
           # @return [ true, false ] If the association is persistable.
-          #
-          # @since 2.1.0
           def persistable?
             _base.persisted? && !_binding? && !_building? && !_assigning?
           end
@@ -105,8 +97,6 @@ module Mongoid
             #   Association::Embedded::EmbedsOne.embedded?
             #
             # @return [ true ] true.
-            #
-            # @since 2.0.0.rc.1
             def embedded?
               true
             end
@@ -120,8 +110,6 @@ module Mongoid
             #
             # @return [ Mongoid::Atomic::Paths::Embedded::One ]
             #   The embedded one atomic path calculator.
-            #
-            # @since 2.1.0
             def path(document)
               Mongoid::Atomic::Paths::Embedded::One.new(document)
             end

--- a/lib/mongoid/association/macros.rb
+++ b/lib/mongoid/association/macros.rb
@@ -24,8 +24,6 @@ module Mongoid
       #   person.associations
       #
       # @return [ Hash ] The associations.
-      #
-      # @since 2.3.1
       def associations
         self.relations
       end
@@ -164,8 +162,6 @@ module Mongoid
         # @param [ Symbol ] name The name of the association.
         # @param [ Hash ] options The association options.
         # @param [ Proc ] block Optional block for defining extensions.
-        #
-        # @since 2.0.0.rc.1
         def has_and_belongs_to_many(name, options = {}, &block)
           define_association!(__method__, name, options, &block)
         end

--- a/lib/mongoid/association/many.rb
+++ b/lib/mongoid/association/many.rb
@@ -19,8 +19,6 @@ module Mongoid
       #   person.addresses.blank?
       #
       # @return [ true, false ] If the association is empty or not.
-      #
-      # @since 2.1.0
       def blank?
         !any?
       end
@@ -36,8 +34,6 @@ module Mongoid
       # @param [ Class ] type The optional type of document to create.
       #
       # @return [ Document ] The newly created document.
-      #
-      # @since 2.0.0.beta.1
       def create(attributes = nil, type = nil, &block)
         if attributes.is_a?(::Array)
           attributes.map { |attrs| create(attrs, type, &block) }
@@ -61,8 +57,6 @@ module Mongoid
       # @raise [ Errors::Validations ] If validation failed.
       #
       # @return [ Document ] The newly created document.
-      #
-      # @since 2.0.0.beta.1
       def create!(attributes = nil, type = nil, &block)
         if attributes.is_a?(::Array)
           attributes.map { |attrs| create!(attrs, type, &block) }
@@ -123,8 +117,6 @@ module Mongoid
       #   relation.nil?
       #
       # @return [ false ] Always false.
-      #
-      # @since 2.0.0
       def nil?
         false
       end
@@ -138,8 +130,6 @@ module Mongoid
       # @param [ true, false ] include_private Whether to include private methods.
       #
       # @return [ true, false ] If the proxy responds to the method.
-      #
-      # @since 2.0.0
       def respond_to?(name, include_private = false)
         [].respond_to?(name, include_private) ||
           klass.respond_to?(name, include_private) || super
@@ -151,8 +141,6 @@ module Mongoid
       #   relation.scoped
       #
       # @return [ Criteria ] The scoped criteria.
-      #
-      # @since 2.1.0
       def scoped
         criteria
       end
@@ -171,8 +159,6 @@ module Mongoid
       # @option options [ Symbol ] :except Dont include these fields.
       #
       # @return [ Hash ] The documents, ready to be serialized.
-      #
-      # @since 2.0.0.rc.6
       def serializable_hash(options = {})
         _target.map { |document| document.serializable_hash(options) }
       end
@@ -184,8 +170,6 @@ module Mongoid
       #   person.addresses.unscoped
       #
       # @return [ Criteria ] The unscoped criteria.
-      #
-      # @since 2.4.0
       def unscoped
         criteria.unscoped
       end

--- a/lib/mongoid/association/marshalable.rb
+++ b/lib/mongoid/association/marshalable.rb
@@ -11,8 +11,6 @@ module Mongoid
       #   Marshal.dump(proxy)
       #
       # @return [ Array<Object> ] The dumped data.
-      #
-      # @since 3.0.15
       def marshal_dump
         [ _base, _target, _association ]
       end
@@ -25,8 +23,6 @@ module Mongoid
       # @param [ Array<Object> ] data The data to set on the proxy.
       #
       # @return [ Array<Object> ] The loaded data.
-      #
-      # @since 3.0.15
       def marshal_load(data)
         @_base, @_target, @_association = data
         extend_proxy(_association.extension) if _association.extension

--- a/lib/mongoid/association/nested.rb
+++ b/lib/mongoid/association/nested.rb
@@ -10,8 +10,6 @@ module Mongoid
     module Nested
 
       # The flags indicating that an association can be destroyed.
-      #
-      # @since 7.0
       DESTROY_FLAGS = [1, "1", true, "true"].freeze
     end
   end

--- a/lib/mongoid/association/nested/many.rb
+++ b/lib/mongoid/association/nested/many.rb
@@ -96,8 +96,6 @@ module Mongoid
         #
         # @param [ Document ] parent The parent document.
         # @param [ Hash ] attrs The single document attributes to process.
-        #
-        # @since 2.0.0
         def process_attributes(parent, attrs)
           return if reject?(parent, attrs)
           if id = attrs.extract_id
@@ -118,8 +116,6 @@ module Mongoid
         # @param [ Document ] parent The parent document.
         # @param [ Proxy ] relation The association proxy.
         # @param [ Document ] doc The doc to destroy.
-        #
-        # @since 3.0.10
         def destroy(parent, relation, doc)
           doc.flagged_for_destroy = true
           if !doc.embedded? || parent.new_record?
@@ -138,8 +134,6 @@ module Mongoid
         #
         # @param [ Proxy ] relation The association proxy.
         # @param [ Document ] doc The document to delete.
-        #
-        # @since 3.0.10
         def destroy_document(relation, doc)
           relation.delete(doc)
           doc.destroy unless doc.embedded? || doc.destroyed?
@@ -154,8 +148,6 @@ module Mongoid
         #
         # @param [ Document ] doc The document to update.
         # @param [ Hash ] attrs The attributes.
-        #
-        # @since 3.0.10
         def update_document(doc, attrs)
           attrs.delete_id
           if association.embedded?
@@ -175,8 +167,6 @@ module Mongoid
         # @param [ Document ] parent The parent document.
         # @param [ String, BSON::ObjectId ] id of the related document.
         # @param [ Hash ] attrs The single document attributes to process.
-        #
-        # @since 6.0.0
         def update_nested_relation(parent, id, attrs)
           first = existing.first
           converted = first ? convert_id(first.class, id) : id

--- a/lib/mongoid/association/nested/nested_buildable.rb
+++ b/lib/mongoid/association/nested/nested_buildable.rb
@@ -14,8 +14,6 @@ module Mongoid
         #   builder.allow_destroy?
         #
         # @return [ true, false ] True if the allow destroy option was set.
-        #
-        # @since 2.0.0.rc.1
         def allow_destroy?
           options[:allow_destroy] || false
         end
@@ -29,8 +27,6 @@ module Mongoid
         # @param [ Hash ] attrs The attributes to check for rejection.
         #
         # @return [ true, false ] True and call proc or method if rejectable, false if not.
-        #
-        # @since 2.0.0.rc.1
         def reject?(document, attrs)
           case callback = options[:reject_if]
             when Symbol
@@ -49,8 +45,6 @@ module Mongoid
         #   builder.update_only?
         #
         # @return [ true, false ] True if the update_only option was set.
-        #
-        # @since 2.0.0.rc.1
         def update_only?
           options[:update_only] || false
         end
@@ -64,8 +58,6 @@ module Mongoid
         # @param [ String ] id The id, usually coming from the form.
         #
         # @return [ BSON::ObjectId, String, Object ] The converted id.
-        #
-        # @since 2.0.0.rc.6
         def convert_id(klass, id)
           klass.using_object_ids? ? BSON::ObjectId.mongoize(id) : id
         end

--- a/lib/mongoid/association/nested/one.rb
+++ b/lib/mongoid/association/nested/one.rb
@@ -23,8 +23,6 @@ module Mongoid
         # @param [ Document ] parent The parent document.
         #
         # @return [ Document ] The built document.
-        #
-        # @since 2.0.0
         def build(parent)
           return if reject?(parent, attributes)
           @existing = parent.send(association.name)
@@ -47,8 +45,6 @@ module Mongoid
         # @param [ Association ] association The association metadata.
         # @param [ Hash ] attributes The attributes hash to attempt to set.
         # @param [ Hash ] options The options defined.
-        #
-        # @since 2.0.0
         def initialize(association, attributes, options)
           @attributes = attributes.with_indifferent_access
           @association = association
@@ -68,8 +64,6 @@ module Mongoid
         #   one.acceptable_id?
         #
         # @return [ true, false ] If the id part of the logic will allow an update.
-        #
-        # @since 2.0.0
         def acceptable_id?
           id = association.klass.extract_id_field(attributes)
           id = convert_id(existing.class, id)
@@ -82,8 +76,6 @@ module Mongoid
         #   one.delete?
         #
         # @return [ true, false ] If the association should be deleted.
-        #
-        # @since 2.0.0
         def delete?
           id = association.klass.extract_id_field(attributes)
           destroyable? && !id.nil?
@@ -96,8 +88,6 @@ module Mongoid
         #
         # @return [ true, false ] If the association can potentially be
         #   destroyed.
-        #
-        # @since 2.0.0
         def destroyable?
           Nested::DESTROY_FLAGS.include?(destroy) && allow_destroy?
         end
@@ -108,8 +98,6 @@ module Mongoid
         #   one.replace?
         #
         # @return [ true, false ] If the document should be replaced.
-        #
-        # @since 2.0.0
         def replace?
           !existing && !destroyable? && !attributes.blank?
         end
@@ -120,8 +108,6 @@ module Mongoid
         #   one.update?
         #
         # @return [ true, false ] If the object should have its attributes updated.
-        #
-        # @since 2.0.0
         def update?
           existing && !destroyable? && acceptable_id?
         end

--- a/lib/mongoid/association/one.rb
+++ b/lib/mongoid/association/one.rb
@@ -14,8 +14,6 @@ module Mongoid
       #   relation.clear
       #
       # @return [ true, false ] If the delete suceeded.
-      #
-      # @since 3.0.0
       def clear
         _target.delete
       end
@@ -26,8 +24,6 @@ module Mongoid
       #   relation.in_memory
       #
       # @return [ Array<Document> ] The documents in memory.
-      #
-      # @since 2.1.0
       def in_memory
         [ _target ]
       end
@@ -40,8 +36,6 @@ module Mongoid
       # @param [ Symbol ] name The method name.
       #
       # @return [ true, false ] If the proxy responds to the method.
-      #
-      # @since 2.1.8
       def respond_to?(name, include_private = false)
         _target.respond_to?(name, include_private) || super
       end
@@ -52,8 +46,6 @@ module Mongoid
       #   proxy.__evolve_object_id__
       #
       # @return [ Object ] The proxy document's id.
-      #
-      # @since 4.0.0
       def __evolve_object_id__
         _target._id
       end

--- a/lib/mongoid/association/options.rb
+++ b/lib/mongoid/association/options.rb
@@ -9,8 +9,6 @@ module Mongoid
       # Returns the name of the parent to a polymorphic child.
       #
       # @return [ String, Symbol ] The name.
-      #
-      # @since 7.0
       def as
         @options[:as]
       end
@@ -18,8 +16,6 @@ module Mongoid
       # Specify what happens to the associated object when the owner is destroyed.
       #
       # @return [ String ] The dependent option.
-      #
-      # @since 7.0
       def dependent
         @options[:dependent]
       end
@@ -27,8 +23,6 @@ module Mongoid
       # The custom sorting options on the association.
       #
       # @return [ Criteria::Queryable::Key ] The custom sorting options.
-      #
-      # @since 7.0
       def order
         @options[:order]
       end
@@ -36,8 +30,6 @@ module Mongoid
       # Whether to index the primary or foreign key field.
       #
       # @return [ true, false ]
-      #
-      # @since 7.0
       def indexed?
         @indexed ||= !!@options[:index]
       end
@@ -45,8 +37,6 @@ module Mongoid
       # Whether the association is autobuilding.
       #
       # @return [ true, false ]
-      #
-      # @since 7.0
       def autobuilding?
         !!@options[:autobuild]
       end
@@ -54,8 +44,6 @@ module Mongoid
       # Is the association cyclic.
       #
       # @return [ true, false ] Whether the association is cyclic.
-      #
-      # @since 7.0
       def cyclic?
         !!@options[:cyclic]
       end
@@ -63,8 +51,6 @@ module Mongoid
       # The name the owning object uses to refer to this association.
       #
       # @return [ String ] The inverse_of option.
-      #
-      # @since 7.0
       def inverse_of
         @options[:inverse_of]
       end
@@ -73,8 +59,6 @@ module Mongoid
       # You can override this and explicitly specify the primary key with the :primary_key option.
       #
       # @return [ Symbol, String ] The primary key.
-      #
-      # @since 7.0
       def primary_key
         @primary_key ||= @options[:primary_key] ? @options[:primary_key].to_s : Relatable::PRIMARY_KEY_DEFAULT
       end
@@ -83,8 +67,6 @@ module Mongoid
       # when the parent object is saved.
       #
       # @return [ true, false ] The autosave option.
-      #
-      # @since 7.0
       def autosave
         !!@options[:autosave]
       end
@@ -93,8 +75,6 @@ module Mongoid
       # Whether the association is counter-cached.
       #
       # @return [ true, false ]
-      #
-      # @since 7.0
       def counter_cached?
         !!@options[:counter_cache]
       end
@@ -102,15 +82,11 @@ module Mongoid
       # Whether this association is polymorphic.
       #
       # @return [ true, false ] Whether the association is polymorphic.
-      #
-      # @since 7.0
       def polymorphic?; false; end
 
       # Whether the association has callbacks cascaded down from the parent.
       #
       # @return [ true, false ] Whether callbacks are cascaded.
-      #
-      # @since 7.0
       def cascading_callbacks?
         !!@options[:cascade_callbacks]
       end
@@ -118,29 +94,21 @@ module Mongoid
       # The store_as option.
       #
       # @return [ nil ] Default is nil.
-      #
-      # @since 7.0
       def store_as; end
 
       # Whether the association has forced nil inverse (So no foreign keys are saved).
       #
       # @return [ false ] Default is false.
-      #
-      # @since 7.0
       def forced_nil_inverse?; false; end
 
       # The field for saving the associated object's type.
       #
       # @return [ nil ] Default is nil.
-      #
-      # @since 7.0
       def type; end
 
       # The field for saving the associated object's type.
       #
       # @return [ nil ] Default is nil.
-      #
-      # @since 7.0
       def touch_field
         @touch_field ||= options[:touch] if (options[:touch].is_a?(String) || options[:touch].is_a?(Symbol))
       end

--- a/lib/mongoid/association/proxy.rb
+++ b/lib/mongoid/association/proxy.rb
@@ -51,8 +51,6 @@ module Mongoid
       # @param [ Document ] base The base document on the proxy.
       # @param [ Document, Array<Document> ] target The target of the proxy.
       # @param [ Association ] association The association metadata.
-      #
-      # @since 2.0.0.rc.1
       def init(base, target, association)
         @_base, @_target, @_association = base, target, association
         yield(self) if block_given?
@@ -70,8 +68,6 @@ module Mongoid
       #   proxy.klass
       #
       # @return [ Class ] The association class.
-      #
-      # @since 3.0.15
       def klass
         _association ? _association.klass : nil
       end
@@ -81,8 +77,6 @@ module Mongoid
       #
       # @example Reset the association criteria.
       #   person.preferences.reset_relation_criteria
-      #
-      # @since 3.0.14
       def reset_unloaded
         _target.reset_unloaded(criteria)
       end
@@ -94,8 +88,6 @@ module Mongoid
       #   proxy.substitutable
       #
       # @return [ Object ] A clone of the target.
-      #
-      # @since 2.1.6
       def substitutable
         _target
       end
@@ -108,8 +100,6 @@ module Mongoid
       #   relation.collection
       #
       # @return [ Collection ] The root's collection.
-      #
-      # @since 2.0.0
       def collection
         root = _base._root
         root.collection unless root.embedded?
@@ -121,8 +111,6 @@ module Mongoid
       #   proxt.characterize_one(name)
       #
       # @param [ Document ] document The document to set on.
-      #
-      # @since 2.0.0.rc.4
       def characterize_one(document)
         document._association = _association unless document._association
       end
@@ -149,8 +137,6 @@ module Mongoid
       #   relation.raise_mixed
       #
       # @raise [ Errors::MixedRelations ] The error.
-      #
-      # @since 2.0.0
       def raise_mixed
         raise Errors::MixedRelations.new(_base.class, _association.klass)
       end
@@ -164,8 +150,6 @@ module Mongoid
       # @param [ Document ] doc The child document getting created.
       #
       # @raise [ Errors::UnsavedDocument ] The error.
-      #
-      # @since 2.0.0.rc.6
       def raise_unsaved(doc)
         raise Errors::UnsavedDocument.new(_base, doc)
       end
@@ -176,8 +160,6 @@ module Mongoid
       #   execute_callback(:before_add)
       #
       # @param [ Symbol ] callback to be executed
-      #
-      # @since 3.1.0
       def execute_callback(callback, doc)
         _association.get_callbacks(callback).each do |c|
           if c.is_a? Proc
@@ -199,8 +181,6 @@ module Mongoid
         # @param [ Association ] association The association metadata.
         #
         # @return [ Criteria ] The ordered criteria.
-        #
-        # @since 3.0.6
         def apply_ordering(criteria, association)
           association.order ? criteria.order_by(association.order) : criteria
         end

--- a/lib/mongoid/association/referenced/auto_save.rb
+++ b/lib/mongoid/association/referenced/auto_save.rb
@@ -14,8 +14,6 @@ module Mongoid
         #   document.autosaved?
         #
         # @return [ true, false ] Has the document already been autosaved?
-        #
-        # @since 3.0.0
         def autosaved?
           Threaded.autosaved?(self)
         end
@@ -24,8 +22,6 @@ module Mongoid
         #
         # @example Begin autosave.
         #   document.__autosaving__
-        #
-        # @since 3.1.3
         def __autosaving__
           Threaded.begin_autosave(self)
           yield
@@ -38,8 +34,6 @@ module Mongoid
         # @example Return true if there is changes on self or in
         #           autosaved associations.
         #   document.changed_for_autosave?
-        #
-        # @since 3.1.3
         def changed_for_autosave?(doc)
           doc.new_record? || doc.changed? || doc.marked_for_destruction?
         end
@@ -53,8 +47,6 @@ module Mongoid
         # @param [ Association ] association The association for which autosaving is enabled.
         #
         # @return [ Class ] The association's owner class.
-        #
-        # @since 7.0
         def self.define_autosave!(association)
           association.inverse_class.tap do |klass|
             save_method = :"autosave_documents_for_#{association.name}"

--- a/lib/mongoid/association/referenced/belongs_to.rb
+++ b/lib/mongoid/association/referenced/belongs_to.rb
@@ -11,8 +11,6 @@ module Mongoid
     module Referenced
 
       # The BelongsTo type association.
-      #
-      # @since 7.0
       class BelongsTo
         include Relatable
         include Buildable
@@ -21,8 +19,6 @@ module Mongoid
         # common ones.
         #
         # @return [ Array<Symbol> ] The extra valid options.
-        #
-        # @since 7.0
         ASSOCIATION_OPTIONS = [
             :autobuild,
             :autosave,
@@ -41,29 +37,21 @@ module Mongoid
         # the shared ones.
         #
         # @return [ Array<Symbol> ] The valid options.
-        #
-        # @since 7.0
         VALID_OPTIONS = (ASSOCIATION_OPTIONS + SHARED_OPTIONS).freeze
 
         # The type of the field holding the foreign key.
         #
         # @return [ Object ]
-        #
-        # @since 7.0
         FOREIGN_KEY_FIELD_TYPE = Object
 
         # The default foreign key suffix.
         #
         # @return [ String ] '_id'
-        #
-        # @since 7.0
         FOREIGN_KEY_SUFFIX = '_id'.freeze
 
         # The list of association complements.
         #
         # @return [ Array<Association> ] The association complements.
-        #
-        # @since 7.0
         def relation_complements
           @relation_complements ||= [ HasMany, HasOne ].freeze
         end
@@ -71,8 +59,6 @@ module Mongoid
         # Setup the instance methods, fields, etc. on the association owning class.
         #
         # @return [ self ]
-        #
-        # @since 7.0
         def setup!
           setup_instance_methods!
           @owner_class.aliased_fields[name.to_s] = foreign_key
@@ -82,29 +68,21 @@ module Mongoid
         # Does this association type store the foreign key?
         #
         # @return [ true ] Always true.
-        #
-        # @since 7.0
         def stores_foreign_key?; true; end
 
         # Is this association type embedded?
         #
         # @return [ false ] Always false.
-        #
-        # @since 7.0
         def embedded?; false; end
 
         # The default for validation the association object.
         #
         # @return [ false ] Always false.
-        #
-        # @since 7.0
         def validation_default; false; end
 
         # Get the foreign key field for saving the association reference.
         #
         # @return [ String ] The foreign key field for saving the association reference.
-        #
-        # @since 7.0
         def foreign_key
           @foreign_key ||= @options[:foreign_key] ? @options[:foreign_key].to_s :
                              default_foreign_key_field
@@ -113,8 +91,6 @@ module Mongoid
         # Get the association proxy class for this association type.
         #
         # @return [ Association::BelongsTo::Proxy ] The proxy class.
-        #
-        # @since 7.0
         def relation
           Proxy
         end
@@ -122,8 +98,6 @@ module Mongoid
         # Is this association polymorphic?
         #
         # @return [ true, false ] Whether this association is polymorphic.
-        #
-        # @since 7.0
         def polymorphic?
           @polymorphic ||= !!@options[:polymorphic]
         end
@@ -131,8 +105,6 @@ module Mongoid
         # The name of the field used to store the type of polymorphic association.
         #
         # @return [ String ] The field used to store the type of polymorphic association.
-        #
-        # @since 7.0
         def inverse_type
           (@inverse_type ||= "#{name}_type") if polymorphic?
         end
@@ -143,8 +115,6 @@ module Mongoid
         # @param [ Hash ] options The options for the association.
         #
         # @return [ Association::Nested::One ] The Nested Builder object.
-        #
-        # @since 7.0
         def nested_builder(attributes, options)
           Nested::One.new(self, attributes, options)
         end
@@ -157,8 +127,6 @@ module Mongoid
         # @param [ Document ] document The document to calculate on.
         #
         # @return [ Root ] The root atomic path calculator.
-        #
-        # @since 2.1.0
         def path(document)
           Mongoid::Atomic::Paths::Root.new(document)
         end

--- a/lib/mongoid/association/referenced/belongs_to/binding.rb
+++ b/lib/mongoid/association/referenced/belongs_to/binding.rb
@@ -19,8 +19,6 @@ module Mongoid
           # @example Bind the documents.
           #   game.person.bind(:continue => true)
           #   game.person = Person.new
-          #
-          # @since 2.0.0.rc.1
           def bind_one
             binding do
               check_polymorphic_inverses!(_target)
@@ -44,8 +42,6 @@ module Mongoid
           # @example Unbind the document.
           #   game.person.unbind(:continue => true)
           #   game.person = nil
-          #
-          # @since 2.0.0.rc.1
           def unbind_one
             binding do
               inverse = _association.inverse(_target)
@@ -72,8 +68,6 @@ module Mongoid
           #   binding.check_inverses!(doc)
           #
           # @param [ Document ] doc The document to check.
-          #
-          # @since 3.0.0
           def check_polymorphic_inverses!(doc)
             inverses = _association.inverses(doc)
             if inverses.length > 1 && _base.send(_association.foreign_key).nil?

--- a/lib/mongoid/association/referenced/belongs_to/buildable.rb
+++ b/lib/mongoid/association/referenced/belongs_to/buildable.rb
@@ -7,8 +7,6 @@ module Mongoid
       class BelongsTo
 
         # The Builder behavior for belongs_to associations.
-        #
-        # @since 7.0
         module Buildable
 
           # This method either takes an _id or an object and queries for the

--- a/lib/mongoid/association/referenced/belongs_to/proxy.rb
+++ b/lib/mongoid/association/referenced/belongs_to/proxy.rb
@@ -50,8 +50,6 @@ module Mongoid
           # @param [ Document, Array<Document> ] replacement The replacement.
           #
           # @return [ self, nil ] The association or nil.
-          #
-          # @since 2.0.0.rc.1
           def substitute(replacement)
             unbind_one
             if replacement
@@ -69,8 +67,6 @@ module Mongoid
           #   binding([ address ])
           #
           # @return [ Binding ] The binding object.
-          #
-          # @since 2.0.0.rc.1
           def binding
             BelongsTo::Binding.new(_base, _target, _association)
           end
@@ -85,8 +81,6 @@ module Mongoid
           # @param [ Document, Object ] replacement The replacement object.
           #
           # @return [ Document ] The document.
-          #
-          # @since 3.1.5
           def normalize(replacement)
             return replacement if replacement.is_a?(Document)
             _association.build(klass, replacement)
@@ -98,8 +92,6 @@ module Mongoid
           #   relation.persistable?
           #
           # @return [ true, false ] If the association is persistable.
-          #
-          # @since 2.1.0
           def persistable?
             _target.persisted? && !_binding? && !_building?
           end
@@ -112,8 +104,6 @@ module Mongoid
             #
             # @param [ Association ] association The association object.
             # @param [ Array<Document> ] docs The array of documents.
-            #
-            # @since 7.0
             def eager_loader(association, docs)
               Eager.new(association, docs)
             end
@@ -125,8 +115,6 @@ module Mongoid
             #   Association::BelongsTo::Proxy.embedded?
             #
             # @return [ false ] Always false.
-            #
-            # @since 2.0.0.rc.1
             def embedded?
               false
             end

--- a/lib/mongoid/association/referenced/counter_cache.rb
+++ b/lib/mongoid/association/referenced/counter_cache.rb
@@ -15,8 +15,6 @@ module Mongoid
         #   post.reset_counters(:comments)
         #
         # @param [ Symbol, Array ] counters One or more counter caches to reset
-        #
-        # @since 4.0.0
         def reset_counters(*counters)
           self.class.with(persistence_context) do |_class|
             _class.reset_counters(self, *counters)
@@ -34,8 +32,6 @@ module Mongoid
           #
           # @param [ String ] id The id of the object that will be reset.
           # @param [ Symbol, Array ] counters One or more counter caches to reset
-          #
-          # @since 3.1.0
           def reset_counters(id, *counters)
             document = id.is_a?(Document) ? id : find(id)
             counters.each do |name|
@@ -55,8 +51,6 @@ module Mongoid
           #
           # @param [ String ] id The id of the object to update.
           # @param [ Hash ] counters
-          #
-          # @since 3.1.0
           def update_counters(id, counters)
             where(:_id => id).inc(counters)
           end
@@ -70,8 +64,6 @@ module Mongoid
           #
           # @param [ Symbol ] counter_name Counter cache name
           # @param [ String ] id The id of the object that will have its counter incremented.
-          #
-          # @since 3.1.0
           def increment_counter(counter_name, id)
             update_counters(id, counter_name.to_sym => 1)
           end
@@ -85,8 +77,6 @@ module Mongoid
           #
           # @param [ Symbol ] counter_name Counter cache name
           # @param [ String ] id The id of the object that will have its counter decremented.
-          #
-          # @since 3.1.0
           def decrement_counter(counter_name, id)
             update_counters(id, counter_name.to_sym => -1)
           end
@@ -102,8 +92,6 @@ module Mongoid
         # @param [ Association ] association The association.
         #
         # @return [ Class ] The association's owning class.
-        #
-        # @since 7.0
         def self.define_callbacks!(association)
           name = association.name
           cache_column = association.counter_cache_column_name.to_sym

--- a/lib/mongoid/association/referenced/eager.rb
+++ b/lib/mongoid/association/referenced/eager.rb
@@ -7,8 +7,6 @@ module Mongoid
       module Eager
 
         # Base class for eager load preload functions.
-        #
-        # @since 4.0.0
         class Base
 
           # Instantiate the eager load class.
@@ -20,8 +18,6 @@ module Mongoid
           # @param [ Array<Document> ] docs Documents to preload the associations
           #
           # @return [ Base ] The eager load preloader
-          #
-          # @since 4.0.0
           def initialize(associations, docs)
             @associations = associations
             @docs = docs
@@ -34,8 +30,6 @@ module Mongoid
           #   loader.run
           #
           # @return [ Array ] The list of documents given.
-          #
-          # @since 4.0.0
           def run
             @loaded = []
             while shift_association
@@ -53,8 +47,6 @@ module Mongoid
           #
           # @example Preload the current association into the documents.
           #   loader.preload
-          #
-          # @since 4.0.0
           def preload
             raise NotImplementedError
           end
@@ -64,8 +56,6 @@ module Mongoid
           # association is not polymorphic, all documents are retrieved in
           # a single query. If the association is polymorphic, one query is
           # issued per association target class.
-          #
-          # @since 4.0.0
           def each_loaded_document(&block)
             each_loaded_document_of_class(@association.klass, keys_from_docs, &block)
           end
@@ -95,8 +85,6 @@ module Mongoid
           #
           # @param [ ObjectId ] id parent`s id
           # @param [ Document, Array ] element to push into the parent
-          #
-          # @since 4.0.0
           def set_on_parent(id, element)
             grouped_docs[id].each do |d|
               set_relation(d, element)
@@ -112,8 +100,6 @@ module Mongoid
           #   loader.grouped_docs
           #
           # @return [ Hash ] hash with grouped documents.
-          #
-          # @since 4.0.0
           def grouped_docs
             @grouped_docs[@association.name] ||= @docs.group_by do |doc|
               doc.send(group_by_key) if doc.respond_to?(group_by_key)
@@ -131,8 +117,6 @@ module Mongoid
           #   loader.keys_from_docs
           #
           # @return [ Array ] keys, ids
-          #
-          # @since 4.0.0
           def keys_from_docs
             grouped_docs.keys
           end
@@ -145,8 +129,6 @@ module Mongoid
           #   loader.group_by_key
           #
           # @return [ Symbol ] Key to group by the current documents.
-          #
-          # @since 4.0.0
           def group_by_key
             raise NotImplementedError
           end
@@ -158,8 +140,6 @@ module Mongoid
           #
           # @param [ Document ] doc The object to set the association on
           # @param [ Document, Array ] element to set into the parent
-          #
-          # @since 4.0.0
           def set_relation(doc, element)
             doc.set_relation(@association.name, element) unless doc.blank?
           end
@@ -172,8 +152,6 @@ module Mongoid
           #   loader.shift_association
           #
           # @return [ Association ] The association object.
-          #
-          # @since 4.0.0
           def shift_association
             @association = @associations.shift
           end

--- a/lib/mongoid/association/referenced/has_and_belongs_to_many.rb
+++ b/lib/mongoid/association/referenced/has_and_belongs_to_many.rb
@@ -11,8 +11,6 @@ module Mongoid
     module Referenced
 
       # The HasAndBelongsToMany type association.
-      #
-      # @since 7.0
       class HasAndBelongsToMany
         include Relatable
         include Buildable
@@ -21,8 +19,6 @@ module Mongoid
         # common ones.
         #
         # @return [ Array<Symbol> ] The extra valid options.
-        #
-        # @since 7.0
         ASSOCIATION_OPTIONS = [
             :after_add,
             :after_remove,
@@ -43,29 +39,21 @@ module Mongoid
         # the shared ones.
         #
         # @return [ Array<Symbol> ] The valid options.
-        #
-        # @since 7.0
         VALID_OPTIONS = (ASSOCIATION_OPTIONS + SHARED_OPTIONS).freeze
 
         # The type of the field holding the foreign key.
         #
         # @return [ Array ]
-        #
-        # @since 7.0
         FOREIGN_KEY_FIELD_TYPE = Array
 
         # The default foreign key suffix.
         #
         # @return [ String ] '_ids'
-        #
-        # @since 7.0
         FOREIGN_KEY_SUFFIX = '_ids'.freeze
 
         # The list of association complements.
         #
         # @return [ Array<Association> ] The association complements.
-        #
-        # @since 7.0
         def relation_complements
           @relation_complements ||= [ self.class ].freeze
         end
@@ -73,8 +61,6 @@ module Mongoid
         # Setup the instance methods, fields, etc. on the association owning class.
         #
         # @return [ self ]
-        #
-        # @since 7.0
         def setup!
           setup_instance_methods!
           self
@@ -83,22 +69,16 @@ module Mongoid
         # Is this association type embedded?
         #
         # @return [ false ] Always false.
-        #
-        # @since 7.0
         def embedded?; false; end
 
         # The default for validation the association object.
         #
         # @return [ false ] Always false.
-        #
-        # @since 7.0
         def validation_default; true; end
 
         # Are ids only saved on this side of the association?
         #
         # @return [ true, false ] Whether this association has a forced nil inverse.
-        #
-        # @since 7.0
         def forced_nil_inverse?
           @forced_nil_inverse ||= @options.key?(:inverse_of) && !@options[:inverse_of]
         end
@@ -106,15 +86,11 @@ module Mongoid
         # Does this association type store the foreign key?
         #
         # @return [ true ] Always true.
-        #
-        # @since 7.0
         def stores_foreign_key?; true; end
 
         # Get the association proxy class for this association type.
         #
         # @return [ Association::HasAndBelongsToMany::Proxy ] The proxy class.
-        #
-        # @since 7.0
         def relation
           Proxy
         end
@@ -122,8 +98,6 @@ module Mongoid
         # Get the foreign key field for saving the association reference.
         #
         # @return [ String ] The foreign key field for saving the association reference.
-        #
-        # @since 7.0
         def foreign_key
           @foreign_key ||= @options[:foreign_key] ? @options[:foreign_key].to_s :
                              default_foreign_key_field
@@ -132,8 +106,6 @@ module Mongoid
         # The criteria used for querying this association.
         #
         # @return [ Mongoid::Criteria ] The criteria used for querying this association.
-        #
-        # @since 7.0
         def criteria(base, id_list = nil)
           query_criteria(id_list || base.send(foreign_key))
         end
@@ -142,8 +114,6 @@ module Mongoid
         #
         # @return [ String ] The foreign key field for saving the association reference
         #  on the inverse side.
-        #
-        # @since 7.0
         def inverse_foreign_key
           if @options.key?(:inverse_foreign_key)
             @options[:inverse_foreign_key]
@@ -168,8 +138,6 @@ module Mongoid
         #
         # @return [ String ] The foreign key setter for saving the association reference
         #  on the inverse side.
-        #
-        # @since 7.0
         def inverse_foreign_key_setter
           @inverse_foreign_key_setter ||= "#{inverse_foreign_key}=" if inverse_foreign_key
         end
@@ -180,8 +148,6 @@ module Mongoid
         # @param [ Hash ] options The options for the association.
         #
         # @return [ Association::Nested::One ] The Nested Builder object.
-        #
-        # @since 7.0
         def nested_builder(attributes, options)
           Nested::Many.new(self, attributes, options)
         end
@@ -194,8 +160,6 @@ module Mongoid
         # @param [ Document ] document The document to calculate on.
         #
         # @return [ Root ] The root atomic path calculator.
-        #
-        # @since 2.1.0
         def path(document)
           Mongoid::Atomic::Paths::Root.new(document)
         end

--- a/lib/mongoid/association/referenced/has_and_belongs_to_many/binding.rb
+++ b/lib/mongoid/association/referenced/has_and_belongs_to_many/binding.rb
@@ -17,8 +17,6 @@ module Mongoid
           #   person.preferences.bind_one(preference)
           #
           # @param [ Document ] doc The single document to bind.
-          #
-          # @since 2.0.0.rc.1
           def bind_one(doc)
             binding do
               inverse_keys = doc.you_must(_association.inverse_foreign_key)
@@ -38,8 +36,6 @@ module Mongoid
           #
           # @example Unbind the document.
           #   person.preferences.unbind_one(document)
-          #
-          # @since 2.0.0.rc.1
           def unbind_one(doc)
             binding do
               _base.send(_association.foreign_key).delete_one(record_id(doc))

--- a/lib/mongoid/association/referenced/has_and_belongs_to_many/buildable.rb
+++ b/lib/mongoid/association/referenced/has_and_belongs_to_many/buildable.rb
@@ -7,8 +7,6 @@ module Mongoid
       class HasAndBelongsToMany
 
         # The Builder behavior for has_and_belongs_to_many associations.
-        #
-        # @since 7.0
         module Buildable
 
           # This builder either takes a hash and queries for the

--- a/lib/mongoid/association/referenced/has_and_belongs_to_many/proxy.rb
+++ b/lib/mongoid/association/referenced/has_and_belongs_to_many/proxy.rb
@@ -25,8 +25,6 @@ module Mongoid
           # @param [ Document, Array<Document> ] args Any number of documents.
           #
           # @return [ Array<Document> ] The loaded docs.
-          #
-          # @since 2.0.0.beta.1
           def <<(*args)
             docs = args.flatten
             return concat(docs) if docs.size > 1
@@ -51,8 +49,6 @@ module Mongoid
           # @param [ Array<Document> ] documents The docs to add.
           #
           # @return [ Array<Document> ] The documents.
-          #
-          # @since 2.4.0
           def concat(documents)
             ids, docs, inserts = {}, [], []
             documents.each do |doc|
@@ -85,8 +81,6 @@ module Mongoid
           # @param [ Class ] type The optional subclass to build.
           #
           # @return [ Document ] The new document.
-          #
-          # @since 2.0.0.beta.1
           def build(attributes = {}, type = nil)
             doc = Factory.build(type || klass, attributes)
             _base.send(foreign_key).push(doc._id)
@@ -109,8 +103,6 @@ module Mongoid
           # @param [ Document ] document The document to remove.
           #
           # @return [ Document ] The matching document.
-          #
-          # @since 2.1.0
           def delete(document)
             doc = super
             if doc && persistable?
@@ -129,8 +121,6 @@ module Mongoid
           #   person.preferences.nullify
           #
           # @param [ Array<Document> ] replacement The replacement documents.
-          #
-          # @since 2.0.0.rc.1
           def nullify(replacement = [])
             _target.each do |doc|
               execute_callback :before_remove, doc
@@ -183,8 +173,6 @@ module Mongoid
           # @param [ Array<Document> ] replacement The replacement target.
           #
           # @return [ Many ] The association.
-          #
-          # @since 2.0.0.rc.1
           def substitute(replacement)
             purge(replacement)
             unless replacement.blank?
@@ -202,8 +190,6 @@ module Mongoid
           #   person.preferences.unscoped
           #
           # @return [ Criteria ] The unscoped criteria.
-          #
-          # @since 2.4.0
           def unscoped
             klass.unscoped.any_in(_id: _base.send(foreign_key))
           end
@@ -217,8 +203,6 @@ module Mongoid
           #   relation.append(document)
           #
           # @param [ Document ] document The document to append to the target.
-          #
-          # @since 2.0.0.rc.1
           def append(document)
             execute_callback :before_add, document
             _target.push(document)
@@ -233,8 +217,6 @@ module Mongoid
           #   relation.binding([ address ])
           #
           # @return [ Binding ] The binding.
-          #
-          # @since 2.0.0.rc.1
           def binding
             HasAndBelongsToMany::Binding.new(_base, _target, _association)
           end
@@ -249,8 +231,6 @@ module Mongoid
           # @param [ Document ] doc The document.
           #
           # @return [ true, false ] If the document can be persisted.
-          #
-          # @since 3.0.20
           def child_persistable?(doc)
             (persistable? || _creating?) &&
                 !(doc.persisted? && _association.forced_nil_inverse?)
@@ -278,8 +258,6 @@ module Mongoid
           # @param [ Symbol ] key The key to flag on the document.
           #
           # @return [ true ] true.
-          #
-          # @since 3.0.0
           def unsynced(doc, key)
             doc._synced[key] = false
             true
@@ -293,8 +271,6 @@ module Mongoid
             #
             # @param [ Association ] association The association object.
             # @param [ Array<Document> ] docs The array of documents.
-            #
-            # @since 7.0
             def eager_loader(association, docs)
               Eager.new(association, docs)
             end
@@ -306,8 +282,6 @@ module Mongoid
             #   Referenced::ManyToMany.embedded?
             #
             # @return [ false ] Always false.
-            #
-            # @since 2.0.0.rc.1
             def embedded?
               false
             end

--- a/lib/mongoid/association/referenced/has_many.rb
+++ b/lib/mongoid/association/referenced/has_many.rb
@@ -12,8 +12,6 @@ module Mongoid
     module Referenced
 
       # The has_many association.
-      #
-      # @since 7.0
       class HasMany
         include Relatable
         include Buildable
@@ -22,8 +20,6 @@ module Mongoid
         # common ones.
         #
         # @return [ Array<Symbol> ] The extra valid options.
-        #
-        # @since 7.0
         ASSOCIATION_OPTIONS = [
             :after_add,
             :after_remove,
@@ -41,22 +37,16 @@ module Mongoid
         # the shared ones.
         #
         # @return [ Array<Symbol> ] The valid options.
-        #
-        # @since 7.0
         VALID_OPTIONS = (ASSOCIATION_OPTIONS + SHARED_OPTIONS).freeze
 
         # The default foreign key suffix.
         #
         # @return [ String ] '_id'
-        #
-        # @since 7.0
         FOREIGN_KEY_SUFFIX = '_id'.freeze
 
         # The list of association complements.
         #
         # @return [ Array<Association> ] The association complements.
-        #
-        # @since 7.0
         def relation_complements
           @relation_complements ||= [ Referenced::BelongsTo ].freeze
         end
@@ -64,8 +54,6 @@ module Mongoid
         # Setup the instance methods, fields, etc. on the association owning class.
         #
         # @return [ self ]
-        #
-        # @since 7.0
         def setup!
           setup_instance_methods!
           self
@@ -74,8 +62,6 @@ module Mongoid
         # Setup the instance methods on the class having this association type.
         #
         # @return [ self ]
-        #
-        # @since 7.0
         def setup_instance_methods!
           define_getter!
           define_ids_getter!
@@ -94,8 +80,6 @@ module Mongoid
         #
         # @return [ String ] The foreign key field on the inverse for saving the
         #   association reference.
-        #
-        # @since 7.0
         def foreign_key
           @foreign_key ||= @options[:foreign_key] ? @options[:foreign_key].to_s :
                              default_foreign_key_field
@@ -104,29 +88,21 @@ module Mongoid
         # Is this association type embedded?
         #
         # @return [ false ] Always false.
-        #
-        # @since 7.0
         def embedded?; false; end
 
         # The default for validation the association object.
         #
         # @return [ true ] Always true.
-        #
-        # @since 7.0
         def validation_default; true; end
 
         # Does this association type store the foreign key?
         #
         # @return [ true ] Always true.
-        #
-        # @since 7.0
         def stores_foreign_key?; false; end
 
         # Get the association proxy class for this association type.
         #
         # @return [ Association::HasMany::Proxy ] The proxy class.
-        #
-        # @since 7.0
         def relation
           Proxy
         end
@@ -134,8 +110,6 @@ module Mongoid
         # The criteria used for querying this association.
         #
         # @return [ Mongoid::Criteria ] The criteria used for querying this association.
-        #
-        # @since 7.0
         def criteria(base)
           query_criteria(base.send(primary_key), base)
         end
@@ -145,8 +119,6 @@ module Mongoid
         # @note Only relevant for polymorphic associations.
         #
         # @return [ String, nil ] The type field.
-        #
-        # @since 7.0
         def type
           @type ||= "#{as}_type" if polymorphic?
         end
@@ -158,8 +130,6 @@ module Mongoid
         # @param [ Class ] object_class The object class.
         #
         # @return [ Mongoid::Criteria ] The criteria object.
-        #
-        # @since 7.0
         def add_polymorphic_criterion(criteria, object_class)
           if polymorphic?
             criteria.where(type => object_class.name)
@@ -171,8 +141,6 @@ module Mongoid
         # Is this association polymorphic?
         #
         # @return [ true, false ] Whether this association is polymorphic.
-        #
-        # @since 7.0
         def polymorphic?
           @polymorphic ||= !!as
         end
@@ -193,8 +161,6 @@ module Mongoid
         # @param [ Hash ] options The options for the association.
         #
         # @return [ Association::Nested::Many ] The Nested Builder object.
-        #
-        # @since 7.0
         def nested_builder(attributes, options)
           Nested::Many.new(self, attributes, options)
         end
@@ -207,8 +173,6 @@ module Mongoid
         # @param [ Document ] document The document to calculate on.
         #
         # @return [ Root ] The root atomic path calculator.
-        #
-        # @since 2.1.0
         def path(document)
           Mongoid::Atomic::Paths::Root.new(document)
         end

--- a/lib/mongoid/association/referenced/has_many/binding.rb
+++ b/lib/mongoid/association/referenced/has_many/binding.rb
@@ -15,8 +15,6 @@ module Mongoid
           #
           # @example Bind one document.
           #   person.posts.bind_one(post)
-          #
-          # @since 2.0.0.rc.1
           def bind_one(doc)
             binding do
               bind_from_relational_parent(doc)
@@ -27,8 +25,6 @@ module Mongoid
           #
           # @example Unbind the document.
           #   person.posts.unbind_one(document)
-          #
-          # @since 2.0.0.rc.1
           def unbind_one(doc)
             binding do
               unbind_from_relational_parent(doc)

--- a/lib/mongoid/association/referenced/has_many/buildable.rb
+++ b/lib/mongoid/association/referenced/has_many/buildable.rb
@@ -7,8 +7,6 @@ module Mongoid
       class HasMany
 
         # The Builder behavior for has_many associations.
-        #
-        # @since 7.0
         module Buildable
 
           # This method either takes an _id or an object and queries for the

--- a/lib/mongoid/association/referenced/has_many/enumerable.rb
+++ b/lib/mongoid/association/referenced/has_many/enumerable.rb
@@ -30,8 +30,6 @@ module Mongoid
           # @param [ Enumerable ] other The other enumerable.
           #
           # @return [ true, false ] If the objects are equal.
-          #
-          # @since 2.1.0
           def ==(other)
             return false unless other.respond_to?(:entries)
             entries == other.entries
@@ -46,8 +44,6 @@ module Mongoid
           # @param [ Object ] other The object to check.
           #
           # @return [ true, false ] If the objects are equal in a case.
-          #
-          # @since 3.1.4
           def ===(other)
             other.class == Class ? (Array == other || Enumerable == other) : self == other
           end
@@ -60,8 +56,6 @@ module Mongoid
           # @param [ Document ] document The document to append.
           #
           # @return [ Document ] The document.
-          #
-          # @since 2.1.0
           def <<(document)
             _added[document._id] = document
             self
@@ -81,8 +75,6 @@ module Mongoid
           #   end
           #
           # @return [ Array<Document> ] The cleared out _added docs.
-          #
-          # @since 2.1.0
           def clear
             if block_given?
               in_memory { |doc| yield(doc) }
@@ -98,8 +90,6 @@ module Mongoid
           #   enumerable.clone
           #
           # @return [ Array<Document> ] An array clone of the enumerable.
-          #
-          # @since 2.1.6
           def clone
             collect { |doc| doc.clone }
           end
@@ -112,8 +102,6 @@ module Mongoid
           # @param [ Document ] document The document to delete.
           #
           # @return [ Document ] The deleted document.
-          #
-          # @since 2.1.0
           def delete(document)
             doc = (_loaded.delete(document._id) || _added.delete(document._id))
             unless doc
@@ -137,8 +125,6 @@ module Mongoid
           #   end
           #
           # @return [ Array<Document> ] The remaining docs.
-          #
-          # @since 2.1.0
           def delete_if(&block)
             load_all!
             deleted = in_memory.select(&block)
@@ -172,8 +158,6 @@ module Mongoid
           #   a = enumerable.each
           #
           # @return [ true ] That the enumerable is now _loaded.
-          #
-          # @since 2.1.0
           def each
             unless block_given?
               return to_enum
@@ -205,8 +189,6 @@ module Mongoid
           #   enumerable.empty?
           #
           # @return [ true, false ] If the enumerable is empty.
-          #
-          # @since 2.1.0
           def empty?
             if _loaded?
               in_memory.count == 0
@@ -266,8 +248,6 @@ module Mongoid
           # @option opts [ :none ] :id_sort Don't apply a sort on _id.
           #
           # @return [ Document ] The first document found.
-          #
-          # @since 2.1.0
           def first(opts = {})
             _loaded.try(:values).try(:first) ||
                 _added[(ul = _unloaded.try(:first, opts)).try(:_id)] ||
@@ -284,8 +264,6 @@ module Mongoid
           #   Enumerable.new([ post ])
           #
           # @param [ Criteria, Array<Document> ] target The wrapped object.
-          #
-          # @since 2.1.0
           def initialize(target, base = nil, association = nil)
             @_base = base
             @_association = association
@@ -308,8 +286,6 @@ module Mongoid
           # @param [ Document ] doc The document to check.
           #
           # @return [ true, false ] If the document is in the target.
-          #
-          # @since 3.0.0
           def include?(doc)
             return super unless _unloaded
             _unloaded.where(_id: doc._id).exists? || _added.has_key?(doc._id)
@@ -322,8 +298,6 @@ module Mongoid
           #   enumerable.inspect
           #
           # @return [ String ] The inspected enum.
-          #
-          # @since 2.1.0
           def inspect
             entries.inspect
           end
@@ -337,8 +311,6 @@ module Mongoid
           #   enumerable.in_memory
           #
           # @return [ Array<Document> ] The in memory docs.
-          #
-          # @since 2.1.0
           def in_memory
             docs = (_loaded.values + _added.values)
             docs.each do |doc|
@@ -363,8 +335,6 @@ module Mongoid
           # @option opts [ :none ] :id_sort Don't apply a sort on _id.
           #
           # @return [ Document ] The last document found.
-          #
-          # @since 2.1.0
           def last(opts = {})
             _added.values.try(:last) ||
                 _loaded.try(:values).try(:last) ||
@@ -378,8 +348,6 @@ module Mongoid
           #   enumerable.load_all!
           #
           # @return [ true ] That the enumerable is _loaded.
-          #
-          # @since 2.1.0
           alias :load_all! :entries
 
           # Has the enumerable been _loaded? This will be true if the criteria has
@@ -389,8 +357,6 @@ module Mongoid
           #   enumerable._loaded?
           #
           # @return [ true, false ] If the enumerable has been _loaded.
-          #
-          # @since 2.1.0
           def _loaded?
             !!@executed
           end
@@ -401,8 +367,6 @@ module Mongoid
           #   Marshal.dump(proxy)
           #
           # @return [ Array<Object> ] The dumped data.
-          #
-          # @since 3.0.15
           def marshal_dump
             [_added, _loaded, _unloaded, @executed]
           end
@@ -413,8 +377,6 @@ module Mongoid
           #   Marshal.load(proxy)
           #
           # @return [ Array<Object> ] The dumped data.
-          #
-          # @since 3.0.15
           def marshal_load(data)
             @_added, @_loaded, @_unloaded, @executed = data
           end
@@ -425,8 +387,6 @@ module Mongoid
           #   enumerable.reset
           #
           # @return [ false ] Always false.
-          #
-          # @since 2.1.0
           def reset
             _loaded.clear
             _added.clear
@@ -440,8 +400,6 @@ module Mongoid
           #   enumerable.reset_unloaded(criteria)
           #
           # @param [ Criteria ] criteria The criteria to replace with.
-          #
-          # @since 3.0.14
           def reset_unloaded(criteria)
             @_unloaded = criteria if _unloaded.is_a?(Criteria)
           end
@@ -456,8 +414,6 @@ module Mongoid
           #   methods.
           #
           # @return [ true, false ] Whether the enumerable responds.
-          #
-          # @since 2.1.0
           def respond_to?(name, include_private = false)
             [].respond_to?(name, include_private) || super
           end
@@ -469,8 +425,6 @@ module Mongoid
           #   enumerable.size
           #
           # @return [ Integer ] The size of the enumerable.
-          #
-          # @since 2.1.0
           def size
             count = (_unloaded ? _unloaded.count : _loaded.count)
             if count.zero?
@@ -490,8 +444,6 @@ module Mongoid
           # @param [ Hash ] options Optional parameters.
           #
           # @return [ String ] The entries all _loaded as a string.
-          #
-          # @since 2.2.0
           def to_json(options = {})
             entries.to_json(options)
           end
@@ -504,8 +456,6 @@ module Mongoid
           # @param [ Hash ] options Optional parameters.
           #
           # @return [ Hash ] The entries all _loaded as a hash.
-          #
-          # @since 2.2.0
           def as_json(options = {})
             entries.as_json(options)
           end
@@ -518,8 +468,6 @@ module Mongoid
           #   enumerable.uniq
           #
           # @return [ Array<Document> ] The unique documents.
-          #
-          # @since 2.1.0
           def uniq
             entries.uniq
           end

--- a/lib/mongoid/association/referenced/has_many/proxy.rb
+++ b/lib/mongoid/association/referenced/has_many/proxy.rb
@@ -29,8 +29,6 @@ module Mongoid
           # @param [ Document, Array<Document> ] args Any number of documents.
           #
           # @return [ Array<Document> ] The loaded docs.
-          #
-          # @since 2.0.0.beta.1
           def <<(*args)
             docs = args.flatten
             return concat(docs) if docs.size > 1
@@ -52,8 +50,6 @@ module Mongoid
           # @param [ Array<Document> ] documents The docs to add.
           #
           # @return [ Array<Document> ] The documents.
-          #
-          # @since 2.4.0
           def concat(documents)
             docs, inserts = [], []
             documents.each do |doc|
@@ -75,8 +71,6 @@ module Mongoid
           # @param [ Class ] type The optional subclass to build.
           #
           # @return [ Document ] The new document.
-          #
-          # @since 2.0.0.beta.1
           def build(attributes = {}, type = nil)
             doc = Factory.build(type || klass, attributes)
             append(doc)
@@ -98,8 +92,6 @@ module Mongoid
           # @param [ Document ] document The document to remove.
           #
           # @return [ Document ] The matching document.
-          #
-          # @since 2.1.0
           def delete(document)
             execute_callback :before_remove, document
             _target.delete(document) do |doc|
@@ -123,8 +115,6 @@ module Mongoid
           # @param [ Hash ] conditions Optional conditions to delete with.
           #
           # @return [ Integer ] The number of documents deleted.
-          #
-          # @since 2.0.0.beta.1
           def delete_all(conditions = nil)
             remove_all(conditions, :delete_all)
           end
@@ -141,8 +131,6 @@ module Mongoid
           # @param [ Hash ] conditions Optional conditions to destroy with.
           #
           # @return [ Integer ] The number of documents destroyd.
-          #
-          # @since 2.0.0.beta.1
           def destroy_all(conditions = nil)
             remove_all(conditions, :destroy_all)
           end
@@ -158,8 +146,6 @@ module Mongoid
           #   end
           #
           # @return [ Array<Document> ] The loaded docs.
-          #
-          # @since 2.1.0
           def each
             if block_given?
               _target.each { |doc| yield(doc) }
@@ -212,8 +198,6 @@ module Mongoid
           # @param [ Proc ] block Optional block to pass.
           #
           # @return [ Document | Array<Document> | nil ] A document or matching documents.
-          #
-          # @since 2.0.0.beta.1
           def find(*args, &block)
             matching = criteria.find(*args, &block)
             Array(matching).each { |doc| _target.push(doc) }
@@ -229,8 +213,6 @@ module Mongoid
           # @param [ Document ] base The document this association hangs off of.
           # @param [ Array<Document> ] target The target of the association.
           # @param [ Association ] association The association metadata.
-          #
-          # @since 2.0.0.beta.1
           def initialize(base, target, association)
             enum = HasMany::Enumerable.new(target, base, association)
             init(base, enum, association) do
@@ -244,8 +226,6 @@ module Mongoid
           #
           # @example Nullify the association.
           #   person.posts.nullify
-          #
-          # @since 2.0.0.rc.1
           def nullify
             criteria.update_all(foreign_key => nil)
             _target.clear do |doc|
@@ -263,8 +243,6 @@ module Mongoid
           #   person.posts.clear
           #
           # @return [ Many ] The association emptied.
-          #
-          # @since 2.0.0.beta.1
           def purge
             unless _association.destructive?
               nullify
@@ -298,8 +276,6 @@ module Mongoid
           # @param [ Array<Document> ] replacement The replacement target.
           #
           # @return [ Many ] The association.
-          #
-          # @since 2.0.0.rc.1
           def substitute(replacement)
             if replacement
               new_docs, docs = replacement.compact, []
@@ -322,8 +298,6 @@ module Mongoid
           #   person.posts.unscoped
           #
           # @return [ Criteria ] The unscoped criteria.
-          #
-          # @since 2.4.0
           def unscoped
             klass.unscoped.where(foreign_key => _base.send(_association.primary_key))
           end
@@ -337,8 +311,6 @@ module Mongoid
           #   relation.append(document)
           #
           # @param [ Document ] document The document to append to the target.
-          #
-          # @since 2.0.0.rc.1
           def append(document)
             with_add_callbacks(document, already_related?(document)) do
               _target.push(document)
@@ -356,8 +328,6 @@ module Mongoid
           # @param [ Document ] document The document to append to the target.
           # @param [ true, false ] already_related Whether the document is already related
           #   to the target.
-          #
-          # @since 5.1.0
           def with_add_callbacks(document, already_related)
             execute_callback :before_add, document unless already_related
             yield
@@ -373,8 +343,6 @@ module Mongoid
           #
           # @return [ true, false ] Whether the document is already related to the base and the
           #   association is persisted.
-          #
-          # @since 5.1.0
           def already_related?(document)
             document.persisted? &&
                 document._association &&
@@ -388,8 +356,6 @@ module Mongoid
           #   relation.binding([ address ])
           #
           # @return [ Binding ] The binding.
-          #
-          # @since 2.0.0.rc.1
           def binding
             HasMany::Binding.new(_base, _target, _association)
           end
@@ -400,8 +366,6 @@ module Mongoid
           #   relation.collection
           #
           # @return [ Collection ] The collection of the association.
-          #
-          # @since 2.0.2
           def collection
             klass.collection
           end
@@ -413,8 +377,6 @@ module Mongoid
           #   relation.criteria
           #
           # @return [ Criteria ] A new criteria.
-          #
-          # @since 2.0.0.beta.1
           def criteria
             @criteria ||= _association.criteria(_base)
           end
@@ -428,8 +390,6 @@ module Mongoid
           # @param [ Document ] document The document to cascade on.
           #
           # @return [ true, false ] If the association is destructive.
-          #
-          # @since 2.1.0
           def cascade!(document)
             if persistable?
               case _association.dependent
@@ -453,8 +413,6 @@ module Mongoid
           # @param [ Proc ] block Optional block to pass.
           #
           # @return [ Criteria, Object ] A Criteria or return value from the target.
-          #
-          # @since 2.0.0.beta.1
           ruby2_keywords def method_missing(name, *args, &block)
             if _target.respond_to?(name)
               _target.send(name, *args, &block)
@@ -474,8 +432,6 @@ module Mongoid
           #
           # @param [ Array<Document> ] docs The delayed inserts.
           # @param [ Array<Hash> ] inserts The raw insert document.
-          #
-          # @since 3.0.0
           def persist_delayed(docs, inserts)
             unless docs.empty?
               collection.insert_many(inserts, session: _session)
@@ -493,8 +449,6 @@ module Mongoid
           #   relation.persistable?
           #
           # @return [ true, false ] If the association is persistable.
-          #
-          # @since 2.1.0
           def persistable?
             !_binding? && (_creating? || _base.persisted? && !_building?)
           end
@@ -512,8 +466,6 @@ module Mongoid
           # @param [ Symbol ] method The deletion method to call.
           #
           # @return [ Integer ] The number of documents deleted.
-          #
-          # @since 2.1.0
           def remove_all(conditions = nil, method = :delete_all)
             selector = conditions || {}
             removed = klass.send(method, selector.merge!(criteria.selector))
@@ -532,8 +484,6 @@ module Mongoid
           #   proxy.remove_not_in([ id ])
           #
           # @param [ Array<Object> ] ids The ids.
-          #
-          # @since 2.4.0
           def remove_not_in(ids)
             removed = criteria.not_in(_id: ids)
             if _association.destructive?
@@ -562,8 +512,6 @@ module Mongoid
           #
           # @param [ Document ] doc The document.
           # @param [ Array<Document> ] inserts The inserts.
-          #
-          # @since 3.0.0
           def save_or_delay(doc, docs, inserts)
             if doc.new_record? && doc.valid?(:create)
               doc.run_before_callbacks(:save, :create)
@@ -587,8 +535,6 @@ module Mongoid
             #   Referenced::Many.embedded?
             #
             # @return [ false ] Always false.
-            #
-            # @since 2.0.0.rc.1
             def embedded?
               false
             end

--- a/lib/mongoid/association/referenced/has_one.rb
+++ b/lib/mongoid/association/referenced/has_one.rb
@@ -11,8 +11,6 @@ module Mongoid
     module Referenced
 
       # The has_one association.
-      #
-      # @since 7.0
       class HasOne
         include Relatable
         include Buildable
@@ -21,8 +19,6 @@ module Mongoid
         # common ones.
         #
         # @return [ Array<Symbol> ] The extra valid options.
-        #
-        # @since 7.0
         ASSOCIATION_OPTIONS = [
             :as,
             :autobuild,
@@ -36,22 +32,16 @@ module Mongoid
         # the shared ones.
         #
         # @return [ Array<Symbol> ] The valid options.
-        #
-        # @since 7.0
         VALID_OPTIONS = (ASSOCIATION_OPTIONS + SHARED_OPTIONS).freeze
 
         # The default foreign key suffix.
         #
         # @return [ String ] '_id'
-        #
-        # @since 7.0
         FOREIGN_KEY_SUFFIX = '_id'.freeze
 
         # The list of association complements.
         #
         # @return [ Array<Association> ] The association complements.
-        #
-        # @since 7.0
         def relation_complements
           @relation_complements ||= [ Referenced::BelongsTo ].freeze
         end
@@ -59,8 +49,6 @@ module Mongoid
         # Setup the instance methods, fields, etc. on the association owning class.
         #
         # @return [ self ]
-        #
-        # @since 7.0
         def setup!
           setup_instance_methods!
           self
@@ -70,8 +58,6 @@ module Mongoid
         #
         # @return [ String ] The foreign key field for saving the
         #   association reference.
-        #
-        # @since 7.0
         def foreign_key
           @foreign_key ||= @options[:foreign_key] ? @options[:foreign_key].to_s :
                              default_foreign_key_field
@@ -80,22 +66,16 @@ module Mongoid
         # Is this association type embedded?
         #
         # @return [ false ] Always false.
-        #
-        # @since 7.0
         def embedded?; false; end
 
         # The default for validation the association object.
         #
         # @return [ true ] Always true.
-        #
-        # @since 7.0
         def validation_default; true; end
 
         # Get the association proxy class for this association type.
         #
         # @return [ Association::HasOne::Proxy ] The proxy class.
-        #
-        # @since 7.0
         def relation
           Proxy
         end
@@ -106,8 +86,6 @@ module Mongoid
         # @param [ Hash ] options The options for the association.
         #
         # @return [ Association::Nested::Many ] The Nested Builder object.
-        #
-        # @since 7.0
         def nested_builder(attributes, options)
           Nested::One.new(self, attributes, options)
         end
@@ -115,8 +93,6 @@ module Mongoid
         # Is this association polymorphic?
         #
         # @return [ true, false ] Whether this association is polymorphic.
-        #
-        # @since 7.0
         def polymorphic?
           @polymorphic ||= !!as
         end
@@ -126,8 +102,6 @@ module Mongoid
         # @note Only relevant for polymorphic associations.
         #
         # @return [ String, nil ] The type field.
-        #
-        # @since 7.0
         def type
           @type ||= "#{as}_type" if polymorphic?
         end
@@ -152,8 +126,6 @@ module Mongoid
         # @param [ Document ] document The document to calculate on.
         #
         # @return [ Root ] The root atomic path calculator.
-        #
-        # @since 2.1.0
         def path(document)
           Mongoid::Atomic::Paths::Root.new(document)
         end
@@ -163,8 +135,6 @@ module Mongoid
         # Setup the instance methods on the class having this association type.
         #
         # @return [ self ]
-        #
-        # @since 7.0
         def setup_instance_methods!
           define_getter!
           define_setter!

--- a/lib/mongoid/association/referenced/has_one/binding.rb
+++ b/lib/mongoid/association/referenced/has_one/binding.rb
@@ -7,8 +7,6 @@ module Mongoid
       class HasOne
 
         # Binding class for has_one associations.
-        #
-        # @since 7.0
         class Binding
           include Bindable
 
@@ -21,8 +19,6 @@ module Mongoid
           # @example Bind the document.
           #   person.game.bind(:continue => true)
           #   person.game = Game.new
-          #
-          # @since 2.0.0.rc.1
           def bind_one
             binding do
               bind_from_relational_parent(_target)
@@ -35,8 +31,6 @@ module Mongoid
           # @example Unbind the document.
           #   person.game.unbind(:continue => true)
           #   person.game = nil
-          #
-          # @since 2.0.0.rc.1
           def unbind_one
             binding do
               unbind_from_relational_parent(_target)

--- a/lib/mongoid/association/referenced/has_one/buildable.rb
+++ b/lib/mongoid/association/referenced/has_one/buildable.rb
@@ -7,8 +7,6 @@ module Mongoid
       class HasOne
 
         # The Builder behavior for has_one associations.
-        #
-        # @since 7.0
         module Buildable
 
           # This method either takes an _id or an object and queries for the

--- a/lib/mongoid/association/referenced/has_one/nested_builder.rb
+++ b/lib/mongoid/association/referenced/has_one/nested_builder.rb
@@ -22,8 +22,6 @@ module Mongoid
           # @param [ Document ] parent The parent document.
           #
           # @return [ Document ] The built document.
-          #
-          # @since 2.0.0
           def build(parent)
             return if reject?(parent, attributes)
             @existing = parent.send(association.name)
@@ -46,8 +44,6 @@ module Mongoid
           # @param [ Association ] association The association metadata.
           # @param [ Hash ] attributes The attributes hash to attempt to set.
           # @param [ Hash ] options The options defined.
-          #
-          # @since 2.0.0
           def initialize(association, attributes, options)
             @attributes = attributes.with_indifferent_access
             @association = association
@@ -66,8 +62,6 @@ module Mongoid
           #   one.acceptable_id?
           #
           # @return [ true, false ] If the id part of the logic will allow an update.
-          #
-          # @since 2.0.0
           def acceptable_id?
             id = convert_id(existing.class, attributes[:_id])
             existing._id == id || id.nil? || (existing._id != id && update_only?)
@@ -79,8 +73,6 @@ module Mongoid
           #   one.delete?
           #
           # @return [ true, false ] If the association should be deleted.
-          #
-          # @since 2.0.0
           def delete?
             destroyable? && !attributes[:_id].nil?
           end
@@ -92,8 +84,6 @@ module Mongoid
           #
           # @return [ true, false ] If the association can potentially be
           #   destroyed.
-          #
-          # @since 2.0.0
           def destroyable?
             [ 1, "1", true, "true" ].include?(destroy) && allow_destroy?
           end
@@ -104,8 +94,6 @@ module Mongoid
           #   one.replace?
           #
           # @return [ true, false ] If the document should be replaced.
-          #
-          # @since 2.0.0
           def replace?
             !existing && !destroyable? && !attributes.blank?
           end
@@ -116,8 +104,6 @@ module Mongoid
           #   one.update?
           #
           # @return [ true, false ] If the object should have its attributes updated.
-          #
-          # @since 2.0.0
           def update?
             existing && !destroyable? && acceptable_id?
           end

--- a/lib/mongoid/association/referenced/has_one/proxy.rb
+++ b/lib/mongoid/association/referenced/has_one/proxy.rb
@@ -34,8 +34,6 @@ module Mongoid
           #
           # @example Nullify the association.
           #   person.game.nullify
-          #
-          # @since 2.0.0.rc.1
           def nullify
             unbind_one
             _target.save
@@ -51,8 +49,6 @@ module Mongoid
           # @param [ Array<Document> ] replacement The replacement target.
           #
           # @return [ One ] The association.
-          #
-          # @since 2.0.0.rc.1
           def substitute(replacement)
             # If the same object currently associated is being assigned,
             # rebind the association and save the target but do not destroy
@@ -88,8 +84,6 @@ module Mongoid
           #   relation.persistable?
           #
           # @return [ true, false ] If the association is persistable.
-          #
-          # @since 2.1.0
           def persistable?
             _base.persisted? && !_binding? && !_building?
           end
@@ -107,8 +101,6 @@ module Mongoid
             #   Referenced::One.embedded?
             #
             # @return [ false ] Always false.
-            #
-            # @since 2.0.0.rc.1
             def embedded?
               false
             end

--- a/lib/mongoid/association/referenced/syncable.rb
+++ b/lib/mongoid/association/referenced/syncable.rb
@@ -18,8 +18,6 @@ module Mongoid
         # @param [ Association ] association The association metadata.
         #
         # @return [ true, false ] If we can sync.
-        #
-        # @since 2.1.0
         def _syncable?(association)
           !_synced?(association.foreign_key) && send(association.foreign_key_check)
         end
@@ -30,8 +28,6 @@ module Mongoid
         #   document._synced
         #
         # @return [ Hash ] The synced foreign keys.
-        #
-        # @since 2.1.0
         def _synced
           @_synced ||= {}
         end
@@ -44,8 +40,6 @@ module Mongoid
         # @param [ String ] foreign_key The foreign key.
         #
         # @return [ true, false ] If we can sync.
-        #
-        # @since 2.1.0
         def _synced?(foreign_key)
           !!_synced[foreign_key]
         end
@@ -58,8 +52,6 @@ module Mongoid
         # @param [ Association ] association The association.
         #
         # @return [ Object ] The updated values.
-        #
-        # @since 2.2.1
         def remove_inverse_keys(association)
           foreign_keys = send(association.foreign_key)
           unless foreign_keys.nil? || foreign_keys.empty?
@@ -75,8 +67,6 @@ module Mongoid
         # @param [ Association ] association The document association.
         #
         # @return [ Object ] The updated values.
-        #
-        # @since 2.1.0
         def update_inverse_keys(association)
           if changes.has_key?(association.foreign_key)
             old, new = changes[association.foreign_key]
@@ -110,8 +100,6 @@ module Mongoid
           #   Person._synced(association)
           #
           # @param [ Association ] association The association metadata.
-          #
-          # @since 2.1.0
           def _synced(association)
             unless association.forced_nil_inverse?
               synced_save(association)
@@ -133,8 +121,6 @@ module Mongoid
           # @param [ Association ] association The association metadata.
           #
           # @return [ Class ] The class getting set up.
-          #
-          # @since 2.1.0
           def synced_save(association)
             set_callback(
                 :save,
@@ -154,8 +140,6 @@ module Mongoid
           # @param [ Association ] association The association metadata.
           #
           # @return [ Class ] The class getting set up.
-          #
-          # @since 2.2.1
           def synced_destroy(association)
             set_callback(
                 :destroy,

--- a/lib/mongoid/association/relatable.rb
+++ b/lib/mongoid/association/relatable.rb
@@ -8,8 +8,6 @@ module Mongoid
   module Association
 
     # This module provides behaviors shared between Association types.
-    #
-    # @since 7.0
     module Relatable
       include Constrainable
       include Options
@@ -17,8 +15,6 @@ module Mongoid
       # The options shared between all association types.
       #
       # @return [ Array<Symbol> ] The shared options.
-      #
-      # @since 7.0
       SHARED_OPTIONS = [
                          :class_name,
                          :inverse_of,
@@ -29,22 +25,16 @@ module Mongoid
       # The primary key default.
       #
       # @return [ String ] The primary key field default.
-      #
-      # @since 7.0
       PRIMARY_KEY_DEFAULT = '_id'.freeze
 
       # The name of the association.
       #
       # @return [ Symbol ] The name of the association.
-      #
-      # @since 7.0
       attr_reader :name
 
       # The options on this association.
       #
       # @return [ Hash ] The options.
-      #
-      # @since 7.0
       attr_reader :options
 
       # Initialize the Association.
@@ -53,8 +43,6 @@ module Mongoid
       # @param [ Symbol ] name The name of the association.
       # @param [ Hash ] opts The association options.
       # @param [ Block ] block The optional block.
-      #
-      # @since 7.0
       def initialize(_class, name, opts = {}, &block)
         @owner_class = _class
         @name = name
@@ -71,8 +59,6 @@ module Mongoid
       # Compare this association to another.
       #
       # @return [ Object ] The object to compare to this association.
-      #
-      # @since 7.0
       def ==(other)
         relation_class_name == other.relation_class_name &&
           inverse_class_name == other.inverse_class_name &&
@@ -86,8 +72,6 @@ module Mongoid
       #
       # @return [ Array<Proc, Symbol> ] A list of the callbacks, either method
       #   names or Procs.
-      #
-      # @since 7.0
       def get_callbacks(callback_type)
         Array(options[callback_type])
       end
@@ -96,8 +80,6 @@ module Mongoid
       # @note Only relevant for polymorphic associations that take the :as option.
       #
       # @return [ String ] The type setter method.
-      #
-      # @since 7.0
       def type_setter
         @type_setter ||= type.__setter__
       end
@@ -108,8 +90,6 @@ module Mongoid
       # @param [ Document ] doc The document to be bound.
       #
       # @return [ true, false ] Whether the document can be bound.
-      #
-      # @since 7.0
       def bindable?(doc); false; end
 
       # Get the inverse names.
@@ -118,8 +98,6 @@ module Mongoid
       #   determining inverses.
       #
       # @return [ Array<Symbol> ] The list of inverse names.
-      #
-      # @since 7.0
       def inverses(other = nil)
         return [ inverse_of ] if inverse_of
         if polymorphic?
@@ -135,8 +113,6 @@ module Mongoid
       #   determining inverses.
       #
       # @return [ Association ] The inverse's association metadata.
-      #
-      # @since 7.0
       def inverse_association(other = nil)
         (other || relation_class).relations[inverse(other)]
       end
@@ -144,8 +120,6 @@ module Mongoid
       # Get the inverse type.
       #
       # @return [ nil ] Default is nil for an association.
-      #
-      # @since 7.0
       def inverse_type; end
 
       # The class name, possibly unqualified or :: prefixed, of the association
@@ -169,8 +143,6 @@ module Mongoid
       #   the +relation_class+ method.
       #
       # @return [ String ] The association objects' class name.
-      #
-      # @since 7.0
       def relation_class_name
         @class_name ||= @options[:class_name] || ActiveSupport::Inflector.classify(name)
       end
@@ -190,8 +162,6 @@ module Mongoid
       # happen to be defined with the same name as the association name).
       #
       # @return [ String ] The association objects' class.
-      #
-      # @since 7.0
       def relation_class
         @klass ||= begin
           cls_name = @options[:class_name] || ActiveSupport::Inflector.classify(name)
@@ -203,8 +173,6 @@ module Mongoid
       # The class name of the object owning this association.
       #
       # @return [ String ] The owning objects' class name.
-      #
-      # @since 7.0
       def inverse_class_name
         @inverse_class_name ||= @owner_class.name
       end
@@ -212,8 +180,6 @@ module Mongoid
       # The class of the object owning this association.
       #
       # @return [ String ] The owning objects' class.
-      #
-      # @since 7.0
       def inverse_class
         @owner_class
       end
@@ -223,8 +189,6 @@ module Mongoid
       # Otherwise, the primary key.
       #
       # @return [ Symbol, String ] The primary key.
-      #
-      # @since 7.0
       def key
         stores_foreign_key? ? foreign_key : primary_key
       end
@@ -232,8 +196,6 @@ module Mongoid
       # The name of the setter on this object for assigning an associated object.
       #
       # @return [ String ] The setter name.
-      #
-      # @since 7.0
       def setter
         @setter ||= "#{name}="
       end
@@ -241,8 +203,6 @@ module Mongoid
       # The name of the inverse setter method.
       #
       # @return [ String ] The name of the inverse setter.
-      #
-      # @since 7.0
       def inverse_setter(other = nil)
         @inverse_setter ||= "#{inverses(other).first}=" unless inverses(other).blank?
       end
@@ -250,8 +210,6 @@ module Mongoid
       # The name of the foreign key setter method.
       #
       # @return [ String ] The name of the foreign key setter.
-      #
-      # @since 7.0
       def foreign_key_setter
         # note: You can't check if this association stores foreign key
         # See HasOne and HasMany binding, they referenced foreign_key_setter
@@ -261,8 +219,6 @@ module Mongoid
       # The atomic path for this association.
       #
       # @return [  Mongoid::Atomic::Paths::Root ] The atomic path object.
-      #
-      # @since 7.0
       def path(document)
         relation.path(document)
       end
@@ -274,8 +230,6 @@ module Mongoid
       #   association.inverse_type_setter
       #
       # @return [ String ] The name of the setter.
-      #
-      # @since 7.0
       def inverse_type_setter
         @inverse_type_setter ||= inverse_type.__setter__
       end
@@ -286,8 +240,6 @@ module Mongoid
       #   association.foreign_key_check
       #
       # @return [ String ] The foreign key check.
-      #
-      # @since 7.0
       def foreign_key_check
         @foreign_key_check ||= "#{foreign_key}_changed?" if (stores_foreign_key? && foreign_key)
       end
@@ -299,8 +251,6 @@ module Mongoid
       #   association.
       #
       # @return [ Proxy ]
-      #
-      # @since 7.0
       def create_relation(owner, target)
         relation.new(owner, target, self)
       end
@@ -308,8 +258,6 @@ module Mongoid
       # Whether the dependent method is destructive.
       #
       # @return [ true, false ] If the dependent method is destructive.
-      #
-      # @since 7.0
       def destructive?
         @destructive ||= !!(dependent && (dependent == :delete_all || dependent == :destroy))
       end
@@ -317,8 +265,6 @@ module Mongoid
       # Get the counter cache column name.
       #
       # @return [ String ] The counter cache column name.
-      #
-      # @since 7.0
       def counter_cache_column_name
         @counter_cache_column_name ||= (@options[:counter_cache].is_a?(String) ||
             @options[:counter_cache].is_a?(Symbol)) ?
@@ -328,8 +274,6 @@ module Mongoid
       # Get the extension.
       #
       # @return [ Module ] The extension module, if one has been defined.
-      #
-      # @since 7.0
       def extension
         @extension ||= @options[:extend]
       end
@@ -337,8 +281,6 @@ module Mongoid
       # Get the inverse name.
       #
       # @return [ Symbol ] The inverse name.
-      #
-      # @since 7.0
       def inverse(other = nil)
         candidates = inverses(other)
         candidates.detect { |c| c } if candidates
@@ -348,8 +290,6 @@ module Mongoid
       #
       # @return [ true, false ] If the associated object(s)
       #   should be validated.
-      #
-      # @since 7.0
       def validate?
         @validate ||= if @options[:validate].nil?
                         validation_default

--- a/lib/mongoid/atomic.rb
+++ b/lib/mongoid/atomic.rb
@@ -34,8 +34,6 @@ module Mongoid
     #   person.add_atomic_pull(address)
     #
     # @param [ Document ] document The embedded document to pull.
-    #
-    # @since 2.2.0
     def add_atomic_pull(document)
       document.flagged_for_destroy = true
       key = document.association_name.to_s
@@ -51,8 +49,6 @@ module Mongoid
     # @param [ Document ] document The child document.
     #
     # @return [ Array<Document> ] The children.
-    #
-    # @since 3.0.0
     def add_atomic_unset(document)
       document.flagged_for_destroy = true
       key = document.association_name.to_s
@@ -66,8 +62,6 @@ module Mongoid
     #   address.atomic_attribute_name(:city)
     #
     # @return [ String ] The path to the document attribute in the database
-    #
-    # @since 3.0.0
     def atomic_attribute_name(name)
       embedded? ? "#{atomic_position}.#{name}" : name
     end
@@ -78,8 +72,6 @@ module Mongoid
     #   person.atomic_array_pushes
     #
     # @return [ Hash ] The array pushes.
-    #
-    # @since 2.4.0
     def atomic_array_pushes
       @atomic_array_pushes ||= {}
     end
@@ -90,8 +82,6 @@ module Mongoid
     #   person.atomic_array_pulls
     #
     # @return [ Hash ] The array pulls.
-    #
-    # @since 2.4.0
     def atomic_array_pulls
       @atomic_array_pulls ||= {}
     end
@@ -102,8 +92,6 @@ module Mongoid
     #   person.atomic_array_add_to_sets
     #
     # @return [ Hash ] The array add_to_sets.
-    #
-    # @since 2.4.0
     def atomic_array_add_to_sets
       @atomic_array_add_to_sets ||= {}
     end
@@ -129,8 +117,6 @@ module Mongoid
     #   person.atomic_updates(children)
     #
     # @return [ Hash ] The updates and their modifiers.
-    #
-    # @since 2.1.0
     def atomic_updates(_use_indexes = false)
       process_flagged_destroys
       mods = Modifiers.new
@@ -192,8 +178,6 @@ module Mongoid
     #   document.atomic_paths
     #
     # @return [ Object ] The associated path.
-    #
-    # @since 2.1.0
     def atomic_paths
       @atomic_paths ||= begin
         if _association
@@ -210,8 +194,6 @@ module Mongoid
     #   person.atomic_pulls
     #
     # @return [ Array<Hash> ] The $pullAll operations.
-    #
-    # @since 2.2.0
     def atomic_pulls
       pulls = {}
       delayed_atomic_pulls.each_pair do |_, docs|
@@ -231,8 +213,6 @@ module Mongoid
     #   person.atomic_pushes
     #
     # @return [ Hash ] The $push and $each operations.
-    #
-    # @since 2.1.0
     def atomic_pushes
       pushable? ? { atomic_position => as_attributes } : {}
     end
@@ -243,8 +223,6 @@ module Mongoid
     #   person.atomic_sets
     #
     # @return [ Hash ] The $set operations.
-    #
-    # @since 2.1.0
     def atomic_sets
       updateable? ? setters : settable? ? { atomic_path => as_attributes } : {}
     end
@@ -255,8 +233,6 @@ module Mongoid
     #   person.atomic_unsets
     #
     # @return [ Array<Hash> ] The $unset operations.
-    #
-    # @since 2.2.0
     def atomic_unsets
       unsets = []
       delayed_atomic_unsets.each_pair do |name, docs|
@@ -275,8 +251,6 @@ module Mongoid
     #   person.delayed_atomic_sets
     #
     # @return [ Hash ] The delayed $sets.
-    #
-    # @since 2.3.0
     def delayed_atomic_sets
       @delayed_atomic_sets ||= {}
     end
@@ -287,8 +261,6 @@ module Mongoid
     #   document.delayed_atomic_pulls
     #
     # @return [ Hash ] name/document pairs.
-    #
-    # @since 2.3.2
     def delayed_atomic_pulls
       @delayed_atomic_pulls ||= {}
     end
@@ -299,8 +271,6 @@ module Mongoid
     #   document.delayed_atomic_unsets
     #
     # @return [ Hash ] The atomic unsets
-    #
-    # @since 3.0.0
     def delayed_atomic_unsets
       @delayed_atomic_unsets ||= {}
     end
@@ -311,8 +281,6 @@ module Mongoid
     #   document.flag_as_destroyed
     #
     # @return [ String ] The atomic path.
-    #
-    # @since 3.0.0
     def flag_as_destroyed
       self.destroyed = true
       self.flagged_for_destroy = false
@@ -325,8 +293,6 @@ module Mongoid
     #   document.flagged_destroys
     #
     # @return [ Array<Proc> ] The flagged destroys.
-    #
-    # @since 3.0.10
     def flagged_destroys
       @flagged_destroys ||= []
     end
@@ -337,8 +303,6 @@ module Mongoid
     #   document.process_flagged_destroys
     #
     # @return [ Array ] The cleared array.
-    #
-    # @since 3.0.10
     def process_flagged_destroys
       _assigning do
         flagged_destroys.each(&:call)
@@ -355,8 +319,6 @@ module Mongoid
     #
     # @param [ Modifiers ] mods The atomic modifications.
     # @param [ Document ] doc The document to update for.
-    #
-    # @since 2.2.0
     def generate_atomic_updates(mods, doc)
       mods.unset(doc.atomic_unsets)
       mods.pull(doc.atomic_pulls)
@@ -379,8 +341,6 @@ module Mongoid
     # @param [ Symbol ] field The optional field.
     #
     # @return [ Hash ] The atomic updates.
-    #
-    # @since 3.0.6
     def touch_atomic_updates(field = nil)
       updates = atomic_updates
       return {} unless atomic_updates.key?("$set")

--- a/lib/mongoid/atomic/modifiers.rb
+++ b/lib/mongoid/atomic/modifiers.rb
@@ -14,8 +14,6 @@ module Mongoid
       #   modifiers.add_to_set({ "preference_ids" => [ "one" ] })
       #
       # @param [ Hash ] modifications The add to set modifiers.
-      #
-      # @since 2.4.0
       def add_to_set(modifications)
         modifications.each_pair do |field, value|
           if add_to_sets.has_key?(field)
@@ -34,8 +32,6 @@ module Mongoid
       #   modifiers.pull_all({ "addresses" => { "street" => "Bond" }})
       #
       # @param [ Hash ] modifications The pull all modifiers.
-      #
-      # @since 3.0.0
       def pull_all(modifications)
         modifications.each_pair do |field, value|
           add_operation(pull_alls, field, value)
@@ -49,8 +45,6 @@ module Mongoid
       #   modifiers.pull({ "addresses" => { "_id" => { "$in" => [ 1, 2, 3 ]}}})
       #
       # @param [ Hash ] modifications The pull all modifiers.
-      #
-      # @since 3.0.0
       def pull(modifications)
         modifications.each_pair do |field, value|
           pulls[field] = value
@@ -64,8 +58,6 @@ module Mongoid
       #   modifiers.push({ "addresses" => { "street" => "Bond" }})
       #
       # @param [ Hash ] modifications The push modifiers.
-      #
-      # @since 2.1.0
       def push(modifications)
         modifications.each_pair do |field, value|
           push_fields[field] = field
@@ -80,8 +72,6 @@ module Mongoid
       #   modifiers.set({ "title" => "sir" })
       #
       # @param [ Hash ] modifications The set modifiers.
-      #
-      # @since 2.1.0
       def set(modifications)
         modifications.each_pair do |field, value|
           next if field == "_id"
@@ -97,8 +87,6 @@ module Mongoid
       #   modifiers.unset([ "addresses" ])
       #
       # @param [ Array<String> ] modifications The unset association names.
-      #
-      # @since 2.2.0
       def unset(modifications)
         modifications.each do |field|
           unsets.update(field => true)
@@ -116,8 +104,6 @@ module Mongoid
       # @param [ Hash ] mods The modifications.
       # @param [ String ] field The field.
       # @param [ Hash ] value The atomic op.
-      #
-      # @since 2.2.0
       def add_operation(mods, field, value)
         if mods.has_key?(field)
           if mods[field].is_a?(Array)
@@ -141,8 +127,6 @@ module Mongoid
       # @param [ Hash ] mods The modifications.
       # @param [ String ] field The field.
       # @param [ Hash ] value The atomic op.
-      #
-      # @since 7.0.0
       def add_each_operation(mods, field, value)
         if mods.has_key?(field)
           value.each do |val|
@@ -159,8 +143,6 @@ module Mongoid
       #   modifiers.add_to_sets
       #
       # @return [ Hash ] The $addToSet operations.
-      #
-      # @since 2.4.0
       def add_to_sets
         self["$addToSet"] ||= {}
       end
@@ -173,8 +155,6 @@ module Mongoid
       # @param [ String ] field The field.
       #
       # @return [ true, false ] If this field is a conflict.
-      #
-      # @since 2.2.0
       def set_conflict?(field)
         name = field.split(".", 2)[0]
         pull_fields.has_key?(name) || push_fields.has_key?(name)
@@ -188,8 +168,6 @@ module Mongoid
       # @param [ String ] field The field.
       #
       # @return [ true, false ] If this field is a conflict.
-      #
-      # @since 2.2.0
       def push_conflict?(field)
         name = field.split(".", 2)[0]
         set_fields.has_key?(name) || pull_fields.has_key?(name) ||
@@ -202,8 +180,6 @@ module Mongoid
       #   modifiers.conflicting_pulls
       #
       # @return [ Hash ] The conflicting pull operations.
-      #
-      # @since 2.2.0
       def conflicting_pulls
         conflicts["$pullAll"] ||= {}
       end
@@ -214,8 +190,6 @@ module Mongoid
       #   modifiers.conflicting_pushs
       #
       # @return [ Hash ] The conflicting push operations.
-      #
-      # @since 2.2.0
       def conflicting_pushes
         conflicts["$push"] ||= {}
       end
@@ -226,8 +200,6 @@ module Mongoid
       #   modifiers.conflicting_sets
       #
       # @return [ Hash ] The conflicting set operations.
-      #
-      # @since 2.2.0
       def conflicting_sets
         conflicts["$set"] ||= {}
       end
@@ -238,8 +210,6 @@ module Mongoid
       #   modifiers.conflicts
       #
       # @return [ Hash ] The conflicting modifications.
-      #
-      # @since 2.1.0
       def conflicts
         self[:conflicts] ||= {}
       end
@@ -250,8 +220,6 @@ module Mongoid
       #   modifiers.pull_fields
       #
       # @return [ Array<String> ] The pull fields.
-      #
-      # @since 2.2.0
       def pull_fields
         @pull_fields ||= {}
       end
@@ -262,8 +230,6 @@ module Mongoid
       #   modifiers.push_fields
       #
       # @return [ Array<String> ] The push fields.
-      #
-      # @since 2.2.0
       def push_fields
         @push_fields ||= {}
       end
@@ -274,8 +240,6 @@ module Mongoid
       #   modifiers.set_fields
       #
       # @return [ Array<String> ] The set fields.
-      #
-      # @since 2.2.0
       def set_fields
         @set_fields ||= {}
       end
@@ -286,8 +250,6 @@ module Mongoid
       #   modifiers.pull_alls
       #
       # @return [ Hash ] The $pullAll operations.
-      #
-      # @since 3.0.0
       def pull_alls
         self["$pullAll"] ||= {}
       end
@@ -298,8 +260,6 @@ module Mongoid
       #   modifiers.pulls
       #
       # @return [ Hash ] The $pull operations.
-      #
-      # @since 3.0.0
       def pulls
         self["$pull"] ||= {}
       end
@@ -310,8 +270,6 @@ module Mongoid
       #   modifiers.pushes
       #
       # @return [ Hash ] The $push/$each operations.
-      #
-      # @since 2.1.0
       def pushes
         self["$push"] ||= {}
       end
@@ -322,8 +280,6 @@ module Mongoid
       #   modifiers.sets
       #
       # @return [ Hash ] The $set operations.
-      #
-      # @since 2.1.0
       def sets
         self["$set"] ||= {}
       end
@@ -334,8 +290,6 @@ module Mongoid
       #   modifiers.unsets
       #
       # @return [ Hash ] The $unset operations.
-      #
-      # @since 2.2.0
       def unsets
         self["$unset"] ||= {}
       end

--- a/lib/mongoid/atomic/paths/embedded.rb
+++ b/lib/mongoid/atomic/paths/embedded.rb
@@ -19,8 +19,6 @@ module Mongoid
         #   many.path
         #
         # @return [ String ] The path to the document.
-        #
-        # @since 2.1.0
         def path
           @path ||= position.sub(/\.\d+\z/, "")
         end

--- a/lib/mongoid/atomic/paths/embedded/many.rb
+++ b/lib/mongoid/atomic/paths/embedded/many.rb
@@ -17,8 +17,6 @@ module Mongoid
           #   Many.new(document)
           #
           # @param [ Document ] document The document to generate the paths for.
-          #
-          # @since 2.1.0
           def initialize(document)
             @document, @parent = document, document._parent
             @insert_modifier, @delete_modifier ="$push", "$pull"
@@ -32,8 +30,6 @@ module Mongoid
           #   many.position
           #
           # @return [ String ] The position of the document.
-          #
-          # @since 2.1.0
           def position
             pos = parent.atomic_position
             locator = document.new_record? ? "" : ".#{document._index}"

--- a/lib/mongoid/atomic/paths/embedded/one.rb
+++ b/lib/mongoid/atomic/paths/embedded/one.rb
@@ -17,8 +17,6 @@ module Mongoid
           #   One.new(document)
           #
           # @param [ Document ] document The document to generate the paths for.
-          #
-          # @since 2.1.0
           def initialize(document)
             @document, @parent = document, document._parent
             @insert_modifier, @delete_modifier ="$set", "$unset"
@@ -32,8 +30,6 @@ module Mongoid
           #   one.position
           #
           # @return [ String ] The position of the document.
-          #
-          # @since 2.1.0
           def position
             pos = parent.atomic_position
             "#{pos}#{"." unless pos.blank?}#{document._association.store_as}"

--- a/lib/mongoid/atomic/paths/root.rb
+++ b/lib/mongoid/atomic/paths/root.rb
@@ -17,8 +17,6 @@ module Mongoid
         #   Root.new(document)
         #
         # @param [ Document ] document The document to generate the paths for.
-        #
-        # @since 2.1.0
         def initialize(document)
           @document, @path, @position = document, "", ""
         end
@@ -30,8 +28,6 @@ module Mongoid
         #   root.insert_modifier
         #
         # @raise [ Errors::InvalidPath ] The error for the attempt.
-        #
-        # @since 3.0.14
         def insert_modifier
           raise Errors::InvalidPath.new(document.class)
         end

--- a/lib/mongoid/attributes.rb
+++ b/lib/mongoid/attributes.rb
@@ -29,8 +29,6 @@ module Mongoid
     # @param [ String, Symbol ] name The name of the attribute.
     #
     # @return [ true, false ] True if present, false if not.
-    #
-    # @since 1.0.0
     def attribute_present?(name)
       attribute = read_raw_attribute(name)
       !attribute.blank? || attribute == false
@@ -44,8 +42,6 @@ module Mongoid
     #   document.attributes_before_type_cast
     #
     # @return [ Hash ] The uncast attributes.
-    #
-    # @since 3.1.0
     def attributes_before_type_cast
       @attributes_before_type_cast ||= {}
     end
@@ -58,8 +54,6 @@ module Mongoid
     # @param [ String, Symbol ] name The name of the attribute.
     #
     # @return [ true, false ] If the key is present in the attributes.
-    #
-    # @since 3.0.0
     def has_attribute?(name)
       attributes.key?(name.to_s)
     end
@@ -74,8 +68,6 @@ module Mongoid
     #
     # @return [ true, false ] If the key is present in the
     #   attributes_before_type_cast.
-    #
-    # @since 3.1.0
     def has_attribute_before_type_cast?(name)
       attributes_before_type_cast.key?(name.to_s)
     end
@@ -92,8 +84,6 @@ module Mongoid
     # @param [ String, Symbol ] name The name of the attribute to get.
     #
     # @return [ Object ] The value of the attribute.
-    #
-    # @since 1.0.0
     def read_attribute(name)
       field = fields[name.to_s]
       raw = read_raw_attribute(name)
@@ -112,8 +102,6 @@ module Mongoid
     #
     # @return [ Object ] The value of the attribute before type cast, if
     #   available. Otherwise, the value of the attribute.
-    #
-    # @since 3.1.0
     def read_attribute_before_type_cast(name)
       attr = name.to_s
       if attributes_before_type_cast.key?(attr)
@@ -133,8 +121,6 @@ module Mongoid
     #
     # @raise [ Errors::ReadonlyAttribute ] If the field cannot be removed due
     #   to being flagged as reaodnly.
-    #
-    # @since 1.0.0
     def remove_attribute(name)
       as_writable_attribute!(name) do |access|
         _assigning do
@@ -157,8 +143,6 @@ module Mongoid
     #
     # @param [ String, Symbol ] name The name of the attribute to update.
     # @param [ Object ] value The value to set for the attribute.
-    #
-    # @since 1.0.0
     def write_attribute(name, value)
       field_name = database_field_name(name)
 
@@ -201,8 +185,6 @@ module Mongoid
     #   person.assign_attributes({ :title => "Mr." }, :as => :admin)
     #
     # @param [ Hash ] attrs The new attributes to set.
-    #
-    # @since 2.2.1
     def assign_attributes(attrs = nil)
       _assigning do
         process_attributes(attrs)
@@ -220,8 +202,6 @@ module Mongoid
     #   person.attributes = { :title => "Mr." }
     #
     # @param [ Hash ] attrs The new attributes to set.
-    #
-    # @since 1.0.0
     def write_attributes(attrs = nil)
       assign_attributes(attrs)
     end
@@ -236,8 +216,6 @@ module Mongoid
     # @param [ String ] name The name of the attribute.
     #
     # @return [ true, false ] If the attribute is missing.
-    #
-    # @since 4.0.0
     def attribute_missing?(name)
       !Projector.new(__selected_fields).attribute_or_path_allowed?(name)
     end
@@ -248,8 +226,6 @@ module Mongoid
     #   document.typed_attributes
     #
     # @return [ Object ] The hash with keys and values of the type-casted attributes.
-    #
-    # @since 6.1.0
     def typed_attributes
       attribute_names.map { |name| [name, send(name)] }.to_h
     end
@@ -264,8 +240,6 @@ module Mongoid
     #   model.hash_dot_syntax?
     #
     # @return [ true, false ] If the string contains a "."
-    #
-    # @since 3.0.15
     def hash_dot_syntax?(string)
       string.include?(".")
     end
@@ -279,8 +253,6 @@ module Mongoid
     # @param [ Object ] value The uncast value.
     #
     # @return [ Object ] The cast value.
-    #
-    # @since 1.0.0
     def typed_value_for(key, value)
       fields.key?(key) ? fields[key].mongoize(value) : value.mongoize
     end
@@ -316,8 +288,6 @@ module Mongoid
       #
       # @param [ Symbol ] name The new name.
       # @param [ Symbol ] original The original name.
-      #
-      # @since 2.3.0
       def alias_attribute(name, original)
         aliased_fields[name.to_s] = original.to_s
 
@@ -368,8 +338,6 @@ module Mongoid
     #
     # @param [ String, Symbol ] field_name The name of the field.
     # @param [ Object ] value The value to be validated.
-    #
-    # @since 3.0.10
     def validate_attribute_value(field_name, value)
       return if value.nil?
       field = fields[field_name]

--- a/lib/mongoid/attributes/dynamic.rb
+++ b/lib/mongoid/attributes/dynamic.rb
@@ -5,8 +5,6 @@ module Mongoid
   module Attributes
 
     # This module contains the behavior for dynamic attributes.
-    #
-    # @since 4.0.0
     module Dynamic
       extend ActiveSupport::Concern
 
@@ -19,8 +17,6 @@ module Mongoid
       # @param [ true, false ] include_private
       #
       # @return [ true, false ] True if it does, false if not.
-      #
-      # @since 4.0.0
       def respond_to?(name, include_private = false)
         super || (
           attributes &&
@@ -36,8 +32,6 @@ module Mongoid
       #   model.define_dynamic_reader(:field)
       #
       # @param [ String ] name The name of the field.
-      #
-      # @since 4.0.0
       def define_dynamic_reader(name)
         return unless name.valid_method_name?
 
@@ -57,8 +51,6 @@ module Mongoid
       #   model.define_dynamic_before_type_cast_reader(:field)
       #
       # @param [ String ] name The name of the field.
-      #
-      # @since 4.0.0
       def define_dynamic_before_type_cast_reader(name)
         class_eval do
           define_method("#{name}_before_type_cast") do
@@ -76,8 +68,6 @@ module Mongoid
       #   model.define_dynamic_writer(:field)
       #
       # @param [ String ] name The name of the field.
-      #
-      # @since 4.0.0
       def define_dynamic_writer(name)
         return unless name.valid_method_name?
 
@@ -96,8 +86,6 @@ module Mongoid
       #
       # @param [ Symbol ] name The name of the field.
       # @param [ Object ] value The value of the field.
-      #
-      # @since 4.0.0
       def process_attribute(name, value)
         responds = respond_to?("#{name}=")
         if !responds
@@ -113,8 +101,6 @@ module Mongoid
       #   document.inspect_dynamic_fields
       #
       # @return [ String ] An array of pretty printed dynamic field values.
-      #
-      # @since 4.0.0
       def inspect_dynamic_fields
         keys = attributes.keys - fields.keys - relations.keys - ["_id", self.class.discriminator_key]
         return keys.map do |name|
@@ -133,8 +119,6 @@ module Mongoid
       # @param [ Array ] args The arguments to the method.
       #
       # @return [ Object ] The result of the method call.
-      #
-      # @since 4.0.0
       def method_missing(name, *args)
         attr = name.to_s
         return super unless attributes.has_key?(attr.reader)

--- a/lib/mongoid/attributes/nested.rb
+++ b/lib/mongoid/attributes/nested.rb
@@ -5,8 +5,6 @@ module Mongoid
   module Attributes
 
     # Defines behavior around that lovel Rails feature nested attributes.
-    #
-    # @since 1.0.0
     module Nested
       extend ActiveSupport::Concern
 
@@ -80,8 +78,6 @@ module Mongoid
         #   Person.autosave_nested_attributes(metadata)
         #
         # @param [ Association ] association The existing association metadata.
-        #
-        # @since 3.1.4
         def autosave_nested_attributes(association)
           # In order for the autosave functionality to work properly, the association needs to be
           # marked as autosave despite the fact that the option isn't present. Because the method

--- a/lib/mongoid/attributes/processing.rb
+++ b/lib/mongoid/attributes/processing.rb
@@ -16,8 +16,6 @@ module Mongoid
       #   person.process_attributes(:title => "sir", :age => 40)
       #
       # @param [ Hash ] attrs The attributes to set.
-      #
-      # @since 2.0.0.rc.7
       def process_attributes(attrs = nil)
         attrs ||= {}
         if !attrs.empty?
@@ -44,8 +42,6 @@ module Mongoid
       # @param [ Object ] value The value of the attribute.
       #
       # @return [ true, false ] True if pending, false if not.
-      #
-      # @since 2.0.0.rc.7
       def pending_attribute?(key, value)
         name = key.to_s
         if relations.has_key?(name)
@@ -65,8 +61,6 @@ module Mongoid
       #   document.pending_relations
       #
       # @return [ Hash ] The pending associations in key/value pairs.
-      #
-      # @since 2.0.0.rc.7
       def pending_relations
         @pending_relations ||= {}
       end
@@ -77,8 +71,6 @@ module Mongoid
       #   document.pending_nested
       #
       # @return [ Hash ] The pending nested attributes in key/value pairs.
-      #
-      # @since 2.0.0.rc.7
       def pending_nested
         @pending_nested ||= {}
       end
@@ -91,8 +83,6 @@ module Mongoid
       #
       # @param [ Symbol ] name The name of the field.
       # @param [ Object ] value The value of the field.
-      #
-      # @since 2.0.0.rc.7
       def process_attribute(name, value)
         if !respond_to?("#{name}=", true) && store_as = aliased_fields.invert[name.to_s]
           name = store_as
@@ -107,8 +97,6 @@ module Mongoid
       #
       # @example Process the nested attributes.
       #   document.process_nested
-      #
-      # @since 2.0.0.rc.7
       def process_nested
         pending_nested.each_pair do |name, value|
           send("#{name}=", value)
@@ -119,8 +107,6 @@ module Mongoid
       #
       # @example Process the pending items.
       #   document.process_pending
-      #
-      # @since 2.0.0.rc.7
       def process_pending
         process_nested and process_relations
         pending_nested.clear and pending_relations.clear
@@ -131,8 +117,6 @@ module Mongoid
       #
       # @example Process the associations.
       #   document.process_relations
-      #
-      # @since 2.0.0.rc.7
       def process_relations
         pending_relations.each_pair do |name, value|
           association = relations[name]

--- a/lib/mongoid/attributes/readonly.rb
+++ b/lib/mongoid/attributes/readonly.rb
@@ -22,8 +22,6 @@ module Mongoid
       #
       # @return [ true, false ] If the document is new, or if the field is not
       #   readonly.
-      #
-      # @since 3.0.0
       def attribute_writable?(name)
         new_record? || (!readonly_attributes.include?(name) && _loaded?(name))
       end
@@ -65,8 +63,6 @@ module Mongoid
         #   end
         #
         # @param [ Array<Symbol> ] names The names of the fields.
-        #
-        # @since 3.0.0
         def attr_readonly(*names)
           names.each do |name|
             readonly_attributes << database_field_name(name)

--- a/lib/mongoid/cacheable.rb
+++ b/lib/mongoid/cacheable.rb
@@ -4,8 +4,6 @@
 module Mongoid
 
   # Encapsulates behavior around caching.
-  #
-  # @since 6.0.0
   module Cacheable
     extend ActiveSupport::Concern
 
@@ -27,8 +25,6 @@ module Mongoid
     #   document.cache_key
     #
     # @return [ String ] the string with or without updated_at
-    #
-    # @since 2.4.0
     def cache_key
       return "#{model_key}/new" if new_record?
       return "#{model_key}/#{_id}-#{updated_at.utc.to_s(cache_timestamp_format)}" if do_or_do_not(:updated_at)

--- a/lib/mongoid/changeable.rb
+++ b/lib/mongoid/changeable.rb
@@ -4,8 +4,6 @@
 module Mongoid
 
   # Defines behavior for dirty tracking.
-  #
-  # @since 4.0.0
   module Changeable
     extend ActiveSupport::Concern
 
@@ -15,8 +13,6 @@ module Mongoid
     #   model.changed
     #
     # @return [ Array<String> ] The changed attributes.
-    #
-    # @since 2.4.0
     def changed
       changed_attributes.keys.select { |attr| attribute_change(attr) }
     end
@@ -27,8 +23,6 @@ module Mongoid
     #   model.changed?
     #
     # @return [ true, false ] If the document is changed.
-    #
-    # @since 2.4.0
     def changed?
       changes.values.any? { |val| val } || children_changed?
     end
@@ -39,8 +33,6 @@ module Mongoid
     #   model.children_changed?
     #
     # @return [ true, false ] If any children have changed.
-    #
-    # @since 2.4.1
     def children_changed?
       _children.any?(&:changed?)
     end
@@ -51,8 +43,6 @@ module Mongoid
     #   model.changed_attributes
     #
     # @return [ Hash<String, Object> ] The attribute changes.
-    #
-    # @since 2.4.0
     def changed_attributes
       @changed_attributes ||= {}
     end
@@ -63,8 +53,6 @@ module Mongoid
     #   model.changes
     #
     # @return [ Hash<String, Array<Object, Object> ] The changes.
-    #
-    # @since 2.4.0
     def changes
       _changes = {}
       changed.each do |attr|
@@ -81,8 +69,6 @@ module Mongoid
     #
     # @example Move the changes to previous.
     #   person.move_changes
-    #
-    # @since 2.1.0
     def move_changes
       @previous_changes = changes
       Atomic::UPDATES.each do |update|
@@ -95,8 +81,6 @@ module Mongoid
     #
     # @example Handle post persistence.
     #   document.post_persist
-    #
-    # @since 3.0.0
     def post_persist
       reset_persisted_children
       move_changes
@@ -108,8 +92,6 @@ module Mongoid
     #   model.previous_changes
     #
     # @return [ Hash<String, Array<Object, Object> ] The previous changes.
-    #
-    # @since 2.4.0
     def previous_changes
       @previous_changes ||= {}
     end
@@ -121,8 +103,6 @@ module Mongoid
     #   model.remove_change(:field)
     #
     # @param [ Symbol, String ] name The name of the field.
-    #
-    # @since 2.1.0
     def remove_change(name)
       changed_attributes.delete(name.to_s)
     end
@@ -136,8 +116,6 @@ module Mongoid
     #   person.setters # returns { "title" => "Madam" }
     #
     # @return [ Hash ] A +Hash+ of atomic setters.
-    #
-    # @since 2.0.0
     def setters
       mods = {}
       changes.each_pair do |name, changes|
@@ -165,8 +143,6 @@ module Mongoid
     # @param [ String ] attr The name of the attribute.
     #
     # @return [ Array<Object> ] The old and new values.
-    #
-    # @since 2.1.0
     def attribute_change(attr)
       attr = database_field_name(attr)
       [changed_attributes[attr], attributes[attr]] if attribute_changed?(attr)
@@ -180,8 +156,6 @@ module Mongoid
     # @param [ String ] attr The name of the attribute.
     #
     # @return [ true, false ] Whether the attribute has changed.
-    #
-    # @since 2.1.6
     def attribute_changed?(attr)
       attr = database_field_name(attr)
       return false unless changed_attributes.key?(attr)
@@ -196,8 +170,6 @@ module Mongoid
     # @param [ String ] attr The name of the attribute.
     #
     # @return [ true, false ] If the attribute differs.
-    #
-    # @since 3.0.0
     def attribute_changed_from_default?(attr)
       field = fields[attr]
       return false unless field
@@ -210,8 +182,6 @@ module Mongoid
     #   model.attribute_was("name")
     #
     # @param [ String ] attr The attribute name.
-    #
-    # @since 2.4.0
     def attribute_was(attr)
       attr = database_field_name(attr)
       attribute_changed?(attr) ? changed_attributes[attr] : attributes[attr]
@@ -225,8 +195,6 @@ module Mongoid
     # @param [ String ] attr The name of the attribute.
     #
     # @return [ Object ] The old value.
-    #
-    # @since 2.3.0
     def attribute_will_change!(attr)
       unless changed_attributes.key?(attr)
         changed_attributes[attr] = read_raw_attribute(attr).__deep_copy__
@@ -241,8 +209,6 @@ module Mongoid
     # @param [ String ] attr The name of the attribute.
     #
     # @return [ Object ] The old value.
-    #
-    # @since 2.4.0
     def reset_attribute!(attr)
       attr = database_field_name(attr)
       attributes[attr] = changed_attributes.delete(attr) if attribute_changed?(attr)
@@ -270,8 +236,6 @@ module Mongoid
       # @param [ String ] meth The name of the accessor.
       #
       # @return [ Module ] The fields module.
-      #
-      # @since 2.4.0
       def create_dirty_methods(name, meth)
         create_dirty_change_accessor(name, meth)
         create_dirty_change_check(name, meth)
@@ -291,8 +255,6 @@ module Mongoid
       #
       # @param [ String ] name The attribute name.
       # @param [ String ] meth The name of the accessor.
-      #
-      # @since 3.0.0
       def create_dirty_change_accessor(name, meth)
         generated_methods.module_eval do
           re_define_method("#{meth}_change") do
@@ -308,8 +270,6 @@ module Mongoid
       #
       # @param [ String ] name The attribute name.
       # @param [ String ] meth The name of the accessor.
-      #
-      # @since 3.0.0
       def create_dirty_change_check(name, meth)
         generated_methods.module_eval do
           re_define_method("#{meth}_changed?") do
@@ -325,8 +285,6 @@ module Mongoid
       #
       # @param [ String ] name The attribute name.
       # @param [ String ] meth The name of the accessor.
-      #
-      # @since 3.0.0
       def create_dirty_default_change_check(name, meth)
         generated_methods.module_eval do
           re_define_method("#{meth}_changed_from_default?") do
@@ -342,8 +300,6 @@ module Mongoid
       #
       # @param [ String ] name The attribute name.
       # @param [ String ] meth The name of the accessor.
-      #
-      # @since 3.0.0
       def create_dirty_previous_value_accessor(name, meth)
         generated_methods.module_eval do
           re_define_method("#{meth}_was") do
@@ -359,8 +315,6 @@ module Mongoid
       #
       # @param [ String ] name The attribute name.
       # @param [ String ] meth The name of the accessor.
-      #
-      # @since 3.0.0
       def create_dirty_change_flag(name, meth)
         generated_methods.module_eval do
           re_define_method("#{meth}_will_change!") do
@@ -376,8 +330,6 @@ module Mongoid
       #
       # @param [ String ] name The attribute name.
       # @param [ String ] meth The name of the accessor.
-      #
-      # @since 3.0.0
       def create_dirty_reset(name, meth)
         generated_methods.module_eval do
           re_define_method("reset_#{meth}!") do
@@ -393,8 +345,6 @@ module Mongoid
       #
       # @param [ String ] name The attribute name.
       # @param [ String ] meth The name of the accessor.
-      #
-      # @since 3.0.0
       def create_dirty_reset_to_default(name, meth)
         generated_methods.module_eval do
           re_define_method("reset_#{meth}_to_default!") do
@@ -410,8 +360,6 @@ module Mongoid
       #
       # @param [ String ] name The attribute name.
       # @param [ String ] meth The name of the accessor.
-      #
-      # @since 6.0.0
       def create_dirty_previously_changed?(name, meth)
         generated_methods.module_eval do
           re_define_method("#{meth}_previously_changed?") do
@@ -427,8 +375,6 @@ module Mongoid
       #
       # @param [ String ] name The attribute name.
       # @param [ String ] meth The name of the accessor.
-      #
-      # @since 6.0.0
       def create_dirty_previous_change(name, meth)
         generated_methods.module_eval do
           re_define_method("#{meth}_previous_change") do

--- a/lib/mongoid/clients.rb
+++ b/lib/mongoid/clients.rb
@@ -22,8 +22,6 @@ module Mongoid
       #   Mongoid::Clients.clear
       #
       # @return [ Array ] The empty clients.
-      #
-      # @since 3.0.0
       def clear
         clients.clear
       end
@@ -34,8 +32,6 @@ module Mongoid
       #   Mongoid::Clients.default
       #
       # @return [ Mongo::Client ] The default client.
-      #
-      # @since 3.0.0
       def default
         with_name(:default)
       end
@@ -46,8 +42,6 @@ module Mongoid
       #   Mongoid::Clients.disconnect
       #
       # @return [ true ] True.
-      #
-      # @since 3.1.0
       def disconnect
         clients.values.each do |client|
           client.close
@@ -62,8 +56,6 @@ module Mongoid
       # @param [ String | Symbol ] name The name of the client.
       #
       # @return [ Mongo::Client ] The named client.
-      #
-      # @since 3.0.0
       def with_name(name)
         name_as_symbol = name.to_sym
         return clients[name_as_symbol] if clients[name_as_symbol]

--- a/lib/mongoid/clients/factory.rb
+++ b/lib/mongoid/clients/factory.rb
@@ -20,8 +20,6 @@ module Mongoid
       # @raise [ Errors::NoClientConfig ] If no config could be found.
       #
       # @return [ Mongo::Client ] The new client.
-      #
-      # @since 3.0.0
       def create(name = nil)
         return default unless name
         config = Mongoid.clients[name]
@@ -38,8 +36,6 @@ module Mongoid
       #   found.
       #
       # @return [ Mongo::Client ] The default client.
-      #
-      # @since 3.0.0
       def default
         create_client(Mongoid.clients[:default])
       end
@@ -56,8 +52,6 @@ module Mongoid
       # @param [ Hash ] configuration The client config.
       #
       # @return [ Mongo::Client ] The client.
-      #
-      # @since 3.0.0
       def create_client(configuration)
         raise Errors::NoClientsConfig.new unless configuration
         config = configuration.dup

--- a/lib/mongoid/clients/options.rb
+++ b/lib/mongoid/clients/options.rb
@@ -19,8 +19,6 @@ module Mongoid
       # @option options [ String | Symbol ] :collection The collection name.
       # @option options [ String | Symbol ] :database The database name.
       # @option options [ String | Symbol ] :client The client name.
-      #
-      # @since 6.0.0
       def with(options_or_context, &block)
         original_context = PersistenceContext.get(self)
         original_cluster = persistence_context.cluster
@@ -92,8 +90,6 @@ module Mongoid
         # @option options [ String | Symbol ] :collection The collection name.
         # @option options [ String | Symbol ] :database The database name.
         # @option options [ String | Symbol ] :client The client name.
-        #
-        # @since 6.0.0
         def with(options, &block)
           original_context = PersistenceContext.get(self)
           original_cluster = persistence_context.cluster

--- a/lib/mongoid/clients/sessions.rb
+++ b/lib/mongoid/clients/sessions.rb
@@ -7,8 +7,6 @@ module Mongoid
     # Encapsulates behavior for getting a session from the client of a model class or instance,
     # setting the session on the current thread, and yielding to a block.
     # The session will be closed after the block completes or raises an error.
-    #
-    # @since 6.4.0
     module Sessions
 
       # Execute a block within the context of a session.
@@ -38,8 +36,6 @@ module Mongoid
       # @return [ Object ] The result of calling the block.
       #
       # @yieldparam [ Mongo::Session ] The session being used for the block.
-      #
-      # @since 6.4.0
       def with_session(options = {})
         if Threaded.get_session
           raise Mongoid::Errors::InvalidSessionUse.new(:invalid_session_nesting)
@@ -97,8 +93,6 @@ module Mongoid
         # @return [ Object ] The result of calling the block.
         #
         # @yieldparam [ Mongo::Session ] The session being used for the block.
-        #
-        # @since 6.4.0
         def with_session(options = {})
           if Threaded.get_session
             raise Mongoid::Errors::InvalidSessionUse.new(:invalid_session_nesting)

--- a/lib/mongoid/clients/storage_options.rb
+++ b/lib/mongoid/clients/storage_options.rb
@@ -48,8 +48,6 @@ module Mongoid
         # @option options [ String | Symbol ] :client The client name.
         #
         # @return [ Class ] The model class.
-        #
-        # @since 3.0.0
         def store_in(options)
           Validators::Storage.validate(self, options)
           storage_options.merge!(options)
@@ -59,8 +57,6 @@ module Mongoid
         #
         # @example Reset the store_in options
         #   Model.reset_storage_options!
-        #
-        # @since 4.0.0
         def reset_storage_options!
           self.storage_options = storage_options_defaults.dup
           PersistenceContext.clear(self)
@@ -72,8 +68,6 @@ module Mongoid
         #   Model.storage_options_defaults
         #
         # @return [ Hash ] Default storage options.
-        #
-        # @since 4.0.0
         def storage_options_defaults
           {
             collection: name.collectionize.to_sym,

--- a/lib/mongoid/clients/validators/storage.rb
+++ b/lib/mongoid/clients/validators/storage.rb
@@ -10,8 +10,6 @@ module Mongoid
         extend self
 
         # The valid options for storage.
-        #
-        # @since 3.0.0
         VALID_OPTIONS = [ :collection, :database, :client ].freeze
 
         # Validate the options provided to :store_in.
@@ -21,8 +19,6 @@ module Mongoid
         #
         # @param [ Class ] klass The model class.
         # @param [ Hash, String, Symbol ] options The provided options.
-        #
-        # @since 3.0.0
         def validate(klass, options)
           valid_keys?(options) or raise Errors::InvalidStorageOptions.new(klass, options)
           valid_parent?(klass) or raise Errors::InvalidStorageParent.new(klass)
@@ -37,8 +33,6 @@ module Mongoid
         # @param [ Class ] klass
         #
         # @return [ true, false ] If the class is valid
-        #
-        # @since 4.0.0
         def valid_parent?(klass)
           !klass.superclass.include?(Mongoid::Document)
         end
@@ -53,8 +47,6 @@ module Mongoid
         # @param [ Hash ] options The options hash.
         #
         # @return [ true, false ] If all keys are valid.
-        #
-        # @since 3.0.0
         def valid_keys?(options)
           return false unless options.is_a?(::Hash)
           options.keys.all? do |key|

--- a/lib/mongoid/composable.rb
+++ b/lib/mongoid/composable.rb
@@ -22,8 +22,6 @@ require "mongoid/validatable"
 module Mongoid
 
   # This module provides inclusions of all behavior in a Mongoid document.
-  #
-  # @since 4.0.0
   module Composable
     extend ActiveSupport::Concern
 
@@ -99,8 +97,6 @@ module Mongoid
     # separately.
     #
     # @return [ Array<Symbol> ] A list of reserved method names.
-    #
-    # @since 6.0.0
     RESERVED_METHOD_NAMES = [ :fields,
                               :aliased_fields,
                               :localized_fields,
@@ -123,8 +119,6 @@ module Mongoid
       #   Mongoid::Components.prohibited_methods
       #
       # @return [ Array<Symbol> ]
-      #
-      # @since 2.1.8
       def prohibited_methods
         @prohibited_methods ||= MODULES.flat_map do |mod|
           mod.instance_methods.map(&:to_sym)

--- a/lib/mongoid/config.rb
+++ b/lib/mongoid/config.rb
@@ -82,8 +82,6 @@ module Mongoid
     #   config.configured?
     #
     # @return [ true, false ] If Mongoid is configured.
-    #
-    # @since 3.0.9
     def configured?
       clients.key?(:default)
     end
@@ -96,8 +94,6 @@ module Mongoid
     #   config.connect_to("mongoid_test")
     #
     # @param [ String ] name The database name.
-    #
-    # @since 3.0.0
     def connect_to(name, options = { read: { mode: :primary }})
       self.clients = {
         default: {
@@ -127,8 +123,6 @@ module Mongoid
     #
     # @param [ String ] path The path to the file.
     # @param [ String, Symbol ] environment The environment to load.
-    #
-    # @since 2.0.1
     def load!(path, environment = nil)
       settings = Environment.load_yaml(path, environment)
       if settings.present?
@@ -146,8 +140,6 @@ module Mongoid
     #   config.models
     #
     # @return [ Array<Class> ] All the models in the application.
-    #
-    # @since 3.1.0
     def models
       @models ||= []
     end
@@ -158,8 +150,6 @@ module Mongoid
     #   config.register_model(Band)
     #
     # @param [ Class ] klass The model to register.
-    #
-    # @since 3.1.0
     def register_model(klass)
       LOCK.synchronize do
         models.push(klass) unless models.include?(klass)
@@ -172,8 +162,6 @@ module Mongoid
     #   config.load_configuration(settings)
     #
     # @param [ Hash ] settings The configuration settings.
-    #
-    # @since 3.1.0
     def load_configuration(settings)
       configuration = settings.with_indifferent_access
       self.options = configuration[:options]
@@ -189,8 +177,6 @@ module Mongoid
     # @param [ String, Symbol ] name The name of the database.
     #
     # @return [ String, Symbol ] The global override.
-    #
-    # @since 3.0.0
     def override_database(name)
       Threaded.database_override = name
     end
@@ -203,8 +189,6 @@ module Mongoid
     # @param [ String, Symbol ] name The name of the client.
     #
     # @return [ String, Symbol ] The global override.
-    #
-    # @since 3.0.0
     def override_client(name)
       Threaded.client_override = name ? name.to_s : nil
     end
@@ -217,8 +201,6 @@ module Mongoid
     # @note This is the fastest way to drop all data.
     #
     # @return [ true ] true.
-    #
-    # @since 2.0.2
     def purge!
       global_client.database.collections.each(&:drop) and true
     end
@@ -231,8 +213,6 @@ module Mongoid
     # @note This will be slower than purge!
     #
     # @return [ true ] true.
-    #
-    # @since 2.0.2
     def truncate!
       global_client.database.collections.each do |collection|
         collection.find.delete_many
@@ -245,8 +225,6 @@ module Mongoid
     #   config.options = { raise_not_found_error: true }
     #
     # @param [ Hash ] options The configuration options.
-    #
-    # @since 3.0.0
     def options=(options)
       if options
         options.each_pair do |option, value|
@@ -262,8 +240,6 @@ module Mongoid
     #   config.clients
     #
     # @return [ Hash ] The clients configuration.
-    #
-    # @since 3.0.0
     def clients
       @clients ||= {}
     end
@@ -274,8 +250,6 @@ module Mongoid
     #   Config.time_zone
     #
     # @return [ String ] The time zone.
-    #
-    # @since 3.0.0
     def time_zone
       use_utc? ? "UTC" : ::Time.zone
     end
@@ -286,8 +260,6 @@ module Mongoid
     #   config.running_with_passenger?
     #
     # @return [ true, false ] If the app is deployed on Passenger.
-    #
-    # @since 3.0.11
     def running_with_passenger?
       @running_with_passenger ||= defined?(PhusionPassenger)
     end

--- a/lib/mongoid/config/environment.rb
+++ b/lib/mongoid/config/environment.rb
@@ -23,8 +23,6 @@ module Mongoid
       #   determined because none of the sources was set.
       #
       # @return [ String ] The name of the current environment.
-      #
-      # @since 2.3.0
       # @api public
       def env_name
         if defined?(::Rails)
@@ -47,8 +45,6 @@ module Mongoid
       #   override the current Mongoid environment.
       #
       # @return [ Hash ] The settings.
-      #
-      # @since 2.3.0
       # @api private
       def load_yaml(path, environment = nil)
         env = environment ? environment.to_s : env_name

--- a/lib/mongoid/config/options.rb
+++ b/lib/mongoid/config/options.rb
@@ -13,8 +13,6 @@ module Mongoid
       #   options.defaults
       #
       # @return [ Hash ] The default options.
-      #
-      # @since 2.3.0
       def defaults
         @defaults ||= {}
       end
@@ -28,8 +26,6 @@ module Mongoid
       # @param [ Hash ] options Extras for the option.
       #
       # @option options [ Object ] :default The default value.
-      #
-      # @since 2.0.0.rc.1
       def option(name, options = {})
         defaults[name] = settings[name] = options[:default]
 
@@ -57,8 +53,6 @@ module Mongoid
       #   config.reset
       #
       # @return [ Hash ] The defaults.
-      #
-      # @since 2.3.0
       def reset
         settings.replace(defaults)
       end
@@ -69,8 +63,6 @@ module Mongoid
       #   options.settings
       #
       # @return [ Hash ] The setting options.
-      #
-      # @since 2.3.0
       def settings
         @settings ||= {}
       end
@@ -81,8 +73,6 @@ module Mongoid
       #   config.log_level
       #
       # @return [ Integer ] The log level.
-      #
-      # @since 5.1.0
       def log_level
         if level = settings[:log_level]
           unless level.is_a?(Integer)

--- a/lib/mongoid/config/validators/client.rb
+++ b/lib/mongoid/config/validators/client.rb
@@ -10,8 +10,6 @@ module Mongoid
         extend self
 
         # Standard configuration options.
-        #
-        # @since 3.0.0
         STANDARD = [ :database, :hosts, :username, :password ].freeze
 
         # Validate the client configuration.
@@ -20,8 +18,6 @@ module Mongoid
         #   Client.validate({ default: { hosts: [ "localhost:27017" ] }})
         #
         # @param [ Hash ] clients The clients config.
-        #
-        # @since 3.0.0
         def validate(clients)
           unless clients.has_key?(:default)
             raise Errors::NoDefaultClient.new(clients.keys)
@@ -44,8 +40,6 @@ module Mongoid
         #
         # @param [ String, Symbol ] name The config key.
         # @param [ Hash ] config The configuration.
-        #
-        # @since 3.0.0
         def validate_client_database(name, config)
           if no_database_or_uri?(config)
             raise Errors::NoClientDatabase.new(name, config)
@@ -61,8 +55,6 @@ module Mongoid
         #
         # @param [ String, Symbol ] name The config key.
         # @param [ Hash ] config The configuration.
-        #
-        # @since 3.0.0
         def validate_client_hosts(name, config)
           if no_hosts_or_uri?(config)
             raise Errors::NoClientHosts.new(name, config)
@@ -79,8 +71,6 @@ module Mongoid
         #
         # @param [ String, Symbol ] name The config key.
         # @param [ Hash ] config The configuration.
-        #
-        # @since 3.0.0
         def validate_client_uri(name, config)
           if both_uri_and_standard?(config)
             raise Errors::MixedClientConfiguration.new(name, config)
@@ -98,8 +88,6 @@ module Mongoid
         # @param [ Hash ] config The configuration options.
         #
         # @return [ true, false ] If no database or uri is defined.
-        #
-        # @since 3.0.0
         def no_database_or_uri?(config)
           !config.has_key?(:database) && !config.has_key?(:uri)
         end
@@ -115,8 +103,6 @@ module Mongoid
         # @param [ Hash ] config The configuration options.
         #
         # @return [ true, false ] If no hosts or uri is defined.
-        #
-        # @since 3.0.0
         def no_hosts_or_uri?(config)
           !config.has_key?(:hosts) && !config.has_key?(:uri)
         end
@@ -132,8 +118,6 @@ module Mongoid
         # @param [ Hash ] config The configuration options.
         #
         # @return [ true, false ] If both standard and uri are defined.
-        #
-        # @since 3.0.0
         def both_uri_and_standard?(config)
           config.has_key?(:uri) && config.keys.any? do |key|
             STANDARD.include?(key.to_sym)

--- a/lib/mongoid/config/validators/option.rb
+++ b/lib/mongoid/config/validators/option.rb
@@ -14,8 +14,6 @@ module Mongoid
         # @example Validate a configuration option.
         #
         # @param [ String ] option The name of the option.
-        #
-        # @since 3.0.0
         def validate(option)
           unless Config.settings.keys.include?(option.to_sym)
             raise Errors::InvalidConfigOption.new(option)

--- a/lib/mongoid/contextual.rb
+++ b/lib/mongoid/contextual.rb
@@ -32,8 +32,6 @@ module Mongoid
     #   criteria.context
     #
     # @return [ Memory, Mongo ] The context.
-    #
-    # @since 3.0.0
     def context
       @context ||= create_context
     end
@@ -49,8 +47,6 @@ module Mongoid
     #   contextual.create_context
     #
     # @return [ Mongo, Memory ] The context.
-    #
-    # @since 3.0.0
     def create_context
       return None.new(self) if empty_and_chainable?
       embedded ? Memory.new(self) : Mongo.new(self)

--- a/lib/mongoid/contextual/aggregable/memory.rb
+++ b/lib/mongoid/contextual/aggregable/memory.rb
@@ -15,8 +15,6 @@ module Mongoid
         # @param [ Symbol ] field The field to average.
         #
         # @return [ Float ] The average.
-        #
-        # @since 3.0.0
         def avg(field)
           count > 0 ? sum(field).to_f / count.to_f : nil
         end
@@ -37,8 +35,6 @@ module Mongoid
         #
         # @return [ Float, Document ] The max value or document with the max
         #   value.
-        #
-        # @since 3.0.0
         def max(field = nil)
           block_given? ? super() : aggregate_by(field, :max_by)
         end
@@ -59,8 +55,6 @@ module Mongoid
         #
         # @return [ Float, Document ] The min value or document with the min
         #   value.
-        #
-        # @since 3.0.0
         def min(field = nil)
           block_given? ? super() : aggregate_by(field, :min_by)
         end
@@ -77,8 +71,6 @@ module Mongoid
         # @param [ Symbol ] field The field to sum.
         #
         # @return [ Float ] The sum value.
-        #
-        # @since 3.0.0
         def sum(field = nil)
           if block_given?
             super()
@@ -100,8 +92,6 @@ module Mongoid
         # @param [ Symbol ] method The method (min_by or max_by).
         #
         # @return [ Integer ] The aggregate.
-        #
-        # @since 3.0.0
         def aggregate_by(field, method)
           count > 0 ? send(method) { |doc| doc.public_send(field) }.public_send(field) : nil
         end

--- a/lib/mongoid/contextual/aggregable/mongo.rb
+++ b/lib/mongoid/contextual/aggregable/mongo.rb
@@ -24,8 +24,6 @@ module Mongoid
         # @return [ Hash ] count is a number of documents with the provided
         #   field. If there're none, then count is 0 and max, min, sum, avg
         #   are nil.
-        #
-        # @since 3.0.0
         def aggregates(field)
           result = collection.find.aggregate(pipeline(field), session: _session).to_a
           if result.empty?
@@ -43,8 +41,6 @@ module Mongoid
         # @param [ Symbol ] field The field to average.
         #
         # @return [ Float ] The average.
-        #
-        # @since 3.0.0
         def avg(field)
           aggregates(field)["avg"]
         end
@@ -65,8 +61,6 @@ module Mongoid
         #
         # @return [ Float, Document ] The max value or document with the max
         #   value.
-        #
-        # @since 3.0.0
         def max(field = nil)
           block_given? ? super() : aggregates(field)["max"]
         end
@@ -87,8 +81,6 @@ module Mongoid
         #
         # @return [ Float, Document ] The min value or document with the min
         #   value.
-        #
-        # @since 3.0.0
         def min(field = nil)
           block_given? ? super() : aggregates(field)["min"]
         end
@@ -105,8 +97,6 @@ module Mongoid
         # @param [ Symbol ] field The field to sum.
         #
         # @return [ Float ] The sum value.
-        #
-        # @since 3.0.0
         def sum(field = nil)
           block_given? ? super() : aggregates(field)["sum"] || 0
         end
@@ -123,8 +113,6 @@ module Mongoid
         # @param [ String, Symbol ] field The name of the field.
         #
         # @return [ Array ] The array of pipeline operators.
-        #
-        # @since 3.1.0
         def pipeline(field)
           db_field = "$#{database_field_name(field)}"
           pipeline = []

--- a/lib/mongoid/contextual/atomic.rb
+++ b/lib/mongoid/contextual/atomic.rb
@@ -13,8 +13,6 @@ module Mongoid
       # @param [ Hash ] adds The operations.
       #
       # @return [ nil ] Nil.
-      #
-      # @since 3.0.0
       def add_to_set(adds)
         view.update_many("$addToSet" => collect_operations(adds))
       end
@@ -27,8 +25,6 @@ module Mongoid
       # @param [ Hash ] adds The operations.
       #
       # @return [ nil ] Nil.
-      #
-      # @since 7.0.0
       def add_each_to_set(adds)
         view.update_many("$addToSet" => collect_each_operations(adds))
       end
@@ -41,8 +37,6 @@ module Mongoid
       # @param [ Hash ] bits The operations.
       #
       # @return [ nil ] Nil.
-      #
-      # @since 3.0.0
       def bit(bits)
         view.update_many("$bit" => collect_operations(bits))
       end
@@ -55,8 +49,6 @@ module Mongoid
       # @param [ Hash ] incs The operations.
       #
       # @return [ nil ] Nil.
-      #
-      # @since 3.0.0
       def inc(incs)
         view.update_many("$inc" => collect_operations(incs))
       end
@@ -72,8 +64,6 @@ module Mongoid
       # @param [ Hash ] pops The operations.
       #
       # @return [ nil ] Nil.
-      #
-      # @since 3.0.0
       def pop(pops)
         view.update_many("$pop" => collect_operations(pops))
       end
@@ -88,8 +78,6 @@ module Mongoid
       # @param [ Hash ] pulls The operations.
       #
       # @return [ nil ] Nil.
-      #
-      # @since 3.0.0
       def pull(pulls)
         view.update_many("$pull" => collect_operations(pulls))
       end
@@ -102,8 +90,6 @@ module Mongoid
       # @param [ Hash ] pulls The operations.
       #
       # @return [ nil ] Nil.
-      #
-      # @since 3.0.0
       def pull_all(pulls)
         view.update_many("$pullAll" => collect_operations(pulls))
       end
@@ -116,8 +102,6 @@ module Mongoid
       # @param [ Hash ] pushes The operations.
       #
       # @return [ nil ] Nil.
-      #
-      # @since 3.0.0
       def push(pushes)
         view.update_many("$push" => collect_operations(pushes))
       end
@@ -130,8 +114,6 @@ module Mongoid
       # @param [ Hash ] pushes The operations.
       #
       # @return [ nil ] Nil.
-      #
-      # @since 3.0.0
       def push_all(pushes)
         view.update_many("$push" => collect_each_operations(pushes))
       end
@@ -144,8 +126,6 @@ module Mongoid
       # @param [ Hash ] renames The operations.
       #
       # @return [ nil ] Nil.
-      #
-      # @since 3.0.0
       def rename(renames)
         operations = renames.inject({}) do |ops, (old_name, new_name)|
           ops[old_name] = new_name.to_s
@@ -162,8 +142,6 @@ module Mongoid
       # @param [ Hash ] sets The operations.
       #
       # @return [ nil ] Nil.
-      #
-      # @since 3.0.0
       def set(sets)
         view.update_many("$set" => collect_operations(sets))
       end
@@ -176,8 +154,6 @@ module Mongoid
       # @param [ String, Symbol, Array ] args The name of the fields.
       #
       # @return [ nil ] Nil.
-      #
-      # @since 3.0.0
       def unset(*args)
         fields = args.__find_args__.collect { |f| [database_field_name(f), true] }
         view.update_many("$unset" => Hash[fields])

--- a/lib/mongoid/contextual/command.rb
+++ b/lib/mongoid/contextual/command.rb
@@ -15,8 +15,6 @@ module Mongoid
       #   command.command
       #
       # @return [ Hash ] The db command.
-      #
-      # @since 3.0.0
       def command
         @command ||= {}
       end
@@ -27,8 +25,6 @@ module Mongoid
       #   command.client
       #
       # @return [ Mongo::Client ] The Mongo client.
-      #
-      # @since 3.0.0
       def client
         collection.database.client
       end

--- a/lib/mongoid/contextual/geo_near.rb
+++ b/lib/mongoid/contextual/geo_near.rb
@@ -18,8 +18,6 @@ module Mongoid
       #   geo_near.average_distance
       #
       # @return [ Float, nil ] The average distance.
-      #
-      # @since 3.1.0
       def average_distance
         average = stats["avgDistance"]
         (average.nil? || average.nan?) ? nil : average
@@ -34,8 +32,6 @@ module Mongoid
       #   end
       #
       # @return [ Enumerator ] The enumerator.
-      #
-      # @since 3.1.0
       def each
         if block_given?
           documents.each do |doc|
@@ -54,8 +50,6 @@ module Mongoid
       # @param [ Integer, Float ] value The distance multiplier.
       #
       # @return [ GeoNear ] The GeoNear wrapper.
-      #
-      # @since 3.1.0
       def distance_multiplier(value)
         command[:distanceMultiplier] = value
         self
@@ -70,8 +64,6 @@ module Mongoid
       #   operation on.
       # @param [ Criteria ] criteria The Mongoid criteria.
       # @param [ String ] near
-      #
-      # @since 3.0.0
       def initialize(collection, criteria, near)
         @collection, @criteria = collection, criteria
         command[:geoNear] = collection.name.to_s
@@ -85,8 +77,6 @@ module Mongoid
       #   geo_near.inspect
       #
       # @return [ String ] The inspection string.
-      #
-      # @since 3.1.0
       def inspect
 %Q{#<Mongoid::Contextual::GeoNear
   selector:   #{criteria.selector.inspect}
@@ -112,8 +102,6 @@ module Mongoid
       # @param [ Integer, Float ] value The maximum distance.
       #
       # @return [ GeoNear, Float ] The GeoNear command or the value.
-      #
-      # @since 3.1.0
       def max_distance(value = nil)
         if value
           command[:maxDistance] = value
@@ -131,8 +119,6 @@ module Mongoid
       # @param [ Integer, Float ] value The minimum distance.
       #
       # @return [ GeoNear ] The GeoNear command.
-      #
-      # @since 3.1.0
       def min_distance(value)
         command[:minDistance] = value
         self
@@ -144,8 +130,6 @@ module Mongoid
       #   geo_near.spherical
       #
       # @return [ GeoNear ] The command.
-      #
-      # @since 3.1.0
       def spherical
         command[:spherical] = true
         self
@@ -159,8 +143,6 @@ module Mongoid
       # @param [ true, false ] value Whether to return unique documents.
       #
       # @return [ GeoNear ] The command.
-      #
-      # @since 3.1.0
       def unique(value = true)
         command[:unique] = value
         self
@@ -172,8 +154,6 @@ module Mongoid
       #   geo_near.execute
       #
       # @return [ Hash ] The raw output
-      #
-      # @since 3.1.0
       def execute
         results
       end
@@ -184,8 +164,6 @@ module Mongoid
       #   geo_near.stats
       #
       # @return [ Hash ] The stats from the command run.
-      #
-      # @since 3.1.0
       def stats
         results["stats"]
       end
@@ -196,8 +174,6 @@ module Mongoid
       #   geo_near.time
       #
       # @return [ Float ] The execution time.
-      #
-      # @since 3.1.0
       def time
         stats["time"]
       end
@@ -208,8 +184,6 @@ module Mongoid
       #   geo_near.empty_and_chainable?
       #
       # @return [ true ] Always true.
-      #
-      # @since 5.1.0
       def empty_and_chainable?
         true
       end
@@ -224,8 +198,6 @@ module Mongoid
       #   geo_near.apply_criteria_options
       #
       # @return [ nil ] Nothing.
-      #
-      # @since 3.0.0
       def apply_criteria_options
         command[:query] = criteria.selector
         if limit = criteria.options[:limit]
@@ -241,8 +213,6 @@ module Mongoid
       #   geo_near.documents
       #
       # @return [ Array, Cursor ] The documents.
-      #
-      # @since 3.0.0
       def documents
         results["results"].map do |attributes|
           doc = Factory.from_db(criteria.klass, attributes["obj"], criteria)
@@ -259,8 +229,6 @@ module Mongoid
       #   geo_near.results
       #
       # @return [ Hash ] The results of the command.
-      #
-      # @since 3.0.0
       def results
         @results ||= client.command(command).first
       end

--- a/lib/mongoid/contextual/map_reduce.rb
+++ b/lib/mongoid/contextual/map_reduce.rb
@@ -17,8 +17,6 @@ module Mongoid
       #   map_reduce.counts
       #
       # @return [ Hash ] The counts.
-      #
-      # @since 3.0.0
       def counts
         results["counts"]
       end
@@ -32,8 +30,6 @@ module Mongoid
       #   end
       #
       # @return [ Enumerator ] The enumerator.
-      #
-      # @since 3.0.0
       def each
         validate_out!
         if block_given?
@@ -51,8 +47,6 @@ module Mongoid
       #   map_reduce.emitted
       #
       # @return [ Integer ] The number of emitted documents.
-      #
-      # @since 3.0.0
       def emitted
         counts["emit"]
       end
@@ -65,8 +59,6 @@ module Mongoid
       # @param [ String ] function The finalize function.
       #
       # @return [ MapReduce ] The map reduce.
-      #
-      # @since 3.0.0
       def finalize(function)
         @map_reduce = @map_reduce.finalize(function)
         self
@@ -80,8 +72,6 @@ module Mongoid
       # @param [ Criteria ] criteria The Mongoid criteria.
       # @param [ String ] map The map js function.
       # @param [ String ] reduce The reduce js function.
-      #
-      # @since 3.0.0
       def initialize(collection, criteria, map, reduce)
         @collection = collection
         @criteria = criteria
@@ -94,8 +84,6 @@ module Mongoid
       #   map_reduce.input
       #
       # @return [ Integer ] The number of input documents.
-      #
-      # @since 3.0.0
       def input
         counts["input"]
       end
@@ -106,8 +94,6 @@ module Mongoid
       #   map_reduce.js_mode
       #
       # @return [ MapReduce ] The map/reduce.
-      #
-      # @since 3.0.0
       def js_mode
         @map_reduce = @map_reduce.js_mode(true)
         self
@@ -134,8 +120,6 @@ module Mongoid
       # @param [ Hash ] location The place to store the results.
       #
       # @return [ MapReduce ] The map/reduce object.
-      #
-      # @since 3.0.0
       def out(location)
         normalized = location.dup
         normalized.update_values do |value|
@@ -151,8 +135,6 @@ module Mongoid
       #   map_reduce.output
       #
       # @return [ Integer ] The number of output documents.
-      #
-      # @since 3.0.0
       def output
         counts["output"]
       end
@@ -163,8 +145,6 @@ module Mongoid
       #   map_reduce.raw
       #
       # @return [ Hash ] The raw output.
-      #
-      # @since 3.0.0
       def raw
         validate_out!
         cmd = command
@@ -180,8 +160,6 @@ module Mongoid
       #   map_reduce.execute
       #
       # @return [ Hash ] The raw output
-      #
-      # @since 3.1.0
       alias :execute :raw
 
       # Get the number of documents reduced by the map/reduce.
@@ -190,8 +168,6 @@ module Mongoid
       #   map_reduce.reduced
       #
       # @return [ Integer ] The number of reduced documents.
-      #
-      # @since 3.0.0
       def reduced
         counts["reduce"]
       end
@@ -204,8 +180,6 @@ module Mongoid
       # @param [ Hash ] object A hash of key/values for the global scope.
       #
       # @return [ MapReduce ]
-      #
-      # @since 3.0.0
       def scope(object)
         @map_reduce = @map_reduce.scope(object)
         self
@@ -217,8 +191,6 @@ module Mongoid
       #   map_reduce.time
       #
       # @return [ Float ] The time in milliseconds.
-      #
-      # @since 3.0.0
       def time
         results["timeMillis"]
       end
@@ -230,8 +202,6 @@ module Mongoid
       #   map_reduce.inspect
       #
       # @return [ String ] The inspection string.
-      #
-      # @since 3.1.0
       def inspect
 %Q{#<Mongoid::Contextual::MapReduce
   selector: #{criteria.selector.inspect}

--- a/lib/mongoid/contextual/memory.rb
+++ b/lib/mongoid/contextual/memory.rb
@@ -27,8 +27,6 @@ module Mongoid
       # @param [ Array ] other The other array.
       #
       # @return [ true, false ] If the objects are equal.
-      #
-      # @since 3.0.0
       def ==(other)
         return false unless other.respond_to?(:entries)
         entries == other.entries
@@ -40,8 +38,6 @@ module Mongoid
       #   context.delete
       #
       # @return [ nil ] Nil.
-      #
-      # @since 3.0.0
       def delete
         deleted = count
         removed = map do |doc|
@@ -64,8 +60,6 @@ module Mongoid
       #   context.destroy
       #
       # @return [ nil ] Nil.
-      #
-      # @since 3.0.0
       def destroy
         deleted = count
         each do |doc|
@@ -84,8 +78,6 @@ module Mongoid
       # @param [ String, Symbol ] field The name of the field.
       #
       # @return [ Array<Object> ] The distinct values for the field.
-      #
-      # @since 3.0.0
       def distinct(field)
         documents.map{ |doc| doc.send(field) }.uniq
       end
@@ -99,8 +91,6 @@ module Mongoid
       #   end
       #
       # @return [ Enumerator ] The enumerator.
-      #
-      # @since 3.0.0
       def each
         if block_given?
           documents_for_iteration.each do |doc|
@@ -118,8 +108,6 @@ module Mongoid
       #   context.exists?
       #
       # @return [ true, false ] If the count is more than zero.
-      #
-      # @since 3.0.0
       def exists?
         count > 0
       end
@@ -130,8 +118,6 @@ module Mongoid
       #   context.first
       #
       # @return [ Document ] The first document.
-      #
-      # @since 3.0.0
       def first(*args)
         eager_load([documents.first]).first
       end
@@ -144,8 +130,6 @@ module Mongoid
       #   Memory.new(criteria)
       #
       # @param [ Criteria ] criteria The criteria.
-      #
-      # @since 3.0.0
       def initialize(criteria)
         @criteria, @klass = criteria, criteria.klass
         @documents = criteria.documents.select do |doc|
@@ -165,8 +149,6 @@ module Mongoid
       # @param [ Hash ] incs The operations.
       #
       # @return [ Enumerator ] The enumerator.
-      #
-      # @since 7.0.0
       def inc(incs)
         each do |document|
           document.inc(incs)
@@ -179,8 +161,6 @@ module Mongoid
       #   context.last
       #
       # @return [ Document ] The last document.
-      #
-      # @since 3.0.0
       def last
         eager_load([documents.last]).first
       end
@@ -191,8 +171,6 @@ module Mongoid
       #   context.length
       #
       # @return [ Integer ] The matching length.
-      #
-      # @since 3.0.0
       def length
         documents.length
       end
@@ -206,8 +184,6 @@ module Mongoid
       # @param [ Integer ] value The number of documents to return.
       #
       # @return [ Mongo ] The context.
-      #
-      # @since 3.0.0
       def limit(value)
         self.limiting = value
         self
@@ -232,8 +208,6 @@ module Mongoid
       # @param [ Integer ] value The number of documents to skip.
       #
       # @return [ Mongo ] The context.
-      #
-      # @since 3.0.0
       def skip(value)
         self.skipping = value
         self
@@ -248,8 +222,6 @@ module Mongoid
       #   pairs.
       #
       # @return [ Mongo ] The context.
-      #
-      # @since 3.0.0
       def sort(values)
         in_place_sort(values) and self
       end
@@ -262,8 +234,6 @@ module Mongoid
       # @param [ Hash ] attributes The new attributes for the document.
       #
       # @return [ nil, false ] False if no attributes were provided.
-      #
-      # @since 3.0.0
       def update(attributes = nil)
         update_documents(attributes, [ first ])
       end
@@ -276,8 +246,6 @@ module Mongoid
       # @param [ Hash ] attributes The new attributes for each document.
       #
       # @return [ nil, false ] False if no attributes were provided.
-      #
-      # @since 3.0.0
       def update_all(attributes = nil)
         update_documents(attributes, entries)
       end
@@ -292,8 +260,6 @@ module Mongoid
       #   context.documents_for_iteration
       #
       # @return [ Array<Document> ] The docs to iterate.
-      #
-      # @since 3.1.0
       def documents_for_iteration
         docs = documents[skipping || 0, limiting || documents.length] || []
         if eager_loadable?
@@ -311,8 +277,6 @@ module Mongoid
       #
       # @param [ Hash ] attributes The attributes.
       # @param [ Array<Document> ] docs The docs to update.
-      #
-      # @since 3.0.4
       def update_documents(attributes, docs)
         return false if !attributes || docs.empty?
         updates = { "$set" => {}}
@@ -332,8 +296,6 @@ module Mongoid
       # @example Get the limiting value.
       #
       # @return [ Integer ] The limit.
-      #
-      # @since 3.0.0
       def limiting
         defined?(@limiting) ? @limiting : nil
       end
@@ -347,8 +309,6 @@ module Mongoid
       # @param [ Integer ] value The limit.
       #
       # @return [ Integer ] The limit.
-      #
-      # @since 3.0.0
       def limiting=(value)
         @limiting = value
       end
@@ -360,8 +320,6 @@ module Mongoid
       # @example Get the skiping value.
       #
       # @return [ Integer ] The skip.
-      #
-      # @since 3.0.0
       def skipping
         defined?(@skipping) ? @skipping : nil
       end
@@ -375,8 +333,6 @@ module Mongoid
       # @param [ Integer ] value The skip.
       #
       # @return [ Integer ] The skip.
-      #
-      # @since 3.0.0
       def skipping=(value)
         @skipping = value
       end
@@ -389,8 +345,6 @@ module Mongoid
       #   context.apply_options
       #
       # @return [ Memory ] self.
-      #
-      # @since 3.0.0
       def apply_options
         raise Errors::InMemoryCollationNotSupported.new if criteria.options[:collation]
         skip(criteria.options[:skip]).limit(criteria.options[:limit])
@@ -400,8 +354,6 @@ module Mongoid
       #
       # @example Apply the sorting params.
       #   context.apply_sorting
-      #
-      # @since 3.0.0
       def apply_sorting
         if spec = criteria.options[:sort]
           in_place_sort(spec)
@@ -419,8 +371,6 @@ module Mongoid
       # @param [ Object ] b The first object.
       #
       # @return [ Integer ] The comparison value.
-      #
-      # @since 3.0.0
       def compare(a, b)
         case
         when a.nil? then b.nil? ? 0 : 1
@@ -435,8 +385,6 @@ module Mongoid
       #   context.in_place_sort(name: 1)
       #
       # @param [ Hash ] values The field/direction sorting pairs.
-      #
-      # @since 3.0.0
       def in_place_sort(values)
         documents.sort! do |a, b|
           values.map do |field, direction|
@@ -454,8 +402,6 @@ module Mongoid
       #   context.prepare_remove(doc)
       #
       # @param [ Document ] doc The document.
-      #
-      # @since 3.0.0
       def prepare_remove(doc)
         @selector ||= root.atomic_selector
         @path ||= doc.atomic_path

--- a/lib/mongoid/contextual/mongo.rb
+++ b/lib/mongoid/contextual/mongo.rb
@@ -19,8 +19,6 @@ module Mongoid
       include Queryable
 
       # Options constant.
-      #
-      # @since 5.0.0
       OPTIONS = [ :hint,
                   :limit,
                   :skip,
@@ -44,8 +42,6 @@ module Mongoid
       #   context.cached?
       #
       # @return [ true, false ] If the context is cached.
-      #
-      # @since 3.0.0
       def cached?
         !!@cache
       end
@@ -67,8 +63,6 @@ module Mongoid
       #   into the count.
       #
       # @return [ Integer ] The number of matches.
-      #
-      # @since 3.0.0
       def count(options = {}, &block)
         return super(&block) if block_given?
         try_cache(:count) { view.count_documents(options) }
@@ -99,8 +93,6 @@ module Mongoid
       #   context.delete
       #
       # @return [ nil ] Nil.
-      #
-      # @since 3.0.0
       def delete
         view.delete_many.deleted_count
       end
@@ -112,8 +104,6 @@ module Mongoid
       #   context.destroy
       #
       # @return [ nil ] Nil.
-      #
-      # @since 3.0.0
       def destroy
         each.inject(0) do |count, doc|
           doc.destroy
@@ -131,8 +121,6 @@ module Mongoid
       # @param [ String, Symbol ] field The name of the field.
       #
       # @return [ Array<Object> ] The distinct values for the field.
-      #
-      # @since 3.0.0
       def distinct(field)
         view.distinct(klass.database_field_name(field)).map do |value|
           value.class.demongoize(value)
@@ -148,8 +136,6 @@ module Mongoid
       #   end
       #
       # @return [ Enumerator ] The enumerator.
-      #
-      # @since 3.0.0
       def each(&block)
         if block_given?
           documents_for_iteration.each do |doc|
@@ -172,8 +158,6 @@ module Mongoid
       #   used to determine the value.
       #
       # @return [ true, false ] If the count is more than zero.
-      #
-      # @since 3.0.0
       def exists?
         return !documents.empty? if cached? && cache_loaded?
         return @count > 0 if instance_variable_defined?(:@count)
@@ -189,8 +173,6 @@ module Mongoid
       #   Band.where(name: "Depeche Mode").explain
       #
       # @return [ Hash ] The explain result.
-      #
-      # @since 3.0.0
       def explain
         view.explain
       end
@@ -209,8 +191,6 @@ module Mongoid
       # @option options [ true, false ] :upsert Create the document if it doesn't exist.
       #
       # @return [ Document ] The result of the command.
-      #
-      # @since 5.0.0
       def find_one_and_update(update, options = {})
         if doc = view.find_one_and_update(update, options)
           Factory.from_db(klass, doc)
@@ -231,8 +211,6 @@ module Mongoid
       # @option options [ true, false ] :upsert Create the document if it doesn't exist.
       #
       # @return [ Document ] The result of the command.
-      #
-      # @since 5.0.0
       def find_one_and_replace(replacement, options = {})
         if doc = view.find_one_and_replace(replacement, options)
           Factory.from_db(klass, doc)
@@ -246,8 +224,6 @@ module Mongoid
       #   context.find_one_and_delete
       #
       # @return [ Document ] The result of the command.
-      #
-      # @since 5.0.0
       def find_one_and_delete
         if doc = view.find_one_and_delete
           Factory.from_db(klass, doc)
@@ -271,8 +247,6 @@ module Mongoid
       #   is defined on the criteria.
       #
       # @return [ Document ] The first document.
-      #
-      # @since 3.0.0
       def first(opts = {})
         return documents.first if cached? && cache_loaded?
         try_cache(:first) do
@@ -294,8 +268,6 @@ module Mongoid
       # Return the first result without applying sort
       #
       # @api private
-      #
-      # @since 4.0.2
       def find_first
         return documents.first if cached? && cache_loaded?
         if raw_doc = view.first
@@ -323,8 +295,6 @@ module Mongoid
       # @return [ GeoNear ] The GeoNear command.
       #
       # @deprecated
-      #
-      # @since 3.1.0
       def geo_near(coordinates)
         GeoNear.new(collection, criteria, coordinates)
       end
@@ -359,8 +329,6 @@ module Mongoid
       #   Mongo.new(criteria)
       #
       # @param [ Criteria ] criteria The criteria.
-      #
-      # @since 3.0.0
       def initialize(criteria)
         @criteria, @klass, @cache = criteria, criteria.klass, criteria.options[:cache]
         @collection = @klass.collection
@@ -386,8 +354,6 @@ module Mongoid
       #
       # @option opts [ :none ] :id_sort Don't apply a sort on _id if no other sort
       #   is defined on the criteria.
-      #
-      # @since 3.0.0
       def last(opts = {})
         try_cache(:last) do
           with_inverse_sorting(opts) do
@@ -405,8 +371,6 @@ module Mongoid
       #   context.length
       #
       # @return [ Integer ] The number of documents.
-      #
-      # @since 3.0.0
       def length
         @length ||= self.count
       end
@@ -420,8 +384,6 @@ module Mongoid
       # @param [ Integer ] value The number of documents to return.
       #
       # @return [ Mongo ] The context.
-      #
-      # @since 3.0.0
       def limit(value)
         @view = view.limit(value) and self
       end
@@ -435,8 +397,6 @@ module Mongoid
       # @param [ String ] reduce The reduce js function.
       #
       # @return [ MapReduce ] The map/reduce lazy wrapper.
-      #
-      # @since 3.0.0
       def map_reduce(map, reduce)
         MapReduce.new(collection, criteria, map, reduce)
       end
@@ -453,8 +413,6 @@ module Mongoid
       # @param [ String, Symbol, Array ] fields Fields to pluck.
       #
       # @return [ Array<Object, Array> ] The plucked values.
-      #
-      # @since 3.1.0
       def pluck(*fields)
         normalized_select = fields.inject({}) do |hash, f|
           hash[klass.database_field_name(f)] = 1
@@ -477,8 +435,6 @@ module Mongoid
       # @param [ Integer ] value The number of documents to skip.
       #
       # @return [ Mongo ] The context.
-      #
-      # @since 3.0.0
       def skip(value)
         @view = view.skip(value) and self
       end
@@ -492,8 +448,6 @@ module Mongoid
       #   pairs.
       #
       # @return [ Mongo ] The context.
-      #
-      # @since 3.0.0
       def sort(values = nil, &block)
         if block_given?
           super(&block)
@@ -517,8 +471,6 @@ module Mongoid
       #   an update should apply.
       #
       # @return [ nil, false ] False if no attributes were provided.
-      #
-      # @since 3.0.0
       def update(attributes = nil, opts = {})
         update_documents(attributes, :update_one, opts)
       end
@@ -535,8 +487,6 @@ module Mongoid
       #   an update should apply.
       #
       # @return [ nil, false ] False if no attributes were provided.
-      #
-      # @since 3.0.0
       def update_all(attributes = nil, opts = {})
         update_documents(attributes, :update_many, opts)
       end
@@ -548,8 +498,6 @@ module Mongoid
       # @param [ String, Symbol ] key The instance variable name
       #
       # @return the result of the block
-      #
-      # @since 3.1.4
       def try_cache(key, &block)
         unless cached?
           yield
@@ -572,8 +520,6 @@ module Mongoid
       # @param [ Symbol ] method The method to use.
       #
       # @return [ true, false ] If the update succeeded.
-      #
-      # @since 3.0.4
       def update_documents(attributes, method = :update_one, opts = {})
         return false unless attributes
         attributes = Hash[attributes.map { |k, v| [klass.database_field_name(k.to_s), v] }]
@@ -586,8 +532,6 @@ module Mongoid
       #
       # @example Apply the field limitations.
       #   context.apply_fields
-      #
-      # @since 3.0.0
       def apply_fields
         if spec = criteria.options[:fields]
           @view = view.projection(spec)
@@ -600,8 +544,6 @@ module Mongoid
       #
       # @example Apply all options.
       #   context.apply_options
-      #
-      # @since 3.1.0
       def apply_options
         apply_fields
         OPTIONS.each do |name|
@@ -618,8 +560,6 @@ module Mongoid
       #
       # @example Apply the skip option.
       #   context.apply_option(:skip)
-      #
-      # @since 3.1.0
       def apply_option(name)
         if spec = criteria.options[name]
           @view = view.send(name, spec)
@@ -632,8 +572,6 @@ module Mongoid
       #
       # @example Apply the inverse sorting params to the given block
       #   context.with_inverse_sorting
-      #
-      # @since 3.0.0
       def with_inverse_sorting(opts = {})
         begin
           if sort = criteria.options[:sort] || ( { _id: 1 } unless opts[:id_sort] == :none )
@@ -653,8 +591,6 @@ module Mongoid
       #   context.cacheable?
       #
       # @return [ true, false ] If caching, and the cache isn't loaded.
-      #
-      # @since 3.0.0
       def cacheable?
         cached? && !cache_loaded?
       end
@@ -668,8 +604,6 @@ module Mongoid
       #   context.cache_loaded?
       #
       # @return [ true, false ] If the cache is loaded.
-      #
-      # @since 3.0.0
       def cache_loaded?
         !!@cache_loaded
       end
@@ -682,8 +616,6 @@ module Mongoid
       #   context.documents
       #
       # @return [ Array<Document> ] The documents.
-      #
-      # @since 3.0.0
       def documents
         @documents ||= []
       end
@@ -702,8 +634,6 @@ module Mongoid
       #   context.documents_for_iteration
       #
       # @return [ Array<Document>, Mongo::Collection::View ] The docs to iterate.
-      #
-      # @since 3.0.0
       def documents_for_iteration
         return documents if cached? && !documents.empty?
         return view unless eager_loadable?
@@ -721,8 +651,6 @@ module Mongoid
       #   end
       #
       # @param [ Document ] document The document to yield to.
-      #
-      # @since 3.0.0
       def yield_document(document, &block)
         doc = document.respond_to?(:_id) ?
             document : Factory.from_db(klass, document, criteria)

--- a/lib/mongoid/contextual/none.rb
+++ b/lib/mongoid/contextual/none.rb
@@ -17,8 +17,6 @@ module Mongoid
       # @param [ Array ] other The other array.
       #
       # @return [ true, false ] If the objects are equal.
-      #
-      # @since 4.0.0
       def ==(other)
         other.is_a?(None)
       end
@@ -44,8 +42,6 @@ module Mongoid
       #   end
       #
       # @return [ Enumerator ] The enumerator.
-      #
-      # @since 4.0.0
       def each
         if block_given?
           [].each { |doc| yield(doc) }
@@ -61,8 +57,6 @@ module Mongoid
       #   context.exists?
       #
       # @return [ true, false ] If the count is more than zero.
-      #
-      # @since 4.0.0
       def exists?; false; end
 
 
@@ -84,8 +78,6 @@ module Mongoid
       #   Null.new(criteria)
       #
       # @param [ Criteria ] criteria The criteria.
-      #
-      # @since 4.0.0
       def initialize(criteria)
         @criteria, @klass = criteria, criteria.klass
       end
@@ -96,8 +88,6 @@ module Mongoid
       #   context.last
       #
       # @return [ nil ] Always nil.
-      #
-      # @since 4.0.0
       def last; nil; end
 
       # Always returns zero.
@@ -106,8 +96,6 @@ module Mongoid
       #   context.length
       #
       # @return [ Integer ] Always zero.
-      #
-      # @since 4.0.0
       def length
         entries.length
       end

--- a/lib/mongoid/contextual/queryable.rb
+++ b/lib/mongoid/contextual/queryable.rb
@@ -16,8 +16,6 @@ module Mongoid
       #   context.blank?
       #
       # @return [ true, false ] If the context is empty.
-      #
-      # @since 3.0.0
       def blank?
         !exists?
       end

--- a/lib/mongoid/copyable.rb
+++ b/lib/mongoid/copyable.rb
@@ -50,8 +50,6 @@ module Mongoid
     #
     # @example clone document
     #   model.clone_document
-    #
-    # @since 3.0.22
     def clone_document
       attrs = as_attributes.__deep_copy__
       process_localized_attributes(self, attrs)
@@ -67,8 +65,6 @@ module Mongoid
     #   model.process_localized_attributes(attributes)
     #
     # @param [ Hash ] attrs The attributes.
-    #
-    # @since 3.0.20
     def process_localized_attributes(klass, attrs)
       klass.localized_fields.keys.each do |name|
         if value = attrs.delete(name)

--- a/lib/mongoid/criteria.rb
+++ b/lib/mongoid/criteria.rb
@@ -42,8 +42,6 @@ module Mongoid
 
     # Static array used to check with method missing - we only need to ever
     # instantiate once.
-    #
-    # @since 4.0.0
     CHECK = []
 
     attr_accessor :embedded, :klass, :parent_document, :association
@@ -56,8 +54,6 @@ module Mongoid
     # @param [ Object ] other The other +Enumerable+ or +Criteria+ to compare to.
     #
     # @return [ true, false ] If the objects are equal.
-    #
-    # @since 1.0.0
     def ==(other)
       return super if other.respond_to?(:selector)
       entries == other
@@ -148,8 +144,6 @@ module Mongoid
     #   criteria.documents
     #
     # @return [ Array<Document> ] The documents.
-    #
-    # @since 3.0.0
     def documents
       @documents ||= []
     end
@@ -161,8 +155,6 @@ module Mongoid
     # @param [ Array<Document> ] docs The embedded documents.
     #
     # @return [ Array<Document> ] The embedded documents.
-    #
-    # @since 3.0.0
     def documents=(docs)
       @documents = docs
     end
@@ -173,8 +165,6 @@ module Mongoid
     #   criteria.embedded?
     #
     # @return [ true, false ] If the criteria is embedded.
-    #
-    # @since 3.0.0
     def embedded?
       !!@embedded
     end
@@ -186,8 +176,6 @@ module Mongoid
     #   criteria.extract_id
     #
     # @return [ Object ] The id.
-    #
-    # @since 2.3.0
     def extract_id
       selector.extract_id
     end
@@ -201,8 +189,6 @@ module Mongoid
     # @param [ Hash ] extras The extra driver options.
     #
     # @return [ Criteria ] The cloned criteria.
-    #
-    # @since 2.0.0
     def extras(extras)
       crit = clone
       crit.options.merge!(extras)
@@ -215,8 +201,6 @@ module Mongoid
     #   criteria.field_list
     #
     # @return [ Array<String> ] The fields.
-    #
-    # @since 2.0.0
     def field_list
       if options[:fields]
         options[:fields].keys.reject{ |key| key == klass.discriminator_key }
@@ -233,8 +217,6 @@ module Mongoid
     #   criteria.freeze
     #
     # @return [ Criteria ] The frozen criteria.
-    #
-    # @since 2.0.0
     def freeze
       context and inclusions and super
     end
@@ -245,8 +227,6 @@ module Mongoid
     #   Criteria.new(Band)
     #
     # @param [ Class ] klass The model class.
-    #
-    # @since 1.0.0
     def initialize(klass)
       @klass = klass
       @embedded = nil
@@ -288,8 +268,6 @@ module Mongoid
     # @param [ Criteria ] other The criteria to merge in.
     #
     # @return [ Criteria ] The merged criteria.
-    #
-    # @since 3.0.0
     def merge!(other)
       criteria = other.to_criteria
       selector.merge!(criteria.selector)
@@ -307,8 +285,6 @@ module Mongoid
     #   criteria.none
     #
     # @return [ Criteria ] The none criteria.
-    #
-    # @since 4.0.0
     def none
       @none = true and self
     end
@@ -319,8 +295,6 @@ module Mongoid
     #   criteria.empty_and_chainable?
     #
     # @return [ true, false ] If the criteria is a none.
-    #
-    # @since 4.0.0
     def empty_and_chainable?
       !!@none
     end
@@ -333,8 +307,6 @@ module Mongoid
     # @param [ Array<Symbol> ] args The names of the fields.
     #
     # @return [ Criteria ] The cloned criteria.
-    #
-    # @since 1.0.0
     def only(*args)
       args = args.flatten
       return clone if args.empty?
@@ -355,8 +327,6 @@ module Mongoid
     # @param [ Hash ] value The mode preference.
     #
     # @return [ Criteria ] The cloned criteria.
-    #
-    # @since 5.0.0
     def read(value = nil)
       clone.tap do |criteria|
         criteria.options.merge!(read: value)
@@ -371,8 +341,6 @@ module Mongoid
     # @param [ Array<Symbol> ] args The names of the fields.
     #
     # @return [ Criteria ] The cloned criteria.
-    #
-    # @since 4.0.3
     def without(*args)
       args -= id_fields
       super(*args)
@@ -399,8 +367,6 @@ module Mongoid
     #   criteria.to_criteria
     #
     # @return [ Criteria ] self.
-    #
-    # @since 3.0.0
     def to_criteria
       self
     end
@@ -411,8 +377,6 @@ module Mongoid
     #   criteria.to_proc
     #
     # @return [ Proc ] The wrapped criteria.
-    #
-    # @since 3.0.0
     def to_proc
       ->{ self }
     end
@@ -447,8 +411,6 @@ module Mongoid
     #   is embedded.
     #
     # @return [ Criteria ] The cloned selectable.
-    #
-    # @since 1.0.0
     def where(*args)
       # Historically this method required exactly one argument.
       # As of https://jira.mongodb.org/browse/MONGOID-4804 it also accepts
@@ -476,8 +438,6 @@ module Mongoid
     #   criteria.without_options
     #
     # @return [ Criteria ] The cloned criteria.
-    #
-    # @since 3.0.4
     def without_options
       crit = clone
       crit.options.clear
@@ -496,8 +456,6 @@ module Mongoid
     # @param [ Hash ] scope The scope for the code.
     #
     # @return [ Criteria ] The criteria.
-    #
-    # @since 3.1.0
     def for_js(javascript, scope = {})
       code = if scope.empty?
         # CodeWithScope is not supported for $where as of MongoDB 4.4
@@ -523,8 +481,6 @@ module Mongoid
     #
     # @raise [ Errors::DocumentNotFound ] If none are found and raising an
     #   error.
-    #
-    # @since 3.0.0
     def check_for_missing_documents!(result, ids)
       if (result.size < ids.size) && Mongoid.raise_not_found_error
         raise Errors::DocumentNotFound.new(klass, ids, ids - result.map(&:_id))
@@ -545,8 +501,6 @@ module Mongoid
     # @param [ Criteria ] other The criteria getting cloned.
     #
     # @return [ nil ] nil.
-    #
-    # @since 1.0.0
     def initialize_copy(other)
       @inclusions = other.inclusions.dup
       @scoping_options = other.scoping_options
@@ -565,8 +519,6 @@ module Mongoid
     # @param [ Array ] args The arguments.
     #
     # @return [ Object ] The result of the method call.
-    #
-    # @since 1.0.0
     ruby2_keywords def method_missing(name, *args, &block)
       if klass.respond_to?(name)
         klass.send(:with_scope, self) do
@@ -586,8 +538,6 @@ module Mongoid
     #   criteria.merge_type_selection
     #
     # @return [ true, false ] If type selection was added.
-    #
-    # @since 3.0.3
     def merge_type_selection
       selector.merge!(type_selection) if type_selectable?
     end
@@ -600,8 +550,6 @@ module Mongoid
     #   criteria.type_selectable?
     #
     # @return [ true, false ] If type selection should be added.
-    #
-    # @since 3.0.3
     def type_selectable?
       klass.hereditary? &&
         !selector.keys.include?(self.discriminator_key) &&
@@ -616,8 +564,6 @@ module Mongoid
     #   criteria.type_selection
     #
     # @return [ Hash ] The type selection.
-    #
-    # @since 3.0.3
     def type_selection
       klasses = klass._types
       if klasses.size > 1
@@ -635,8 +581,6 @@ module Mongoid
     #   criteria.selector_with_type_selection
     #
     # @return [ Hash ] The selector.
-    #
-    # @since 3.0.3
     def selector_with_type_selection
       type_selectable? ? selector.merge(type_selection) : selector
     end

--- a/lib/mongoid/criteria/findable.rb
+++ b/lib/mongoid/criteria/findable.rb
@@ -16,8 +16,6 @@ module Mongoid
       # @raise [ Errors::DocumentNotFound ] If nothing returned.
       #
       # @return [ Document, Array<Document> ] The document(s).
-      #
-      # @since 2.0.0
       def execute_or_raise(ids, multi)
         result = multiple_from_db(ids)
         check_for_missing_documents!(result, ids)
@@ -35,8 +33,6 @@ module Mongoid
       # @param [ Array<BSON::ObjectId> ] args The ids to search for.
       #
       # @return [ Array<Document>, Document ] The matching document(s).
-      #
-      # @since 1.0.0
       def find(*args)
         ids = args.__find_args__
         raise_invalid if ids.any?(&:nil?)
@@ -88,8 +84,6 @@ module Mongoid
       #   criteria.id_finder
       #
       # @return [ Symbol ] The name of the finder method.
-      #
-      # @since 3.1.0
       def id_finder
         @id_finder ||= extract_id ? :all_of : :where
       end
@@ -104,8 +98,6 @@ module Mongoid
       # @param [ Array<Object> ] ids The ids to fetch with.
       #
       # @return [ Array<Document> ] The matching documents.
-      #
-      # @since 3.0.0
       def from_database(ids)
         from_database_selector(ids).entries
       end
@@ -128,8 +120,6 @@ module Mongoid
       # @param [ Array<Object> ] ids The ids to convert.
       #
       # @return [ Array<Object> ] The converted ids.
-      #
-      # @since 3.0.0
       def mongoize_ids(ids)
         ids.map do |id|
           id = id[:_id] if id.respond_to?(:keys) && id[:_id]
@@ -143,8 +133,6 @@ module Mongoid
       #   criteria.raise_invalid
       #
       # @raise [ Errors::InvalidOptions ] The error.
-      #
-      # @since 2.0.0
       def raise_invalid
         raise Errors::InvalidFind.new
       end

--- a/lib/mongoid/criteria/includable.rb
+++ b/lib/mongoid/criteria/includable.rb
@@ -26,8 +26,6 @@ module Mongoid
       #   load.
       #
       # @return [ Criteria ] The cloned criteria.
-      #
-      # @since 2.2.0
       def includes(*relations)
         extract_includes_list(klass, relations)
         clone
@@ -39,8 +37,6 @@ module Mongoid
       #   Person.includes(:game).inclusions
       #
       # @return [ Array<Association> ] The inclusions.
-      #
-      # @since 2.2.0
       def inclusions
         @inclusions ||= []
       end
@@ -53,8 +49,6 @@ module Mongoid
       # @param [ Array<Association> ] value The inclusions.
       #
       # @return [ Array<Association> ] The new inclusions.
-      #
-      # @since 3.0.0
       def inclusions=(value)
         @inclusions = value
       end
@@ -70,8 +64,6 @@ module Mongoid
       # @param [ Symbol ] association The association.
       #
       # @raise [ Errors::InvalidIncludes ] If no association is found.
-      #
-      # @since 5.1.0
       def add_inclusion(_klass, association)
         inclusions.push(association) unless inclusions.include?(association)
       end

--- a/lib/mongoid/criteria/inspectable.rb
+++ b/lib/mongoid/criteria/inspectable.rb
@@ -12,8 +12,6 @@ module Mongoid
       #   criteria.inspect
       #
       # @return [ String ] The inspection string.
-      #
-      # @since 1.0.0
       def inspect
 %Q{#<Mongoid::Criteria
   selector: #{selector.inspect}

--- a/lib/mongoid/criteria/marshalable.rb
+++ b/lib/mongoid/criteria/marshalable.rb
@@ -11,8 +11,6 @@ module Mongoid
       #   Marshal.dump(criteria)
       #
       # @return [ Array<Object> ] The dumped data.
-      #
-      # @since 3.0.15
       def marshal_dump
         data = [ klass, driver, inclusions, documents, strategy, negating ]
         data.push(scoping_options).push(dump_hash(:selector)).push(dump_hash(:options))
@@ -24,8 +22,6 @@ module Mongoid
       #   Marshal.load(criteria)
       #
       # @param [ Array ] data The raw data.
-      #
-      # @since 3.0.15
       def marshal_load(data)
         @scoping_options, raw_selector, raw_options = data.pop(3)
         @klass, @driver, @inclusions, @documents, @strategy, @negating = data

--- a/lib/mongoid/criteria/modifiable.rb
+++ b/lib/mongoid/criteria/modifiable.rb
@@ -19,8 +19,6 @@ module Mongoid
       #   Person.where(:age.gt => 5).build
       #
       # @return [ Document ] A non-persisted document.
-      #
-      # @since 2.0.0
       def build(attrs = {}, &block)
         create_document(:new, attrs, &block)
       end
@@ -36,8 +34,6 @@ module Mongoid
       #   Person.where(:age.gt => 5).create
       #
       # @return [ Document ] A newly created document.
-      #
-      # @since 2.0.0.rc.1
       def create(attrs = {}, &block)
         create_document(:create, attrs, &block)
       end
@@ -55,8 +51,6 @@ module Mongoid
       # @raise [ Errors::Validations ] on a validation error.
       #
       # @return [ Document ] A newly created document.
-      #
-      # @since 3.0.0
       def create!(attrs = {}, &block)
         create_document(:create!, attrs, &block)
       end
@@ -70,8 +64,6 @@ module Mongoid
       #   Person.create_with(job: 'Engineer').find_or_create_by(employer: 'MongoDB')
       #
       # @return [ Mongoid::Criteria ] A criteria.
-      #
-      # @since 5.1.0
       def create_with(attrs = {})
         tap do
           @create_attrs ||= {}
@@ -130,8 +122,6 @@ module Mongoid
       # @param [ Hash ] attrs The additional attributes to add.
       #
       # @return [ Document ] A matching or newly created document.
-      #
-      # @since 3.1.0
       def first_or_create(attrs = nil, &block)
         first_or(:create, attrs, &block)
       end
@@ -146,8 +136,6 @@ module Mongoid
       # @param [ Hash ] attrs The additional attributes to add.
       #
       # @return [ Document ] A matching or newly created document.
-      #
-      # @since 3.1.0
       def first_or_create!(attrs = nil, &block)
         first_or(:create!, attrs, &block)
       end
@@ -161,8 +149,6 @@ module Mongoid
       # @param [ Hash ] attrs The additional attributes to add.
       #
       # @return [ Document ] A matching or newly initialized document.
-      #
-      # @since 3.1.0
       def first_or_initialize(attrs = nil, &block)
         first_or(:new, attrs, &block)
       end
@@ -181,8 +167,6 @@ module Mongoid
       # @param [ Hash ] attrs Additional attributes to use.
       #
       # @return [ Document ] The new or saved document.
-      #
-      # @since 3.0.0
       def create_document(method, attrs = nil, &block)
         attrs = (create_attrs || {}).merge(attrs || {})
         attributes = selector.reduce(attrs) do |hash, (key, value)|
@@ -228,8 +212,6 @@ module Mongoid
       # @param [ Hash ] attrs The attributes to query or set.
       #
       # @return [ Document ] The first or new document.
-      #
-      # @since 3.1.0
       def first_or(method, attrs = {}, &block)
         first || create_document(method, attrs, &block)
       end

--- a/lib/mongoid/criteria/options.rb
+++ b/lib/mongoid/criteria/options.rb
@@ -5,8 +5,6 @@ module Mongoid
   class Criteria
 
     # Module containing functionality for getting options on a Criteria object.
-    #
-    # @since 6.0.0
     module Options
 
       private

--- a/lib/mongoid/criteria/queryable.rb
+++ b/lib/mongoid/criteria/queryable.rb
@@ -47,8 +47,6 @@ module Mongoid
       # @param [ Object ] other The object to compare against.
       #
       # @return [ true, false ] If the objects are equal.
-      #
-      # @since 1.0.0
       def ==(other)
         return false unless other.is_a?(Queryable)
         selector == other.selector && options == other.options
@@ -63,8 +61,6 @@ module Mongoid
       # @param [ Hash ] aliases The optional field aliases.
       # @param [ Hash ] serializers The optional field serializers.
       # @param [ Symbol ] driver The driver being used.
-      #
-      # @since 1.0.0
       def initialize(aliases = {}, serializers = {}, driver = :mongo)
         @aliases, @driver, @serializers = aliases, driver.to_sym, serializers
         @options = Options.new(aliases, serializers)
@@ -80,8 +76,6 @@ module Mongoid
       #   queryable.initialize_copy(criteria)
       #
       # @param [ Queryable ] other The original copy.
-      #
-      # @since 1.0.0
       def initialize_copy(other)
         @options = other.options.__deep_copy__
         @selector = other.selector.__deep_copy__

--- a/lib/mongoid/criteria/queryable/aggregable.rb
+++ b/lib/mongoid/criteria/queryable/aggregable.rb
@@ -6,8 +6,6 @@ module Mongoid
     module Queryable
 
       # Provides a DSL around crafting aggregation framework commands.
-      #
-      # @since 2.0.0
       module Aggregable
         extend Macroable
 
@@ -24,8 +22,6 @@ module Mongoid
         #   aggregable.aggregating?
         #
         # @return [ true, false ] If the aggregable is aggregating.
-        #
-        # @since 2.0.0
         def aggregating?
           !!@aggregating
         end
@@ -41,8 +37,6 @@ module Mongoid
         # @param [ Hash ] operation The group operation.
         #
         # @return [ Aggregable ] The aggregable.
-        #
-        # @since 2.0.0
         def group(operation)
           aggregation(operation) do |pipeline|
             pipeline.group(operation)
@@ -65,8 +59,6 @@ module Mongoid
         # @param [ Hash ] operation The projection to make.
         #
         # @return [ Aggregable ] The aggregable.
-        #
-        # @since 2.0.0
         def project(operation = nil)
           aggregation(operation) do |pipeline|
             pipeline.project(operation)
@@ -81,8 +73,6 @@ module Mongoid
         # @param [ String, Symbol ] field The name of the field to unwind.
         #
         # @return [ Aggregable ] The aggregable.
-        #
-        # @since 2.0.0
         def unwind(field)
           aggregation(field) do |pipeline|
             pipeline.unwind(field)
@@ -103,8 +93,6 @@ module Mongoid
         # @param [ Hash ] operation The operation for the pipeline.
         #
         # @return [ Aggregable ] The cloned aggregable.
-        #
-        # @since 2.0.0
         def aggregation(operation)
           return self unless operation
           clone.tap do |query|

--- a/lib/mongoid/criteria/queryable/extensions/array.rb
+++ b/lib/mongoid/criteria/queryable/extensions/array.rb
@@ -17,8 +17,6 @@ module Mongoid
           # @param [ Object ] object The object to add.
           #
           # @return [ Object ] The result of the add.
-          #
-          # @since 1.0.0
           def __add__(object)
             object.__add_from_array__(self)
           end
@@ -29,8 +27,6 @@ module Mongoid
           #   [ 1, 2 ].__array__
           #
           # @return [ Array ] self
-          #
-          # @since 1.0.0
           def __array__; self; end
 
           # Makes a deep copy of the array, deep copying every element inside the
@@ -40,8 +36,6 @@ module Mongoid
           #   [ 1, 2, 3 ].__deep_copy__
           #
           # @return [ Array ] The deep copy of the array.
-          #
-          # @since 1.0.0
           def __deep_copy__
             map { |value| value.__deep_copy__ }
           end
@@ -53,8 +47,6 @@ module Mongoid
           #   [ Date.new(2010, 1, 1) ].__evolve_date__
           #
           # @return [ Array<Time> ] The array as times at midnight UTC.
-          #
-          # @since 1.0.0
           def __evolve_date__
             map { |value| value.__evolve_date__ }
           end
@@ -65,8 +57,6 @@ module Mongoid
           #   obj.__expand_complex__
           #
           # @return [ Array ] The expanded array.
-          #
-          # @since 1.1.0
           def __expand_complex__
             map do |value|
               value.__expand_complex__
@@ -79,8 +69,6 @@ module Mongoid
           #   [ 1231231231 ].__evolve_time__
           #
           # @return [ Array<Time> ] The array as times.
-          #
-          # @since 1.0.0
           def __evolve_time__
             map { |value| value.__evolve_time__ }
           end
@@ -93,8 +81,6 @@ module Mongoid
           # @param [ Object ] object The object to intersect with.
           #
           # @return [ Object ] The result of the intersection.
-          #
-          # @since 1.0.0
           def __intersect__(object)
             object.__intersect_from_array__(self)
           end
@@ -106,8 +92,6 @@ module Mongoid
           #   [ :field, 1 ].__sort_option__
           #
           # @return [ Hash ] The array as sort criterion.
-          #
-          # @since 1.0.0
           def __sort_option__
             multi.inject({}) do |options, criteria|
               options.merge!(criteria.__sort_pair__)
@@ -121,8 +105,6 @@ module Mongoid
           #   [ field, 1 ].__sort_pair__
           #
           # @return [ Hash ] The field/direction pair.
-          #
-          # @since 1.0.0
           def __sort_pair__
             { first => last.to_direction }
           end
@@ -135,8 +117,6 @@ module Mongoid
           # @param [ Proc ] block The block to execute on each value.
           #
           # @return [ Array ] the array.
-          #
-          # @since 1.0.0
           def update_values(&block)
             replace(map(&block))
           end
@@ -151,8 +131,6 @@ module Mongoid
           #   [ 1, 2, 3 ].multi
           #
           # @return [ Array ] The multi-dimensional array.
-          #
-          # @since 1.0.0
           def multi
             first.is_a?(::Symbol) || first.is_a?(::String) ? [ self ] : self
           end
@@ -167,8 +145,6 @@ module Mongoid
             # @param [ Object ] object The object to evolve.
             #
             # @return [ Object ] The evolved object.
-            #
-            # @since 1.0.0
             def evolve(object)
               if object.is_a?(::Array)
                 object.map { |obj| obj.class.evolve(obj) }

--- a/lib/mongoid/criteria/queryable/extensions/big_decimal.rb
+++ b/lib/mongoid/criteria/queryable/extensions/big_decimal.rb
@@ -22,8 +22,6 @@ module Mongoid
             # @param [ BigDecimal ] object The object to convert.
             #
             # @return [ String ] The big decimal as a string.
-            #
-            # @since 1.0.0
             def evolve(object)
               __evolve__(object) do |obj|
                 obj ? obj.to_s : obj

--- a/lib/mongoid/criteria/queryable/extensions/boolean.rb
+++ b/lib/mongoid/criteria/queryable/extensions/boolean.rb
@@ -19,8 +19,6 @@ module Mongoid
             # @param [ Object ] object The object to evolve.
             #
             # @return [ true, false ] The boolean value.
-            #
-            # @since 1.0.0
             def evolve(object)
               __evolve__(object) do |obj|
                 obj.to_s =~ (/\A(true|t|yes|y|on|1|1.0)\z/i) ? true : false

--- a/lib/mongoid/criteria/queryable/extensions/date.rb
+++ b/lib/mongoid/criteria/queryable/extensions/date.rb
@@ -15,8 +15,6 @@ module Mongoid
           #   date.__evolve_date__
           #
           # @return [ Time ] The date as a UTC time at midnight.
-          #
-          # @since 1.0.0
           def __evolve_date__
             ::Time.utc(year, month, day, 0, 0, 0, 0)
           end
@@ -27,8 +25,6 @@ module Mongoid
           #   date.__evolve_time__
           #
           # @return [ Time ] The date as a local time.
-          #
-          # @since 1.0.0
           def __evolve_time__
             ::Time.local(year, month, day)
           end
@@ -49,8 +45,6 @@ module Mongoid
             # @param [ Object ] object The object to evolve.
             #
             # @return [ Time ] The evolved date.
-            #
-            # @since 1.0.0
             def evolve(object)
               object.__evolve_date__
             end

--- a/lib/mongoid/criteria/queryable/extensions/date_time.rb
+++ b/lib/mongoid/criteria/queryable/extensions/date_time.rb
@@ -15,8 +15,6 @@ module Mongoid
           #   date_time.__evolve_time__
           #
           # @return [ Time ] The converted time in UTC.
-          #
-          # @since 1.0.0
           def __evolve_time__
             usec = strftime("%6N").to_f
             u = utc
@@ -36,8 +34,6 @@ module Mongoid
             # @param [ Object ] object The object to evolve.
             #
             # @return [ Time ] The evolved date time.
-            #
-            # @since 1.0.0
             def evolve(object)
               object.__evolve_time__
             end

--- a/lib/mongoid/criteria/queryable/extensions/hash.rb
+++ b/lib/mongoid/criteria/queryable/extensions/hash.rb
@@ -17,8 +17,6 @@ module Mongoid
           # @param [ Hash ] object The other hash to add.
           #
           # @return [ Hash ] The hash with object added.
-          #
-          # @since 1.0.0
           def __add__(object)
             apply_strategy(:__add__, object)
           end
@@ -31,8 +29,6 @@ module Mongoid
           # @param [ Array ] array The array to add to.
           #
           # @return [ Hash ] The merged hash.
-          #
-          # @since 1.0.0
           def __add_from_array__(array)
             { keys.first => array.__add__(values.first) }
           end
@@ -45,8 +41,6 @@ module Mongoid
           # @param [ Hash ] object The other hash to intersect.
           #
           # @return [ Hash ] The hash with object intersected.
-          #
-          # @since 1.0.0
           def __intersect__(object)
             apply_strategy(:__intersect__, object)
           end
@@ -59,8 +53,6 @@ module Mongoid
           # @param [ Array ] array The array to intersect to.
           #
           # @return [ Hash ] The merged hash.
-          #
-          # @since 1.0.0
           def __intersect_from_array__(array)
             { keys.first => array.__intersect__(values.first) }
           end
@@ -73,8 +65,6 @@ module Mongoid
           # @param [ Object ] object The object to intersect to.
           #
           # @return [ Hash ] The merged hash.
-          #
-          # @since 1.0.0
           def __intersect_from_object__(object)
             { keys.first => object.__intersect__(values.first) }
           end
@@ -87,8 +77,6 @@ module Mongoid
           # @param [ Hash ] object The other hash to union.
           #
           # @return [ Hash ] The hash with object unioned.
-          #
-          # @since 1.0.0
           def __union__(object)
             apply_strategy(:__union__, object)
           end
@@ -101,8 +89,6 @@ module Mongoid
           # @param [ Object ] object The object to union to.
           #
           # @return [ Hash ] The merged hash.
-          #
-          # @since 1.0.0
           def __union_from_object__(object)
             { keys.first => object.__union__(values.first) }
           end
@@ -113,8 +99,6 @@ module Mongoid
           #   { field: value }.__deep_copy__
           #
           # @return [ Hash ] The copied hash.
-          #
-          # @since 1.0.0
           def __deep_copy__
             {}.tap do |copy|
               each_pair do |key, value|
@@ -129,8 +113,6 @@ module Mongoid
           #   { field: 1 }.__sort_option__
           #
           # @return [ Hash ] The hash as sort option.
-          #
-          # @since 1.0.0
           def __sort_option__
             tap do |hash|
               hash.each_pair do |key, value|
@@ -145,8 +127,6 @@ module Mongoid
           #   obj.__expand_complex__
           #
           # @return [ Hash ] The expanded hash.
-          #
-          # @since 1.0.5
           def __expand_complex__
             replacement = {}
             each_pair do |key, value|
@@ -163,8 +143,6 @@ module Mongoid
           # @param [ Proc ] block The block to execute on each value.
           #
           # @return [ Hash ] the hash.
-          #
-          # @since 1.0.0
           def update_values(&block)
             each_pair do |key, value|
               store(key, block[value])
@@ -184,8 +162,6 @@ module Mongoid
           # @param [ Object ] object The object to merge.
           #
           # @return [ Hash ] The merged hash.
-          #
-          # @since 1.0.0
           def apply_strategy(strategy, object)
             tap do |hash|
               object.each_pair do |key, value|

--- a/lib/mongoid/criteria/queryable/extensions/nil_class.rb
+++ b/lib/mongoid/criteria/queryable/extensions/nil_class.rb
@@ -17,8 +17,6 @@ module Mongoid
           # @param [ Object ] object The object to add.
           #
           # @return [ Object ] The provided object.
-          #
-          # @since 1.0.0
           def __add__(object); object; end
 
           # Add this object to nil.
@@ -29,8 +27,6 @@ module Mongoid
           # @param [ Object ] object The object to expanded.
           #
           # @return [ Object ] The provided object.
-          #
-          # @since 1.0.0
           def __expanded__(object); object; end
 
           # Evolve the nil into a date or time.
@@ -39,8 +35,6 @@ module Mongoid
           #   nil.__evolve_time__
           #
           # @return [ nil ] nil.
-          #
-          # @since 1.0.0
           def __evolve_time__; self; end
           alias :__evolve_date__ :__evolve_time__
 
@@ -52,8 +46,6 @@ module Mongoid
           # @param [ Object ] object The object to intersect.
           #
           # @return [ Object ] The provided object.
-          #
-          # @since 1.0.0
           def __intersect__(object); object; end
 
           # Add this object to nil.
@@ -64,8 +56,6 @@ module Mongoid
           # @param [ Object ] object The object to override.
           #
           # @return [ Object ] The provided object.
-          #
-          # @since 1.0.0
           def __override__(object); object; end
 
           # Add this object to nil.
@@ -76,8 +66,6 @@ module Mongoid
           # @param [ Object ] object The object to union.
           #
           # @return [ Object ] The provided object.
-          #
-          # @since 1.0.0
           def __union__(object); object; end
         end
       end

--- a/lib/mongoid/criteria/queryable/extensions/numeric.rb
+++ b/lib/mongoid/criteria/queryable/extensions/numeric.rb
@@ -16,8 +16,6 @@ module Mongoid
           #   125214512412.1123.__evolve_date__
           #
           # @return [ Time ] The time representation at UTC midnight.
-          #
-          # @since 1.0.0
           def __evolve_date__
             time = ::Time.at(self).utc
             ::Time.utc(time.year, time.month, time.day, 0, 0, 0, 0)
@@ -29,8 +27,6 @@ module Mongoid
           #   125214512412.1123.__evolve_time__
           #
           # @return [ Time ] The time representation.
-          #
-          # @since 1.0.0
           def __evolve_time__
             ::Time.at(self).utc
           end
@@ -41,8 +37,6 @@ module Mongoid
           #   1.to_direction
           #
           # @return [ Integer ] self.
-          #
-          # @since 1.0.0
           def to_direction; self; end
 
           module ClassMethods
@@ -57,8 +51,6 @@ module Mongoid
             # @param [ Object ] object The object to convert.
             #
             # @return [ Object ] The converted number.
-            #
-            # @since 1.0.0
             def __numeric__(object)
               object.to_s =~ /(\A[-+]?[0-9]+\z)|(\.0+\z)|(\.\z)/ ? object.to_i : Float(object)
             end
@@ -71,8 +63,6 @@ module Mongoid
             # @param [ Object ] object The object to evolve.
             #
             # @return [ Integer ] The evolved object.
-            #
-            # @since 1.0.0
             def evolve(object)
               __evolve__(object) do |obj|
                 __numeric__(obj) rescue obj

--- a/lib/mongoid/criteria/queryable/extensions/object.rb
+++ b/lib/mongoid/criteria/queryable/extensions/object.rb
@@ -17,8 +17,6 @@ module Mongoid
           # @param [ Object ] object The object to add.
           #
           # @return [ Object ] The result of the add.
-          #
-          # @since 1.0.0
           def __add__(object)
             (object == self) ? self : [ self, object ].flatten.uniq
           end
@@ -31,8 +29,6 @@ module Mongoid
           # @param [ Array ] array The array to add to.
           #
           # @return [ Array ] The merged object.
-          #
-          # @since 1.0.0
           def __add_from_array__(array)
             array.concat(Array(self)).uniq
           end
@@ -45,8 +41,6 @@ module Mongoid
           # @param [ Object ] object The object to intersect.
           #
           # @return [ Array ] The result of the intersect.
-          #
-          # @since 1.0.0
           def __intersect__(object)
             object.__intersect_from_object__(self)
           end
@@ -59,8 +53,6 @@ module Mongoid
           # @param [ Array ] array The array to intersect to.
           #
           # @return [ Array ] The merged object.
-          #
-          # @since 1.0.0
           def __intersect_from_array__(array)
             array & Array(self)
           end
@@ -73,8 +65,6 @@ module Mongoid
           # @param [ Object ] object The value to intersect to.
           #
           # @return [ Array ] The merged object.
-          #
-          # @since 1.0.0
           def __intersect_from_object__(object)
             Array(object) & Array(self)
           end
@@ -87,8 +77,6 @@ module Mongoid
           # @param [ Object ] object The object to union.
           #
           # @return [ Array ] The result of the union.
-          #
-          # @since 1.0.0
           def __union__(object)
             object.__union_from_object__(self)
           end
@@ -101,8 +89,6 @@ module Mongoid
           # @param [ Object ] object The value to union to.
           #
           # @return [ Array ] The merged object.
-          #
-          # @since 1.0.0
           def __union_from_object__(object)
             (Array(object) + Array(self)).uniq
           end
@@ -114,8 +100,6 @@ module Mongoid
           #   1.__deep_copy__
           #
           # @return [ Object ] self.
-          #
-          # @since 1.0.0
           def __deep_copy__; self; end
 
           # Get the object as an array.
@@ -124,8 +108,6 @@ module Mongoid
           #   4.__array__
           #
           # @return [ Array ] The wrapped object.
-          #
-          # @since 1.0.0
           def __array__
             [ self ]
           end
@@ -136,8 +118,6 @@ module Mongoid
           #   obj.__expand_complex__
           #
           # @return [ Object ] self.
-          #
-          # @since 1.0.5
           def __expand_complex__
             self
           end
@@ -148,8 +128,6 @@ module Mongoid
           #   obj.regexp?
           #
           # @return [ false ] Always false.
-          #
-          # @since 1.0.4
           def regexp?
             false
           end
@@ -164,8 +142,6 @@ module Mongoid
             #   Object.evolve("test")
             #
             # @return [ Object ] The provided object.
-            #
-            # @since 1.0.0
             def evolve(object)
               object
             end
@@ -184,8 +160,6 @@ module Mongoid
             #   end
             #
             # @return [ Object ] The evolved object.
-            #
-            # @since 1.0.0
             def __evolve__(object)
               return nil if object.nil?
               case object

--- a/lib/mongoid/criteria/queryable/extensions/range.rb
+++ b/lib/mongoid/criteria/queryable/extensions/range.rb
@@ -15,8 +15,6 @@ module Mongoid
           #   1...3.__array__
           #
           # @return [ Array ] The range as an array.
-          #
-          # @since 1.0.0
           def __array__
             to_a
           end
@@ -27,8 +25,6 @@ module Mongoid
           #   (11231312..213123131).__evolve_date__
           #
           # @return [ Hash ] The min/max range query with times at midnight.
-          #
-          # @since 1.0.0
           def __evolve_date__
             { "$gte" => min.__evolve_date__, "$lte" => max.__evolve_date__ }
           end
@@ -39,8 +35,6 @@ module Mongoid
           #   (11231312..213123131).__evolve_date__
           #
           # @return [ Hash ] The min/max range query with times.
-          #
-          # @since 1.0.0
           def __evolve_time__
             { "$gte" => min.__evolve_time__, "$lte" => max.__evolve_time__ }
           end
@@ -55,8 +49,6 @@ module Mongoid
             # @param [ Range ] object The range to evolve.
             #
             # @return [ Hash ] The range as a gte/lte criteria.
-            #
-            # @since 1.0.0
             def evolve(object)
               return object unless object.is_a?(::Range)
               { "$gte" => object.min, "$lte" => object.max }

--- a/lib/mongoid/criteria/queryable/extensions/regexp.rb
+++ b/lib/mongoid/criteria/queryable/extensions/regexp.rb
@@ -15,8 +15,6 @@ module Mongoid
           #   /\A[123]/.regexp?
           #
           # @return [ true ] Always true.
-          #
-          # @since 1.0.0
           def regexp?; true; end
 
           module ClassMethods
@@ -29,8 +27,6 @@ module Mongoid
             # @param [ Regexp, String ] object The object to evolve.
             #
             # @return [ Regexp ] The evolved regex.
-            #
-            # @since 1.0.0
             def evolve(object)
               __evolve__(object) do |obj|
                 ::Regexp.new(obj)
@@ -46,8 +42,6 @@ module Mongoid
             #   bson_raw_regexp.regexp?
             #
             # @return [ true ] Always true.
-            #
-            # @since 5.2.1
             def regexp?; true; end
 
             module ClassMethods
@@ -60,8 +54,6 @@ module Mongoid
               # @param [ BSON::Regexp::Raw, String ] object The object to evolve.
               #
               # @return [ BSON::Regexp::Raw ] The evolved raw regex.
-              #
-              # @since 5.2.1
               def evolve(object)
                 __evolve__(object) do |obj|
                   obj.is_a?(String) ? BSON::Regexp::Raw.new(obj) : obj

--- a/lib/mongoid/criteria/queryable/extensions/set.rb
+++ b/lib/mongoid/criteria/queryable/extensions/set.rb
@@ -20,8 +20,6 @@ module Mongoid
             # @param [ Set, Object ] object The object to evolve.
             #
             # @return [ Array ] The evolved set.
-            #
-            # @since 1.0.0
             def evolve(object)
               return object if !object || !object.respond_to?(:map)
               object.map{ |obj| obj.class.evolve(obj) }

--- a/lib/mongoid/criteria/queryable/extensions/string.rb
+++ b/lib/mongoid/criteria/queryable/extensions/string.rb
@@ -15,8 +15,6 @@ module Mongoid
           #   "2012-1-1".__evolve_date__
           #
           # @return [ Time ] The time at UTC midnight.
-          #
-          # @since 1.0.0
           def __evolve_date__
             time = ::Time.parse(self)
             ::Time.utc(time.year, time.month, time.day, 0, 0, 0, 0)
@@ -28,8 +26,6 @@ module Mongoid
           #   "2012-1-1".__evolve_time__
           #
           # @return [ Time ] The string as a time.
-          #
-          # @since 1.0.0
           def __evolve_time__
             __mongoize_time__.utc
           end
@@ -40,8 +36,6 @@ module Mongoid
           #   "test".__mongo_expression__
           #
           # @return [ String ] The string with $ at the front.
-          #
-          # @since 2.0.0
           def __mongo_expression__
             start_with?("$") ? self : "$#{self}"
           end
@@ -52,8 +46,6 @@ module Mongoid
           #   "field ASC".__sort_option__
           #
           # @return [ Hash ] The string as a sort option hash.
-          #
-          # @since 1.0.0
           def __sort_option__
             split(/,/).inject({}) do |hash, spec|
               hash.tap do |_hash|
@@ -72,8 +64,6 @@ module Mongoid
           # @param [ true, false ] negating If the selection should be negated.
           #
           # @return [ Hash ] The selection.
-          #
-          # @since 1.0.0
           def __expr_part__(value, negating = false)
             ::String.__expr_part__(self, value, negating)
           end
@@ -84,8 +74,6 @@ module Mongoid
           #   "1".to_direction
           #
           # @return [ Integer ] The direction.
-          #
-          # @since 1.0.0
           def to_direction
             self =~ /desc/i ? -1 : 1
           end
@@ -102,8 +90,6 @@ module Mongoid
             # @param [ true, false ] negating If the selection should be negated.
             #
             # @return [ Hash ] The selection.
-            #
-            # @since 2.0.0
             def __expr_part__(key, value, negating = false)
               if negating
                 { key => { "$#{value.regexp? ? "not" : "ne"}" => value }}
@@ -121,8 +107,6 @@ module Mongoid
             # @param [ Object ] object The object to convert.
             #
             # @return [ String ] The value as a string.
-            #
-            # @since 1.0.0
             def evolve(object)
               __evolve__(object) do |obj|
                 obj.regexp? ? obj : obj.to_s

--- a/lib/mongoid/criteria/queryable/extensions/symbol.rb
+++ b/lib/mongoid/criteria/queryable/extensions/symbol.rb
@@ -18,8 +18,6 @@ module Mongoid
           # @param [ true, false ] negating If the selection should be negated.
           #
           # @return [ Hash ] The selection.
-          #
-          # @since 1.0.0
           def __expr_part__(value, negating = false)
             ::String.__expr_part__(self, value, negating)
           end
@@ -30,8 +28,6 @@ module Mongoid
           #   "1".to_direction
           #
           # @return [ Integer ] The direction.
-          #
-          # @since 1.0.0
           def to_direction
             to_s.to_direction
           end
@@ -47,8 +43,6 @@ module Mongoid
             # @param [ Symbol ] strategy The name of the merge strategy.
             # @param [ String ] operator The MongoDB operator.
             # @param [ String ] additional The additional MongoDB operator.
-            #
-            # @since 1.0.0
             def add_key(name, strategy, operator, additional = nil, &block)
               define_method(name) do
                 method = "__#{strategy}__".to_sym
@@ -65,8 +59,6 @@ module Mongoid
             # @param [ Object ] object The object to convert.
             #
             # @return [ Symbol ] The value as a symbol.
-            #
-            # @since 1.0.0
             def evolve(object)
               __evolve__(object) { |obj| obj.to_sym }
             end

--- a/lib/mongoid/criteria/queryable/extensions/time.rb
+++ b/lib/mongoid/criteria/queryable/extensions/time.rb
@@ -15,8 +15,6 @@ module Mongoid
           #   time.__evolve_date__
           #
           # @return [ Time ] The date at midnight UTC.
-          #
-          # @since 1.0.0
           def __evolve_date__
             ::Time.utc(year, month, day, 0, 0, 0, 0)
           end
@@ -27,8 +25,6 @@ module Mongoid
           #   time.__evolve_time__
           #
           # @return [ Time ] The time in UTC.
-          #
-          # @since 1.0.0
           def __evolve_time__
             getutc
           end
@@ -46,8 +42,6 @@ module Mongoid
             # @param [ Object ] object The object to evolve.
             #
             # @return [ Time ] The evolved date time.
-            #
-            # @since 1.0.0
             def evolve(object)
               object.__evolve_time__
             end

--- a/lib/mongoid/criteria/queryable/extensions/time_with_zone.rb
+++ b/lib/mongoid/criteria/queryable/extensions/time_with_zone.rb
@@ -15,8 +15,6 @@ module Mongoid
           #   time.__evolve_date__
           #
           # @return [ Time ] The date at midnight UTC.
-          #
-          # @since 1.0.0
           def __evolve_date__
             ::Time.utc(year, month, day, 0, 0, 0, 0)
           end
@@ -27,8 +25,6 @@ module Mongoid
           #   time.__evolve_time__
           #
           # @return [ Time ] The time in UTC.
-          #
-          # @since 1.0.0
           def __evolve_time__
             utc
           end
@@ -46,8 +42,6 @@ module Mongoid
             # @param [ Object ] object The object to evolve.
             #
             # @return [ Time ] The evolved date time.
-            #
-            # @since 1.0.0
             def evolve(object)
               object.__evolve_time__
             end

--- a/lib/mongoid/criteria/queryable/key.rb
+++ b/lib/mongoid/criteria/queryable/key.rb
@@ -84,8 +84,6 @@ module Mongoid
         # @param [ Object ] other The object to compare to.
         #
         # @return [ true, false ] If the objects are equal.
-        #
-        # @since 1.0.0
         def ==(other)
           return false unless other.is_a?(Key)
           name == other.name && operator == other.operator && expanded == other.expanded
@@ -95,8 +93,6 @@ module Mongoid
         # Calculate the hash code for a key.
         #
         # @return [ Fixnum ] The hash code for the key.
-        #
-        # @since 1.1.0
         def hash
           [name, operator, expanded].hash
         end
@@ -114,8 +110,6 @@ module Mongoid
         # @param [ String | Integer ] operator The MongoDB operator,
         #   or sort direction (1 or -1).
         # @param [ String ] expanded The Mongo expanded operator.
-        #
-        # @since 1.0.0
         def initialize(name, strategy, operator, expanded = nil, &block)
           unless operator.is_a?(String) || operator.is_a?(Integer)
             raise ArgumentError, "Operator must be a string or an integer: #{operator.inspect}"
@@ -134,8 +128,6 @@ module Mongoid
         # @param [ true, false ] negating If the selection should be negated.
         #
         # @return [ Hash ] The raw MongoDB selector.
-        #
-        # @since 1.0.0
         def __expr_part__(object, negating = false)
           { name.to_s => transform_value(object, negating) }
         end
@@ -166,8 +158,6 @@ module Mongoid
         #   key.__sort_option__
         #
         # @return [ Hash ] The field/direction pair.
-        #
-        # @since 1.0.0
         def __sort_option__
           { name => operator }
         end
@@ -179,8 +169,6 @@ module Mongoid
         #   key.to_s
         #
         # @return [ String ] The key as a string.
-        #
-        # @since 1.1.0
         def to_s
           @name.to_s
         end

--- a/lib/mongoid/criteria/queryable/macroable.rb
+++ b/lib/mongoid/criteria/queryable/macroable.rb
@@ -18,8 +18,6 @@ module Mongoid
         # @param [ Symbol ] strategy The merge strategy.
         # @param [ String ] operator The MongoDB operator.
         # @param [ String ] additional The additional MongoDB operator.
-        #
-        # @since 1.0.0
         def key(name, strategy, operator, additional = nil, &block)
           ::Symbol.add_key(name, strategy, operator, additional, &block)
         end

--- a/lib/mongoid/criteria/queryable/mergeable.rb
+++ b/lib/mongoid/criteria/queryable/mergeable.rb
@@ -17,8 +17,6 @@ module Mongoid
         #   mergeable.intersect.in(field: [ 1, 2, 3 ])
         #
         # @return [ Mergeable ] The intersect flagged mergeable.
-        #
-        # @since 1.0.0
         def intersect
           use(:__intersect__)
         end
@@ -29,8 +27,6 @@ module Mongoid
         #   mergeable.override.in(field: [ 1, 2, 3 ])
         #
         # @return [ Mergeable ] The override flagged mergeable.
-        #
-        # @since 1.0.0
         def override
           use(:__override__)
         end
@@ -41,8 +37,6 @@ module Mongoid
         #   mergeable.union.in(field: [ 1, 2, 3 ])
         #
         # @return [ Mergeable ] The union flagged mergeable.
-        #
-        # @since 1.0.0
         def union
           use(:__union__)
         end
@@ -53,8 +47,6 @@ module Mongoid
         #   mergeable.reset_strategies!
         #
         # @return [ Criteria ] self.
-        #
-        # @since 1.0.0
         def reset_strategies!
           self.strategy = nil
           self.negating = nil
@@ -74,8 +66,6 @@ module Mongoid
         # @param [ String ] operator The MongoDB operator.
         #
         # @return [ Mergeable ] The new mergeable.
-        #
-        # @since 1.0.0
         def __add__(criterion, operator)
           with_strategy(:__add__, criterion, operator)
         end
@@ -92,8 +82,6 @@ module Mongoid
         # @param [ String ] inner The inner MongoDB operator.
         #
         # @return [ Mergeable ] The new mergeable.
-        #
-        # @since 1.0.0
         def __expanded__(criterion, outer, inner)
           selection(criterion) do |selector, field, value|
             selector.store(field, { outer => { inner => value }})
@@ -111,8 +99,6 @@ module Mongoid
         # @param [ Hash ] criterion The criteria.
         #
         # @return [ Mergeable ] The cloned object.
-        #
-        # @since 2.0.0
         def __merge__(criterion)
           selection(criterion) do |selector, field, value|
             selector.merge!(field.__expr_part__(value))
@@ -130,8 +116,6 @@ module Mongoid
         # @param [ String ] operator The MongoDB operator.
         #
         # @return [ Mergeable ] The new mergeable.
-        #
-        # @since 1.0.0
         def __intersect__(criterion, operator)
           with_strategy(:__intersect__, criterion, operator)
         end
@@ -152,8 +136,6 @@ module Mongoid
         # @param [ String ] operator The MongoDB operator.
         #
         # @return [ Mergeable ] The new mergeable.
-        #
-        # @since 1.0.0
         def __multi__(criteria, operator)
           clone.tap do |query|
             sel = query.selector
@@ -337,8 +319,6 @@ module Mongoid
         # @param [ String ] operator The MongoDB operator.
         #
         # @return [ Mergeable ] The new mergeable.
-        #
-        # @since 1.0.0
         def __override__(criterion, operator)
           if criterion.is_a?(Selectable)
             criterion = criterion.selector
@@ -365,8 +345,6 @@ module Mongoid
         # @param [ String ] operator The MongoDB operator.
         #
         # @return [ Mergeable ] The new mergeable.
-        #
-        # @since 1.0.0
         def __union__(criterion, operator)
           with_strategy(:__union__, criterion, operator)
         end
@@ -381,8 +359,6 @@ module Mongoid
         # @param [ Symbol ] strategy The strategy to use.
         #
         # @return [ Mergeable ] The existing mergeable.
-        #
-        # @since 1.0.0
         def use(strategy)
           tap do |mergeable|
             mergeable.strategy = strategy
@@ -401,8 +377,6 @@ module Mongoid
         # @param [ String ] operator The MongoDB operator.
         #
         # @return [ Mergeable ] The cloned query.
-        #
-        # @since 1.0.0
         def with_strategy(strategy, criterion, operator)
           selection(criterion) do |selector, field, value|
             selector.store(
@@ -423,8 +397,6 @@ module Mongoid
         # @param [ Object ] value The value.
         #
         # @return [ Object ] The serialized value.
-        #
-        # @since 1.0.0
         def prepare(field, operator, value)
           unless operator =~ /exists|type|size/
             value = value.__expand_complex__

--- a/lib/mongoid/criteria/queryable/optional.rb
+++ b/lib/mongoid/criteria/queryable/optional.rb
@@ -21,8 +21,6 @@ module Mongoid
         # @param [ Array<Symbol> ] fields The fields to sort.
         #
         # @return [ Optional ] The cloned optional.
-        #
-        # @since 1.0.0
         def ascending(*fields)
           sort_with_list(*fields, 1)
         end
@@ -39,8 +37,6 @@ module Mongoid
         # @param [ Integer ] value The batch size.
         #
         # @return [ Optional ] The cloned optional.
-        #
-        # @since 1.0.0
         def batch_size(value = nil)
           option(value) { |options| options.store(:batch_size, value) }
         end
@@ -53,8 +49,6 @@ module Mongoid
         # @param [ Array<Symbol> ] fields The fields to sort.
         #
         # @return [ Optional ] The cloned optional.
-        #
-        # @since 1.0.0
         def descending(*fields)
           sort_with_list(*fields, -1)
         end
@@ -70,8 +64,6 @@ module Mongoid
         # @param [ Hash ] value The index hint.
         #
         # @return [ Optional ] The cloned optional.
-        #
-        # @since 1.0.0
         def hint(value = nil)
           option(value) { |options| options.store(:hint, value) }
         end
@@ -84,8 +76,6 @@ module Mongoid
         # @param [ Integer ] value The number of documents to return.
         #
         # @return [ Optional ] The cloned optional.
-        #
-        # @since 1.0.0
         def limit(value = nil)
           option(value) do |options, query|
             val = value.to_i
@@ -103,8 +93,6 @@ module Mongoid
         # @param [ Integer ] value The max number of documents to scan.
         #
         # @return [ Optional ] The cloned optional.
-        #
-        # @since 1.0.0
         def max_scan(value = nil)
           option(value) { |options| options.store(:max_scan, value) }
         end
@@ -117,8 +105,6 @@ module Mongoid
         # @param [ Integer ] value The max time in milliseconds for processing operations on a cursor.
         #
         # @return [ Optional ] The cloned optional.
-        #
-        # @since 6.0.0
         def max_time_ms(value = nil)
           option(value) { |options| options.store(:max_time_ms, value) }
         end
@@ -129,8 +115,6 @@ module Mongoid
         #   optional.no_timeout
         #
         # @return [ Optional ] The cloned optional.
-        #
-        # @since 1.0.0
         def no_timeout
           clone.tap { |query| query.options.store(:timeout, false) }
         end
@@ -143,8 +127,6 @@ module Mongoid
         # @param [ Array<Symbol> ] args The fields to return.
         #
         # @return [ Optional ] The cloned optional.
-        #
-        # @since 1.0.0
         def only(*args)
           args = args.flatten
           option(*args) do |options|
@@ -185,8 +167,6 @@ module Mongoid
         # @param [ Array, Hash, String ] spec The sorting specification.
         #
         # @return [ Optional ] The cloned optional.
-        #
-        # @since 1.0.0
         def order_by(*spec)
           option(spec) do |options, query|
             spec.compact.each do |criterion|
@@ -208,8 +188,6 @@ module Mongoid
         # @param [ Array, Hash, String ] spec The sorting specification.
         #
         # @return [ Optional ] The cloned optional.
-        #
-        # @since 2.1.0
         def reorder(*spec)
           clone.tap do |query|
             query.options.delete(:sort)
@@ -224,8 +202,6 @@ module Mongoid
         # @param [ Integer ] value The number to skip.
         #
         # @return [ Optional ] The cloned optional.
-        #
-        # @since 1.0.0
         def skip(value = nil)
           option(value) do |options, query|
             val = value.to_i
@@ -243,8 +219,6 @@ module Mongoid
         # @param [ Hash ] criterion The slice options.
         #
         # @return [ Optional ] The cloned optional.
-        #
-        # @since 1.0.0
         def slice(criterion = nil)
           option(criterion) do |options|
             options.__union__(
@@ -261,8 +235,6 @@ module Mongoid
         #   optional.snapshot
         #
         # @return [ Optional ] The cloned optional.
-        #
-        # @since 1.0.0
         def snapshot
           clone.tap do |query|
             query.options.store(:snapshot, true)
@@ -277,8 +249,6 @@ module Mongoid
         # @param [ Array<Symbol> ] args The fields to ignore.
         #
         # @return [ Optional ] The cloned optional.
-        #
-        # @since 1.0.0
         def without(*args)
           args = args.flatten
           option(*args) do |options|
@@ -301,8 +271,6 @@ module Mongoid
         # @param [ String ] comment The comment to be associated with the query.
         #
         # @return [ Optional ] The cloned optional.
-        #
-        # @since 2.2.0
         def comment(comment = nil)
           clone.tap do |query|
             query.options.store(:comment, comment)
@@ -320,8 +288,6 @@ module Mongoid
         # @param [ Symbol ] type The type of cursor to create.
         #
         # @return [ Optional ] The cloned optional.
-        #
-        # @since 2.2.0
         def cursor_type(type)
           clone.tap { |query| query.options.store(:cursor_type, type) }
         end
@@ -334,8 +300,6 @@ module Mongoid
         # @param [ Hash ] collation_doc The document describing the collation to use.
         #
         # @return [ Optional ] The cloned optional.
-        #
-        # @since 6.1.0
         def collation(collation_doc)
           clone.tap { |query| query.options.store(:collation, collation_doc) }
         end
@@ -354,8 +318,6 @@ module Mongoid
         # @param [ Integer ] direction The sort direction.
         #
         # @return [ Optional ] The cloned optional.
-        #
-        # @since 1.0.0
         def add_sort_option(options, field, direction)
           if driver == :mongo1x
             sorting = (options[:sort] || []).dup
@@ -379,8 +341,6 @@ module Mongoid
         # @param [ Array ] args The options.
         #
         # @return [ Queryable ] The cloned queryable.
-        #
-        # @since 1.0.0
         def option(*args)
           clone.tap do |query|
             unless args.compact.empty?
@@ -400,8 +360,6 @@ module Mongoid
         # @param [ Integer ] direction The sort direction.
         #
         # @return [ Optional ] The cloned optional.
-        #
-        # @since 1.0.0
         def sort_with_list(*fields, direction)
           option(fields) do |options, query|
             fields.flatten.compact.each do |field|
@@ -419,8 +377,6 @@ module Mongoid
           #   Optional.forwardables
           #
           # @return [ Array<Symbol> ] The names of the forwardable methods.
-          #
-          # @since 1.0.0
           def forwardables
             public_instance_methods(false) - [ :options, :options= ]
           end

--- a/lib/mongoid/criteria/queryable/options.rb
+++ b/lib/mongoid/criteria/queryable/options.rb
@@ -15,8 +15,6 @@ module Mongoid
         #   options.fields
         #
         # @return [ Hash ] The fields options.
-        #
-        # @since 1.0.0
         def fields
           self[:fields]
         end
@@ -27,8 +25,6 @@ module Mongoid
         #   options.limit
         #
         # @return [ Integer ] The limit option.
-        #
-        # @since 1.0.0
         def limit
           self[:limit]
         end
@@ -39,8 +35,6 @@ module Mongoid
         #   options.skip
         #
         # @return [ Integer ] The skip option.
-        #
-        # @since 1.0.0
         def skip
           self[:skip]
         end
@@ -51,8 +45,6 @@ module Mongoid
         #   options.sort
         #
         # @return [ Hash ] The sort options.
-        #
-        # @since 1.0.0
         def sort
           self[:sort]
         end
@@ -67,8 +59,6 @@ module Mongoid
         # @param [ Object ] value The value to add.
         #
         # @return [ Object ] The stored object.
-        #
-        # @since 1.0.0
         def store(key, value, localize = true)
           super(key, evolve(value, localize))
         end
@@ -80,8 +70,6 @@ module Mongoid
         #   options.to_pipeline
         #
         # @return [ Array<Hash> ] The options in pipeline form.
-        #
-        # @since 2.0.0
         def to_pipeline
           pipeline = []
           pipeline.push({ "$skip" => skip }) if skip
@@ -96,8 +84,6 @@ module Mongoid
         #   options.__deep_copy__
         #
         # @return [ Options ] The copied options.
-        #
-        # @since 6.1.1
         def __deep_copy__
           self.class.new(aliases, serializers) do |copy|
             each_pair do |key, value|
@@ -118,8 +104,6 @@ module Mongoid
         # @param [ Object ] value The value to serialize.
         #
         # @return [ Object ] The serialized object.
-        #
-        # @since 1.0.0
         def evolve(value, localize = true)
           case value
           when Hash
@@ -139,8 +123,6 @@ module Mongoid
         # @param [ Hash ] value The hash to serialize.
         #
         # @return [ Object ] The serialized hash.
-        #
-        # @since 1.0.0
         def evolve_hash(value, localize = true)
           value.inject({}) do |hash, (field, _value)|
             name, serializer = storage_pair(field)

--- a/lib/mongoid/criteria/queryable/pipeline.rb
+++ b/lib/mongoid/criteria/queryable/pipeline.rb
@@ -6,8 +6,6 @@ module Mongoid
     module Queryable
 
       # Represents an aggregation pipeline.
-      #
-      # @since 2.0.0
       class Pipeline < Array
 
         # @attribute [r] aliases The field aliases.
@@ -20,8 +18,6 @@ module Mongoid
         #   pipeline.__deep_copy__
         #
         # @return [ Pipeline ] The cloned pipeline.
-        #
-        # @since 2.0.0
         def __deep_copy__
           self.class.new(aliases) do |copy|
             each do |entry|
@@ -38,8 +34,6 @@ module Mongoid
         # @param [ Hash ] entry The group entry.
         #
         # @return [ Pipeline ] The pipeline.
-        #
-        # @since 2.0.0
         def group(entry)
           push("$group" => evolve(entry.__expand_complex__))
         end
@@ -51,8 +45,6 @@ module Mongoid
         #
         # @param [ Hash ] aliases A hash of mappings from aliases to the actual
         #   field names in the database.
-        #
-        # @since 2.0.0
         def initialize(aliases = {})
           @aliases = aliases
           yield(self) if block_given?
@@ -80,8 +72,6 @@ module Mongoid
         #   document.
         #
         # @return [ Pipeline ] The pipeline.
-        #
-        # @since 2.0.0
         def unwind(field_or_doc)
           unless field_or_doc.respond_to? :keys
             normalized = field_or_doc.to_s
@@ -104,8 +94,6 @@ module Mongoid
         # @param [ Hash ] entry The entry to evolve.
         #
         # @return [ Hash ] The evolved entry.
-        #
-        # @since 2.0.0
         def evolve(entry)
           aggregate = Selector.new(aliases)
           entry.each_pair do |field, value|

--- a/lib/mongoid/criteria/queryable/selectable.rb
+++ b/lib/mongoid/criteria/queryable/selectable.rb
@@ -12,18 +12,12 @@ module Mongoid
         extend Macroable
 
         # Constant for a LineString $geometry.
-        #
-        # @since 2.0.0
         LINE_STRING = "LineString"
 
         # Constant for a Point $geometry.
-        #
-        # @since 2.0.0
         POINT = "Point"
 
         # Constant for a Polygon $geometry.
-        #
-        # @since 2.0.0
         POLYGON = "Polygon"
 
         # @attribute [rw] negating If the next expression is negated.
@@ -41,8 +35,6 @@ module Mongoid
         # @param [ Hash ] criterion The key value pairs for $all matching.
         #
         # @return [ Selectable ] The cloned selectable.
-        #
-        # @since 1.0.0
         def all(*criteria)
           if criteria.empty?
             return clone.tap do |query|
@@ -82,8 +74,6 @@ module Mongoid
         #   matches or Criteria objects that all must match to return results.
         #
         # @return [ Selectable ] The new selectable.
-        #
-        # @since 1.0.0
         def and(*criteria)
           _mongoid_flatten_arrays(criteria).inject(self.clone) do |c, new_s|
             if new_s.is_a?(Selectable)
@@ -130,8 +120,6 @@ module Mongoid
         # @param [ Hash ] criterion Multiple key/range pairs.
         #
         # @return [ Selectable ] The cloned selectable.
-        #
-        # @since 1.0.0
         def between(criterion)
           if criterion.nil?
             raise Errors::CriteriaArgumentRequired, :between
@@ -162,8 +150,6 @@ module Mongoid
         # @param [ Hash ] criterion The field/match pairs.
         #
         # @return [ Selectable ] The cloned selectable.
-        #
-        # @since 1.0.0
         def elem_match(criterion)
           if criterion.nil?
             raise Errors::CriteriaArgumentRequired, :elem_match
@@ -187,8 +173,6 @@ module Mongoid
         # @param [ Hash ] criterion The field/boolean existence checks.
         #
         # @return [ Selectable ] The cloned selectable.
-        #
-        # @since 1.0.0
         def exists(criterion)
           if criterion.nil?
             raise Errors::CriteriaArgumentRequired, :exists
@@ -282,8 +266,6 @@ module Mongoid
         # @param [ Hash ] criterion The field/value pairs to check.
         #
         # @return [ Selectable ] The cloned selectable.
-        #
-        # @since 1.0.0
         def gt(criterion)
           if criterion.nil?
             raise Errors::CriteriaArgumentRequired, :gt
@@ -304,8 +286,6 @@ module Mongoid
         # @param [ Hash ] criterion The field/value pairs to check.
         #
         # @return [ Selectable ] The cloned selectable.
-        #
-        # @since 1.0.0
         def gte(criterion)
           if criterion.nil?
             raise Errors::CriteriaArgumentRequired, :gte
@@ -329,8 +309,6 @@ module Mongoid
         # @param [ Hash ] condition The field/value criterion pairs.
         #
         # @return [ Selectable ] The cloned selectable.
-        #
-        # @since 1.0.0
         def in(condition)
           if condition.nil?
             raise Errors::CriteriaArgumentRequired, :in
@@ -364,8 +342,6 @@ module Mongoid
         # @param [ Hash ] criterion The field/value pairs to check.
         #
         # @return [ Selectable ] The cloned selectable.
-        #
-        # @since 1.0.0
         def lt(criterion)
           if criterion.nil?
             raise Errors::CriteriaArgumentRequired, :lt
@@ -386,8 +362,6 @@ module Mongoid
         # @param [ Hash ] criterion The field/value pairs to check.
         #
         # @return [ Selectable ] The cloned selectable.
-        #
-        # @since 1.0.0
         def lte(criterion)
           if criterion.nil?
             raise Errors::CriteriaArgumentRequired, :lte
@@ -405,8 +379,6 @@ module Mongoid
         # @param [ Hash ] criterion The field/distance pairs.
         #
         # @return [ Selectable ] The cloned selectable.
-        #
-        # @since 1.0.0
         def max_distance(criterion)
           if criterion.nil?
             raise Errors::CriteriaArgumentRequired, :max_distance
@@ -427,8 +399,6 @@ module Mongoid
         # @param [ Hash ] criterion The field/mod selections.
         #
         # @return [ Selectable ] The cloned selectable.
-        #
-        # @since 1.0.0
         def mod(criterion)
           if criterion.nil?
             raise Errors::CriteriaArgumentRequired, :mod
@@ -449,8 +419,6 @@ module Mongoid
         # @param [ Hash ] criterion The field/ne selections.
         #
         # @return [ Selectable ] The cloned selectable.
-        #
-        # @since 1.0.0
         def ne(criterion)
           if criterion.nil?
             raise Errors::CriteriaArgumentRequired, :ne
@@ -472,8 +440,6 @@ module Mongoid
         # @param [ Hash ] criterion The field/location pair.
         #
         # @return [ Selectable ] The cloned selectable.
-        #
-        # @since 1.0.0
         def near(criterion)
           if criterion.nil?
             raise Errors::CriteriaArgumentRequired, :near
@@ -494,8 +460,6 @@ module Mongoid
         # @param [ Hash ] criterion The field/location pair.
         #
         # @return [ Selectable ] The cloned selectable.
-        #
-        # @since 1.0.0
         def near_sphere(criterion)
           if criterion.nil?
             raise Errors::CriteriaArgumentRequired, :near_sphere
@@ -519,8 +483,6 @@ module Mongoid
         # @param [ Hash ] condition The field/value criterion pairs.
         #
         # @return [ Selectable ] The cloned selectable.
-        #
-        # @since 1.0.0
         def nin(condition)
           if condition.nil?
             raise Errors::CriteriaArgumentRequired, :nin
@@ -552,8 +514,6 @@ module Mongoid
         #   matches or Criteria objects.
         #
         # @return [ Selectable ] The new selectable.
-        #
-        # @since 1.0.0
         def nor(*criteria)
           _mongoid_add_top_level_operation('$nor', criteria)
         end
@@ -564,8 +524,6 @@ module Mongoid
         #   selectable.negating?
         #
         # @return [ true, false ] If the selectable is negating.
-        #
-        # @since 1.0.0
         def negating?
           !!negating
         end
@@ -585,8 +543,6 @@ module Mongoid
         #   matches or Criteria objects to negate.
         #
         # @return [ Selectable ] The new selectable.
-        #
-        # @since 1.0.0
         def not(*criteria)
           if criteria.empty?
             dup.tap { |query| query.negating = true }
@@ -648,8 +604,6 @@ module Mongoid
         #   thereof. Passing arrays is deprecated.
         #
         # @return [ Selectable ] The new selectable.
-        #
-        # @since 1.0.0
         def or(*criteria)
           _mongoid_add_top_level_operation('$or', criteria)
         end
@@ -680,8 +634,6 @@ module Mongoid
         #   thereof. Passing arrays is deprecated.
         #
         # @return [ Selectable ] The new selectable.
-        #
-        # @since 1.0.0
         def any_of(*criteria)
           criteria = _mongoid_flatten_arrays(criteria)
           case criteria.length
@@ -735,8 +687,6 @@ module Mongoid
         # @param [ Hash ] criterion The field/size pairs criterion.
         #
         # @return [ Selectable ] The cloned selectable.
-        #
-        # @since 1.0.0
         def with_size(criterion)
           if criterion.nil?
             raise Errors::CriteriaArgumentRequired, :with_size
@@ -763,8 +713,6 @@ module Mongoid
         # @param [ Hash ] criterion The field/type pairs.
         #
         # @return [ Selectable ] The cloned selectable.
-        #
-        # @since 1.0.0
         def with_type(criterion)
           if criterion.nil?
             raise Errors::CriteriaArgumentRequired, :with_type
@@ -797,8 +745,6 @@ module Mongoid
         #   for options.
         #
         # @return [ Selectable ] The cloned selectable.
-        #
-        # @since 2.2.0
         def text_search(terms, opts = nil)
           if terms.nil?
             raise Errors::CriteriaArgumentRequired, :terms
@@ -834,8 +780,6 @@ module Mongoid
         # @param [ String, Hash ] criterion The javascript or standard selection.
         #
         # @return [ Selectable ] The cloned selectable.
-        #
-        # @since 1.0.0
         def where(*criteria)
           criteria.inject(clone) do |query, criterion|
             if criterion.nil?
@@ -875,8 +819,6 @@ module Mongoid
         # @param [ Hash ] criterion The field/value pairs.
         #
         # @return [ Selectable ] The cloned selectable.
-        #
-        # @since 1.0.0
         # @api private
         def expr_query(criterion)
           if criterion.nil?
@@ -911,8 +853,6 @@ module Mongoid
         #   end
         #
         # @param [ Hash ] criterion The criterion.
-        #
-        # @since 1.0.0
         def typed_override(criterion, operator)
           if criterion
             criterion.update_values do |value|
@@ -932,8 +872,6 @@ module Mongoid
         # @param [ String ] criterion The javascript as a string.
         #
         # @return [ Selectable ] The cloned selectable
-        #
-        # @since 1.0.0
         def js_query(criterion)
           clone.tap do |query|
             if negating?
@@ -955,8 +893,6 @@ module Mongoid
         # @param [ Hash ] criterion The selection to store.
         #
         # @return [ Selectable ] The cloned selectable.
-        #
-        # @since 1.0.0
         # @api private
         def selection(criterion = nil)
           clone.tap do |query|
@@ -977,8 +913,6 @@ module Mongoid
           #   Selectable.forwardables
           #
           # @return [ Array<Symbol> ] The names of the forwardable methods.
-          #
-          # @since 1.0.0
           def forwardables
             public_instance_methods(false) -
               [ :negating, :negating=, :negating?, :selector, :selector= ]

--- a/lib/mongoid/criteria/queryable/selector.rb
+++ b/lib/mongoid/criteria/queryable/selector.rb
@@ -17,8 +17,6 @@ module Mongoid
         # @param [ Hash, Selector ] other The object to merge in.
         #
         # @return [ Selector ] The selector.
-        #
-        # @since 1.0.0
         def merge!(other)
           other.each_pair do |key, value|
             if value.is_a?(Hash) && self[key.to_s].is_a?(Hash)
@@ -50,8 +48,6 @@ module Mongoid
         # @param [ Object ] value The value to add.
         #
         # @return [ Object ] The stored object.
-        #
-        # @since 1.0.0
         def store(key, value)
           name, serializer = storage_pair(key)
           if multi_selection?(name)
@@ -71,8 +67,6 @@ module Mongoid
         #   selector.to_pipeline
         #
         # @return [ Array<Hash> ] The pipeline entry for the selector.
-        #
-        # @since 2.0.0
         def to_pipeline
           pipeline = []
           pipeline.push({ "$match" => self }) unless empty?
@@ -90,8 +84,6 @@ module Mongoid
         # @param [ Array<Hash> ] specs The multi-selection.
         #
         # @return [ Array<Hash> ] The serialized values.
-        #
-        # @since 1.0.0
         #
         # @api private
         def evolve_multi(specs)
@@ -142,8 +134,6 @@ module Mongoid
         # @param [ Object ] value The value to serialize.
         #
         # @return [ Object ] The serialized object.
-        #
-        # @since 1.0.0
         def evolve(serializer, value)
           case value
           when Hash
@@ -166,8 +156,6 @@ module Mongoid
         # @param [ Array<Object> ] value The array to serialize.
         #
         # @return [ Object ] The serialized array.
-        #
-        # @since 1.0.0
         def evolve_array(serializer, value)
           value.map do |_value|
             evolve(serializer, _value)
@@ -185,8 +173,6 @@ module Mongoid
         # @param [ Hash ] value The hash to serialize.
         #
         # @return [ Object ] The serialized hash.
-        #
-        # @since 1.0.0
         def evolve_hash(serializer, value)
           value.each_pair do |operator, _value|
             if operator =~ /exists|type|size/
@@ -208,8 +194,6 @@ module Mongoid
         # @param [ String ] key The key to check.
         #
         # @return [ true, false ] If the key is for a multi-select.
-        #
-        # @since 1.0.0
         def multi_selection?(key)
           %w($and $or $nor).include?(key)
         end

--- a/lib/mongoid/criteria/queryable/smash.rb
+++ b/lib/mongoid/criteria/queryable/smash.rb
@@ -18,8 +18,6 @@ module Mongoid
         #   smash.__deep_copy__
         #
         # @return [ Smash ] The copied hash.
-        #
-        # @since 1.0.0
         def __deep_copy__
           self.class.new(aliases, serializers) do |copy|
             each_pair do |key, value|
@@ -39,8 +37,6 @@ module Mongoid
         #   responsible for serializing values. The keys of the hash must be
         #   strings that match the field name, and the values must respond to
         #   #localized? and #evolve(object).
-        #
-        # @since 1.0.0
         def initialize(aliases = {}, serializers = {})
           @aliases, @serializers = aliases, serializers
           yield(self) if block_given?
@@ -54,8 +50,6 @@ module Mongoid
         # @param [ String ] key The key.
         #
         # @return [ Object ] The found object.
-        #
-        # @since 2.0.0
         def [](key)
           fetch(aliases[key]) { super }
         end
@@ -75,8 +69,6 @@ module Mongoid
         # @param [ Object ] serializer The optional field serializer.
         #
         # @return [ String ] The normalized key.
-        #
-        # @since 1.0.0
         def localized_key(name, serializer)
           serializer && serializer.localized? ? "#{name}.#{::I18n.locale}" : name
         end
@@ -93,8 +85,6 @@ module Mongoid
         #
         # @return [ Array<String, Object> ] The name of the db field and
         #   serializer.
-        #
-        # @since 1.0.0
         def storage_pair(key)
           field = key.to_s
           name = aliases[field] || field

--- a/lib/mongoid/criteria/scopable.rb
+++ b/lib/mongoid/criteria/scopable.rb
@@ -11,8 +11,6 @@ module Mongoid
       #   criteria.apply_default_scope
       #
       # @return [ Criteria ] The criteria.
-      #
-      # @since 3.0.0
       def apply_default_scope
         klass.without_default_scope do
           merge!(klass.default_scoping.call)
@@ -29,8 +27,6 @@ module Mongoid
       # @param [ Criteria ] other The other criteria.
       #
       # @return [ Criteria ] The criteria with scoping removed.
-      #
-      # @since 3.0.0
       def remove_scoping(other)
         if other
           reject_matching(other, :selector, :options)
@@ -49,8 +45,6 @@ module Mongoid
       # @param [ Hash ] options Additional query options.
       #
       # @return [ Criteria ] The scoped criteria.
-      #
-      # @since 3.0.0
       def scoped(options = nil)
         crit = clone
         crit.options.merge!(options || {})
@@ -66,8 +60,6 @@ module Mongoid
       #   criteria.scoped?
       #
       # @return [ true, false ] If the default scope is applied.
-      #
-      # @since 3.0.0
       def scoped?
         !!(defined?(@scoped) ? @scoped : nil)
       end
@@ -78,8 +70,6 @@ module Mongoid
       #   criteria.unscoped
       #
       # @return [ Criteria ] The unscoped criteria.
-      #
-      # @since 3.0.0
       def unscoped
         crit = clone
         unless unscoped?
@@ -95,8 +85,6 @@ module Mongoid
       #   criteria.unscoped?
       #
       # @return [ true, false ] If the criteria is force unscoped.
-      #
-      # @since 3.0.0
       def unscoped?
         !!(defined?(@unscoped) ? @unscoped : nil)
       end
@@ -107,8 +95,6 @@ module Mongoid
       #   criteria.scoping_options
       #
       # @return [ Array ] Scoped, unscoped.
-      #
-      # @since 3.0.0
       def scoping_options
         [ (defined?(@scoped) ? @scoped : nil), (defined?(@unscoped) ? @unscoped : nil) ]
       end
@@ -121,8 +107,6 @@ module Mongoid
       # @param [ Array ] options Scoped, unscoped.
       #
       # @return [ Array ] The new scoping options.
-      #
-      # @since 3.0.0
       def scoping_options=(options)
         @scoped, @unscoped = options
       end
@@ -136,8 +120,6 @@ module Mongoid
       #   criteria.with_default_scope
       #
       # @return [ Criteria ] The criteria.
-      #
-      # @since 3.0.0
       def with_default_scope
         crit = clone
         if klass.default_scopable? && !unscoped? && !scoped?

--- a/lib/mongoid/document.rb
+++ b/lib/mongoid/document.rb
@@ -40,8 +40,6 @@ module Mongoid
     # that should be used instead.
     # When ruby driver 2.3.0 is released and Mongoid can be updated
     # to require >= 2.3.0, the BSON constant can be used.
-    #
-    # @since 6.0.0
     ILLEGAL_KEY = /(\A[$])|(\.)/.freeze
 
     # Freezes the internal attributes of the document.
@@ -50,8 +48,6 @@ module Mongoid
     #   document.freeze
     #
     # @return [ Document ] The document.
-    #
-    # @since 2.0.0
     def freeze
       as_attributes.freeze and self
     end
@@ -62,8 +58,6 @@ module Mongoid
     #   document.frozen?
     #
     # @return [ true, false ] True if frozen, else false.
-    #
-    # @since 2.0.0
     def frozen?
       attributes.frozen?
     end
@@ -78,8 +72,6 @@ module Mongoid
     #   document.hash
     #
     # @return [ Integer ] The hash of the document's identity.
-    #
-    # @since 1.0.0
     def hash
       identity.hash
     end
@@ -92,8 +84,6 @@ module Mongoid
     #   document.identity
     #
     # @return [ Array ] An array containing [document.class, document._id]
-    #
-    # @since 3.0.0
     def identity
       [ self.class, self._id ]
     end
@@ -111,8 +101,6 @@ module Mongoid
     # @param [ Hash ] attrs The attributes to set up the document with.
     #
     # @return [ Document ] A new document.
-    #
-    # @since 1.0.0
     def initialize(attrs = nil)
       @__parent = nil
       _building do
@@ -136,8 +124,6 @@ module Mongoid
     #   document.model_name
     #
     # @return [ String ] The model name.
-    #
-    # @since 3.0.16
     def model_name
       self.class.model_name
     end
@@ -148,8 +134,6 @@ module Mongoid
     #   document.to_key
     #
     # @return [ String ] The id of the document or nil if new.
-    #
-    # @since 2.4.0
     def to_key
       (persisted? || destroyed?) ? [ _id.to_s ] : nil
     end
@@ -160,8 +144,6 @@ module Mongoid
     #   document.to_a
     #
     # @return [ Array<Document> ] An array with the document as its only item.
-    #
-    # @since 1.0.0
     def to_a
       [ self ]
     end
@@ -174,8 +156,6 @@ module Mongoid
     #   person.as_document
     #
     # @return [ Hash ] A hash of all attributes in the hierarchy.
-    #
-    # @since 1.0.0
     def as_document
       BSON::Document.new(as_attributes)
     end
@@ -198,8 +178,6 @@ module Mongoid
     #   nil values in the json document.
     #
     # @return [ Hash ] The document as json.
-    #
-    # @since 5.1.0
     def as_json(options = nil)
       rv = super
       if options && options[:compact]
@@ -219,8 +197,6 @@ module Mongoid
     # @param [ Class ] klass The class to become.
     #
     # @return [ Document ] An instance of the specified class.
-    #
-    # @since 2.0.0
     def becomes(klass)
       unless klass.include?(Mongoid::Document)
         raise ArgumentError, "A class which includes Mongoid::Document is expected"
@@ -255,8 +231,6 @@ module Mongoid
     # Returns the logger
     #
     # @return [ Logger ] The configured logger or a default Logger instance.
-    #
-    # @since 2.2.0
     def logger
       Mongoid.logger
     end
@@ -267,8 +241,6 @@ module Mongoid
     #   model.model_key
     #
     # @return [ String ] The model key.
-    #
-    # @since 2.4.0
     def model_key
       @model_cache_key ||= self.class.model_name.cache_key
     end
@@ -300,8 +272,6 @@ module Mongoid
       # @param [ Document, Object ] other The other object to compare with.
       #
       # @return [ true, false ] True if the classes are equal, false if not.
-      #
-      # @since 2.0.0.rc.4
       def ===(other)
         other.class == Class ? self <= other : other.is_a?(self)
       end
@@ -317,8 +287,6 @@ module Mongoid
       #   criteria.
       #
       # @return [ Document ] A new document.
-      #
-      # @since 1.0.0
       def instantiate(attrs = nil, selected_fields = nil)
         attributes = attrs || {}
         doc = allocate
@@ -337,8 +305,6 @@ module Mongoid
       #   document._types
       #
       # @return [ Array<Class> ] All subclasses of the current document.
-      #
-      # @since 1.0.0
       def _types
         @_type ||= (descendants + [ self ]).uniq.map(&:discriminator_value)
       end
@@ -358,8 +324,6 @@ module Mongoid
       # Set the i18n scope to overwrite ActiveModel.
       #
       # @return [ Symbol ] :mongoid
-      #
-      # @since 2.0.0
       def i18n_scope
         :mongoid
       end
@@ -370,8 +334,6 @@ module Mongoid
       #   Person.logger
       #
       # @return [ Logger ] The configured logger or a default Logger instance.
-      #
-      # @since 2.2.0
       def logger
         Mongoid.logger
       end

--- a/lib/mongoid/equality.rb
+++ b/lib/mongoid/equality.rb
@@ -14,8 +14,6 @@ module Mongoid
     # @param [ Document ] other The document to compare with.
     #
     # @return [ Integer ] -1, 0, 1.
-    #
-    # @since 1.0.0
     def <=>(other)
       attributes["_id"].to_s <=> other.attributes["_id"].to_s
     end
@@ -29,8 +27,6 @@ module Mongoid
     # @param [ Document, Object ] other The other object to compare with.
     #
     # @return [ true, false ] True if the ids are equal, false if not.
-    #
-    # @since 1.0.0
     def ==(other)
       self.class == other.class &&
           attributes["_id"] == other.attributes["_id"]
@@ -44,8 +40,6 @@ module Mongoid
     # @param [ Document, Object ] other The other object to compare with.
     #
     # @return [ true, false ] True if the classes are equal, false if not.
-    #
-    # @since 1.0.0
     def ===(other)
       other.class == Class ? self.class === other : self == other
     end
@@ -58,8 +52,6 @@ module Mongoid
     # @param [ Document, Object ] other The object to check against.
     #
     # @return [ true, false ] True if equal, false if not.
-    #
-    # @since 1.0.0
     def eql?(other)
       self == (other)
     end

--- a/lib/mongoid/errors/ambiguous_relationship.rb
+++ b/lib/mongoid/errors/ambiguous_relationship.rb
@@ -33,8 +33,6 @@ module Mongoid
       # @param [ Class ] inverse The inverse class.
       # @param [ Symbol ] name The relation name.
       # @param [ Array<Symbol> ] candidates The potential inverses.
-      #
-      # @since 3.0.0
       def initialize(klass, inverse, name, candidates)
         super(
           compose_message(

--- a/lib/mongoid/errors/callback.rb
+++ b/lib/mongoid/errors/callback.rb
@@ -15,8 +15,6 @@ module Mongoid
       #
       # @param [ Class ] klass The class of the document.
       # @param [ Symbol ] method The name of the method.
-      #
-      # @since 2.2.0
       def initialize(klass, method)
         super(
           compose_message("callbacks", { klass: klass, method: method })

--- a/lib/mongoid/errors/delete_restriction.rb
+++ b/lib/mongoid/errors/delete_restriction.rb
@@ -14,8 +14,6 @@ module Mongoid
       #   destroyed.
       # @param [ Symbol ] association_name The name of the dependent
       #   association that prevents the document from being deleted.
-      #
-      # @since 3.0.0
       def initialize(document, association_name)
         super(
           compose_message(

--- a/lib/mongoid/errors/document_not_destroyed.rb
+++ b/lib/mongoid/errors/document_not_destroyed.rb
@@ -6,8 +6,6 @@ module Mongoid
 
     # Raised when attempting to destroy a document that had destory callbacks
     # return false.
-    #
-    # @since 4.0.0
     class DocumentNotDestroyed < MongoidError
 
       # Instnatiate the exception.
@@ -17,8 +15,6 @@ module Mongoid
       #
       # @param [ Object ] id The document id.
       # @param [ Class ] klass The document class.
-      #
-      # @since 4.0.0
       def initialize(id, klass)
         super(compose_message("document_not_destroyed", { id: id.inspect, klass: klass }))
       end

--- a/lib/mongoid/errors/document_not_found.rb
+++ b/lib/mongoid/errors/document_not_found.rb
@@ -52,8 +52,6 @@ module Mongoid
       # @param [ Object, Array ] unmatched The ids that did not match.
       #
       # @return [ String ] The missing string.
-      #
-      # @since 3.0.0
       def missing(unmatched)
         if unmatched.is_a?(::Array)
           unmatched.join(", ")
@@ -70,8 +68,6 @@ module Mongoid
       # @param [ Object, Array ] params The ids that were searched for.
       #
       # @return [ String ] The searched string.
-      #
-      # @since 3.0.0
       def searched(params)
         if params.is_a?(::Array)
           params.take(3).join(", ") + " ..."
@@ -88,8 +84,6 @@ module Mongoid
       # @param [ Object, Array ] params What was searched for.
       #
       # @return [ Integer ] The total number.
-      #
-      # @since 3.0.0
       def total(params)
         params.is_a?(::Array) ? params.count : 1
       end
@@ -100,8 +94,6 @@ module Mongoid
       #   error.problem
       #
       # @return [ String ] The problem.
-      #
-      # @since 3.0.0
       def message_key(params)
         case params
           when Hash then "document_with_attributes_not_found"

--- a/lib/mongoid/errors/eager_load.rb
+++ b/lib/mongoid/errors/eager_load.rb
@@ -16,8 +16,6 @@ module Mongoid
       #   EagerLoad.new(:preferences)
       #
       # @param [ Symbol ] name The name of the association.
-      #
-      # @since 2.2.0
       def initialize(name)
         super(compose_message("eager_load", { name: name }))
       end

--- a/lib/mongoid/errors/in_memory_collation_not_supported.rb
+++ b/lib/mongoid/errors/in_memory_collation_not_supported.rb
@@ -12,8 +12,6 @@ module Mongoid
       #
       # @example Create the new unsupported collation error.
       #   InMemoryCollationNotSupported.new
-      #
-      # @since 6.1.0
       def initialize
         super(compose_message("in_memory_collation_not_supported"))
       end

--- a/lib/mongoid/errors/invalid_config_option.rb
+++ b/lib/mongoid/errors/invalid_config_option.rb
@@ -14,8 +14,6 @@ module Mongoid
       #   InvalidConfigOption.new(:name, [ :option ])
       #
       # @param [ Symbol, String ] name The attempted config option name.
-      #
-      # @since 3.0.0
       def initialize(name)
         super(
           compose_message(

--- a/lib/mongoid/errors/invalid_dependent_strategy.rb
+++ b/lib/mongoid/errors/invalid_dependent_strategy.rb
@@ -16,8 +16,6 @@ module Mongoid
       #   dependency is defined.
       # @param [ Symbol, String ] invalid_strategy The attempted invalid strategy.
       # @param [ Array<Symbol> ] valid_strategies The valid strategies.
-      #
-      # @since 7.0.0
       def initialize(association, invalid_strategy, valid_strategies)
         super(
             compose_message(

--- a/lib/mongoid/errors/invalid_field.rb
+++ b/lib/mongoid/errors/invalid_field.rb
@@ -40,8 +40,6 @@ module Mongoid
       # @param [ Symbol ] name The method name.
       #
       # @return [ Class, Module ] The originating class or module.
-      #
-      # @since 3.0.0
       def origin(klass, name)
         klass.instance_method(name).owner
       end
@@ -55,8 +53,6 @@ module Mongoid
       # @param [ Symbol ] name The method name.
       #
       # @return [ Array<String, Integer> ] The location of the method.
-      #
-      # @since 3.0.0
       def location(klass, name)
         @location ||=
           (klass.instance_method(name).source_location || [ "Unknown", 0 ])

--- a/lib/mongoid/errors/invalid_field_option.rb
+++ b/lib/mongoid/errors/invalid_field_option.rb
@@ -17,8 +17,6 @@ module Mongoid
       # @param [ Symbol ] name The method name.
       # @param [ Symbol ] option The option name.
       # @param [ Array<Symbol> ] valid All the valid options.
-      #
-      # @since 3.0.0
       def initialize(klass, name, option, valid)
         super(
           compose_message(

--- a/lib/mongoid/errors/invalid_find.rb
+++ b/lib/mongoid/errors/invalid_find.rb
@@ -11,8 +11,6 @@ module Mongoid
       #
       # @example Create the error.
       #   InvalidFind.new
-      #
-      # @since 2.2.0
       def initialize
         super(compose_message("calling_document_find_with_nil_is_invalid", {}))
       end

--- a/lib/mongoid/errors/invalid_includes.rb
+++ b/lib/mongoid/errors/invalid_includes.rb
@@ -15,8 +15,6 @@ module Mongoid
       #
       # @param [ Class ] klass The model class.
       # @param [ Array<Object> ] args The arguments passed to the includes.
-      #
-      # @since 3.0.2
       def initialize(klass, args)
         super(
           compose_message(

--- a/lib/mongoid/errors/invalid_index.rb
+++ b/lib/mongoid/errors/invalid_index.rb
@@ -15,8 +15,6 @@ module Mongoid
       # @param [ Class ] klass The model class.
       # @param [ Hash ] spec The invalid specification.
       # @param [ Hash ] options The invalid options.
-      #
-      # @since 3.0.0
       def initialize(klass, spec, options)
         super(
           compose_message(

--- a/lib/mongoid/errors/invalid_options.rb
+++ b/lib/mongoid/errors/invalid_options.rb
@@ -15,8 +15,6 @@ module Mongoid
       # @param [ Symbol ] name The name of the association.
       # @param [ Symbol ] invalid The invalid option.
       # @param [ Array<Symbol> ] valid The allowed options.
-      #
-      # @since 2.1.0
       def initialize(name, invalid, valid)
         super(
           compose_message(

--- a/lib/mongoid/errors/invalid_path.rb
+++ b/lib/mongoid/errors/invalid_path.rb
@@ -13,8 +13,6 @@ module Mongoid
       #   InvalidPath.new(Address)
       #
       # @param [ Class ] klass The document class.
-      #
-      # @since 3.0.14
       def initialize(klass)
         super(compose_message("invalid_path", { klass: klass }))
       end

--- a/lib/mongoid/errors/invalid_persistence_option.rb
+++ b/lib/mongoid/errors/invalid_persistence_option.rb
@@ -5,8 +5,6 @@ module Mongoid
   module Errors
 
     # Raised when invalid options are used to create a persistence context.
-    #
-    # @since 6.0.0
     class InvalidPersistenceOption < MongoidError
 
       # Instantiate the persistence context option error.
@@ -16,8 +14,6 @@ module Mongoid
       #
       # @param [ Symbol ] invalid The invalid option.
       # @param [ Array<Symbol> ] valid The allowed options.
-      #
-      # @since 6.0.0
       def initialize(invalid, valid)
         super(
             compose_message(

--- a/lib/mongoid/errors/invalid_relation.rb
+++ b/lib/mongoid/errors/invalid_relation.rb
@@ -6,8 +6,6 @@ module Mongoid
 
     # This error is raised when trying to create an association that conflicts with
     # an already defined method.
-    #
-    # @since 6.0.0
     class InvalidRelation < MongoidError
 
       # Create the new error.
@@ -42,8 +40,6 @@ module Mongoid
       # @param [ Symbol ] name The method name.
       #
       # @return [ Class, Module ] The originating class or module.
-      #
-      # @since 6.0.0
       def origin(klass, name)
         klass.instance_method(name).owner
       end
@@ -57,8 +53,6 @@ module Mongoid
       # @param [ Symbol ] name The method name.
       #
       # @return [ Array<String, Integer> ] The location of the method.
-      #
-      # @since 6.0.0
       def location(klass, name)
         @location ||=
             (klass.instance_method(name).source_location || [ "Unknown", 0 ])

--- a/lib/mongoid/errors/invalid_relation_option.rb
+++ b/lib/mongoid/errors/invalid_relation_option.rb
@@ -16,8 +16,6 @@ module Mongoid
       # @param [ String, Symbol ] name The association name.
       # @param [ Symbol ] option The invalid option.
       # @param [ Array<Symbol> ] valid_options The valid option.
-      #
-      # @since 3.0.0
       def initialize(klass, name, option, valid_options)
         super(
             compose_message(

--- a/lib/mongoid/errors/invalid_scope.rb
+++ b/lib/mongoid/errors/invalid_scope.rb
@@ -14,8 +14,6 @@ module Mongoid
       #
       # @param [ Class ] klass The model class.
       # @param [ Object ] value The attempted scope value.
-      #
-      # @since 3.0.0
       def initialize(klass, value)
         super(
           compose_message("invalid_scope", { klass: klass, value: value })

--- a/lib/mongoid/errors/invalid_session_use.rb
+++ b/lib/mongoid/errors/invalid_session_use.rb
@@ -6,8 +6,6 @@ module Mongoid
 
     # This error is raised when a session is attempted to be used with a model whose client cannot use it, if
     #   sessions are nested, or if the mongodb deployment doesn't support sessions.
-    #
-    # @since 6.4.0
     class InvalidSessionUse < MongoidError
 
       # Create the error.
@@ -16,8 +14,6 @@ module Mongoid
       #   InvalidSessionUse.new(:invalid_session_use)
       #
       # @param [ :invalid_sesion_use, :invalid_session_nesting ] error_type The type of session misuse.
-      #
-      # @since 6.4.0
       def initialize(error_type)
         super(compose_message(error_type.to_s))
       end

--- a/lib/mongoid/errors/invalid_storage_options.rb
+++ b/lib/mongoid/errors/invalid_storage_options.rb
@@ -14,8 +14,6 @@ module Mongoid
       #
       # @param [ Class ] klass The model class.
       # @param [ Hash, String, Symbol ] options The provided options.
-      #
-      # @since 3.0.0
       def initialize(klass, options)
         super(
           compose_message(

--- a/lib/mongoid/errors/invalid_storage_parent.rb
+++ b/lib/mongoid/errors/invalid_storage_parent.rb
@@ -13,8 +13,6 @@ module Mongoid
       #    InvalidStorageParent.new(Person)
       #
       # @param [ Class ] klass The model class.
-      #
-      # @since 4.0.0
       def initialize(klass)
         super(
           compose_message(

--- a/lib/mongoid/errors/invalid_time.rb
+++ b/lib/mongoid/errors/invalid_time.rb
@@ -14,8 +14,6 @@ module Mongoid
       #   InvalidTime.new("this is not a time")
       #
       # @param [ Object ] value The value that was attempted.
-      #
-      # @since 2.3.1
       def initialize(value)
         super(compose_message("invalid_time", { value: value }))
       end

--- a/lib/mongoid/errors/inverse_not_found.rb
+++ b/lib/mongoid/errors/inverse_not_found.rb
@@ -16,8 +16,6 @@ module Mongoid
       # @param [ Symbol ] name The name of the association.
       # @param [ Class ] klass The child class.
       # @param [ Symbol ] inverse The attempted inverse key.
-      #
-      # @since 3.0.0
       def initialize(base, name, klass, inverse)
         super(
           compose_message(

--- a/lib/mongoid/errors/mixed_client_configuration.rb
+++ b/lib/mongoid/errors/mixed_client_configuration.rb
@@ -15,8 +15,6 @@ module Mongoid
       #
       # @param [ Symbol ] name The name of the client config.
       # @param [ Hash ] config The configuration options.
-      #
-      # @since 3.0.0
       def initialize(name, config)
         super(
           compose_message(

--- a/lib/mongoid/errors/mixed_relations.rb
+++ b/lib/mongoid/errors/mixed_relations.rb
@@ -18,8 +18,6 @@ module Mongoid
     #     embedded_in :person
     #     referenced_in :post
     #   end
-    #
-    # @since 2.0.0
     class MixedRelations < MongoidError
       def initialize(root_klass, embedded_klass)
         super(

--- a/lib/mongoid/errors/mongoid_error.rb
+++ b/lib/mongoid/errors/mongoid_error.rb
@@ -19,8 +19,6 @@ module Mongoid
       #   error.compose_message
       #
       # @return [ String ] The composed message.
-      #
-      # @since 3.0.0
       def compose_message(key, attributes = {})
         @problem = translate_problem(key, attributes)
         @summary = translate_summary(key, attributes)
@@ -60,8 +58,6 @@ module Mongoid
       # @param [ Hash ] attributes The attributes to interpolate.
       #
       # @return [ String ] The problem.
-      #
-      # @since 3.0.0
       def translate_problem(key, attributes)
         translate("#{key}.message", attributes)
       end
@@ -75,8 +71,6 @@ module Mongoid
       # @param [ Hash ] attributes The attributes to interpolate.
       #
       # @return [ String ] The summary.
-      #
-      # @since 3.0.0
       def translate_summary(key, attributes)
         translate("#{key}.summary", attributes)
       end
@@ -90,8 +84,6 @@ module Mongoid
       # @param [ Hash ] attributes The attributes to interpolate.
       #
       # @return [ String ] The resolution.
-      #
-      # @since 3.0.0
       def translate_resolution(key, attributes)
         translate("#{key}.resolution", attributes)
       end

--- a/lib/mongoid/errors/nested_attributes_metadata_not_found.rb
+++ b/lib/mongoid/errors/nested_attributes_metadata_not_found.rb
@@ -15,8 +15,6 @@ module Mongoid
       #
       # @param [ Class ] klass The class of the document.
       # @param [ Symbol, String ] name The name of the association
-      #
-      # @since 3.0.0
       def initialize(klass, name)
         super(
           compose_message(

--- a/lib/mongoid/errors/no_client_config.rb
+++ b/lib/mongoid/errors/no_client_config.rb
@@ -14,8 +14,6 @@ module Mongoid
       #   NoClientConfig.new(:analytics)
       #
       # @param [ String | Symbol ] name The name of the client.
-      #
-      # @since 3.0.0
       def initialize(name)
         super(compose_message("no_client_config", { name: name }))
       end

--- a/lib/mongoid/errors/no_client_database.rb
+++ b/lib/mongoid/errors/no_client_database.rb
@@ -14,8 +14,6 @@ module Mongoid
       #
       # @param [ Symbol, String ] name The db config key.
       # @param [ Hash ] config The hash configuration options.
-      #
-      # @since 3.0.0
       def initialize(name, config)
         super(
           compose_message(

--- a/lib/mongoid/errors/no_client_hosts.rb
+++ b/lib/mongoid/errors/no_client_hosts.rb
@@ -14,8 +14,6 @@ module Mongoid
       #
       # @param [ Symbol, String ] name The db config key.
       # @param [ Hash ] config The hash configuration options.
-      #
-      # @since 3.0.0
       def initialize(name, config)
         super(
           compose_message(

--- a/lib/mongoid/errors/no_clients_config.rb
+++ b/lib/mongoid/errors/no_clients_config.rb
@@ -12,8 +12,6 @@ module Mongoid
       #
       # @example Create the error.
       #   NoClientsConfig.new
-      #
-      # @since 3.0.0
       def initialize
         super(compose_message("no_clients_config", {}))
       end

--- a/lib/mongoid/errors/no_default_client.rb
+++ b/lib/mongoid/errors/no_default_client.rb
@@ -13,8 +13,6 @@ module Mongoid
       #   NoDefaultClient.new([ :analytics ])
       #
       # @param [ Array<Symbol> ] keys The defined clients.
-      #
-      # @since 3.0.0
       def initialize(keys)
         super(
           compose_message("no_default_client", { keys: keys.join(", ") })

--- a/lib/mongoid/errors/no_environment.rb
+++ b/lib/mongoid/errors/no_environment.rb
@@ -11,8 +11,6 @@ module Mongoid
       #
       # @example Create the new no environment error.
       #   NoEnvironment.new
-      #
-      # @since 2.4.0
       def initialize
         super(compose_message("no_environment", {}))
       end

--- a/lib/mongoid/errors/no_map_reduce_output.rb
+++ b/lib/mongoid/errors/no_map_reduce_output.rb
@@ -14,8 +14,6 @@ module Mongoid
       #   NoMapReduceOutput.new({ map: "" })
       #
       # @param [ Hash ] command The map/reduce command.
-      #
-      # @since 3.0.0
       def initialize(command)
         super(
           compose_message("no_map_reduce_output", { command: command })

--- a/lib/mongoid/errors/no_metadata.rb
+++ b/lib/mongoid/errors/no_metadata.rb
@@ -13,8 +13,6 @@ module Mongoid
       #   NoMetadata.new(Address)
       #
       # @param [ Class ] klass The document class.
-      #
-      # @since 3.0.0
       def initialize(klass)
         super(compose_message("no_metadata", { klass: klass }))
       end

--- a/lib/mongoid/errors/no_parent.rb
+++ b/lib/mongoid/errors/no_parent.rb
@@ -14,8 +14,6 @@ module Mongoid
       #   NoParent.new(klass)
       #
       # @param [ Class ] klass The class of the embedded document.
-      #
-      # @since 3.0.0
       def initialize(klass)
         super(
           compose_message("no_parent", { klass: klass })

--- a/lib/mongoid/errors/readonly_attribute.rb
+++ b/lib/mongoid/errors/readonly_attribute.rb
@@ -15,8 +15,6 @@ module Mongoid
       #
       # @param [ Symbol, String ] name The name of the attribute.
       # @param [ Object ] value The attempted set value.
-      #
-      # @since 3.0.0
       def initialize(name, value)
         super(
           compose_message("readonly_attribute", { name: name, value: value })

--- a/lib/mongoid/errors/readonly_document.rb
+++ b/lib/mongoid/errors/readonly_document.rb
@@ -6,8 +6,6 @@ module Mongoid
 
     # Raised when attempting to persist a document that was loaded from the
     # database with partial fields.
-    #
-    # @since 4.0.0
     class ReadonlyDocument < MongoidError
 
       # Instnatiate the exception.
@@ -16,8 +14,6 @@ module Mongoid
       #   ReadonlyDocument.new(Band)
       #
       # @param [ Class ] klass The document class.
-      #
-      # @since 4.0.0
       def initialize(klass)
         super(compose_message("readonly_document", { klass: klass }))
       end

--- a/lib/mongoid/errors/unknown_attribute.rb
+++ b/lib/mongoid/errors/unknown_attribute.rb
@@ -15,8 +15,6 @@ module Mongoid
       #
       # @param [ Class ] klass The model class.
       # @param [ String, Symbol ] name The name of the attribute.
-      #
-      # @since 3.0.0
       def initialize(klass, name)
         super(
           compose_message("unknown_attribute", { klass: klass.name, name: name })

--- a/lib/mongoid/errors/unknown_model.rb
+++ b/lib/mongoid/errors/unknown_model.rb
@@ -15,8 +15,6 @@ module Mongoid
       #
       # @param [ String ] klass The model class.
       # @param [ String ] value The value used to determine the (invalid) class.
-      #
-      # @since 7.0.0
       def initialize(klass, value)
         super(
             compose_message("unknown_model", { klass: klass, value: value })

--- a/lib/mongoid/errors/unsupported_javascript.rb
+++ b/lib/mongoid/errors/unsupported_javascript.rb
@@ -14,8 +14,6 @@ module Mongoid
       #
       # @param [ Class ] klass The embedded document class.
       # @param [ String ] javascript The javascript expression.
-      #
-      # @since 3.0.0
       def initialize(klass, javascript)
         super(
           compose_message(

--- a/lib/mongoid/evolvable.rb
+++ b/lib/mongoid/evolvable.rb
@@ -12,8 +12,6 @@ module Mongoid
     #   document.__evolve_object_id__
     #
     # @return [ Object ] The document's id.
-    #
-    # @since 3.0.0
     def __evolve_object_id__
       _id
     end

--- a/lib/mongoid/extensions/array.rb
+++ b/lib/mongoid/extensions/array.rb
@@ -11,8 +11,6 @@ module Mongoid
       #   [ id ].__evolve_object_id__
       #
       # @return [ Array<BSON::ObjectId> ] The converted array.
-      #
-      # @since 3.0.0
       def __evolve_object_id__
         map!(&:__evolve_object_id__)
         self
@@ -24,8 +22,6 @@ module Mongoid
       #   [ 1, 2, 3 ].__find_args__
       #
       # @return [ Array ] The array of args.
-      #
-      # @since 3.0.0
       def __find_args__
         flat_map{ |a| a.__find_args__ }.uniq{ |a| a.to_s }
       end
@@ -36,8 +32,6 @@ module Mongoid
       #   [ id ].__mongoize_object_id__
       #
       # @return [ Array<BSON::ObjectId> ] The converted array.
-      #
-      # @since 3.0.0
       def __mongoize_object_id__
         map!(&:__mongoize_object_id__).compact!
         self
@@ -54,8 +48,6 @@ module Mongoid
       # @return [ Time | ActiveSupport::TimeWithZone ] Local time in the
       #   configured default time zone corresponding to date/time components
       #   in this array.
-      #
-      # @since 3.0.0
       def __mongoize_time__
         ::Time.configured.local(*self)
       end
@@ -75,8 +67,6 @@ module Mongoid
       # for backwards compatibility only. It always returns false.
       #
       # @return [ false ] Always false.
-      #
-      # @since 3.1.0
       # @deprecated
       def blank_criteria?
         false
@@ -88,8 +78,6 @@ module Mongoid
       #   [ 1, 2, 3 ].multi_arged?
       #
       # @return [ true, false ] If the array is multi args.
-      #
-      # @since 3.0.0
       def multi_arged?
         !first.is_a?(Hash) && first.resizable? || size > 1
       end
@@ -101,8 +89,6 @@ module Mongoid
       #   object.mongoize
       #
       # @return [ Array ] The object.
-      #
-      # @since 3.0.0
       def mongoize
         ::Array.mongoize(self)
       end
@@ -118,8 +104,6 @@ module Mongoid
       # @param [ Object ] object The object to delete.
       #
       # @return [ Object ] The deleted object.
-      #
-      # @since 2.1.0
       def delete_one(object)
         position = index(object)
         position ? delete_at(position) : nil
@@ -131,8 +115,6 @@ module Mongoid
       #   object.resizable?
       #
       # @return [ true ] true.
-      #
-      # @since 3.0.0
       def resizable?
         true
       end
@@ -148,8 +130,6 @@ module Mongoid
         # @param [ Object ] object The object to convert.
         #
         # @return [ Array ] The array of ids.
-        #
-        # @since 3.0.0
         def __mongoize_fk__(association, object)
           if object.resizable?
             object.blank? ? object : association.convert_to_foreign_key(object)
@@ -167,8 +147,6 @@ module Mongoid
         # @param [ Object ] object The object to mongoize.
         #
         # @return [ Array ] The object mongoized.
-        #
-        # @since 3.0.0
         def mongoize(object)
           if object.is_a?(::Array)
             evolve(object).collect{ |obj| obj.class.mongoize(obj) }
@@ -183,8 +161,6 @@ module Mongoid
         #   Array.resizable?
         #
         # @return [ true ] true.
-        #
-        # @since 3.0.0
         def resizable?
           true
         end

--- a/lib/mongoid/extensions/big_decimal.rb
+++ b/lib/mongoid/extensions/big_decimal.rb
@@ -11,8 +11,6 @@ module Mongoid
       #   bd.__to_inc__
       #
       # @return [ Float ] The big decimal as a float.
-      #
-      # @since 3.0.3
       def __to_inc__
         to_f
       end
@@ -24,8 +22,6 @@ module Mongoid
       #   object.mongoize
       #
       # @return [ Object ] The object.
-      #
-      # @since 3.0.0
       def mongoize
         to_s
       end
@@ -36,8 +32,6 @@ module Mongoid
       #   object.numeric?
       #
       # @return [ true ] Always true.
-      #
-      # @since 6.0.0
       def numeric?
         true
       end
@@ -52,8 +46,6 @@ module Mongoid
         # @param [ Object ] object The object to demongoize.
         #
         # @return [ BigDecimal, nil ] A BigDecimal derived from the object or nil.
-        #
-        # @since 3.0.0
         def demongoize(object)
           object && object.numeric? ? BigDecimal(object.to_s) : nil
         end
@@ -66,8 +58,6 @@ module Mongoid
         # @param [ Object ] object The object to Mongoize
         #
         # @return [ String, nil ] A String representing the object or nil.
-        #
-        # @since 3.0.7
         def mongoize(object)
           object && object.numeric? ? object.to_s : nil
         end

--- a/lib/mongoid/extensions/boolean.rb
+++ b/lib/mongoid/extensions/boolean.rb
@@ -13,8 +13,6 @@ module Mongoid
       #   Boolean.mongoize("123.11")
       #
       # @return [ String ] The object mongoized.
-      #
-      # @since 3.0.0
       def mongoize(object)
         evolve(object)
       end

--- a/lib/mongoid/extensions/date.rb
+++ b/lib/mongoid/extensions/date.rb
@@ -20,8 +20,6 @@ module Mongoid
       # @return [ Time | ActiveSupport::TimeWithZone ] Local time in the
       #   configured default time zone corresponding to local midnight of
       #   this date.
-      #
-      # @since 3.0.0
       def __mongoize_time__
         ::Time.configured.local(year, month, day)
       end
@@ -33,8 +31,6 @@ module Mongoid
       #   date.mongoize
       #
       # @return [ Time ] The object mongoized.
-      #
-      # @since 3.0.0
       def mongoize
         ::Date.mongoize(self)
       end
@@ -49,8 +45,6 @@ module Mongoid
         # @param [ Time ] object The time from Mongo.
         #
         # @return [ Date ] The object as a date.
-        #
-        # @since 3.0.0
         def demongoize(object)
           ::Date.new(object.year, object.month, object.day) if object
         end
@@ -64,8 +58,6 @@ module Mongoid
         # @param [ Object ] object The object to mongoize.
         #
         # @return [ Time ] The object mongoized.
-        #
-        # @since 3.0.0
         def mongoize(object)
           unless object.blank?
             begin

--- a/lib/mongoid/extensions/date_time.rb
+++ b/lib/mongoid/extensions/date_time.rb
@@ -11,8 +11,6 @@ module Mongoid
       #   date_time.__mongoize_time__
       #
       # @return [ Time | ActiveSupport::TimeWithZone ] The mongoized time.
-      #
-      # @since 3.0.0
       def __mongoize_time__
         if Mongoid.use_activesupport_time_zone?
           in_time_zone(::Time.zone)
@@ -29,8 +27,6 @@ module Mongoid
       #   date_time.mongoize
       #
       # @return [ Time ] The object mongoized.
-      #
-      # @since 3.0.0
       def mongoize
         ::DateTime.mongoize(self)
       end
@@ -45,8 +41,6 @@ module Mongoid
         # @param [ Time ] object The time from Mongo.
         #
         # @return [ DateTime ] The object as a date.
-        #
-        # @since 3.0.0
         def demongoize(object)
           ::Time.demongoize(object).try(:to_datetime)
         end
@@ -60,8 +54,6 @@ module Mongoid
         # @param [ Object ] object The object to convert.
         #
         # @return [ Time ] The object mongoized.
-        #
-        # @since 3.0.0
         def mongoize(object)
           ::Time.mongoize(object)
         end

--- a/lib/mongoid/extensions/decimal128.rb
+++ b/lib/mongoid/extensions/decimal128.rb
@@ -11,8 +11,6 @@ module Mongoid
       #   decimal128.__evolve_decimal128__
       #
       # @return [ BSON::Decimal128 ] self.
-      #
-      # @since 6.1.0
       def __evolve_decimal128__
         self
       end
@@ -27,8 +25,6 @@ module Mongoid
         # @param [ Object ] object The object to evolve.
         #
         # @return [ BSON::Decimal128 ] The decimal128.
-        #
-        # @since 6.1.0
         def evolve(object)
           object.__evolve_decimal128__
         end

--- a/lib/mongoid/extensions/false_class.rb
+++ b/lib/mongoid/extensions/false_class.rb
@@ -11,8 +11,6 @@ module Mongoid
       #   object.__sortable__
       #
       # @return [ Integer ] 0.
-      #
-      # @since 3.0.0
       def __sortable__
         0
       end
@@ -25,8 +23,6 @@ module Mongoid
       # @param [ Class ] other The class to check.
       #
       # @return [ true, false ] If the other is a boolean.
-      #
-      # @since 1.0.0
       def is_a?(other)
         if other == Mongoid::Boolean || other.class == Mongoid::Boolean
           return true

--- a/lib/mongoid/extensions/float.rb
+++ b/lib/mongoid/extensions/float.rb
@@ -11,8 +11,6 @@ module Mongoid
       #   1335532685.117847.__mongoize_time__
       #
       # @return [ Time | ActiveSupport::TimeWithZone ] The time.
-      #
-      # @since 3.0.0
       def __mongoize_time__
         ::Time.configured.at(self)
       end
@@ -23,8 +21,6 @@ module Mongoid
       #   object.numeric?
       #
       # @return [ true ] Always true.
-      #
-      # @since 3.0.0
       def numeric?
         true
       end
@@ -40,8 +36,6 @@ module Mongoid
         # @param [ Object ] object The object to mongoize.
         #
         # @return [ String ] The object mongoized.
-        #
-        # @since 3.0.0
         def mongoize(object)
           unless object.blank?
             __numeric__(object).to_f rescue 0.0

--- a/lib/mongoid/extensions/hash.rb
+++ b/lib/mongoid/extensions/hash.rb
@@ -11,8 +11,6 @@ module Mongoid
       #   { field: id }.__evolve_object_id__
       #
       # @return [ Hash ] The converted hash.
-      #
-      # @since 3.0.0
       def __evolve_object_id__
         update_values(&:__evolve_object_id__)
       end
@@ -23,8 +21,6 @@ module Mongoid
       #   { field: id }.__mongoize_object_id__
       #
       # @return [ Hash ] The converted hash.
-      #
-      # @since 3.0.0
       def __mongoize_object_id__
         if id = self['$oid']
           BSON::ObjectId.from_string(id)
@@ -39,8 +35,6 @@ module Mongoid
       #   { name: "Placebo" }.__consolidate__
       #
       # @return [ Hash ] A new consolidated hash.
-      #
-      # @since 3.0.0
       def __consolidate__(klass)
         consolidated = {}
         each_pair do |key, value|
@@ -103,8 +97,6 @@ module Mongoid
       #
       # @return [ true | false ] Whether hash contains known unsatisfiable
       #   conditions.
-      #
-      # @since 3.1.0
       # @deprecated
       alias :blank_criteria? :_mongoid_unsatisfiable_criteria?
 
@@ -114,8 +106,6 @@ module Mongoid
       #   {}.delete_id
       #
       # @return [ Object ] The deleted value, or nil.
-      #
-      # @since 3.0.2
       def delete_id
         delete("_id") || delete(:_id) || delete("id") || delete(:id)
       end
@@ -127,8 +117,6 @@ module Mongoid
       #   { :_id => 1 }.extract_id
       #
       # @return [ Object ] The value of the id.
-      #
-      # @since 2.3.2
       def extract_id
         self["_id"] || self[:_id] || self["id"] || self[:id]
       end
@@ -141,8 +129,6 @@ module Mongoid
       # @param [ String ] string the dot syntax string.
       #
       # @return [ Object ] The matching value.
-      #
-      # @since 3.0.15
       def __nested__(string)
         keys = string.split(".")
         value = self
@@ -164,8 +150,6 @@ module Mongoid
       #   object.mongoize
       #
       # @return [ Hash ] The object.
-      #
-      # @since 3.0.0
       def mongoize
         ::Hash.mongoize(self)
       end
@@ -176,8 +160,6 @@ module Mongoid
       #   {}.resizable?
       #
       # @return [ true ] true.
-      #
-      # @since 3.0.0
       def resizable?
         true
       end
@@ -190,8 +172,6 @@ module Mongoid
       #   { klass: Band, where: { name: "Depeche Mode" }.to_criteria
       #
       # @return [ Criteria ] The criteria.
-      #
-      # @since 3.0.7
       def to_criteria
         criteria = Criteria.new(delete(:klass) || delete("klass"))
         each_pair do |method, args|
@@ -215,8 +195,6 @@ module Mongoid
       # @param [ Object ] value The value to mongoize.
       #
       # @return [ Object ] The mongoized value.
-      #
-      # @since 3.1.0
       def mongoize_for(operator, klass, key, value)
         field = klass.fields[key.to_s]
         if field
@@ -241,8 +219,6 @@ module Mongoid
         # @param [ Object ] object The object to mongoize.
         #
         # @return [ Hash ] The object mongoized.
-        #
-        # @since 3.0.0
         def mongoize(object)
           return if object.nil?
           evolve(object.dup).update_values { |value| value.mongoize }
@@ -254,8 +230,6 @@ module Mongoid
         #   {}.resizable?
         #
         # @return [ true ] true.
-        #
-        # @since 3.0.0
         def resizable?
           true
         end

--- a/lib/mongoid/extensions/integer.rb
+++ b/lib/mongoid/extensions/integer.rb
@@ -11,8 +11,6 @@ module Mongoid
       #   1335532685.__mongoize_time__
       #
       # @return [ Time | ActiveSupport::TimeWithZone ] The time.
-      #
-      # @since 3.0.0
       def __mongoize_time__
         ::Time.configured.at(self)
       end
@@ -23,8 +21,6 @@ module Mongoid
       #   object.numeric?
       #
       # @return [ true ] Always true.
-      #
-      # @since 3.0.0
       def numeric?
         true
       end
@@ -35,8 +31,6 @@ module Mongoid
       #   object.unconvertable_to_bson?
       #
       # @return [ true ] If the object is unconvertable.
-      #
-      # @since 2.2.1
       def unconvertable_to_bson?
         true
       end
@@ -50,8 +44,6 @@ module Mongoid
         #   BigDecimal.mongoize("123.11")
         #
         # @return [ String ] The object mongoized.
-        #
-        # @since 3.0.0
         def mongoize(object)
           unless object.blank?
             __numeric__(object).to_i rescue 0

--- a/lib/mongoid/extensions/module.rb
+++ b/lib/mongoid/extensions/module.rb
@@ -17,8 +17,6 @@ module Mongoid
       # @param [ Proc ] block The method body.
       #
       # @return [ Method ] The new method.
-      #
-      # @since 3.0.0
       def re_define_method(name, &block)
         undef_method(name) if method_defined?(name)
         define_method(name, &block)

--- a/lib/mongoid/extensions/nil_class.rb
+++ b/lib/mongoid/extensions/nil_class.rb
@@ -11,8 +11,6 @@ module Mongoid
       #   object.__setter__
       #
       # @return [ nil ] Always nil.
-      #
-      # @since 3.1.0
       def __setter__
         self
       end
@@ -23,8 +21,6 @@ module Mongoid
       #   nil.collectionize
       #
       # @return [ String ] A blank string.
-      #
-      # @since 1.0.0
       def collectionize
         to_s.collectionize
       end

--- a/lib/mongoid/extensions/object.rb
+++ b/lib/mongoid/extensions/object.rb
@@ -11,8 +11,6 @@ module Mongoid
       #   object.__evolve_object_id__
       #
       # @return [ Object ] self.
-      #
-      # @since 3.0.0
       def __evolve_object_id__
         self
       end
@@ -24,8 +22,6 @@ module Mongoid
       #   object.__find_args__
       #
       # @return [ Object ] self.
-      #
-      # @since 3.0.0
       def __find_args__
         self
       end
@@ -41,8 +37,6 @@ module Mongoid
       #   object.__mongoize_time__
       #
       # @return [ Object ] self.
-      #
-      # @since 3.0.0
       # @deprecated
       def __mongoize_time__
         self
@@ -54,8 +48,6 @@ module Mongoid
       #   object.__setter__
       #
       # @return [ String ] The object as a string plus =.
-      #
-      # @since 3.1.0
       def __setter__
         "#{self}="
       end
@@ -66,8 +58,6 @@ module Mongoid
       #   object.__sortable__
       #
       # @return [ Object ] self.
-      #
-      # @since 3.0.0
       def __sortable__
         self
       end
@@ -78,8 +68,6 @@ module Mongoid
       #   1.__to_inc__
       #
       # @return [ Object ] The object.
-      #
-      # @since 3.0.3
       def __to_inc__
         self
       end
@@ -93,8 +81,6 @@ module Mongoid
       # for backwards compatibility only. It always returns false.
       #
       # @return [ false ] Always false.
-      #
-      # @since 3.1.0
       # @deprecated
       def blank_criteria?
         false
@@ -110,8 +96,6 @@ module Mongoid
       #
       # @return [ Object, nil ] The result of the method call or nil if the
       #   method does not exist.
-      #
-      # @since 2.0.0.rc.1
       def do_or_do_not(name, *args)
         send(name, *args) if name && respond_to?(name)
       end
@@ -124,8 +108,6 @@ module Mongoid
       # @param [ String ] name The name of the variable.
       #
       # @return [ Object, false ] The value or false.
-      #
-      # @since 2.0.0.rc.1
       def ivar(name)
         var_name = "@_#{name}"
         if instance_variable_defined?(var_name)
@@ -142,8 +124,6 @@ module Mongoid
       #   object.mongoize
       #
       # @return [ Object ] The object.
-      #
-      # @since 3.0.0
       def mongoize
         self
       end
@@ -154,8 +134,6 @@ module Mongoid
       #   object.multi_arged?
       #
       # @return [ false ] false.
-      #
-      # @since 3.0.0
       def multi_arged?
         false
       end
@@ -166,8 +144,6 @@ module Mongoid
       #   object.numeric?
       #
       # @return [ false ] Always false.
-      #
-      # @since 3.0.0
       def numeric?
         false
       end
@@ -180,8 +156,6 @@ module Mongoid
       # @param [ String ] name The name of the variable.
       #
       # @return [ true, false ] If the variable was defined.
-      #
-      # @since 2.1.0
       def remove_ivar(name)
         if instance_variable_defined?("@_#{name}")
           return remove_instance_variable("@_#{name}")
@@ -197,8 +171,6 @@ module Mongoid
       #   object.resizable?
       #
       # @return [ false ] false.
-      #
-      # @since 3.0.0
       def resizable?
         false
       end
@@ -209,8 +181,6 @@ module Mongoid
       #   object.substitutable
       #
       # @return [ Object ] self.
-      #
-      # @since 2.0.0
       def substitutable
         self
       end
@@ -225,8 +195,6 @@ module Mongoid
       #
       # @return [ Object, nil ] The result of the method call or nil if the
       #   method does not exist. Nil if the object is frozen.
-      #
-      # @since 2.2.1
       def you_must(name, *args)
         frozen? ? nil : do_or_do_not(name, *args)
       end
@@ -243,8 +211,6 @@ module Mongoid
         # @param [ Object ] object The object to convert.
         #
         # @return [ Object ] The converted object.
-        #
-        # @since 3.0.0
         def __mongoize_fk__(association, object)
           return nil if !object || object == ""
           association.convert_to_foreign_key(object)
@@ -258,8 +224,6 @@ module Mongoid
         # @param [ Object ] object The object to demongoize.
         #
         # @return [ Object ] The object.
-        #
-        # @since 3.0.0
         def demongoize(object)
           object
         end
@@ -273,8 +237,6 @@ module Mongoid
         # @param [ Object ] object The object to mongoize.
         #
         # @return [ Object ] The object mongoized.
-        #
-        # @since 3.0.0
         def mongoize(object)
           object.mongoize
         end

--- a/lib/mongoid/extensions/object_id.rb
+++ b/lib/mongoid/extensions/object_id.rb
@@ -11,8 +11,6 @@ module Mongoid
       #   object_id.__evolve_object_id__
       #
       # @return [ BSON::ObjectId ] self.
-      #
-      # @since 3.0.0
       def __evolve_object_id__
         self
       end
@@ -28,8 +26,6 @@ module Mongoid
         # @param [ Object ] object The object to evolve.
         #
         # @return [ BSON::ObjectId ] The object id.
-        #
-        # @since 3.0.0
         def evolve(object)
           object.__evolve_object_id__
         end
@@ -42,8 +38,6 @@ module Mongoid
         # @param [ Object ] object The object to convert.
         #
         # @return [ BSON::ObjectId ] The object id.
-        #
-        # @since 3.0.0
         def mongoize(object)
           object.__mongoize_object_id__
         end

--- a/lib/mongoid/extensions/range.rb
+++ b/lib/mongoid/extensions/range.rb
@@ -11,8 +11,6 @@ module Mongoid
       #   range.__find_args__
       #
       # @return [ Array ] The range as an array.
-      #
-      # @since 3.0.0
       def __find_args__
         to_a
       end
@@ -24,8 +22,6 @@ module Mongoid
       #   range.mongoize
       #
       # @return [ Hash ] The object mongoized.
-      #
-      # @since 3.0.0
       def mongoize
         ::Range.mongoize(self)
       end
@@ -36,8 +32,6 @@ module Mongoid
       #   range.resizable?
       #
       # @return [ true ] True.
-      #
-      # @since 3.0.0
       def resizable?
         true
       end
@@ -52,8 +46,6 @@ module Mongoid
         # @param [ Hash ] object The object to demongoize.
         #
         # @return [ Range ] The range.
-        #
-        # @since 3.0.0
         def demongoize(object)
           object.nil? ? nil : ::Range.new(object["min"], object["max"], object["exclude_end"])
         end
@@ -67,8 +59,6 @@ module Mongoid
         # @param [ Range ] object The object to mongoize.
         #
         # @return [ Hash ] The object mongoized.
-        #
-        # @since 3.0.0
         def mongoize(object)
           return nil if object.nil?
           return object if object.is_a?(::Hash)

--- a/lib/mongoid/extensions/regexp.rb
+++ b/lib/mongoid/extensions/regexp.rb
@@ -16,8 +16,6 @@ module Mongoid
         # @param [ Regexp, String ] object The object to mongoize.
         #
         # @return [ Regexp ] The object mongoized.
-        #
-        # @since 3.0.0
         def mongoize(object)
           return nil if object.nil?
           ::Regexp.new(object)

--- a/lib/mongoid/extensions/set.rb
+++ b/lib/mongoid/extensions/set.rb
@@ -12,8 +12,6 @@ module Mongoid
       #   set.mongoize
       #
       # @return [ Array ] The object mongoized.
-      #
-      # @since 3.0.0
       def mongoize
         ::Set.mongoize(self)
       end
@@ -28,8 +26,6 @@ module Mongoid
         # @param [ Array ] object The object to demongoize.
         #
         # @return [ Set ] The set.
-        #
-        # @since 3.0.0
         def demongoize(object)
           ::Set.new(object)
         end
@@ -43,8 +39,6 @@ module Mongoid
         # @param [ Set ] object The object to mongoize.
         #
         # @return [ Array ] The object mongoized.
-        #
-        # @since 3.0.0
         def mongoize(object)
           object.to_a
         end

--- a/lib/mongoid/extensions/string.rb
+++ b/lib/mongoid/extensions/string.rb
@@ -14,8 +14,6 @@ module Mongoid
       #   "test".__evolve_object_id__
       #
       # @return [ String, BSON::ObjectId ] The evolved string.
-      #
-      # @since 3.0.0
       def __evolve_object_id__
         convert_to_object_id
       end
@@ -26,8 +24,6 @@ module Mongoid
       #   "test".__mongoize_object_id__
       #
       # @return [ String, BSON::ObjectId, nil ] The mongoized string.
-      #
-      # @since 3.0.0
       def __mongoize_object_id__
         convert_to_object_id unless blank?
       end
@@ -42,8 +38,6 @@ module Mongoid
       #
       # @return [ Time | ActiveSupport::TimeWithZone ] Local time in the
       #   configured default time zone corresponding to this string.
-      #
-      # @since 3.0.0
       def __mongoize_time__
         # This extra parse from Time is because ActiveSupport::TimeZone
         # either returns nil or Time.now if the string is empty or invalid,
@@ -63,8 +57,6 @@ module Mongoid
       #   "namespace/model".collectionize
       #
       # @return [ String ] The string in collection friendly form.
-      #
-      # @since 1.0.0
       def collectionize
         tableize.gsub("/", "_")
       end
@@ -75,8 +67,6 @@ module Mongoid
       #   "_id".mongoid_id?
       #
       # @return [ true, false ] If the string is id or _id.
-      #
-      # @since 2.3.1
       def mongoid_id?
         self =~ /\A(|_)id\z/
       end
@@ -88,8 +78,6 @@ module Mongoid
       #   "1234.23".numeric?
       #
       # @return [ true, false ] If the string is a number.
-      #
-      # @since 3.0.0
       def numeric?
         !!Float(self)
       rescue ArgumentError
@@ -102,8 +90,6 @@ module Mongoid
       #   "model=".reader
       #
       # @return [ String ] The string stripped of "=".
-      #
-      # @since 1.0.0
       def reader
         delete("=").sub(/\_before\_type\_cast\z/, '')
       end
@@ -114,8 +100,6 @@ module Mongoid
       #   "model=".writer?
       #
       # @return [ true, false ] If the string contains "=".
-      #
-      # @since 1.0.0
       def writer?
         include?("=")
       end
@@ -126,8 +110,6 @@ module Mongoid
       #   "model=".valid_method_name?
       #
       # @return [ true, false ] If the string contains a valid Ruby identifier.
-      #
-      # @since 3.0.15
       def valid_method_name?
         /[@$"-]/ !~ self
       end
@@ -138,8 +120,6 @@ module Mongoid
       #   "price_before_type_cast".before_type_cast?
       #
       # @return [ true, false ] If the string ends with "_before_type_cast"
-      #
-      # @since 3.1.0
       def before_type_cast?
         ends_with?("_before_type_cast")
       end
@@ -150,8 +130,6 @@ module Mongoid
       #   object.unconvertable_to_bson?
       #
       # @return [ true, false ] If the object is unconvertable.
-      #
-      # @since 2.2.1
       def unconvertable_to_bson?
         @unconvertable_to_bson ||= false
       end
@@ -166,8 +144,6 @@ module Mongoid
       #   string.convert_to_object_id
       #
       # @return [ String, BSON::ObjectId ] The string or the id.
-      #
-      # @since 3.0.0
       def convert_to_object_id
         BSON::ObjectId.legal?(self) ? BSON::ObjectId.from_string(self) : self
       end
@@ -182,8 +158,6 @@ module Mongoid
         # @param [ Object ] object The object to demongoize.
         #
         # @return [ String ] The object.
-        #
-        # @since 3.0.0
         def demongoize(object)
           object.try(:to_s)
         end
@@ -197,8 +171,6 @@ module Mongoid
         # @param [ Object ] object The object to mongoize.
         #
         # @return [ String ] The object mongoized.
-        #
-        # @since 3.0.0
         def mongoize(object)
           demongoize(object)
         end

--- a/lib/mongoid/extensions/symbol.rb
+++ b/lib/mongoid/extensions/symbol.rb
@@ -11,8 +11,6 @@ module Mongoid
       #   :_id.mongoid_id?
       #
       # @return [ true, false ] If the symbol is :id or :_id.
-      #
-      # @since 2.3.1
       def mongoid_id?
         to_s.mongoid_id?
       end
@@ -27,8 +25,6 @@ module Mongoid
         # @param [ Object ] object The object to demongoize.
         #
         # @return [ Symbol ] The object.
-        #
-        # @since 3.0.0
         def demongoize(object)
           object.try(:to_sym)
         end
@@ -42,8 +38,6 @@ module Mongoid
         # @param [ Object ] object The object to mongoize.
         #
         # @return [ Symbol ] The object mongoized.
-        #
-        # @since 3.0.0
         def mongoize(object)
           demongoize(object)
         end

--- a/lib/mongoid/extensions/time.rb
+++ b/lib/mongoid/extensions/time.rb
@@ -11,8 +11,6 @@ module Mongoid
       # (which are themselves).
       #
       # @return [ Time ] self.
-      #
-      # @since 3.0.0
       def __mongoize_time__
         self
       end
@@ -30,8 +28,6 @@ module Mongoid
       #   time.mongoize
       #
       # @return [ Time ] The object mongoized.
-      #
-      # @since 3.0.0
       def mongoize
         ::Time.mongoize(self)
       end
@@ -45,8 +41,6 @@ module Mongoid
         #   ::Time.configured
         #
         # @return [ Time ] The configured time.
-        #
-        # @since 3.0.0
         def configured
           Mongoid.use_activesupport_time_zone? ? (::Time.zone || ::Time) : ::Time
         end
@@ -59,8 +53,6 @@ module Mongoid
         # @param [ Time ] object The time from Mongo.
         #
         # @return [ Time ] The object as a date.
-        #
-        # @since 3.0.0
         def demongoize(object)
           return nil if object.blank?
           object = object.getlocal unless Mongoid::Config.use_utc?
@@ -79,8 +71,6 @@ module Mongoid
         # @param [ Object ] object The object to mongoize.
         #
         # @return [ Time ] The object mongoized.
-        #
-        # @since 3.0.0
         def mongoize(object)
           return nil if object.blank?
           begin

--- a/lib/mongoid/extensions/time_with_zone.rb
+++ b/lib/mongoid/extensions/time_with_zone.rb
@@ -11,8 +11,6 @@ module Mongoid
       # (which are themselves).
       #
       # @return [ ActiveSupport::TimeWithZone ] self.
-      #
-      # @since 3.0.0
       def __mongoize_time__
         self
       end
@@ -24,8 +22,6 @@ module Mongoid
       #   date_time.mongoize
       #
       # @return [ Time ] The object mongoized.
-      #
-      # @since 3.0.0
       def mongoize
         ::ActiveSupport::TimeWithZone.mongoize(self)
       end
@@ -40,8 +36,6 @@ module Mongoid
         # @param [ Time ] object The time from Mongo.
         #
         # @return [ TimeWithZone ] The object as a date.
-        #
-        # @since 3.0.0
         def demongoize(object)
           return nil if object.blank?
           ::Time.demongoize(object).in_time_zone
@@ -56,8 +50,6 @@ module Mongoid
         # @param [ Object ] object The object to convert.
         #
         # @return [ Time ] The object mongoized.
-        #
-        # @since 3.0.0
         def mongoize(object)
           ::Time.mongoize(object)
         end

--- a/lib/mongoid/extensions/true_class.rb
+++ b/lib/mongoid/extensions/true_class.rb
@@ -11,8 +11,6 @@ module Mongoid
       #   object.__sortable__
       #
       # @return [ Integer ] 1.
-      #
-      # @since 3.0.0
       def __sortable__
         1
       end
@@ -25,8 +23,6 @@ module Mongoid
       # @param [ Class ] other The class to check.
       #
       # @return [ true, false ] If the other is a boolean.
-      #
-      # @since 1.0.0
       def is_a?(other)
         if other == Mongoid::Boolean || other.class == Mongoid::Boolean
           return true

--- a/lib/mongoid/fields.rb
+++ b/lib/mongoid/fields.rb
@@ -16,8 +16,6 @@ module Mongoid
     Boolean = Mongoid::Boolean
 
     # For fields defined with symbols use the correct class.
-    #
-    # @since 4.0.0
     TYPE_MAPPINGS = {
       array: Array,
       big_decimal: BigDecimal,
@@ -110,8 +108,6 @@ module Mongoid
     #   model.apply_pre_processed_defaults
     #
     # @return [ Array<String ] The names of the non-proc defaults.
-    #
-    # @since 2.4.0
     def apply_pre_processed_defaults
       pre_processed_defaults.each do |name|
         apply_default(name)
@@ -124,8 +120,6 @@ module Mongoid
     #   model.apply_post_processed_defaults
     #
     # @return [ Array<String ] The names of the proc defaults.
-    #
-    # @since 2.4.0
     def apply_post_processed_defaults
       post_processed_defaults.each do |name|
         apply_default(name)
@@ -138,8 +132,6 @@ module Mongoid
     #   model.apply_default("name")
     #
     # @param [ String ] name The name of the field.
-    #
-    # @since 2.4.0
     def apply_default(name)
       unless attributes.key?(name)
         if field = fields[name]
@@ -156,8 +148,6 @@ module Mongoid
     #
     # @example Apply all the defaults.
     #   model.apply_defaults
-    #
-    # @since 2.4.0
     def apply_defaults
       apply_pre_processed_defaults
       apply_post_processed_defaults
@@ -172,8 +162,6 @@ module Mongoid
     #   docment.attribute_names
     #
     # @return [ Array<String> ] The field names
-    #
-    # @since 3.0.0
     def attribute_names
       self.class.attribute_names
     end
@@ -187,8 +175,6 @@ module Mongoid
     # @param [ String, Symbol ] name The name to get.
     #
     # @return [ String ] The name of the field as it's stored in the db.
-    #
-    # @since 3.0.7
     def database_field_name(name)
       self.class.database_field_name(name)
     end
@@ -202,8 +188,6 @@ module Mongoid
     # @param [ Object ] value The current value.
     #
     # @return [ true, false ] If we set the field lazily.
-    #
-    # @since 3.1.0
     def lazy_settable?(field, value)
       !frozen? && value.nil? && field.lazy?
     end
@@ -237,8 +221,6 @@ module Mongoid
       # @param [ Symbol ] option_name the option name to match against
       # @param [ Proc ] block the handler to execute when the option is
       #   provided.
-      #
-      # @since 2.1.0
       def option(option_name, &block)
         options[option_name] = block
       end
@@ -250,8 +232,6 @@ module Mongoid
       #   # => { :required => #<Proc:0x00000100976b38> }
       #
       # @return [ Hash ] the option map
-      #
-      # @since 2.1.0
       def options
         @options ||= {}
       end
@@ -268,8 +248,6 @@ module Mongoid
       #   Model.attribute_names
       #
       # @return [ Array<String> ] The field names
-      #
-      # @since 3.0.0
       def attribute_names
         fields.keys
       end
@@ -283,8 +261,6 @@ module Mongoid
       # @param [ String, Symbol ] name The name to get.
       #
       # @return [ String ] The name of the field as it's stored in the db.
-      #
-      # @since 3.0.7
       def database_field_name(name)
         return nil unless name
         normalized = name.to_s
@@ -325,8 +301,6 @@ module Mongoid
       # @param [ Class ] type The new type of field.
       #
       # @return [ Serializable ] The new field.
-      #
-      # @since 2.1.0
       def replace_field(name, type)
         remove_defaults(name)
         add_field(name, fields[name].options.merge(type: type))
@@ -339,8 +313,6 @@ module Mongoid
       #   person.using_object_ids?
       #
       # @return [ true, false ] If the class uses BSON::ObjectIds for the id.
-      #
-      # @since 1.0.0
       def using_object_ids?
         fields["_id"].object_id_field?
       end
@@ -354,8 +326,6 @@ module Mongoid
       #   Model.add_defaults(field)
       #
       # @param [ Field ] field The field to add for.
-      #
-      # @since 2.4.0
       def add_defaults(field)
         default, name = field.default_val, field.name.to_s
         remove_defaults(name)
@@ -424,8 +394,6 @@ module Mongoid
       # @param [ Symbol ] name The name of the field.
       # @param [ Symbol ] meth The name of the accessor.
       # @param [ Hash ] options The options.
-      #
-      # @since 2.0.0
       def create_accessors(name, meth, options = {})
         field = fields[name]
 
@@ -449,8 +417,6 @@ module Mongoid
       # @param [ String ] name The name of the attribute.
       # @param [ String ] meth The name of the method.
       # @param [ Field ] field The field.
-      #
-      # @since 2.4.0
       def create_field_getter(name, meth, field)
         generated_methods.module_eval do
           re_define_method(meth) do
@@ -475,8 +441,6 @@ module Mongoid
       #
       # @param [ String ] name The name of the attribute.
       # @param [ String ] meth The name of the method.
-      #
-      # @since 3.1.0
       def create_field_getter_before_type_cast(name, meth)
         generated_methods.module_eval do
           re_define_method("#{meth}_before_type_cast") do
@@ -497,8 +461,6 @@ module Mongoid
       # @param [ String ] name The name of the attribute.
       # @param [ String ] meth The name of the method.
       # @param [ Field ] field The field.
-      #
-      # @since 2.4.0
       def create_field_setter(name, meth, field)
         generated_methods.module_eval do
           re_define_method("#{meth}=") do |value|
@@ -518,8 +480,6 @@ module Mongoid
       #
       # @param [ String ] name The name of the attribute.
       # @param [ String ] meth The name of the method.
-      #
-      # @since 2.4.0
       def create_field_check(name, meth)
         generated_methods.module_eval do
           re_define_method("#{meth}?") do
@@ -536,8 +496,6 @@ module Mongoid
       #
       # @param [ String ] name The name of the attribute.
       # @param [ String ] meth The name of the method.
-      #
-      # @since 2.4.0
       def create_translations_getter(name, meth)
         generated_methods.module_eval do
           re_define_method("#{meth}_translations") do
@@ -556,8 +514,6 @@ module Mongoid
       # @param [ String ] name The name of the attribute.
       # @param [ String ] meth The name of the method.
       # @param [ Field ] field The field.
-      #
-      # @since 2.4.0
       def create_translations_setter(name, meth, field)
         generated_methods.module_eval do
           re_define_method("#{meth}_translations=") do |value|
@@ -579,8 +535,6 @@ module Mongoid
       #   Person.generated_methods
       #
       # @return [ Module ] The module of generated methods.
-      #
-      # @since 2.0.0
       def generated_methods
         @generated_methods ||= begin
           mod = Module.new
@@ -595,8 +549,6 @@ module Mongoid
       #   Model.remove_defaults(name)
       #
       # @param [ String ] name The field name.
-      #
-      # @since 2.4.0
       def remove_defaults(name)
         pre_processed_defaults.delete_one(name)
         post_processed_defaults.delete_one(name)

--- a/lib/mongoid/fields/foreign_key.rb
+++ b/lib/mongoid/fields/foreign_key.rb
@@ -18,8 +18,6 @@ module Mongoid
       # @param [ Hash ] mods The current modifications.
       # @param [ Array ] new_elements The new elements to add.
       # @param [ Array ] old_elements The old elements getting removed.
-      #
-      # @since 2.4.0
       def add_atomic_changes(document, name, key, mods, new_elements, old_elements)
         old = (old_elements || [])
         new = (new_elements || [])
@@ -47,8 +45,6 @@ module Mongoid
       #   field.foreign_key?
       #
       # @return [ true, false ] If the field is a foreign key.
-      #
-      # @since 2.4.0
       def foreign_key?
         true
       end
@@ -61,8 +57,6 @@ module Mongoid
       # @param [ Object ] object The object to evolve.
       #
       # @return [ Object ] The evolved object.
-      #
-      # @since 3.0.0
       def evolve(object)
         if object_id_field? || object.is_a?(Document)
           if association.polymorphic?
@@ -81,8 +75,6 @@ module Mongoid
       #   field.lazy?
       #
       # @return [ true, false ] If the field is lazy.
-      #
-      # @since 3.1.0
       def lazy?
         type.resizable?
       end
@@ -95,8 +87,6 @@ module Mongoid
       # @param [ Object ] object The object to Mongoize.
       #
       # @return [ Object ] The mongoized object.
-      #
-      # @since 3.0.0
       def mongoize(object)
         if type.resizable? || object_id_field?
           type.__mongoize_fk__(association, object)
@@ -111,8 +101,6 @@ module Mongoid
       #   field.object_id_field?
       #
       # @return [ true, false ] If the field is a BSON::ObjectId.
-      #
-      # @since 2.2.0
       def object_id_field?
         @object_id_field ||=
             association.polymorphic? ? true : association.klass.using_object_ids?
@@ -124,8 +112,6 @@ module Mongoid
       #   field.resizable?
       #
       # @return [ true, false ] If the field is resizable.
-      #
-      # @since 3.0.2
       def resizable?
         type.resizable?
       end
@@ -141,8 +127,6 @@ module Mongoid
       # @param [ Document ] doc The document.
       #
       # @return [ Object ] The called proc.
-      #
-      # @since 3.0.0
       def evaluate_default_proc(doc)
         serialize_default(default_val[])
       end
@@ -155,8 +139,6 @@ module Mongoid
       #   field.related_id_field
       #
       # @return [ Fields::Standard ] The field.
-      #
-      # @since 3.0.0
       def related_id_field
         @related_id_field ||= association.klass.fields["_id"]
       end
@@ -172,8 +154,6 @@ module Mongoid
       # @param [ Object ] object The default.
       #
       # @return [ Object ] The serialized default.
-      #
-      # @since 3.0.0
       def serialize_default(object); object; end
     end
   end

--- a/lib/mongoid/fields/localized.rb
+++ b/lib/mongoid/fields/localized.rb
@@ -14,8 +14,6 @@ module Mongoid
       # @param [ Hash ] object The hash of translations.
       #
       # @return [ Object ] The value for the current locale.
-      #
-      # @since 2.3.0
       def demongoize(object)
         if object
           type.demongoize(lookup(object))
@@ -28,8 +26,6 @@ module Mongoid
       #   field.localized?
       #
       # @return [ true, false ] If the field is localized.
-      #
-      # @since 2.3.0
       def localized?
         true
       end
@@ -42,8 +38,6 @@ module Mongoid
       # @param [ String ] object The string to convert.
       #
       # @return [ Hash ] The locale with string translation.
-      #
-      # @since 2.3.0
       def mongoize(object)
         { ::I18n.locale.to_s => type.mongoize(object) }
       end
@@ -58,8 +52,6 @@ module Mongoid
       #   field.fallbacks?
       #
       # @return [ true, false ] If fallbacks should be used.
-      #
-      # @since 5.1.0
       def fallbacks?
         return true if options[:fallbacks].nil?
         !!options[:fallbacks]
@@ -75,8 +67,6 @@ module Mongoid
       # @param [ Hash ] object The localized object.
       #
       # @return [ Object ] The object for the locale.
-      #
-      # @since 3.0.0
       def lookup(object)
         locale = ::I18n.locale
 

--- a/lib/mongoid/fields/standard.rb
+++ b/lib/mongoid/fields/standard.rb
@@ -23,8 +23,6 @@ module Mongoid
       # @param [ Hash ] mods The current modifications.
       # @param [ Array ] new The new elements to add.
       # @param [ Array ] old The old elements getting removed.
-      #
-      # @since 2.4.0
       def add_atomic_changes(document, name, key, mods, new, old)
         mods[key] = new
       end
@@ -38,8 +36,6 @@ module Mongoid
       # @param [ Document ] doc The document the field belongs to.
       #
       # @return [ Object ] The serialized default value.
-      #
-      # @since 2.1.8
       def eval_default(doc)
         if fields = doc.__selected_fields
           evaluated_default(doc) if included?(fields)
@@ -54,8 +50,6 @@ module Mongoid
       #   field.foreign_key?
       #
       # @return [ true, false ] If the field is a foreign key.
-      #
-      # @since 2.4.0
       def foreign_key?
         false
       end
@@ -70,8 +64,6 @@ module Mongoid
       # @option options [ Class ] :type The class of the field.
       # @option options [ Object ] :default The default value for the field.
       # @option options [ String ] :label The field's label.
-      #
-      # @since 3.0.0
       def initialize(name, options = {})
         @name = name
         @options = options
@@ -92,8 +84,6 @@ module Mongoid
       #   field.lazy?
       #
       # @return [ true, false ] If the field is lazy.
-      #
-      # @since 3.1.0
       def lazy?
         false
       end
@@ -104,8 +94,6 @@ module Mongoid
       #   field.localized?
       #
       # @return [ true, false ] If the field is localized.
-      #
-      # @since 2.3.0
       def localized?
         false
       end
@@ -116,8 +104,6 @@ module Mongoid
       #   field.metadata
       #
       # @return [ Metadata ] The association metadata.
-      #
-      # @since 2.2.0
       def association
         @association ||= options[:association]
       end
@@ -128,8 +114,6 @@ module Mongoid
       #   field.object_id_field?
       #
       # @return [ true, false ] If the field is a BSON::ObjectId.
-      #
-      # @since 2.2.0
       def object_id_field?
         @object_id_field ||= (type == BSON::ObjectId)
       end
@@ -140,8 +124,6 @@ module Mongoid
       #   field.pre_processed?
       #
       # @return [ true, false ] If the field's default is pre-processed.
-      #
-      # @since 3.0.0
       def pre_processed?
         @pre_processed ||=
           (options[:pre_processed] || (default_val && !default_val.is_a?(::Proc)))
@@ -153,8 +135,6 @@ module Mongoid
       #   field.type
       #
       # @return [ Class ] The name of the class.
-      #
-      # @since 2.1.0
       def type
         @type ||= options[:type] || Object
       end
@@ -169,8 +149,6 @@ module Mongoid
       #   field.default_name
       #
       # @return [ String ] The method name.
-      #
-      # @since 3.0.0
       def default_name
         @default_name ||= "__#{name}_default__"
       end
@@ -186,8 +164,6 @@ module Mongoid
       #
       # @param [ Class, Module ] object The class or module the field is
       #   defined on.
-      #
-      # @since 3.0.0
       def define_default_method(object)
         object.__send__(:define_method, default_name, default_val)
       end
@@ -203,8 +179,6 @@ module Mongoid
       # @param [ Hash ] fields The field limitations.
       #
       # @return [ true, false ] If the field was included.
-      #
-      # @since 2.4.4
       def included?(fields)
         (fields.values.first == 1 && fields[name.to_s] == 1) ||
           (fields.values.first == 0 && !fields.has_key?(name.to_s))
@@ -218,8 +192,6 @@ module Mongoid
       # @param [ Document ] doc The doc being applied to.
       #
       # @return [ Object ] The default value.
-      #
-      # @since 2.4.4
       def evaluated_default(doc)
         if default_val.respond_to?(:call)
           evaluate_default_proc(doc)
@@ -237,8 +209,6 @@ module Mongoid
       # @param [ Document ] doc The document.
       #
       # @return [ Object ] The called proc.
-      #
-      # @since 3.0.0
       def evaluate_default_proc(doc)
         serialize_default(doc.__send__(default_name))
       end
@@ -254,8 +224,6 @@ module Mongoid
       # @param [ Object ] object The default.
       #
       # @return [ Object ] The serialized default.
-      #
-      # @since 3.0.0
       def serialize_default(object)
         mongoize(object)
       end

--- a/lib/mongoid/fields/validators/macro.rb
+++ b/lib/mongoid/fields/validators/macro.rb
@@ -10,8 +10,6 @@ module Mongoid
         extend self
 
         # The warning message to give when a field is of type Symbol.
-        #
-        # @since 7.0.0
         FIELD_TYPE_IS_SYMBOL = 'The BSON symbol type is deprecated; use String instead'.freeze
 
         OPTIONS = [
@@ -36,8 +34,6 @@ module Mongoid
         # @param [ Class ] klass The model class.
         # @param [ Symbol ] name The field name.
         # @param [ Hash ] options The provided options.
-        #
-        # @since 3.0.0
         def validate(klass, name, options)
           validate_field_name(klass, name)
           validate_name_uniqueness(klass, name, options)
@@ -52,8 +48,6 @@ module Mongoid
         # @param [ Class ] klass The model class.
         # @param [ Symbol ] name The field name.
         # @param [ Hash ] options The provided options.
-        #
-        # @since 6.0.0
         def validate_relation(klass, name, options = {})
           [name, "#{name}?".to_sym, "#{name}=".to_sym].each do |n|
             if Mongoid.destructive_fields.include?(n)
@@ -117,8 +111,6 @@ module Mongoid
         # @param [ Hash ] options The provided options.
         #
         # @raise [ Errors::InvalidFieldOption ] If an option is invalid.
-        #
-        # @since 3.0.0
         def validate_options(klass, name, options)
           options.keys.each do |option|
             if !OPTIONS.include?(option) && !Fields.options.include?(option)

--- a/lib/mongoid/findable.rb
+++ b/lib/mongoid/findable.rb
@@ -5,8 +5,6 @@ module Mongoid
 
   # This module defines the finder methods that hang off the document at the
   # class level.
-  #
-  # @since 4.0.0
   module Findable
     extend Forwardable
 
@@ -149,8 +147,6 @@ module Mongoid
     # and Mongoid.raise_not_found_error is true.
     #
     # @return [ Document, nil ] A matching document.
-    #
-    # @since 3.0.0
     def find_by(attrs = {})
       result = where(attrs).find_first
       if result.nil? && Mongoid.raise_not_found_error

--- a/lib/mongoid/indexable.rb
+++ b/lib/mongoid/indexable.rb
@@ -8,8 +8,6 @@ require "ostruct"
 module Mongoid
 
   # Encapsulates behavior around defining indexes.
-  #
-  # @since 4.0.0
   module Indexable
     extend ActiveSupport::Concern
 
@@ -26,8 +24,6 @@ module Mongoid
       #   Person.create_indexes
       #
       # @return [ true ] If the operation succeeded.
-      #
-      # @since 1.0.0
       def create_indexes
         return unless index_specifications
 
@@ -52,8 +48,6 @@ module Mongoid
       #   Person.remove_indexes
       #
       # @return [ true ] If the operation succeeded.
-      #
-      # @since 3.0.0
       def remove_indexes
         indexed_database_names.each do |database|
           with(database: database) do |klass|
@@ -79,8 +73,6 @@ module Mongoid
       #   Person.add_indexes
       #
       # @return [ true ] If the operation succeeded.
-      #
-      # @since 1.0.0
       def add_indexes
         if hereditary? && !index_keys.include?(self.discriminator_key.to_sym => 1)
           index({ self.discriminator_key.to_sym => 1 }, unique: false, background: true)
@@ -101,8 +93,6 @@ module Mongoid
       # @param [ Hash ] options The index options.
       #
       # @return [ Hash ] The index options.
-      #
-      # @since 1.0.0
       def index(spec, options = nil)
         specification = Specification.new(self, spec, options)
         if !index_specifications.include?(specification)
@@ -119,8 +109,6 @@ module Mongoid
       # @param [ String ] index_name The index name.
       #
       # @return [ Specification ] The found specification.
-      #
-      # @since 4.0.0
       def index_specification(index_hash, index_name = nil)
         index = OpenStruct.new(fields: index_hash.keys, key: index_hash)
         index_specifications.detect do |spec|
@@ -139,8 +127,6 @@ module Mongoid
       #   Model.indexed_database_names
       #
       # @return [ Array<String> ] The names.
-      #
-      # @since 3.1.0
       def indexed_database_names
         index_specifications.map do |spec|
           spec.options[:database] || database_name
@@ -155,8 +141,6 @@ module Mongoid
       #   Model.index_keys
       #
       # @return [ Array<Hash> ] The specification keys.
-      #
-      # @since 4.0.0
       def index_keys
         index_specifications.map(&:key)
       end

--- a/lib/mongoid/indexable/specification.rb
+++ b/lib/mongoid/indexable/specification.rb
@@ -5,14 +5,10 @@ module Mongoid
   module Indexable
 
     # Encapsulates behavior around an index specification.
-    #
-    # @since 4.0.0
     class Specification
 
       # The mappings of nice Ruby-style names to the corresponding driver
       # option name.
-      #
-      # @since 4.0.0
       MAPPINGS = {
         expire_after_seconds: :expire_after
       }
@@ -33,8 +29,6 @@ module Mongoid
       # @param [ Specification ] other The spec to compare against.
       #
       # @return [ true, false ] If the specs are equal.
-      #
-      # @since 4.0.0
       def ==(other)
         fields == other.fields && key == other.key
       end
@@ -47,8 +41,6 @@ module Mongoid
       # @param [ Class ] klass The class the index is defined on.
       # @param [ Hash ] key The hash of name/direction pairs.
       # @param [ Hash ] opts the index options.
-      #
-      # @since 4.0.0
       def initialize(klass, key, opts = nil)
         options = opts || {}
         Validators::Options.validate(klass, key, options)
@@ -64,8 +56,6 @@ module Mongoid
       #   specification.name
       #
       # @return [ String ] name The index name.
-      #
-      # @since 5.0.2
       def name
         @name ||= key.reduce([]) do |n, (k,v)|
           n << "#{k}_#{v}"
@@ -84,8 +74,6 @@ module Mongoid
       # @param [ Hash ] key The index key(s).
       #
       # @return [ Hash ] The normalized specification.
-      #
-      # @since 4.0.0
       def normalize_key(key)
         normalized = {}
         key.each_pair do |name, direction|
@@ -104,8 +92,6 @@ module Mongoid
       # @param [ Hash ] opts The index options.
       #
       # @return [ Hash ] The normalized options.
-      #
-      # @since 4.0.0
       def normalize_options(opts)
         options = {}
         opts.each_pair do |option, value|

--- a/lib/mongoid/indexable/validators/options.rb
+++ b/lib/mongoid/indexable/validators/options.rb
@@ -53,8 +53,6 @@ module Mongoid
         # @param [ Hash ] options The index options.
         #
         # @raise [ Errors::InvalidIndex ] If validation failed.
-        #
-        # @since 3.0.0
         def validate(klass, spec, options)
           validate_spec(klass, spec, options)
           validate_options(klass, spec, options)
@@ -74,8 +72,6 @@ module Mongoid
         # @param [ Hash ] options The index options.
         #
         # @raise [ Errors::InvalidIndex ] If validation failed.
-        #
-        # @since 3.0.0
         def validate_options(klass, spec, options)
           options.each_pair do |name, value|
             unless VALID_OPTIONS.include?(name)
@@ -96,8 +92,6 @@ module Mongoid
         # @param [ Hash ] options The index options.
         #
         # @raise [ Errors::InvalidIndex ] If validation failed.
-        #
-        # @since 3.0.0
         def validate_spec(klass, spec, options)
           raise Errors::InvalidIndex.new(klass, spec, options) if !spec.is_a?(::Hash)
           spec.each_pair do |name, value|

--- a/lib/mongoid/inspectable.rb
+++ b/lib/mongoid/inspectable.rb
@@ -4,8 +4,6 @@
 module Mongoid
 
   # Contains the bahvior around inspecting documents via inspect.
-  #
-  # @since 4.0.0
   module Inspectable
 
     # Returns the class name plus its attributes. If using dynamic fields will
@@ -15,8 +13,6 @@ module Mongoid
     #   person.inspect
     #
     # @return [ String ] A nice pretty string to look at.
-    #
-    # @since 1.0.0
     def inspect
       inspection = []
       inspection.concat(inspect_fields).concat(inspect_dynamic_fields)
@@ -33,8 +29,6 @@ module Mongoid
     #   document.inspect_fields
     #
     # @return [ String ] An array of pretty printed field values.
-    #
-    # @since 1.0.0
     def inspect_fields
       fields.map do |name, field|
         unless name == "_id"
@@ -52,8 +46,6 @@ module Mongoid
     #   document.inspect_dynamic_fields
     #
     # @return [ String ] An array of pretty printed dynamic field values.
-    #
-    # @since 1.0.0
     def inspect_dynamic_fields
       []
     end

--- a/lib/mongoid/interceptable.rb
+++ b/lib/mongoid/interceptable.rb
@@ -4,8 +4,6 @@
 module Mongoid
 
   # This module contains all the callback hooks for Mongoid.
-  #
-  # @since 4.0.0
   module Interceptable
     extend ActiveSupport::Concern
 
@@ -51,8 +49,6 @@ module Mongoid
     # @param [ Symbol ] kind The type of callback.
     #
     # @return [ true, false ] If the callback can be executed.
-    #
-    # @since 3.0.6
     def callback_executable?(kind)
       respond_to?("_#{kind}_callbacks")
     end
@@ -66,8 +62,6 @@ module Mongoid
     # @param [ Symbol ] kind The callback kind.
     #
     # @return [ true, false ] If the document is in a callback state.
-    #
-    # @since 3.1.0
     def in_callback_state?(kind)
       [ :create, :destroy ].include?(kind) || new_record? || flagged_for_destroy? || changed?
     end
@@ -83,8 +77,6 @@ module Mongoid
     # @param [ Array<Symbol> ] kinds The events that are occurring.
     #
     # @return [ Object ] The result of the chain executing.
-    #
-    # @since 3.0.0
     def run_after_callbacks(*kinds)
       kinds.each do |kind|
         run_targeted_callbacks(:after, kind)
@@ -102,8 +94,6 @@ module Mongoid
     # @param [ Array<Symbol> ] kinds The events that are occurring.
     #
     # @return [ Object ] The result of the chain executing.
-    #
-    # @since 3.0.0
     def run_before_callbacks(*kinds)
       kinds.each do |kind|
         run_targeted_callbacks(:before, kind)
@@ -123,8 +113,6 @@ module Mongoid
     # @param [ Array ] args Any options.
     #
     # @return [ Document ] The document
-    #
-    # @since 2.3.0
     ruby2_keywords def run_callbacks(kind, *args, &block)
       cascadable_children(kind).each do |child|
         if child.run_callbacks(child_callback_type(kind, child), *args) == false
@@ -149,8 +137,6 @@ module Mongoid
     #   document.before_callback_halted?
     #
     # @return [ true, false ] If a before callback was halted.
-    #
-    # @since 3.0.3
     def before_callback_halted?
       !!@before_callback_halted
     end
@@ -163,8 +149,6 @@ module Mongoid
     # @param [ Symbol ] kind The type of callback.
     #
     # @return [ Array<Document> ] The children.
-    #
-    # @since 2.3.0
     def cascadable_children(kind, children = Set.new)
       embedded_relations.each_pair do |name, association|
         next unless association.cascading_callbacks?
@@ -193,8 +177,6 @@ module Mongoid
     # @param [ Document ] child The child document.
     #
     # @return [ true, false ] If the child should fire the callback.
-    #
-    # @since 2.3.0
     def cascadable_child?(kind, child, association)
       return false if kind == :initialize || kind == :find || kind == :touch
       return false if kind == :validate && association.validate?
@@ -213,8 +195,6 @@ module Mongoid
     # @param [ Document ] child The child document
     #
     # @return [ Symbol ] The name of the callback.
-    #
-    # @since 2.3.0
     def child_callback_type(kind, child)
       if kind == :update
         return :create if child.new_record?
@@ -236,8 +216,6 @@ module Mongoid
     # @param [ Symbol ] filter The callback that halted.
     # @param [ Symbol ] name The name of the callback that was halted
     #   (requires Rails 6.1+)
-    #
-    # @since 3.0.3
     def halted_callback_hook(filter, name = nil)
       @before_callback_halted = true
     end
@@ -252,8 +230,6 @@ module Mongoid
     # @param [ Symbol ] kind The type of callback, :save, :create, :update.
     #
     # @return [ Object ] The result of the chain execution.
-    #
-    # @since 3.0.0
     def run_targeted_callbacks(place, kind)
       name = "_run__#{place}__#{kind}__callbacks"
       unless respond_to?(name)

--- a/lib/mongoid/loggable.rb
+++ b/lib/mongoid/loggable.rb
@@ -15,8 +15,6 @@ module Mongoid
     #   Loggable.logger
     #
     # @return [ Logger ] The logger.
-    #
-    # @since 3.0.0
     def logger
       return @logger if defined?(@logger)
       @logger = rails_logger || default_logger
@@ -30,8 +28,6 @@ module Mongoid
     # @param [ Logger ] logger The logger to set.
     #
     # @return [ Logger ] The new logger.
-    #
-    # @since 3.0.0
     def logger=(logger)
       @logger = logger
     end
@@ -46,8 +42,6 @@ module Mongoid
     #   Loggable.default_logger
     #
     # @return [ Logger ] The default logger.
-    #
-    # @since 3.0.0
     def default_logger
       logger = Logger.new(STDERR)
       logger.level = Mongoid::Config.log_level
@@ -62,8 +56,6 @@ module Mongoid
     #   Loggable.rails_logger
     #
     # @return [ Logger ] The Rails logger.
-    #
-    # @since 3.0.0
     def rails_logger
       if defined?(::Rails)
         ::Rails.logger

--- a/lib/mongoid/matchable.rb
+++ b/lib/mongoid/matchable.rb
@@ -5,8 +5,6 @@ module Mongoid
 
   # This module contains all the behavior for Ruby implementations of MongoDB
   # selectors.
-  #
-  # @since 4.0.0
   module Matchable
     extend ActiveSupport::Concern
 
@@ -19,8 +17,6 @@ module Mongoid
     # @param [ Hash ] selector The MongoDB selector.
     #
     # @return [ true, false ] True if matches, false if not.
-    #
-    # @since 1.0.0
     def _matches?(selector)
       Matcher::Expression.matches?(self, selector)
     end

--- a/lib/mongoid/persistable.rb
+++ b/lib/mongoid/persistable.rb
@@ -19,8 +19,6 @@ require "mongoid/persistable/unsettable"
 module Mongoid
 
   # Contains general behavior for persistence operations.
-  #
-  # @since 2.0.0
   module Persistable
     extend ActiveSupport::Concern
     include Creatable
@@ -40,8 +38,6 @@ module Mongoid
     include Unsettable
 
     # The atomic operations that deal with arrays or sets in the db.
-    #
-    # @since 4.0.0
     LIST_OPERATIONS = [ "$addToSet", "$push", "$pull", "$pullAll" ].freeze
 
     # Execute operations atomically (in a single database call) for everything
@@ -89,8 +85,6 @@ module Mongoid
     #   for the same document, if one exists.
     #
     # @return [ true, false ] If the operation succeeded.
-    #
-    # @since 4.0.0
     def atomically(join_context: nil)
       join_context = Mongoid.join_contexts if join_context.nil?
       call_depth = @atomic_depth ||= 0
@@ -128,8 +122,6 @@ module Mongoid
     #   Person.fail_due_to_validation!(person)
     #
     # @raise [ Errors::Validations ] The validation error.
-    #
-    # @since 4.0.0
     def fail_due_to_validation!
       raise Errors::Validations.new(self)
     end
@@ -142,8 +134,6 @@ module Mongoid
     # @param [ Symbol ] method The method being called.
     #
     # @raise [ Errors::Callback ] The callback error.
-    #
-    # @since 4.0.0
     def fail_due_to_callback!(method)
       raise Errors::Callback.new(self.class, method)
     end
@@ -158,8 +148,6 @@ module Mongoid
     #   document.executing_atomically?
     #
     # @return [ true, false ] If we are current executing atomically.
-    #
-    # @since 4.0.0
     def executing_atomically?
       !@atomic_updates_to_execute_stack.nil?
     end
@@ -175,8 +163,6 @@ module Mongoid
     # @param [ Hash ] options The options.
     #
     # @return [ true ] true.
-    #
-    # @since 4.0.0
     def post_process_persist(result, options = {})
       post_persist unless result == false
       errors.clear unless performing_validations?(options)
@@ -194,8 +180,6 @@ module Mongoid
     #   end
     #
     # @return [ Object ] The result of the operation.
-    #
-    # @since 4.0.0
     def prepare_atomic_operation
       operations = yield({})
       persist_or_delay_atomic_operation(operations)
@@ -216,8 +200,6 @@ module Mongoid
     # @param [ Hash ] operations The atomic operations.
     #
     # @return [ Hash ] The operations.
-    #
-    # @since 4.0.0
     def process_atomic_operations(operations)
       operations.each do |field, value|
         access = database_field_name(field)
@@ -295,8 +277,6 @@ module Mongoid
     #   document.persist_or_delay_atomic_operation(ops)
     #
     # @param [ Hash ] operation The operation.
-    #
-    # @since 4.0.0
     def persist_or_delay_atomic_operation(operation)
       if executing_atomically?
         operation.each do |(name, hash)|
@@ -316,8 +296,6 @@ module Mongoid
     #   persist_atomic_operations(ops)
     #
     # @param [ Hash ] operations The atomic operations.
-    #
-    # @since 4.0.0
     def persist_atomic_operations(operations)
       if persisted? && operations && !operations.empty?
         selector = atomic_selector

--- a/lib/mongoid/persistable/creatable.rb
+++ b/lib/mongoid/persistable/creatable.rb
@@ -5,8 +5,6 @@ module Mongoid
   module Persistable
 
     # Defines behavior for persistence operations that create new documents.
-    #
-    # @since 4.0.0
     module Creatable
       extend ActiveSupport::Concern
 
@@ -19,8 +17,6 @@ module Mongoid
       # @param [ Hash ] options Options to pass to insert.
       #
       # @return [ Document ] The persisted document.
-      #
-      # @since 1.0.0
       def insert(options = {})
         prepare_insert(options) do
           if embedded?
@@ -41,8 +37,6 @@ module Mongoid
       #   document.inserts
       #
       # @return [ Hash ] The insert ops.
-      #
-      # @since 2.1.0
       def atomic_inserts
         { atomic_insert_modifier => { atomic_position => as_attributes }}
       end
@@ -55,8 +49,6 @@ module Mongoid
       #   document.insert_as_embedded
       #
       # @return [ Document ] The document.
-      #
-      # @since 4.0.0
       def insert_as_embedded
         raise Errors::NoParent.new(self.class.name) unless _parent
         if _parent.new_record?
@@ -77,8 +69,6 @@ module Mongoid
       #   document.insert_as_root
       #
       # @return [ Document ] The document.
-      #
-      # @since 4.0.0
       def insert_as_root
         collection.insert_one(as_attributes, session: _session)
       end
@@ -92,8 +82,6 @@ module Mongoid
       #   document.post_process_insert
       #
       # @return [ true ] true.
-      #
-      # @since 4.0.0
       def post_process_insert
         self.new_record = false
         flag_children_persisted
@@ -112,8 +100,6 @@ module Mongoid
       # @param [ Hash ] options The options.
       #
       # @return [ Document ] The document.
-      #
-      # @since 4.0.0
       def prepare_insert(options = {})
         return self if performing_validations?(options) &&
           invalid?(options[:context] || :create)
@@ -142,8 +128,6 @@ module Mongoid
         #   Array of multiple attributes for multiple documents.
         #
         # @return [ Document, Array<Document> ] The newly created document(s).
-        #
-        # @since 1.0.0
         def create(attributes = nil, &block)
           _creating do
             if attributes.is_a?(::Array)
@@ -171,8 +155,6 @@ module Mongoid
         #   Array of multiple attributes for multiple documents.
         #
         # @return [ Document, Array<Document> ] The newly created document(s).
-        #
-        # @since 1.0.0
         def create!(attributes = nil, &block)
           _creating do
             if attributes.is_a?(::Array)

--- a/lib/mongoid/persistable/deletable.rb
+++ b/lib/mongoid/persistable/deletable.rb
@@ -5,8 +5,6 @@ module Mongoid
   module Persistable
 
     # Defines behavior for persistence operations that delete documents.
-    #
-    # @since 4.0.0
     module Deletable
       extend ActiveSupport::Concern
 
@@ -18,8 +16,6 @@ module Mongoid
       # @param [ Hash ] options Options to pass to remove.
       #
       # @return [ TrueClass ] True.
-      #
-      # @since 1.0.0
       def delete(options = {})
         raise Errors::ReadonlyDocument.new(self.class) if readonly?
         prepare_delete do
@@ -44,8 +40,6 @@ module Mongoid
       #   document.atomic_deletes
       #
       # @return [ Hash ] The atomic deletes.
-      #
-      # @since 4.0.0
       def atomic_deletes
         { atomic_delete_modifier => { atomic_path => _index ? { "_id" => _id } : true }}
       end
@@ -60,8 +54,6 @@ module Mongoid
       # @param [ Hash ] options The deletion options.
       #
       # @return [ true ] If the operation succeeded.
-      #
-      # @since 4.0.0
       def delete_as_embedded(options = {})
         _parent.remove_child(self) if notifying_parent?(options)
         if _parent.persisted?
@@ -81,8 +73,6 @@ module Mongoid
       #   document.delete_as_root
       #
       # @return [ true ] If the document was removed.
-      #
-      # @since 4.0.0
       def delete_as_root
         collection.find(atomic_selector).delete_one(session: _session)
         true
@@ -98,8 +88,6 @@ module Mongoid
       # @param [ Hash ] options The delete options.
       #
       # @return [ true, false ] If the parent should be notified.
-      #
-      # @since 4.0.0
       def notifying_parent?(options = {})
         !options.delete(:suppress)
       end
@@ -114,8 +102,6 @@ module Mongoid
       #   end
       #
       # @return [ Object ] The result of the block.
-      #
-      # @since 4.0.0
       def prepare_delete
         yield(self)
         freeze
@@ -137,8 +123,6 @@ module Mongoid
         # @param [ Hash ] conditions Optional conditions to delete by.
         #
         # @return [ Integer ] The number of documents deleted.
-        #
-        # @since 1.0.0
         def delete_all(conditions = {})
           selector = hereditary? ? conditions.merge(discriminator_key.to_sym => discriminator_value) : conditions
           where(selector).delete

--- a/lib/mongoid/persistable/destroyable.rb
+++ b/lib/mongoid/persistable/destroyable.rb
@@ -5,8 +5,6 @@ module Mongoid
   module Persistable
 
     # Defines behavior for persistence operations that destroy documents.
-    #
-    # @since 4.0.0
     module Destroyable
       extend ActiveSupport::Concern
 
@@ -18,8 +16,6 @@ module Mongoid
       # @param [ Hash ] options Options to pass to destroy.
       #
       # @return [ true, false ] True if successful, false if not.
-      #
-      # @since 1.0.0
       def destroy(options = nil)
         raise Errors::ReadonlyDocument.new(self.class) if readonly?
         self.flagged_for_destroy = true
@@ -53,8 +49,6 @@ module Mongoid
         # @param [ Hash ] conditions Optional conditions to destroy by.
         #
         # @return [ Integer ] The number of documents destroyed.
-        #
-        # @since 1.0.0
         def destroy_all(conditions = nil)
           where(conditions || {}).destroy
         end

--- a/lib/mongoid/persistable/incrementable.rb
+++ b/lib/mongoid/persistable/incrementable.rb
@@ -5,8 +5,6 @@ module Mongoid
   module Persistable
 
     # Defines behavior for $inc operations.
-    #
-    # @since 4.0.0
     module Incrementable
       extend ActiveSupport::Concern
 
@@ -20,8 +18,6 @@ module Mongoid
       # @param [ Hash ] increments The field/inc increment pairs.
       #
       # @return [ Document ] The document.
-      #
-      # @since 4.0.0
       def inc(increments)
         prepare_atomic_operation do |ops|
           process_atomic_operations(increments) do |field, value|

--- a/lib/mongoid/persistable/logical.rb
+++ b/lib/mongoid/persistable/logical.rb
@@ -5,8 +5,6 @@ module Mongoid
   module Persistable
 
     # Defines behavior for logical bitwise operations.
-    #
-    # @since 4.0.0
     module Logical
       extend ActiveSupport::Concern
 
@@ -19,8 +17,6 @@ module Mongoid
       # @param [ Hash ] operations The bitwise operations.
       #
       # @return [ Document ] The document.
-      #
-      # @since 4.0.0
       def bit(operations)
         prepare_atomic_operation do |ops|
           process_atomic_operations(operations) do |field, values|

--- a/lib/mongoid/persistable/poppable.rb
+++ b/lib/mongoid/persistable/poppable.rb
@@ -5,8 +5,6 @@ module Mongoid
   module Persistable
 
     # Defines behavior for $pop operations.
-    #
-    # @since 4.0.0
     module Poppable
       extend ActiveSupport::Concern
 
@@ -24,8 +22,6 @@ module Mongoid
       # @param [ Hash ] pops The field/value pop operations.
       #
       # @return [ Document ] The document.
-      #
-      # @since 4.0.0
       def pop(pops)
         prepare_atomic_operation do |ops|
           process_atomic_operations(pops) do |field, value|

--- a/lib/mongoid/persistable/pullable.rb
+++ b/lib/mongoid/persistable/pullable.rb
@@ -5,8 +5,6 @@ module Mongoid
   module Persistable
 
     # Defines behavior for $pull and $pullAll operations.
-    #
-    # @since 4.0.0
     module Pullable
       extend ActiveSupport::Concern
 
@@ -20,8 +18,6 @@ module Mongoid
       # @param [ Hash ] pulls The field/value pull pairs.
       #
       # @return [ Document ] The document.
-      #
-      # @since 4.0.0
       def pull(pulls)
         prepare_atomic_operation do |ops|
           process_atomic_operations(pulls) do |field, value|
@@ -40,8 +36,6 @@ module Mongoid
       # @param [ Hash ] pulls The pull all operations.
       #
       # @return [ Document ] The document.
-      #
-      # @since 4.0.0
       def pull_all(pulls)
         prepare_atomic_operation do |ops|
           process_atomic_operations(pulls) do |field, value|

--- a/lib/mongoid/persistable/pushable.rb
+++ b/lib/mongoid/persistable/pushable.rb
@@ -5,8 +5,6 @@ module Mongoid
   module Persistable
 
     # Defines behavior for $push and $addToSet operations.
-    #
-    # @since 4.0.0
     module Pushable
       extend ActiveSupport::Concern
 
@@ -19,8 +17,6 @@ module Mongoid
       # @param [ Hash ] adds The field/value pairs to add.
       #
       # @return [ Document ] The document.
-      #
-      # @since 4.0.0
       def add_to_set(adds)
         prepare_atomic_operation do |ops|
           process_atomic_operations(adds) do |field, value|
@@ -52,8 +48,6 @@ module Mongoid
       # @param [ Hash ] pushes The $push operations.
       #
       # @return [ Document ] The document.
-      #
-      # @since 4.0.0
       def push(pushes)
         prepare_atomic_operation do |ops|
           process_atomic_operations(pushes) do |field, value|

--- a/lib/mongoid/persistable/renamable.rb
+++ b/lib/mongoid/persistable/renamable.rb
@@ -5,8 +5,6 @@ module Mongoid
   module Persistable
 
     # Defines behavior for $rename operations.
-    #
-    # @since 4.0.0
     module Renamable
       extend ActiveSupport::Concern
 
@@ -20,8 +18,6 @@ module Mongoid
       # @param [ Hash ] renames The rename pairs of old name/new name.
       #
       # @return [ Document ] The document.
-      #
-      # @since 4.0.0
       def rename(renames)
         prepare_atomic_operation do |ops|
           process_atomic_operations(renames) do |old_field, new_field|

--- a/lib/mongoid/persistable/savable.rb
+++ b/lib/mongoid/persistable/savable.rb
@@ -5,8 +5,6 @@ module Mongoid
   module Persistable
 
     # Defines behavior for persistence operations that save documents.
-    #
-    # @since 4.0.0
     module Savable
 
       # Save the document - will perform an insert if the document is new, and
@@ -18,8 +16,6 @@ module Mongoid
       # @param [ Hash ] options Options to pass to the save.
       #
       # @return [ true, false ] True is success, false if not.
-      #
-      # @since 1.0.0
       def save(options = {})
         if new_record?
           !insert(options).new_record?
@@ -40,8 +36,6 @@ module Mongoid
       # @raise [ Errors::Callback ] If a callback returns false.
       #
       # @return [ true, false ] True if validation passed.
-      #
-      # @since 1.0.0
       def save!(options = {})
         unless save(options)
           fail_due_to_validation! unless errors.empty?

--- a/lib/mongoid/persistable/settable.rb
+++ b/lib/mongoid/persistable/settable.rb
@@ -5,8 +5,6 @@ module Mongoid
   module Persistable
 
     # Defines behavior for $set operations.
-    #
-    # @since 4.0.0
     module Settable
       extend ActiveSupport::Concern
 
@@ -47,8 +45,6 @@ module Mongoid
       # @param [ Hash ] setters The field/value pairs to set.
       #
       # @return [ Document ] The document.
-      #
-      # @since 4.0.0
       def set(setters)
         prepare_atomic_operation do |ops|
           process_atomic_operations(setters) do |field, value|

--- a/lib/mongoid/persistable/unsettable.rb
+++ b/lib/mongoid/persistable/unsettable.rb
@@ -5,8 +5,6 @@ module Mongoid
   module Persistable
 
     # Defines behavior for $unset operations.
-    #
-    # @since 4.0.0
     module Unsettable
       extend ActiveSupport::Concern
 
@@ -20,8 +18,6 @@ module Mongoid
       #   unset.
       #
       # @return [ Document ] The document.
-      #
-      # @since 4.0.0
       def unset(*fields)
         prepare_atomic_operation do |ops|
           fields.flatten.each do |field|

--- a/lib/mongoid/persistable/updatable.rb
+++ b/lib/mongoid/persistable/updatable.rb
@@ -6,8 +6,6 @@ module Mongoid
 
     # Defines behavior for persistence operations that update existing
     # documents.
-    #
-    # @since 4.0.0
     module Updatable
 
       # Update a single attribute and persist the entire document.
@@ -23,8 +21,6 @@ module Mongoid
       #   to being flagged as reaodnly.
       #
       # @return [ true, false ] True if save was successfull, false if not.
-      #
-      # @since 2.0.0
       def update_attribute(name, value)
         as_writable_attribute!(name, value) do |access|
           normalized = name.to_s
@@ -41,8 +37,6 @@ module Mongoid
       # @param [ Hash ] attributes The attributes to update.
       #
       # @return [ true, false ] True if validation passed, false if not.
-      #
-      # @since 1.0.0
       def update(attributes = {})
         assign_attributes(attributes)
         save
@@ -61,8 +55,6 @@ module Mongoid
       # @raise [ Errors::Callbacks ] If a callback returns false.
       #
       # @return [ true, false ] True if validation passed.
-      #
-      # @since 1.0.0
       def update!(attributes = {})
         result = update_attributes(attributes)
         unless result
@@ -83,8 +75,6 @@ module Mongoid
       #   document.init_atomic_updates
       #
       # @return [ Array<Hash> ] The updates and conflicts.
-      #
-      # @since 4.0.0
       def init_atomic_updates
         updates = atomic_updates
         conflicts = updates.delete(:conflicts) || {}
@@ -103,8 +93,6 @@ module Mongoid
       # @param [ Hash ] options The options.
       #
       # @return [ true, false ] The result of the update.
-      #
-      # @since 4.0.0
       def prepare_update(options = {})
         return false if performing_validations?(options) &&
           invalid?(options[:context] || :update)
@@ -128,8 +116,6 @@ module Mongoid
       # @option options [ true, false ] :validate Whether or not to validate.
       #
       # @return [ true, false ] True if succeeded, false if not.
-      #
-      # @since 1.0.0
       def update_document(options = {})
         prepare_update(options) do
           updates, conflicts = init_atomic_updates

--- a/lib/mongoid/persistable/upsertable.rb
+++ b/lib/mongoid/persistable/upsertable.rb
@@ -5,8 +5,6 @@ module Mongoid
   module Persistable
 
     # Defines behavior for persistence operations that upsert documents.
-    #
-    # @since 4.0.0
     module Upsertable
 
       # Perform an upsert of the document. If the document does not exist in the
@@ -19,8 +17,6 @@ module Mongoid
       # @param [ Hash ] options The validation options.
       #
       # @return [ true ] True.
-      #
-      # @since 3.0.0
       def upsert(options = {})
         prepare_upsert(options) do
           collection.find(atomic_selector).update_one(
@@ -42,8 +38,6 @@ module Mongoid
       # @param [ Hash ] options The options hash.
       #
       # @return [ true, false ] If the operation succeeded.
-      #
-      # @since 4.0.0
       def prepare_upsert(options = {})
         return false if performing_validations?(options) && invalid?(:upsert)
         result = run_callbacks(:upsert) do

--- a/lib/mongoid/persistence_context.rb
+++ b/lib/mongoid/persistence_context.rb
@@ -5,8 +5,6 @@ module Mongoid
 
   # Object encapsulating logic for setting/getting a collection and database name
   # and a client with particular options to use when persisting models.
-  #
-  # @since 6.0.0
   class PersistenceContext
     extend Forwardable
 
@@ -19,8 +17,6 @@ module Mongoid
     # The options defining this persistence context.
     #
     # @return [ Hash ] The persistence context options.
-    #
-    # @since 6.0.0
     attr_reader :options
 
     # Extra options in addition to driver client options that determine the
@@ -28,8 +24,6 @@ module Mongoid
     #
     # @return [ Array<Symbol> ] The list of extra options besides client options
     #   that determine the persistence context.
-    #
-    # @since 6.0.0
     EXTRA_OPTIONS = [ :client,
                       :collection
                     ].freeze
@@ -38,8 +32,6 @@ module Mongoid
     #
     # @return [ Array<Symbol> ] The full list of options defining the persistence
     #   context.
-    #
-    # @since 6.0.0
     VALID_OPTIONS = ( Mongo::Client::VALID_OPTIONS + EXTRA_OPTIONS ).freeze
 
     # Initialize the persistence context object.
@@ -50,8 +42,6 @@ module Mongoid
     # @param [ Object ] object The class or model instance for which a persistence context
     #   should be created.
     # @param [ Hash ] opts The persistence context options.
-    #
-    # @since 6.0.0
     def initialize(object, opts = {})
       @object = object
       set_options!(opts)
@@ -67,8 +57,6 @@ module Mongoid
     #
     # @return [ Mongo::Collection ] The collection for this persistence
     #   context.
-    #
-    # @since 6.0.0
     def collection(parent = nil)
       parent ? parent.collection.with(client_options) : client[collection_name.to_sym]
     end
@@ -80,8 +68,6 @@ module Mongoid
     #
     # @return [ String ] The collection name for this persistence
     #  context.
-    #
-    # @since 6.0.0
     def collection_name
       @collection_name ||= (__evaluate__(options[:collection] ||
                              storage_options[:collection]))
@@ -94,8 +80,6 @@ module Mongoid
     #
     # @return [ String ] The database name for this persistence
     #  context.
-    #
-    # @since 6.0.0
     def database_name
       __evaluate__(database_name_option) || client.database.name
     end
@@ -107,8 +91,6 @@ module Mongoid
     #
     # @return [ Mongo::Client ] The client for this persistence
     #  context.
-    #
-    # @since 6.0.0
     def client
       @client ||= begin
         client = Clients.with_name(client_name)
@@ -136,8 +118,6 @@ module Mongoid
     # @param [ Object ] other The object to be compared with this one.
     #
     # @return [ true, false ] Whether the two persistence contexts are equal.
-    #
-    # @since 6.0.0
     def ==(other)
       return false unless other.is_a?(PersistenceContext)
       options == other.options
@@ -192,8 +172,6 @@ module Mongoid
       #   options or a persistence context object.
       #
       # @return [ Mongoid::PersistenceContext ] The persistence context for the object.
-      #
-      # @since 6.0.0
       def set(object, options_or_context)
         key = "[mongoid][#{object.object_id}]:context"
         existing_context = Thread.current[key]
@@ -218,8 +196,6 @@ module Mongoid
       # @param [ Object ] object The class or model instance.
       #
       # @return [ Mongoid::PersistenceContext ] The persistence context for the object.
-      #
-      # @since 6.0.0
       def get(object)
         Thread.current["[mongoid][#{object.object_id}]:context"]
       end
@@ -233,8 +209,6 @@ module Mongoid
       # @param [ Mongo::Cluster ] cluster The original cluster before this context was used.
       # @param [ Mongoid::PersistenceContext ] original_context The original persistence
       #   context that was set before this context was used.
-      #
-      # @since 6.0.0
       def clear(object, cluster = nil, original_context = nil)
         if context = get(object)
           context.client.close unless (context.cluster.equal?(cluster) || cluster.nil?)

--- a/lib/mongoid/positional.rb
+++ b/lib/mongoid/positional.rb
@@ -5,8 +5,6 @@ module Mongoid
 
   # This module is responsible for taking update selectors and switching out
   # the indexes for the $ positional operator where appropriate.
-  #
-  # @since 4.0.0
   module Positional
 
     # Takes the provided selector and atomic operations and replaces the
@@ -33,8 +31,6 @@ module Mongoid
     # @param [ Hash ] processed The processed update operations.
     #
     # @return [ Hash ] The new operations.
-    #
-    # @since 3.1.0
     def positionally(selector, operations, processed = {})
       if selector.size == 1 || selector.values.any? { |val| val.nil? }
         return operations

--- a/lib/mongoid/query_cache.rb
+++ b/lib/mongoid/query_cache.rb
@@ -4,8 +4,6 @@
 module Mongoid
 
   # A cache of database queries on a per-request basis.
-  #
-  # @since 4.0.0
   module QueryCache
     class << self
 
@@ -15,8 +13,6 @@ module Mongoid
       #   QueryCache.cache_table
       #
       # @return [ Hash ] The hash of cached queries.
-      #
-      # @since 4.0.0
       # @api private
       def cache_table
         if defined?(Mongo::QueryCache)
@@ -32,8 +28,6 @@ module Mongoid
       #   QueryCache.clear_cache
       #
       # @return [ nil ] Always nil.
-      #
-      # @since 4.0.0
       def clear_cache
         if defined?(Mongo::QueryCache)
           Mongo::QueryCache.clear
@@ -48,8 +42,6 @@ module Mongoid
       #   QueryCache.enabled = true
       #
       # @param [ true, false ] value The enabled value.
-      #
-      # @since 4.0.0
       def enabled=(value)
         if defined?(Mongo::QueryCache)
           Mongo::QueryCache.enabled = value
@@ -64,8 +56,6 @@ module Mongoid
       #   QueryCache.enabled?
       #
       # @return [ true, false ] If the cache is enabled.
-      #
-      # @since 4.0.0
       def enabled?
         if defined?(Mongo::QueryCache)
           Mongo::QueryCache.enabled?
@@ -80,8 +70,6 @@ module Mongoid
       #   QueryCache.cache { collection.find }
       #
       # @return [ Object ] The result of the block.
-      #
-      # @since 4.0.0
       def cache(&block)
         if defined?(Mongo::QueryCache)
           Mongo::QueryCache.cache(&block)
@@ -122,8 +110,6 @@ module Mongoid
     else
       # The middleware to be added to a rack application in order to activate the
       # query cache.
-      #
-      # @since 4.0.0
       class Middleware
 
         # Instantiate the middleware.
@@ -132,8 +118,6 @@ module Mongoid
         #   Middleware.new(app)
         #
         # @param [ Object ] app The rack application stack.
-        #
-        # @since 4.0.0
         def initialize(app)
           @app = app
         end
@@ -146,8 +130,6 @@ module Mongoid
         # @param [ Object ] env The environment.
         #
         # @return [ Object ] The result of the call.
-        #
-        # @since 4.0.0
         def call(env)
           QueryCache.cache do
             @app.call(env)
@@ -160,8 +142,6 @@ module Mongoid
 
     # A Cursor that attempts to load documents from memory first before hitting
     # the database if the same query has already been executed.
-    #
-    # @since 5.0.0
     # @deprecated This class is only used with driver versions 2.13 and lower.
     class CachedCursor < Mongo::Cursor
 
@@ -172,8 +152,6 @@ module Mongoid
       #   cursor.each do |doc|
       #     # ...
       #   end
-      #
-      # @since 5.0.0
       def each
         if @cached_documents
           @cached_documents.each do |doc|
@@ -190,8 +168,6 @@ module Mongoid
       #   cursor.inspect
       #
       # @return [ String ] A string representation of a +Cursor+ instance.
-      #
-      # @since 2.0.0
       def inspect
         "#<Mongoid::QueryCache::CachedCursor:0x#{object_id} @view=#{@view.inspect}>"
       end
@@ -211,8 +187,6 @@ module Mongoid
 
     # Included to add behavior for clearing out the query cache on certain
     # operations.
-    #
-    # @since 4.0.0
     # @deprecated This module is only used with driver versions 2.13 and lower.
     module Base
 
@@ -231,8 +205,6 @@ module Mongoid
 
     # Contains enhancements to the Mongo::Collection::View in order to get a
     # cached cursor or a regular cursor on iteration.
-    #
-    # @since 5.0.0
     # @deprecated This module is only used with driver versions 2.13 and lower.
     module View
       extend ActiveSupport::Concern
@@ -256,8 +228,6 @@ module Mongoid
       #   view.each do |doc|
       #     # ...
       #   end
-      #
-      # @since 5.0.0
       def each
         if system_collection? || !QueryCache.enabled? || (respond_to?(:write?, true) && write?)
           super
@@ -311,8 +281,6 @@ module Mongoid
     end
 
     # Adds behavior to the query cache for collections.
-    #
-    # @since 5.0.0
     # @deprecated This module is only used with driver versions 2.13 and lower.
     module Collection
       extend ActiveSupport::Concern

--- a/lib/mongoid/railtie.rb
+++ b/lib/mongoid/railtie.rb
@@ -8,8 +8,6 @@ module Rails
   module Mongoid
 
     # Hooks Mongoid into Rails 3 and higher.
-    #
-    # @since 2.0.0
     class Railtie < Rails::Railtie
 
       # Mapping of rescued exceptions to HTTP responses
@@ -18,8 +16,6 @@ module Rails
       #   railtie.rescue_responses
       #
       # @ return [Hash] rescued responses
-      #
-      # @since 2.4.3
       def self.rescue_responses
         {
           "Mongoid::Errors::DocumentNotFound" => :not_found,
@@ -45,14 +41,10 @@ module Rails
       #       config.mongoid.logger = Logger.new(STDERR, :warn)
       #     end
       #   end
-      #
-      # @since 2.0.0
       config.mongoid = ::Mongoid::Config
 
       # Initialize Mongoid. This will look for a mongoid.yml in the config
       # directory and configure mongoid appropriately.
-      #
-      # @since 2.0.0
       initializer "mongoid.load-config" do
         config_file = Rails.root.join("config", "mongoid.yml")
         if config_file.file?
@@ -72,8 +64,6 @@ module Rails
 
       # Set the proper error types for Rails. DocumentNotFound errors should be
       # 404s and not 500s, validation errors are 422s.
-      #
-      # @since 2.0.0
       config.after_initialize do
         unless config.action_dispatch.rescue_responses
           ActionDispatch::ShowExceptions.rescue_responses.update(Railtie.rescue_responses)
@@ -86,8 +76,6 @@ module Rails
       #
       # This will happen for every request in development, once in other
       # environments.
-      #
-      # @since 2.0.0
       initializer "mongoid.preload-models" do |app|
         config.to_prepare do
           ::Rails::Mongoid.preload_models(app)
@@ -98,8 +86,6 @@ module Rails
       # code, so we have no way in the intitializer to know if we are
       # generating a mongoid.yml. So instead of failing, we catch all the
       # errors and print them out.
-      #
-      # @since 3.0.0
       def handle_configuration_error(e)
         puts "There is a configuration error with the current mongoid.yml."
         puts e.message

--- a/lib/mongoid/reloadable.rb
+++ b/lib/mongoid/reloadable.rb
@@ -4,8 +4,6 @@
 module Mongoid
 
   # This module handles reloading behavior of documents.
-  #
-  # @since 4.0.0
   module Reloadable
 
     # Reloads the +Document+ attributes from the database. If the document has
@@ -18,8 +16,6 @@ module Mongoid
     # @raise [ Errors::DocumentNotFound ] If the document was deleted.
     #
     # @return [ Document ] The document, reloaded.
-    #
-    # @since 1.0.0
     def reload
       if @atomic_selector
         # Clear atomic_selector cache for sharded clusters. MONGOID-5076
@@ -50,8 +46,6 @@ module Mongoid
     #   document._reload
     #
     # @return [ Hash ] The reloaded attributes.
-    #
-    # @since 2.3.2
     def _reload
       embedded? ? reload_embedded_document : reload_root_document
     end
@@ -62,8 +56,6 @@ module Mongoid
     #   document.reload_root_document
     #
     # @return [ Hash ] The reloaded attributes.
-    #
-    # @since 2.3.2
     def reload_root_document
       {}.merge(collection.find(atomic_selector, session: _session).read(mode: :primary).first || {})
     end
@@ -74,8 +66,6 @@ module Mongoid
     #   document.reload_embedded_document
     #
     # @return [ Hash ] The reloaded attributes.
-    #
-    # @since 2.3.2
     def reload_embedded_document
       extract_embedded_attributes({}.merge(
         collection(_root).find(_root.atomic_selector).read(mode: :primary).first
@@ -90,8 +80,6 @@ module Mongoid
     # @param [ Hash ] attributes The document in the db.
     #
     # @return [ Hash ] The document's extracted attributes.
-    #
-    # @since 2.3.2
     def extract_embedded_attributes(attributes)
       atomic_position.split(".").inject(attributes) do |attrs, part|
         attrs = attrs[part =~ /\d/ ? part.to_i : part]

--- a/lib/mongoid/scopable.rb
+++ b/lib/mongoid/scopable.rb
@@ -5,8 +5,6 @@ module Mongoid
 
   # This module contains behavior for all Mongoid scoping - named scopes,
   # default scopes, and criteria accessors via scoped and unscoped.
-  #
-  # @since 4.0.0
   module Scopable
     extend ActiveSupport::Concern
 
@@ -27,8 +25,6 @@ module Mongoid
     #   document.apply_default_scoping
     #
     # @return [ true, false ] If default scoping was applied.
-    #
-    # @since 4.0.0
     def apply_default_scoping
       if default_scoping
         default_scoping.call.selector.each do |field, value|
@@ -52,8 +48,6 @@ module Mongoid
       #   Band.scopes
       #
       # @return [ Hash ] The scopes defined for this class
-      #
-      # @since 3.1.4
       def scopes
         defined_scopes = {}
         ancestors.reverse.each do |klass|
@@ -86,8 +80,6 @@ module Mongoid
       # @raise [ Errors::InvalidScope ] If the scope is not a proc or criteria.
       #
       # @return [ Proc ] The default scope.
-      #
-      # @since 1.0.0
       def default_scope(value = nil)
         value = Proc.new { yield } if block_given?
         check_scope_validity(value)
@@ -100,8 +92,6 @@ module Mongoid
       #   Band.default_scopable?
       #
       # @return [ true, false ] If the default scope can be applied.
-      #
-      # @since 3.0.0
       def default_scopable?
         default_scoping? && !Threaded.without_default_scope?(self)
       end
@@ -114,8 +104,6 @@ module Mongoid
       #   Model.queryable
       #
       # @return [ Criteria ] The queryable.
-      #
-      # @since 3.0.0
       def queryable
         crit = Threaded.current_scope(self) || Criteria.new(self)
         crit.embedded = true if (crit.klass.embedded? && !crit.klass.cyclic?)
@@ -141,8 +129,6 @@ module Mongoid
       #
       # @raise [ Errors::InvalidScope ] If the scope is not a proc.
       # @raise [ Errors::ScopeOverwrite ] If the scope name already exists.
-      #
-      # @since 1.0.0
       def scope(name, value, &block)
         normalized = name.to_sym
         check_scope_validity(value)
@@ -169,8 +155,6 @@ module Mongoid
       # @option options [ Array ] :sort Optional sorting options.
       #
       # @return [ Criteria ] A scoped criteria.
-      #
-      # @since 3.0.0
       def scoped(options = nil)
         queryable.scoped(options)
       end
@@ -189,8 +173,6 @@ module Mongoid
       #
       # @return [ Criteria, Object ] The unscoped criteria or result of the
       #   block.
-      #
-      # @since 3.0.0
       def unscoped
         if block_given?
           without_default_scope do
@@ -207,8 +189,6 @@ module Mongoid
       #   Model.with_default_scope
       #
       # @return [ Criteria ] The criteria.
-      #
-      # @since 3.0.0
       def with_default_scope
         queryable.with_default_scope
       end
@@ -223,8 +203,6 @@ module Mongoid
       # @param [ Criteria ] criteria The criteria to apply.
       #
       # @return [ Criteria ] The yielded criteria.
-      #
-      # @since 1.0.0
       def with_scope(criteria)
         Threaded.set_current_scope(criteria, self)
         begin
@@ -242,8 +220,6 @@ module Mongoid
       #   end
       #
       # @return [ Object ] The result of the block.
-      #
-      # @since 3.0.0
       def without_default_scope
         Threaded.begin_without_default_scope(self)
         yield
@@ -264,8 +240,6 @@ module Mongoid
       #
       # @raise [ Errors::ScopeOverwrite ] If the name exists and configured to
       #   raise the error.
-      #
-      # @since 2.1.0
       def check_scope_name(name)
         if _declared_scopes[name] || respond_to?(name, true)
           if Mongoid.scope_overwrite_exception
@@ -292,8 +266,6 @@ module Mongoid
       # @param [ Object ] value The intended scope.
       #
       # @raise [ Errors::InvalidScope ] If the scope is not a valid object.
-      #
-      # @since 3.0.0
       def check_scope_validity(value)
         unless value.respond_to?(:call)
           raise Errors::InvalidScope.new(self, value)
@@ -311,8 +283,6 @@ module Mongoid
       # @param [ Symbol ] name The method/scope name.
       #
       # @return [ Method ] The defined method.
-      #
-      # @since 3.0.0
       def define_scope_method(name)
         singleton_class.class_eval do
           define_method(name) do |*args|
@@ -336,8 +306,6 @@ module Mongoid
       #   Model.process_default_scope(value)
       #
       # @param [ Criteria, Proc ] value The default scope value.
-      #
-      # @since 3.0.5
       def process_default_scope(value)
         if existing = default_scoping
           ->{ existing.call.merge(value.to_proc.call) }

--- a/lib/mongoid/selectable.rb
+++ b/lib/mongoid/selectable.rb
@@ -4,8 +4,6 @@
 module Mongoid
 
   # Provides behavior for generating the selector for a specific document.
-  #
-  # @since 4.0.0
   module Selectable
     extend ActiveSupport::Concern
 
@@ -17,8 +15,6 @@ module Mongoid
     #   document.atomic_selector
     #
     # @return [ Hash ] The document's selector.
-    #
-    # @since 1.0.0
     def atomic_selector
       @atomic_selector ||=
         (embedded? ? embedded_atomic_selector : root_atomic_selector_in_db)
@@ -34,8 +30,6 @@ module Mongoid
     #   document.embedded_atomic_selector
     #
     # @return [ Hash ] The embedded document selector.
-    #
-    # @since 4.0.0
     def embedded_atomic_selector
       if persisted? && _id_changed?
         _parent.atomic_selector
@@ -50,8 +44,6 @@ module Mongoid
     # @api private
     #
     # @return [ Hash ] The root document selector.
-    #
-    # @since 4.0.0
     def root_atomic_selector_in_db
       { "_id" => _id }.merge!(shard_key_selector_in_db)
     end

--- a/lib/mongoid/serializable.rb
+++ b/lib/mongoid/serializable.rb
@@ -5,8 +5,6 @@ module Mongoid
 
   # This module provides the extra behavior for including associations in JSON
   # and XML serialization.
-  #
-  # @since 4.0.0
   module Serializable
     extend ActiveSupport::Concern
 
@@ -42,8 +40,6 @@ module Mongoid
     # @option options [ Symbol ] :methods What methods to include.
     #
     # @return [ Hash ] The document, ready to be serialized.
-    #
-    # @since 2.0.0.rc.6
     def serializable_hash(options = nil)
       options ||= {}
       attrs = {}
@@ -73,8 +69,6 @@ module Mongoid
     #   document.send(:field_names)
     #
     # @return [ Array<String> ] The names of the fields.
-    #
-    # @since 3.0.0
     def field_names(options)
       names = (as_attributes.keys + attribute_names).uniq.sort
 
@@ -104,8 +98,6 @@ module Mongoid
     # @param [ Hash ] options The options.
     #
     # @return [ Object ] The attribute.
-    #
-    # @since 3.0.0
     def serialize_attribute(attrs, name, names, options)
       if relations.key?(name)
         value = send(name)
@@ -129,8 +121,6 @@ module Mongoid
     # @option options [ Symbol ] :include What associations to include
     # @option options [ Symbol ] :only Limit the fields to only these.
     # @option options [ Symbol ] :except Dont include these fields.
-    #
-    # @since 2.0.0.rc.6
     def serialize_relations(attributes = {}, options = {})
       inclusions = options[:include]
       relation_names(inclusions).each do |name|
@@ -151,8 +141,6 @@ module Mongoid
     # @param [ Hash, Symbol, Array<Symbol> ] inclusions The inclusions.
     #
     # @return [ Array<Symbol> ] The names of the included associations.
-    #
-    # @since 2.0.0.rc.6
     def relation_names(inclusions)
       inclusions.is_a?(Hash) ? inclusions.keys : Array.wrap(inclusions)
     end
@@ -168,8 +156,6 @@ module Mongoid
     # @param [ Symbol ] name The name of the association.
     #
     # @return [ Hash ] The options for the association.
-    #
-    # @since 2.0.0.rc.6
     def relation_options(inclusions, options, name)
       if inclusions.is_a?(Hash)
         inclusions[name]

--- a/lib/mongoid/shardable.rb
+++ b/lib/mongoid/shardable.rb
@@ -4,8 +4,6 @@
 module Mongoid
 
   # This module contains behavior for adding shard key fields to updates.
-  #
-  # @since 4.0.0
   module Shardable
     extend ActiveSupport::Concern
 
@@ -46,8 +44,6 @@ module Mongoid
     #   model.shard_key_fields
     #
     # @return [ Array<String> ] The shard key field names.
-    #
-    # @since 1.0.0
     def shard_key_fields
       self.class.shard_key_fields
     end
@@ -97,8 +93,6 @@ module Mongoid
       #
       #     shard_key first_name: 1, last_name: 1
       #   end
-      #
-      # @since 2.0.0
       def shard_key(*args)
         unless args.first.is_a?(Hash)
           # Shorthand syntax

--- a/lib/mongoid/stateful.rb
+++ b/lib/mongoid/stateful.rb
@@ -39,8 +39,6 @@ module Mongoid
     #   document.flagged_for_destroy?
     #
     # @return [ true, false ] If the document is flagged.
-    #
-    # @since 2.3.2
     def flagged_for_destroy?
       @flagged_for_destroy ||= false
     end
@@ -78,8 +76,6 @@ module Mongoid
     #   document.readonly?
     #
     # @return [ true, false ] If the document is readonly.
-    #
-    # @since 4.0.0
     def readonly?
       __selected_fields != nil
     end
@@ -90,8 +86,6 @@ module Mongoid
     #   person.settable?
     #
     # @return [ true, false ] Is this document a new embeds one?
-    #
-    # @since 2.1.0
     def settable?
       new_record? && embedded_one? && _parent.persisted?
     end
@@ -102,8 +96,6 @@ module Mongoid
     #   person.updateable?
     #
     # @return [ true, false ] If the document is changed and persisted.
-    #
-    # @since 2.1.0
     def updateable?
       persisted? && changed?
     end

--- a/lib/mongoid/tasks/database.rb
+++ b/lib/mongoid/tasks/database.rb
@@ -13,8 +13,6 @@ module Mongoid
       #   Mongoid::Tasks::Database.create_indexes
       #
       # @return [ Array<Class> ] The indexed models.
-      #
-      # @since 2.1.0
       def create_indexes(models = ::Mongoid.models)
         models.each do |model|
           next if model.index_specifications.empty?
@@ -72,8 +70,6 @@ module Mongoid
       #   Mongoid::Tasks::Database.remove_undefined_indexes
       #
       # @return [ Hash{Class => Array(Hash)}] The list of indexes that were removed by model.
-      #
-      # @since 4.0.0
       def remove_undefined_indexes(models = ::Mongoid.models)
         undefined_indexes(models).each do |model, indexes|
           indexes.each do |index|

--- a/lib/mongoid/threaded.rb
+++ b/lib/mongoid/threaded.rb
@@ -12,18 +12,12 @@ module Mongoid
     DATABASE_OVERRIDE_KEY = "[mongoid]:db-override"
 
     # Constant for the key to store clients.
-    #
-    # @since 5.0.0
     CLIENTS_KEY = "[mongoid]:clients"
 
     # The key to override the client.
-    #
-    # @since 5.0.0
     CLIENT_OVERRIDE_KEY = "[mongoid]:client-override"
 
     # The key for the current thread's scope stack.
-    #
-    # @since 2.0.0
     CURRENT_SCOPE_KEY = "[mongoid]:current-scope"
 
     AUTOSAVES_KEY = "[mongoid]:autosaves"
@@ -43,8 +37,6 @@ module Mongoid
     # @param [ String ] name The name of the stack
     #
     # @return [ true ] True.
-    #
-    # @since 2.4.0
     def begin_execution(name)
       stack(name).push(true)
     end
@@ -55,8 +47,6 @@ module Mongoid
     #   Threaded.database_override
     #
     # @return [ String, Symbol ] The override.
-    #
-    # @since 3.0.0
     def database_override
       Thread.current[DATABASE_OVERRIDE_KEY]
     end
@@ -69,8 +59,6 @@ module Mongoid
     # @param [ String, Symbol ] name The global override name.
     #
     # @return [ String, Symbol ] The override.
-    #
-    # @since 3.0.0
     def database_override=(name)
       Thread.current[DATABASE_OVERRIDE_KEY] = name
     end
@@ -83,8 +71,6 @@ module Mongoid
     # @param [ Symbol ] name The name of the stack
     #
     # @return [ true ] If the stack is being executed.
-    #
-    # @since 2.4.0
     def executing?(name)
       !stack(name).empty?
     end
@@ -97,8 +83,6 @@ module Mongoid
     # @param [ Symbol ] name The name of the stack
     #
     # @return [ true ] True.
-    #
-    # @since 2.4.0
     def exit_execution(name)
       stack(name).pop
     end
@@ -111,8 +95,6 @@ module Mongoid
     # @param [ Symbol ] name The name of the stack
     #
     # @return [ Array ] The stack.
-    #
-    # @since 2.4.0
     def stack(name)
       Thread.current[STACK_KEYS[name]] ||= []
     end
@@ -123,8 +105,6 @@ module Mongoid
     #   Threaded.begin_autosave(doc)
     #
     # @param [ Document ] document The document to autosave.
-    #
-    # @since 3.0.0
     def begin_autosave(document)
       autosaves_for(document.class).push(document._id)
     end
@@ -135,8 +115,6 @@ module Mongoid
     #   Threaded.begin_validate(doc)
     #
     # @param [ Document ] document The document to validate.
-    #
-    # @since 2.1.9
     def begin_validate(document)
       validations_for(document.class).push(document._id)
     end
@@ -147,8 +125,6 @@ module Mongoid
     #   Threaded.exit_autosave(doc)
     #
     # @param [ Document ] document The document to autosave.
-    #
-    # @since 3.0.0
     def exit_autosave(document)
       autosaves_for(document.class).delete_one(document._id)
     end
@@ -159,8 +135,6 @@ module Mongoid
     #   Threaded.exit_validate(doc)
     #
     # @param [ Document ] document The document to validate.
-    #
-    # @since 2.1.9
     def exit_validate(document)
       validations_for(document.class).delete_one(document._id)
     end
@@ -195,8 +169,6 @@ module Mongoid
     #   Threaded.client_override
     #
     # @return [ String, Symbol ] The override.
-    #
-    # @since 5.0.0
     def client_override
       Thread.current[CLIENT_OVERRIDE_KEY]
     end
@@ -209,8 +181,6 @@ module Mongoid
     # @param [ String, Symbol ] name The global override name.
     #
     # @return [ String, Symbol ] The override.
-    #
-    # @since 3.0.0
     def client_override=(name)
       Thread.current[CLIENT_OVERRIDE_KEY] = name
     end
@@ -224,8 +194,6 @@ module Mongoid
     # @param [ Klass ] klass The class type of the scope.
     #
     # @return [ Criteria ] The scope.
-    #
-    # @since 5.0.0
     def current_scope(klass = nil)
       if klass && Thread.current[CURRENT_SCOPE_KEY].respond_to?(:keys)
         Thread.current[CURRENT_SCOPE_KEY][
@@ -244,8 +212,6 @@ module Mongoid
     # @param [ Criteria ] scope The current scope.
     #
     # @return [ Criteria ] The scope.
-    #
-    # @since 5.0.0
     def current_scope=(scope)
       Thread.current[CURRENT_SCOPE_KEY] = scope
     end
@@ -259,8 +225,6 @@ module Mongoid
     # @param [ Class ] klass The current model class.
     #
     # @return [ Criteria ] The scope.
-    #
-    # @since 5.0.1
     def set_current_scope(scope, klass)
       if scope.nil?
         if Thread.current[CURRENT_SCOPE_KEY]
@@ -293,8 +257,6 @@ module Mongoid
     # @param [ Document ] document The document to check.
     #
     # @return [ true, false ] If the document is autosaved.
-    #
-    # @since 2.1.9
     def autosaved?(document)
       autosaves_for(document.class).include?(document._id)
     end
@@ -307,8 +269,6 @@ module Mongoid
     # @param [ Document ] document The document to check.
     #
     # @return [ true, false ] If the document is validated.
-    #
-    # @since 2.1.9
     def validated?(document)
       validations_for(document.class).include?(document._id)
     end
@@ -319,8 +279,6 @@ module Mongoid
     #   Threaded.autosaves
     #
     # @return [ Hash ] The current autosaves.
-    #
-    # @since 3.0.0
     def autosaves
       Thread.current[AUTOSAVES_KEY] ||= {}
     end
@@ -331,8 +289,6 @@ module Mongoid
     #   Threaded.validations
     #
     # @return [ Hash ] The current validations.
-    #
-    # @since 2.1.9
     def validations
       Thread.current[VALIDATIONS_KEY] ||= {}
     end
@@ -345,8 +301,6 @@ module Mongoid
     # @param [ Class ] klass The class to check.
     #
     # @return [ Array ] The current autosaves.
-    #
-    # @since 3.0.0
     def autosaves_for(klass)
       autosaves[klass] ||= []
     end
@@ -358,8 +312,6 @@ module Mongoid
     # @param [ Class ] klass The class to check.
     #
     # @return [ Array ] The current validations.
-    #
-    # @since 2.1.9
     def validations_for(klass)
       validations[klass] ||= []
     end
@@ -370,8 +322,6 @@ module Mongoid
     #   Threaded.set_session(session)
     #
     # @param [ Mongo::Session ] session The session to save.
-    #
-    # @since 6.4.0
     def set_session(session)
       Thread.current[:session] = session
     end
@@ -382,8 +332,6 @@ module Mongoid
     #   Threaded.get_session
     #
     # @return [ Mongo::Session, nil ] The session cached on this thread or nil.
-    #
-    # @since 6.4.0
     def get_session
       Thread.current[:session]
     end
@@ -394,8 +342,6 @@ module Mongoid
     #   Threaded.clear_session
     #
     # @return [ nil ]
-    #
-    # @since 6.4.0
     def clear_session
       session = get_session
       session.end_session if session

--- a/lib/mongoid/threaded/lifecycle.rb
+++ b/lib/mongoid/threaded/lifecycle.rb
@@ -26,8 +26,6 @@ module Mongoid
       #   end
       #
       # @return [ Object ] The yielded value.
-      #
-      # @since 2.2.0
       def _assigning
         Threaded.begin_execution(ASSIGN)
         yield
@@ -41,8 +39,6 @@ module Mongoid
       #   proxy._assigning?
       #
       # @return [ true, false ] If the thread is assigning.
-      #
-      # @since 2.1.0
       def _assigning?
         Threaded.executing?(ASSIGN)
       end
@@ -55,8 +51,6 @@ module Mongoid
       #   end
       #
       # @return [ Object ] The return value of the block.
-      #
-      # @since 2.1.0
       def _binding
         Threaded.begin_execution(BIND)
         yield
@@ -70,8 +64,6 @@ module Mongoid
       #   proxy.binding?
       #
       # @return [ true, false ] If the thread is binding.
-      #
-      # @since 2.1.0
       def _binding?
         Threaded.executing?(BIND)
       end
@@ -84,8 +76,6 @@ module Mongoid
       #   end
       #
       # @return [ Object ] The return value of the block.
-      #
-      # @since 2.1.0
       def _building
         Threaded.begin_execution(BUILD)
         yield
@@ -99,8 +89,6 @@ module Mongoid
       #   proxy._building?
       #
       # @return [ true, false ] If the thread is building.
-      #
-      # @since 2.1.0
       def _building?
         Threaded.executing?(BUILD)
       end
@@ -111,8 +99,6 @@ module Mongoid
       #   proxy.creating?
       #
       # @return [ true, false ] If the thread is creating.
-      #
-      # @since 2.1.0
       def _creating?
         Threaded.executing?(CREATE)
       end
@@ -125,8 +111,6 @@ module Mongoid
       #   end
       #
       # @return [ Object ] The return value of the block.
-      #
-      # @since 2.3.2
       def _loading
         Threaded.begin_execution(LOAD)
         yield
@@ -140,8 +124,6 @@ module Mongoid
       #   proxy._loading?
       #
       # @return [ true, false ] If the thread is loading.
-      #
-      # @since 2.3.2
       def _loading?
         Threaded.executing?(LOAD)
       end
@@ -156,8 +138,6 @@ module Mongoid
         #   end
         #
         # @return [ Object ] The return value of the block.
-        #
-        # @since 2.1.0
         def _creating
           Threaded.begin_execution(CREATE)
           yield

--- a/lib/mongoid/timestamps/timeless.rb
+++ b/lib/mongoid/timestamps/timeless.rb
@@ -15,8 +15,6 @@ module Mongoid
       #   document.clear_timeless_option
       #
       # @return [ true ] True.
-      #
-      # @since 3.1.4
       def clear_timeless_option
         if self.persisted?
           self.class.clear_timeless_option_on_update
@@ -32,8 +30,6 @@ module Mongoid
       #   person.timeless.save
       #
       # @return [ Document ] The document this was called on.
-      #
-      # @since 2.3.0
       def timeless
         self.class.timeless
         self
@@ -63,8 +59,6 @@ module Mongoid
         #   Person.timeless.create(:title => "Sir")
         #
         # @return [ Class ] The class this was called on.
-        #
-        # @since 2.3.0
         def timeless
           counter = 0
           counter += 1 if self < Mongoid::Timestamps::Created

--- a/lib/mongoid/timestamps/updated.rb
+++ b/lib/mongoid/timestamps/updated.rb
@@ -37,8 +37,6 @@ module Mongoid
       #   document.able_to_set_updated_at?
       #
       # @return [ true, false ] If the timestamp can be set.
-      #
-      # @since 2.4.0
       def able_to_set_updated_at?
         !frozen? && !timeless? && (new_record? || changed?)
       end

--- a/lib/mongoid/touchable.rb
+++ b/lib/mongoid/touchable.rb
@@ -21,8 +21,6 @@ module Mongoid
       # @param [ Symbol ] field The name of an additional field to update.
       #
       # @return [ true/false ] false if record is new_record otherwise true.
-      #
-      # @since 3.0.0
       def touch(field = nil)
         return false if _root.new_record?
         current = Time.now
@@ -70,8 +68,6 @@ module Mongoid
     # @param [ Association ] association The association metadata.
     #
     # @return [ Class ] The model class.
-    #
-    # @since 3.0.0
     def define_touchable!(association)
       name = association.name
       method_name = define_relation_touch_method(name, association)
@@ -95,8 +91,6 @@ module Mongoid
     #
     # @param [ Symbol ] name The name of the association.
     # @param [ Association ] association The association metadata.
-    #
-    # @since 3.1.0
     #
     # @return [ Symbol ] The method name.
     def define_relation_touch_method(name, association)

--- a/lib/mongoid/traversable.rb
+++ b/lib/mongoid/traversable.rb
@@ -6,8 +6,6 @@ require "mongoid/fields/validators/macro"
 module Mongoid
 
   # Provides behavior around traversing the document graph.
-  #
-  # @since 4.0.0
   module Traversable
     extend ActiveSupport::Concern
 
@@ -139,8 +137,6 @@ module Mongoid
     #   document.collect_children
     #
     # @return [ Array<Document> ] The children.
-    #
-    # @since 2.4.0
     def collect_children
       children = []
       embedded_relations.each_pair do |name, association|
@@ -161,8 +157,6 @@ module Mongoid
     #   document.flag_children_persisted
     #
     # @return [ Array<Document> ] The flagged children.
-    #
-    # @since 3.0.7
     def flag_children_persisted
       _children.each do |child|
         child.new_record = false
@@ -201,8 +195,6 @@ module Mongoid
     #   document.remove_child(child)
     #
     # @param [ Document ] child The child (embedded) document to remove.
-    #
-    # @since 2.0.0.beta.1
     def remove_child(child)
       name = child.association_name
       if child.embedded_one?
@@ -220,8 +212,6 @@ module Mongoid
     #   document.reset_persisted_children
     #
     # @return [ Array<Document> ] The children.
-    #
-    # @since 2.1.0
     def reset_persisted_children
       _children.each do |child|
         child.move_changes
@@ -239,8 +229,6 @@ module Mongoid
     #   document._reset_memoized_children!
     #
     # @return [ nil ] nil.
-    #
-    # @since 5.0.0
     def _reset_memoized_children!
       _parent._reset_memoized_children! if _parent
       @__children = nil
@@ -265,8 +253,6 @@ module Mongoid
     #   document._root?
     #
     # @return [ true, false ] If the document is the root.
-    #
-    # @since 3.1.0
     def _root?
       _parent ? false : true
     end
@@ -291,8 +277,6 @@ module Mongoid
       #   Person.inherited(Doctor)
       #
       # @param [ Class ] subclass The inheriting class.
-      #
-      # @since 2.0.0.rc.6
       def inherited(subclass)
         super
         @_type = nil

--- a/lib/mongoid/validatable.rb
+++ b/lib/mongoid/validatable.rb
@@ -26,8 +26,6 @@ module Mongoid
     #
     # @example Begin validation.
     #   document.begin_validate
-    #
-    # @since 2.1.9
     def begin_validate
       Threaded.begin_validate(self)
     end
@@ -36,8 +34,6 @@ module Mongoid
     #
     # @example Exit validation.
     #   document.exit_validate
-    #
-    # @since 2.1.9
     def exit_validate
       Threaded.exit_validate(self)
     end
@@ -50,8 +46,6 @@ module Mongoid
     # @param [ Hash ] options The options to check.
     #
     # @return [ true, false ] If we are validating.
-    #
-    # @since 4.0.0
     def performing_validations?(options = {})
       options[:validate].nil? ? true : options[:validate]
     end
@@ -66,8 +60,6 @@ module Mongoid
     # @param [ Symbol ] attr The name of the field or association.
     #
     # @return [ Object ] The value of the field or the association.
-    #
-    # @since 2.0.0.rc.1
     def read_attribute_for_validation(attr)
       attribute = database_field_name(attr)
       if relations.key?(attribute)
@@ -93,8 +85,6 @@ module Mongoid
     # @param [ Symbol ] context The optional validation context.
     #
     # @return [ true, false ] True if valid, false if not.
-    #
-    # @since 2.0.0.rc.6
     def valid?(context = nil)
       super context ? context : (new_record? ? :create : :update)
     end
@@ -105,8 +95,6 @@ module Mongoid
     #   document.validated?
     #
     # @return [ true, false ] Has the document already been validated?
-    #
-    # @since 2.0.0.rc.2
     def validated?
       Threaded.validated?(self)
     end
@@ -117,8 +105,6 @@ module Mongoid
     #   document.validating_with_query?
     #
     # @return [ true, false ] If we are validating with a query.
-    #
-    # @since 3.0.2
     def validating_with_query?
       self.class.validating_with_query?
     end
@@ -132,8 +118,6 @@ module Mongoid
       #   Person.validates_relation(association)
       #
       # @param [ Association ] association The association metadata.
-      #
-      # @since 2.0.0.rc.1
       def validates_relation(association)
         if association.validate?
           validates_associated(association.name)
@@ -151,8 +135,6 @@ module Mongoid
       # @note See ActiveModel::Validations::With for full options. This is
       #   overridden to add autosave functionality when presence validation is
       #   added.
-      #
-      # @since 3.0.0
       def validates_with(*args, &block)
         if args.first == PresenceValidator
           args.last[:attributes].each do |name|
@@ -171,8 +153,6 @@ module Mongoid
       #   Model.validating_with_query?
       #
       # @return [ true, false ] If we are validating with a query.
-      #
-      # @since 3.0.2
       def validating_with_query?
         Threaded.executing?("#{name}-validate-with-query")
       end

--- a/lib/mongoid/validatable/associated.rb
+++ b/lib/mongoid/validatable/associated.rb
@@ -28,8 +28,6 @@ module Mongoid
       # @param [ Document ] document The document to validate.
       # @param [ Symbol ] attribute The association to validate.
       # @param [ Object ] value The value of the association.
-      #
-      # @since 2.0.0
       def validate_each(document, attribute, value)
         begin
           document.begin_validate

--- a/lib/mongoid/validatable/localizable.rb
+++ b/lib/mongoid/validatable/localizable.rb
@@ -15,8 +15,6 @@ module Mongoid
       # @param [ Document ] document The document.
       # @param [ Symbol, String ] attribute The attribute to validate.
       # @param [ Object ] value The attribute value.
-      #
-      # @since 2.4.2
       def validate_each(document, attribute, value)
         field = document.fields[document.database_field_name(attribute)]
         if field.try(:localized?) && !value.blank?

--- a/lib/mongoid/validatable/macros.rb
+++ b/lib/mongoid/validatable/macros.rb
@@ -54,8 +54,6 @@ module Mongoid
       #   end
       #
       # @param [ Array ] args The names of the fields to validate.
-      #
-      # @since 2.4.0
       def validates_format_of(*args)
         validates_with(FormatValidator, _merge_attributes(args))
       end
@@ -71,8 +69,6 @@ module Mongoid
       #   end
       #
       # @param [ Array ] args The names of the fields to validate.
-      #
-      # @since 2.4.0
       def validates_length_of(*args)
         validates_with(LengthValidator, _merge_attributes(args))
       end
@@ -88,8 +84,6 @@ module Mongoid
       #   end
       #
       # @param [ Array ] args The names of the fields to validate.
-      #
-      # @since 2.4.0
       def validates_presence_of(*args)
         validates_with(PresenceValidator, _merge_attributes(args))
       end

--- a/lib/mongoid/validatable/presence.rb
+++ b/lib/mongoid/validatable/presence.rb
@@ -25,8 +25,6 @@ module Mongoid
       # @param [ Document ] document The document to validate.
       # @param [ Symbol ] attribute The attribute name.
       # @param [ Object ] value The current value of the field.
-      #
-      # @since 2.4.0
       def validate_each(document, attribute, value)
         field = document.fields[document.database_field_name(attribute)]
         if field.try(:localized?) && !value.blank?
@@ -60,8 +58,6 @@ module Mongoid
       # @param [ Object ] value The value.
       #
       # @return [ true, false ] If the doc is missing.
-      #
-      # @since 3.0.0
       def relation_or_fk_missing?(doc, attr, value)
         return true if value.blank? && doc.send(attr).blank?
         association = doc.relations[attr.to_s]
@@ -78,8 +74,6 @@ module Mongoid
       # @param [ Object ] value The value.
       #
       # @return [ true, false ] If the value is not present.
-      #
-      # @since 3.0.5
       def not_present?(value)
         value.blank? && value != false
       end

--- a/lib/mongoid/validatable/queryable.rb
+++ b/lib/mongoid/validatable/queryable.rb
@@ -16,8 +16,6 @@ module Mongoid
       # @param [ Document ] document The document being validated.
       #
       # @return [ Object ] The result of the yield.
-      #
-      # @since 3.0.2
       def with_query(document)
         klass = document.class
         begin

--- a/lib/mongoid/validatable/uniqueness.rb
+++ b/lib/mongoid/validatable/uniqueness.rb
@@ -38,8 +38,6 @@ module Mongoid
       # @param [ Object ] value The value of the field.
       #
       # @return [ Errors ] The errors.
-      #
-      # @since 1.0.0
       def validate_each(document, attribute, value)
         with_query(document) do
           attrib, val = to_validate(document, attribute, value)
@@ -64,8 +62,6 @@ module Mongoid
       # @param [ Document ] document The document to validate.
       # @param [ Symbol ] attribute The name of the attribute.
       # @param [ Object ] value The value of the object.
-      #
-      # @since 2.4.10
       def add_error(document, attribute, value)
         document.errors.add(
           attribute, :taken, **options.except(:case_sensitive, :scope).merge(value: value)
@@ -80,8 +76,6 @@ module Mongoid
       #   validator.case_sensitive?
       #
       # @return [ true, false ] If the validation is case sensitive.
-      #
-      # @since 2.3.0
       def case_sensitive?
         !(options[:case_sensitive] == false)
       end
@@ -99,8 +93,6 @@ module Mongoid
       # @param [ Object ] value The value of the object.
       #
       # @return [ Criteria ] The criteria.
-      #
-      # @since 2.4.10
       def create_criteria(base, document, attribute, value)
         criteria = scope(base.unscoped, document, attribute)
         criteria.selector.update(criterion(document, attribute, value.mongoize))
@@ -119,8 +111,6 @@ module Mongoid
       # @param [ Object ] value The value of the object.
       #
       # @return [ Criteria ] The uniqueness criteria.
-      #
-      # @since 2.3.0
       def criterion(document, attribute, value)
         field = document.database_field_name(attribute)
 
@@ -147,8 +137,6 @@ module Mongoid
       # @param [ Object ] value The value to filter.
       #
       # @return [ Object, Regexp ] The value, filtered or not.
-      #
-      # @since 2.3.0
       def filter(value)
         !case_sensitive? && value ? /\A#{Regexp.escape(value.to_s)}\z/i : value
       end
@@ -164,8 +152,6 @@ module Mongoid
       # @param [ Document ] document The document being validated.
       #
       # @return [ Criteria ] The scoped criteria.
-      #
-      # @since 2.3.0
       def scope(criteria, document, _attribute)
         Array.wrap(options[:scope]).each do |item|
           name = document.database_field_name(item)
@@ -184,8 +170,6 @@ module Mongoid
       # @param [ Document ] document The embedded document.
       #
       # @return [ true, false ] If the validation should be skipped.
-      #
-      # @since 2.3.0
       def skip_validation?(document)
         !document._parent || document.embedded_one?
       end
@@ -200,8 +184,6 @@ module Mongoid
       # @param [ Document ] document The embedded document.
       #
       # @return [ true, false ] If the scope reference has changed.
-      #
-      # @since
       def scope_value_changed?(document)
         Array.wrap(options[:scope]).any? do |item|
           document.send("attribute_changed?", item.to_s)
@@ -223,8 +205,6 @@ module Mongoid
       # @param [ Object ] value The value of the attribute.
       #
       # @return [ Array<Object, Object> ] The field and value.
-      #
-      # @since 2.4.4
       def to_validate(document, attribute, value)
         association = document.relations[attribute.to_s]
         if association && association.stores_foreign_key?
@@ -244,8 +224,6 @@ module Mongoid
       # @param [ Document ] document The document.
       # @param [ Symbol ] attribute The attribute name.
       # @param [ Object ] value The value.
-      #
-      # @since 2.4.10
       def validate_embedded(document, attribute, value)
         return if skip_validation?(document)
         relation = document._parent.send(document.association_name)
@@ -264,8 +242,6 @@ module Mongoid
       # @param [ Document ] document The document.
       # @param [ Symbol ] attribute The attribute name.
       # @param [ Object ] value The value.
-      #
-      # @since 2.4.10
       def validate_root(document, attribute, value)
         klass = document.class
 
@@ -289,8 +265,6 @@ module Mongoid
       # @param [ Symbol ] attribute The attribute to validate.
       #
       # @return [ true, false ] If we need to validate.
-      #
-      # @since 2.4.4
       def validation_required?(document, attribute)
         document.new_record? ||
           document.send("attribute_changed?", attribute.to_s) ||
@@ -308,8 +282,6 @@ module Mongoid
       # @param [ Symbol ] attribute The attribute to validate.
       #
       # @return [ true, false ] If the attribute is localized.
-      #
-      # @since 4.0.0
       def localized?(document, attribute)
         document.fields[document.database_field_name(attribute)].try(:localized?)
       end

--- a/lib/rails/mongoid.rb
+++ b/lib/rails/mongoid.rb
@@ -45,8 +45,6 @@ module Rails
     #   Mongoid.load_model("/mongoid/behavior")
     #
     # @param [ String ] file The base filename.
-    #
-    # @since 2.0.0.rc.3
     def load_model(file)
       begin
         require_dependency(file)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -155,31 +155,21 @@ RSpec.configure do |config|
 end
 
 # A subscriber to be used with the Ruby driver for testing.
-#
-# @since 6.4.0
 class EventSubscriber
 
   # The started events.
-  #
-  # @since 6.4.0
   attr_reader :started_events
 
   # The succeeded events.
-  #
-  # @since 6.4.0
   attr_reader :succeeded_events
 
   # The failed events.
-  #
-  # @since 6.4.0
   attr_reader :failed_events
 
   # Create the test event subscriber.
   #
   # @example Create the subscriber
   #   EventSubscriber.new
-  #
-  # @since 6.4.0
   def initialize
     @started_events = []
     @succeeded_events = []
@@ -189,8 +179,6 @@ class EventSubscriber
   # Cache the succeeded event.
   #
   # @param [ Event ] event The event.
-  #
-  # @since 6.4.0
   def succeeded(event)
     @succeeded_events.push(event)
   end
@@ -198,8 +186,6 @@ class EventSubscriber
   # Cache the started event.
   #
   # @param [ Event ] event The event.
-  #
-  # @since 6.4.0
   def started(event)
     @started_events.push(event)
   end
@@ -207,15 +193,11 @@ class EventSubscriber
   # Cache the failed event.
   #
   # @param [ Event ] event The event.
-  #
-  # @since 6.4.0
   def failed(event)
     @failed_events.push(event)
   end
 
   # Clear all cached events.
-  #
-  # @since 6.4.0
   def clear_events!
     @started_events = []
     @succeeded_events = []


### PR DESCRIPTION
Fixes MONGOID-5141

`@since` comments are generally not useful:

1. The project is now quite mature. `@since` was perhaps useful when there were radical changes between 1.0, 2.0, and 3.0, but those days are long gone.
2. They do not reflect significant interface changes to methods
3. They are not accurate, for example they have been kept in-place when code was moved to other classes
4. We're not adding them on new PRs, and it confuses first-time contributors
5. It adds clutter and makes code harder to read.

Instead of tagging each method with `@since`, we should simply be following Semver, and be mindful when we are change public method behavior.