### PR TITLE
MONGOID-4500 + MONGOID-5421: Improvement to Mongoid::Contextual::Aggregable::Memory handling of nil / non-numeric values / type conversion.

### DIFF
--- a/docs/release-notes/mongoid-8.0.txt
+++ b/docs/release-notes/mongoid-8.0.txt
@@ -382,6 +382,54 @@ Mongoid 7 behavior:
   end
 
 
+``max``, ``min``, ``avg``, ``sum`` Aggregations On Embedded Documents
+---------------------------------------------------------------------
+
+Mongoid 8.0 converts fields of embedded documents that are being numerically
+aggregated (that is, aggregated using the ``max``, ``min``, ``avg`` and ``sum``
+methods) to numbers, if possible, prior to performing the aggregation.
+Any values which are not numeric are ignored.
+
+This conversion permits numeric aggregations over ``BigDecimal`` values stored
+in the database as strings.
+
+Mongoid 8.0 behavior:
+
+.. code-block:: ruby
+
+  class Cat
+    include Mongoid::Document
+
+    field :age, type: Integer
+
+    embeds_many :kittens
+  end
+
+  class Kitten
+    include Mongoid::Document
+
+    embedded_in :cat
+
+    field :age, type: Integer
+  end
+
+  Cat.create!(age: 12)
+  Cat.create!(age: '11')
+  Cat.create!(age: 'hello')
+
+  Cat.sum(:age)
+  # => 23
+
+  cat = Cat.create!
+
+  cat.kittens.create!(age: 12)
+  cat.kittens.create!(age: '11')
+  cat.kittens.create!(age: 'hello')
+
+  cat.kittens.sum(:age)
+  # => 23
+
+
 ``#pluck`` on Embedded Criteria Returns ``nil`` Values
 ------------------------------------------------------
 

--- a/lib/mongoid/extensions/decimal128.rb
+++ b/lib/mongoid/extensions/decimal128.rb
@@ -14,6 +14,16 @@ module Mongoid
         self
       end
 
+      # Is the BSON::Decimal128 a number?
+      #
+      # @example Is the object a number?.
+      #   object.numeric?
+      #
+      # @return [ true ] Always true.
+      def numeric?
+        true
+      end
+
       module ClassMethods
 
         # Evolve the object into a mongo-friendly value to query with.

--- a/spec/mongoid/contextual/aggregable/memory_spec.rb
+++ b/spec/mongoid/contextual/aggregable/memory_spec.rb
@@ -4,11 +4,11 @@ require "spec_helper"
 
 describe Mongoid::Contextual::Aggregable::Memory do
 
-  describe "#aggregates" do
-    let(:context) do
-      Mongoid::Contextual::Memory.new(criteria)
-    end
+  let(:context) do
+    Mongoid::Contextual::Memory.new(criteria)
+  end
 
+  describe "#aggregates" do
     subject { context.aggregates(:likes) }
 
     context 'when no documents found' do
@@ -46,289 +46,553 @@ describe Mongoid::Contextual::Aggregable::Memory do
 
   describe "#avg" do
 
-    context "when provided a single field" do
+    context "when the types are Integers" do
 
-      context "when there are matching documents" do
+      let!(:depeche) do
+        Band.create!(name: "Depeche Mode", likes: 1000)
+      end
 
-        context "when the types are integers" do
+      let!(:tool) do
+        Band.create!(name: "Tool", likes: 500)
+      end
 
-          let!(:depeche) do
-            Band.create!(name: "Depeche Mode", likes: 1000)
-          end
-
-          let!(:tool) do
-            Band.create!(name: "Tool", likes: 500)
-          end
-
-          let(:criteria) do
-            Band.all.tap do |criteria|
-              criteria.documents = [ depeche, tool ]
-            end
-          end
-
-          let(:context) do
-            Mongoid::Contextual::Memory.new(criteria)
-          end
-
-          let(:avg) do
-            context.avg(:likes)
-          end
-
-          it "returns the avg of the provided field" do
-            expect(avg).to eq(750)
-          end
-        end
-
-        context "when the types are floats" do
-
-          let!(:depeche) do
-            Band.create!(name: "Depeche Mode", rating: 10)
-          end
-
-          let!(:tool) do
-            Band.create!(name: "Tool", rating: 5)
-          end
-
-          let(:criteria) do
-            Band.all.tap do |criteria|
-              criteria.documents = [ depeche, tool ]
-            end
-          end
-
-          let(:context) do
-            Mongoid::Contextual::Memory.new(criteria)
-          end
-
-          let(:avg) do
-            context.avg(:rating)
-          end
-
-          it "returns the avg of the provided field" do
-            expect(avg).to eq(7.5)
-          end
+      let(:criteria) do
+        Band.all.tap do |criteria|
+          criteria.documents = [ depeche, tool ]
         end
       end
 
-      context "when no documents match" do
+      let(:avg) do
+        context.avg(:likes)
+      end
+
+      it "returns the avg of the provided field" do
+        expect(avg).to eq(750)
+      end
+
+      it 'returns a float' do
+        avg.should be_a(Float)
+      end
+
+      context 'when integers are negative' do
 
         let!(:depeche) do
-          Band.create!(name: "Depeche Mode", likes: 1000)
+          Band.create!(name: "Depeche Mode", likes: -1000)
         end
 
-        let(:criteria) do
-          Band.where(name: "New Order")
+        it "returns the avg of the provided field" do
+          expect(avg).to eq(-250)
         end
 
-        let(:context) do
-          Mongoid::Contextual::Memory.new(criteria)
+        it 'returns a float' do
+          avg.should be_a(Float)
         end
+      end
+    end
 
-        let(:avg) do
-          context.avg(:likes)
-        end
+    context "when the types are Floats" do
 
-        it "returns nil" do
-          expect(avg).to be_nil
+      let!(:depeche) do
+        Band.create!(name: "Depeche Mode", rating: 10)
+      end
+
+      let!(:tool) do
+        Band.create!(name: "Tool", rating: 5)
+      end
+
+      let(:criteria) do
+        Band.all.tap do |criteria|
+          criteria.documents = [ depeche, tool ]
         end
+      end
+
+      let(:avg) do
+        context.avg(:rating)
+      end
+
+      it "returns the avg of the provided field" do
+        expect(avg).to eq(7.5)
+      end
+    end
+
+    context "when no documents match" do
+
+      let!(:depeche) do
+        Band.create!(name: "Depeche Mode", likes: 1000)
+      end
+
+      let(:criteria) do
+        Band.where(name: "New Order")
+      end
+
+      let(:avg) do
+        context.avg(:likes)
+      end
+
+      it "returns nil" do
+        expect(avg).to be_nil
+      end
+    end
+
+    context "when there are a mix of types" do
+
+      let!(:bands) do
+        [ Band.create!(name: "The Flaming Lips", mojo: 7.7),
+          Band.create!(name: "Spinal Tap", mojo: BigDecimal('11')),
+          Band.create!(name: "Spirit of the Beehive", mojo: 10),
+          Band.create!(name: "Burning Spear", mojo: '7.3'),
+          Band.create!(name: "Justin Bieber", mojo: nil),
+          Band.create!(name: "Alex G", mojo: "string") ]
+      end
+
+      let(:criteria) do
+        Band.all.tap do |criteria|
+          criteria.documents = bands
+        end
+      end
+
+      let(:avg) do
+        context.avg(:mojo)
+      end
+
+      it "coerces types to calculate avg" do
+        expect(avg).to eq(9.0)
+      end
+
+      it "database only averages Numeric types" do
+        expect(Band.all.avg(:mojo).to_big_decimal).to be_within(0.000001).of(9.566666)
+      end
+    end
+
+    context "when there no numeric values" do
+
+      let!(:bands) do
+        [ Band.create!(name: "Sheena Easton", mojo: 9..5),
+          Band.create!(name: "Justin Bieber", mojo: nil),
+          Band.create!(name: "The Beatles", mojo: Date.yesterday),
+          Band.create!(name: "Alex G", mojo: "string") ]
+      end
+
+      let(:criteria) do
+        Band.all.tap do |criteria|
+          criteria.documents = bands
+        end
+      end
+
+      let(:avg) do
+        context.avg(:mojo)
+      end
+
+      it "returns avg as nil" do
+        expect(avg).to be_nil
+      end
+
+      it "database returns avg as nil" do
+        expect(Band.all.avg(:mojo)).to eq(nil)
       end
     end
   end
 
   describe "#max" do
 
-    context "when provided a single field" do
+    let!(:depeche) do
+      Band.create!(name: "Depeche Mode", likes: 1000)
+    end
 
-      let!(:depeche) do
-        Band.create!(name: "Depeche Mode", likes: 1000)
+    let!(:tool) do
+      Band.create!(name: "Tool", likes: 500)
+    end
+
+    let(:criteria) do
+      Band.all.tap do |crit|
+        crit.documents = [ depeche, tool ]
+      end
+    end
+
+    context "when provided a Symbol" do
+
+      let(:max) do
+        context.max(:likes)
       end
 
-      let!(:tool) do
-        Band.create!(name: "Tool", likes: 500)
+      it "returns the max of the provided field" do
+        expect(max).to eq(1000)
       end
 
-      let(:criteria) do
-        Band.all.tap do |crit|
-          crit.documents = [ depeche, tool ]
+      context "when no documents match" do
+
+        let(:criteria) do
+          Band.where(name: "New Order")
         end
-      end
-
-      let(:context) do
-        Mongoid::Contextual::Memory.new(criteria)
-      end
-
-      context "when provided a symbol" do
 
         let(:max) do
           context.max(:likes)
         end
 
-        it "returns the max of the provided field" do
-          expect(max).to eq(1000)
-        end
-
-        context "when no documents match" do
-
-          let(:criteria) do
-            Band.where(name: "New Order")
-          end
-
-          let(:context) do
-            Mongoid::Contextual::Memory.new(criteria)
-          end
-
-          let(:max) do
-            context.max(:likes)
-          end
-
-          it "returns nil" do
-            expect(max).to be_nil
-          end
+        it "returns nil" do
+          expect(max).to be_nil
         end
       end
 
-      context "when provided a block" do
+      context "when there are a mix of types" do
 
-        let(:max) do
-          context.max do |a, b|
-            a.likes <=> b.likes
+        let!(:bands) do
+          [ Band.create!(name: "The Flaming Lips", mojo: 7.7),
+            Band.create!(name: "Spinal Tap", mojo: BigDecimal('11')),
+            Band.create!(name: "Spirit of the Beehive", mojo: 10),
+            Band.create!(name: "Burning Spear", mojo: '7.3'),
+            Band.create!(name: "Justin Bieber", mojo: nil),
+            Band.create!(name: "Alex G", mojo: "string") ]
+        end
+
+        let(:criteria) do
+          Band.all.tap do |criteria|
+            criteria.documents = bands
           end
         end
 
-        it "returns the document with the max value for the field" do
-          expect(max).to eq(depeche)
+        let(:max) do
+          context.max(:mojo)
         end
+
+        it "coerces types to calculate max" do
+          expect(max).to eq 11
+          expect(max).to be_a BigDecimal
+        end
+      end
+
+      context "when there no numeric values" do
+
+        let!(:bands) do
+          [ Band.create!(name: "Sheena Easton", mojo: 9..5),
+            Band.create!(name: "Justin Bieber", mojo: nil),
+            Band.create!(name: "The Beatles", mojo: Date.yesterday),
+            Band.create!(name: "Alex G", mojo: "string") ]
+        end
+
+        let(:criteria) do
+          Band.all.tap do |criteria|
+            criteria.documents = bands
+          end
+        end
+
+        let(:max) do
+          context.avg(:mojo)
+        end
+
+        it "returns max as nil" do
+          expect(max).to be_nil
+        end
+      end
+    end
+
+    context "when provided a block" do
+
+      let(:max) do
+        context.max do |a, b|
+          a.likes <=> b.likes
+        end
+      end
+
+      it "returns the document with the max value for the field" do
+        expect(max).to eq(depeche)
       end
     end
   end
 
   describe "#min" do
 
-    context "when provided a single field" do
+    let!(:depeche) do
+      Band.create!(name: "Depeche Mode", likes: 1000)
+    end
 
-      let!(:depeche) do
-        Band.create!(name: "Depeche Mode", likes: 1000)
+    let!(:tool) do
+      Band.create!(name: "Tool", likes: 500)
+    end
+
+    let(:criteria) do
+      Band.all.tap do |crit|
+        crit.documents = [ depeche, tool ]
+      end
+    end
+
+    context "when provided a Symbol" do
+
+      let(:min) do
+        context.min(:likes)
       end
 
-      let!(:tool) do
-        Band.create!(name: "Tool", likes: 500)
+      it "returns the min of the provided field" do
+        expect(min).to eq(500)
       end
 
-      let(:criteria) do
-        Band.all.tap do |crit|
-          crit.documents = [ depeche, tool ]
+      context "when no documents match" do
+
+        let(:criteria) do
+          Band.where(name: "New Order")
         end
-      end
-
-      let(:context) do
-        Mongoid::Contextual::Memory.new(criteria)
-      end
-
-      context "when provided a symbol" do
 
         let(:min) do
           context.min(:likes)
         end
 
-        it "returns the min of the provided field" do
-          expect(min).to eq(500)
-        end
-
-        context "when no documents match" do
-
-          let(:criteria) do
-            Band.where(name: "New Order")
-          end
-
-          let(:context) do
-            Mongoid::Contextual::Memory.new(criteria)
-          end
-
-          let(:min) do
-            context.min(:likes)
-          end
-
-          it "returns nil" do
-            expect(min).to be_nil
-          end
+        it "returns nil" do
+          expect(min).to be_nil
         end
       end
 
-      context "when provided a block" do
+      context "when there are a mix of types" do
 
-        let(:min) do
-          context.min do |a, b|
-            a.likes <=> b.likes
+        let!(:bands) do
+          [ Band.create!(name: "The Flaming Lips", mojo: 7.7),
+            Band.create!(name: "Spinal Tap", mojo: BigDecimal('11')),
+            Band.create!(name: "Spirit of the Beehive", mojo: 10),
+            Band.create!(name: "Burning Spear", mojo: '7.3'),
+            Band.create!(name: "Justin Bieber", mojo: nil),
+            Band.create!(name: "Alex G", mojo: "string") ]
+        end
+
+        let(:criteria) do
+          Band.all.tap do |criteria|
+            criteria.documents = bands
           end
         end
 
-        it "returns the document with the min value for the field" do
-          expect(min).to eq(tool)
+        let(:min) do
+          context.min(:mojo)
         end
+
+        it "coerces types to calculate min" do
+          expect(min).to eq 7.3
+          expect(min).to be_a Float
+        end
+      end
+
+      context "when there no numeric values" do
+
+        let!(:bands) do
+          [ Band.create!(name: "Sheena Easton", mojo: 9..5),
+            Band.create!(name: "Justin Bieber", mojo: nil),
+            Band.create!(name: "The Beatles", mojo: Date.yesterday),
+            Band.create!(name: "Alex G", mojo: "string") ]
+        end
+
+        let(:criteria) do
+          Band.all.tap do |criteria|
+            criteria.documents = bands
+          end
+        end
+
+        let(:min) do
+          context.min(:mojo)
+        end
+
+        it "returns min as nil" do
+          expect(min).to be_nil
+        end
+      end
+    end
+
+    context "when provided a block" do
+
+      let(:min) do
+        context.min do |a, b|
+          a.likes <=> b.likes
+        end
+      end
+
+      it "returns the document with the min value for the field" do
+        expect(min).to eq(tool)
       end
     end
   end
 
   describe "#sum" do
 
-    context "when provided a single field" do
+    let!(:depeche) do
+      Band.create!(name: "Depeche Mode", likes: 1000)
+    end
 
-      let!(:depeche) do
-        Band.create!(name: "Depeche Mode", likes: 1000)
+    let!(:tool) do
+      Band.create!(name: "Tool", likes: 500)
+    end
+
+    let(:criteria) do
+      Band.all.tap do |crit|
+        crit.documents = [ depeche, tool ]
+      end
+    end
+
+    context 'when values are integers' do
+
+      let(:sum) do
+        context.sum(:likes)
       end
 
-      let!(:tool) do
-        Band.create!(name: "Tool", likes: 500)
-      end
+      shared_examples 'sums and returns an integer' do
+        it 'sums' do
+          sum.should == 1500
+        end
 
-      let(:criteria) do
-        Band.all.tap do |crit|
-          crit.documents = [ depeche, tool ]
+        it 'returns integer' do
+          sum.should be_a(Integer)
         end
       end
 
-      let(:context) do
-        Mongoid::Contextual::Memory.new(criteria)
+      include_examples 'sums and returns an integer'
+
+      context 'when values are numeric strings' do
+
+        let!(:depeche) do
+          Band.create!(name: "Depeche Mode", likes: '1000')
+        end
+
+        include_examples 'sums and returns an integer'
       end
 
-      context "when provided a symbol" do
+      context 'when values are negative integers' do
+
+        let!(:depeche) do
+          Band.create!(name: "Depeche Mode", likes: -1000)
+        end
+
+        shared_examples 'sums and returns an integer' do
+          it 'sums' do
+            sum.should == -500
+          end
+
+          it 'returns integer' do
+            sum.should be_a(Integer)
+          end
+        end
+
+        include_examples 'sums and returns an integer'
+
+        context 'when values are negative numeric strings' do
+
+          let!(:depeche) do
+            Band.create!(name: "Depeche Mode", likes: '-1000')
+          end
+
+          include_examples 'sums and returns an integer'
+        end
+      end
+    end
+
+    context 'when values are floats' do
+
+      let!(:depeche) do
+        Band.create!(name: "Depeche Mode", likes: 1000.0)
+      end
+
+      let(:sum) do
+        context.sum(:likes)
+      end
+
+      it 'sums' do
+        sum.should == 1500
+      end
+
+      it 'returns integer' do
+        sum.should be_a(Integer)
+      end
+    end
+
+    context "when provided a Symbol" do
+
+      let(:sum) do
+        context.sum(:likes)
+      end
+
+      it "returns the sum of the provided field" do
+        expect(sum).to eq(1500)
+      end
+
+      context "when no documents match" do
+
+        let(:criteria) do
+          Band.where(name: "New Order")
+        end
 
         let(:sum) do
           context.sum(:likes)
         end
 
-        it "returns the sum of the provided field" do
-          expect(sum).to eq(1500)
-        end
-
-        context "when no documents match" do
-
-          let(:criteria) do
-            Band.where(name: "New Order")
-          end
-
-          let(:context) do
-            Mongoid::Contextual::Memory.new(criteria)
-          end
-
-          let(:sum) do
-            context.sum(:likes)
-          end
-
-          it "returns zero" do
-            expect(sum).to eq(0)
-          end
+        it "returns zero" do
+          expect(sum).to eq(0)
         end
       end
 
-      context "when provided a block" do
+      context "when there are a mix of types" do
+
+        let!(:bands) do
+          [ Band.create!(name: "The Flaming Lips", mojo: 7.7),
+            Band.create!(name: "Spinal Tap", mojo: BigDecimal('11')),
+            Band.create!(name: "Spirit of the Beehive", mojo: 10),
+            Band.create!(name: "Burning Spear", mojo: '7.3'),
+            Band.create!(name: "Justin Bieber", mojo: nil),
+            Band.create!(name: "Sheena Easton", mojo: 9..5),
+            Band.create!(name: "The Beatles", mojo: Date.yesterday),
+            Band.create!(name: "Alex G", mojo: "string") ]
+        end
+
+        let(:criteria) do
+          Band.all.tap do |criteria|
+            criteria.documents = bands
+          end
+        end
 
         let(:sum) do
-          context.sum(&:likes)
+          context.sum(:mojo)
         end
 
-        it "returns the sum for the provided block" do
-          expect(sum).to eq(1500)
+        it "coerces types to calculate sum" do
+          expect(sum).to eq 36
+          expect(sum).to be_a BigDecimal
         end
+
+        it "database only sums Float and Integer types" do
+          expect(Band.all.sum(:mojo).to_big_decimal).to be_within(Float::EPSILON).of(28.7)
+        end
+      end
+
+      context "when there no numeric values" do
+
+        let!(:bands) do
+          [ Band.create!(name: "Sheena Easton", mojo: 9..5),
+            Band.create!(name: "Justin Bieber", mojo: nil),
+            Band.create!(name: "The Beatles", mojo: Date.yesterday),
+            Band.create!(name: "Alex G", mojo: "string") ]
+        end
+
+        let(:criteria) do
+          Band.all.tap do |criteria|
+            criteria.documents = bands
+          end
+        end
+
+        let(:sum) do
+          context.sum(:mojo)
+        end
+
+        it "returns sum as zero" do
+          expect(sum).to eq 0
+        end
+
+        it "database returns sum as zero" do
+          expect(Band.all.sum(:mojo)).to eq(0)
+        end
+      end
+    end
+
+    context "when provided a block" do
+
+      let(:sum) do
+        context.sum(&:likes)
+      end
+
+      it "returns the sum for the provided block" do
+        expect(sum).to eq(1500)
       end
     end
   end

--- a/spec/mongoid/contextual/aggregable/memory_table.yml
+++ b/spec/mongoid/contextual/aggregable/memory_table.yml
@@ -1,0 +1,103 @@
+sets:
+  integers:
+    values:
+      - 324
+      - 4553
+      - -74
+      - 634
+      - 0
+      - 3484
+      - -3394
+      - 493
+    expected:
+      integer:
+        avg: 752.5
+        sum: 6020
+        min: -3394
+        max: 4553
+      float:
+        avg: 752.5
+        sum: 6020.0
+        min: -3394.0
+        max: 4553.0
+      big_decimal:
+        avg: !ruby/object:BigDecimal 36:0.7525e3
+        sum: !ruby/object:BigDecimal 18:0.602e4
+        min: !ruby/object:BigDecimal 18:-0.3394e4
+        max: !ruby/object:BigDecimal 18:0.4553e4
+      object:
+        avg: 752.5
+        sum: 6020
+        min: -3394
+        max: 4553
+
+  floats:
+    values:
+      - 233.132425
+      - -974.332
+      - 532.53323
+      - 0
+    expected:
+      integer:
+        avg: -52.25
+        sum: -209
+        min: -974
+        max: 532
+      float:
+        avg: -52.16658625
+        sum: -208.666345
+        min: -974.332
+        max: 532.53323
+      big_decimal:
+        avg: !ruby/object:BigDecimal 45:-0.5216658625e2
+        sum: !ruby/object:BigDecimal 27:-0.208666345e3
+        min: !ruby/object:BigDecimal 18:-0.974332e3
+        max: !ruby/object:BigDecimal 18:0.53253323e3
+      object:
+        avg: -52.16658625
+        sum: -208.666345
+        min: -974.332
+        max: 532.53323
+
+  mixed:
+    values:
+      - 233
+      - '-974.332'
+      - ~
+      - 532.45642
+      - '-5675'
+      - 348.434
+      - 'Foobar'
+      - -3394
+      - -493
+      - ''
+      - '0 1 2 3'
+      - !ruby/object:BigDecimal 18:0.53245642e3
+      - -5675
+      - '0.434'
+      - !ruby/object:BigDecimal 18:-0.97676e5
+      - 0.434
+      - 7455.96
+      - -0.0544
+      - '   '
+    expected:
+      integer:
+        avg: -7484.7857
+        sum: -104787
+        min: -97676
+        max: 7455
+      float:
+        avg: -7484.5865
+        sum: -104784.2116
+        min: -97676.0
+        max: 7455.96
+      big_decimal:
+        avg: !ruby/object:BigDecimal 27:-0.7484586540e4
+        sum: !ruby/object:BigDecimal 27:-0.1047842116e6
+        min: !ruby/object:BigDecimal 18:-0.97676e5
+        max: !ruby/object:BigDecimal 18:0.745596e4
+      object:
+        avg: !ruby/object:BigDecimal 27:-0.7484586540e4
+        sum: !ruby/object:BigDecimal 27:-0.1047842116e6
+        min: !ruby/object:BigDecimal 18:-0.97676e5
+        max: 7455.96

--- a/spec/mongoid/contextual/aggregable/memory_table_spec.rb
+++ b/spec/mongoid/contextual/aggregable/memory_table_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Mongoid::Contextual::Aggregable::Memory do
+
+  let(:criteria) do
+    Band.all.tap do |crit|
+      crit.documents = documents
+    end
+  end
+
+  let(:context) do
+    Mongoid::Contextual::Memory.new(criteria)
+  end
+
+  file = File.read(File.join(File.dirname(__FILE__), 'memory_table.yml'))
+  table = if RUBY_VERSION.start_with?("2.5")
+            YAML.safe_load(file, [BigDecimal])
+          else
+            YAML.safe_load(file, permitted_classes: [BigDecimal])
+          end.deep_symbolize_keys.fetch(:sets)
+
+  table.each do |name, spec|
+    context "DB values are #{name}" do
+      let(:documents) do
+        spec[:values].map do |value|
+          Band.create!({ name: 'Foobar', views: value, rating: value, sales: value, mojo: value })
+        end
+      end
+
+      { integer: :views,
+        float: :rating,
+        big_decimal: :sales,
+        object: :mojo }.each do |type, field|
+
+        %i[sum avg min max].each do |method|
+          context "#{type.to_s.camelize} field :#{method}" do
+            let(:expected) do
+              spec.dig(:expected, type, method)
+            end
+
+            let(:result) do
+              context.send(method, field)
+            end
+
+            it 'produces the expected result' do
+              if result.is_a?(Integer)
+                expect(result).to eq expected
+              else
+                expect(result).to be_within(0.001).of(expected)
+              end
+            end
+
+            it 'produces the expected type' do
+              expect(result).to be_a expected.class
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/support/models/band.rb
+++ b/spec/support/models/band.rb
@@ -20,6 +20,7 @@ class Band
   field :y, as: :years, type: Integer
   field :founded, type: Date
   field :deleted, type: Boolean
+  field :mojo, type: Object
   field :fans
 
   embeds_many :records, cascade_callbacks: true


### PR DESCRIPTION
Fixes MONGOID-4500

`Mongoid::Contextual::Aggregable::Memory` provides `#min, #max, #sum, #avg` for `Criteria` whose documents have currently been loaded to memory (most commonly embedded documents.) These functions are particularly useful when working with embedded documents.

This PR improves those methods so that the in-memory behavior of is closer (*but intentionally not exactly the same as*) MongoDB's server behavior. The primary difference with the server is that this PR allows summing/averaging mixed strings and integer values, e.g. for the use case that fields have `type: BigDecimal` (which is stored in the DB as a string.)

The following table summarizes the change for `sum, avg, min, max`:

| Case | Current In-Memory Behavior | New In-Memory Behavior | Database Behavior |
| --- | --- | --- | --- |
| All results are Integer/Float | Works correctly | Works correctly | Works correctly |
| nil is present in the results | Throws error | Ignores nil | Ignores nil |
| Non-numeric values (e.g. Date) are present in the results | Throws error | Ignores non-numeric | `sum, avg` = ignores non-numeric; `min, max` = behaves strangely (e.g. returns a seemingly random non-numeric value) |
| Numeric-like strings are present in the result (e.g. stored by BigDecimal) | Throws error (even when BigDecimal is used) | Converts numeric-like Strings to numbers | `sum, avg` = ignores numeric-like Strings (undesirable for user); `min, max` = behaves strangely |