### PR TITLE
MONGOID-5143 [Code Comments Only] Remove magic comment "# encoding: utf-8"

### DIFF
--- a/examples/mongoid_test.rb
+++ b/examples/mongoid_test.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require 'mongoid'
 require 'mongoid/support/query_counter'

--- a/lib/mongoid.rb
+++ b/lib/mongoid.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "support/ruby_version"
 

--- a/lib/mongoid/association.rb
+++ b/lib/mongoid/association.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require 'mongoid/association/accessors'
 require 'mongoid/association/builders'

--- a/lib/mongoid/association/accessors.rb
+++ b/lib/mongoid/association/accessors.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Association

--- a/lib/mongoid/association/bindable.rb
+++ b/lib/mongoid/association/bindable.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Association

--- a/lib/mongoid/association/builders.rb
+++ b/lib/mongoid/association/builders.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Association

--- a/lib/mongoid/association/constrainable.rb
+++ b/lib/mongoid/association/constrainable.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Association

--- a/lib/mongoid/association/depending.rb
+++ b/lib/mongoid/association/depending.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Association

--- a/lib/mongoid/association/eager_loadable.rb
+++ b/lib/mongoid/association/eager_loadable.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "mongoid/association/referenced/eager"
 

--- a/lib/mongoid/association/embedded.rb
+++ b/lib/mongoid/association/embedded.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require 'mongoid/association/embedded/cyclic'
 require 'mongoid/association/embedded/embedded_in'

--- a/lib/mongoid/association/embedded/batchable.rb
+++ b/lib/mongoid/association/embedded/batchable.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Association

--- a/lib/mongoid/association/embedded/cyclic.rb
+++ b/lib/mongoid/association/embedded/cyclic.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Association

--- a/lib/mongoid/association/embedded/embedded_in.rb
+++ b/lib/mongoid/association/embedded/embedded_in.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require 'mongoid/association/embedded/embedded_in/binding'
 require 'mongoid/association/embedded/embedded_in/buildable'

--- a/lib/mongoid/association/embedded/embedded_in/binding.rb
+++ b/lib/mongoid/association/embedded/embedded_in/binding.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Association

--- a/lib/mongoid/association/embedded/embedded_in/buildable.rb
+++ b/lib/mongoid/association/embedded/embedded_in/buildable.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Association

--- a/lib/mongoid/association/embedded/embedded_in/proxy.rb
+++ b/lib/mongoid/association/embedded/embedded_in/proxy.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Association

--- a/lib/mongoid/association/embedded/embeds_many.rb
+++ b/lib/mongoid/association/embedded/embeds_many.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require 'mongoid/association/embedded/embeds_many/binding'
 require 'mongoid/association/embedded/embeds_many/buildable'

--- a/lib/mongoid/association/embedded/embeds_many/binding.rb
+++ b/lib/mongoid/association/embedded/embeds_many/binding.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Association

--- a/lib/mongoid/association/embedded/embeds_many/buildable.rb
+++ b/lib/mongoid/association/embedded/embeds_many/buildable.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Association

--- a/lib/mongoid/association/embedded/embeds_many/proxy.rb
+++ b/lib/mongoid/association/embedded/embeds_many/proxy.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require 'mongoid/association/embedded/batchable'
 

--- a/lib/mongoid/association/embedded/embeds_one.rb
+++ b/lib/mongoid/association/embedded/embeds_one.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require 'mongoid/association/embedded/embeds_one/binding'
 require 'mongoid/association/embedded/embeds_one/buildable'

--- a/lib/mongoid/association/embedded/embeds_one/binding.rb
+++ b/lib/mongoid/association/embedded/embeds_one/binding.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Association

--- a/lib/mongoid/association/embedded/embeds_one/buildable.rb
+++ b/lib/mongoid/association/embedded/embeds_one/buildable.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Association

--- a/lib/mongoid/association/embedded/embeds_one/proxy.rb
+++ b/lib/mongoid/association/embedded/embeds_one/proxy.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Association

--- a/lib/mongoid/association/macros.rb
+++ b/lib/mongoid/association/macros.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Association

--- a/lib/mongoid/association/many.rb
+++ b/lib/mongoid/association/many.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Association

--- a/lib/mongoid/association/marshalable.rb
+++ b/lib/mongoid/association/marshalable.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Association

--- a/lib/mongoid/association/nested.rb
+++ b/lib/mongoid/association/nested.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require 'mongoid/association/nested/nested_buildable'
 require 'mongoid/association/nested/many'

--- a/lib/mongoid/association/nested/many.rb
+++ b/lib/mongoid/association/nested/many.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Association

--- a/lib/mongoid/association/nested/nested_buildable.rb
+++ b/lib/mongoid/association/nested/nested_buildable.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Association

--- a/lib/mongoid/association/nested/one.rb
+++ b/lib/mongoid/association/nested/one.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Association

--- a/lib/mongoid/association/one.rb
+++ b/lib/mongoid/association/one.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Association

--- a/lib/mongoid/association/options.rb
+++ b/lib/mongoid/association/options.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Association

--- a/lib/mongoid/association/proxy.rb
+++ b/lib/mongoid/association/proxy.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "mongoid/association/marshalable"
 

--- a/lib/mongoid/association/referenced.rb
+++ b/lib/mongoid/association/referenced.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require 'mongoid/association/referenced/auto_save'
 require 'mongoid/association/referenced/counter_cache'

--- a/lib/mongoid/association/referenced/auto_save.rb
+++ b/lib/mongoid/association/referenced/auto_save.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Association

--- a/lib/mongoid/association/referenced/belongs_to.rb
+++ b/lib/mongoid/association/referenced/belongs_to.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require 'mongoid/association/referenced/belongs_to/binding'
 require 'mongoid/association/referenced/belongs_to/buildable'

--- a/lib/mongoid/association/referenced/belongs_to/binding.rb
+++ b/lib/mongoid/association/referenced/belongs_to/binding.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Association

--- a/lib/mongoid/association/referenced/belongs_to/buildable.rb
+++ b/lib/mongoid/association/referenced/belongs_to/buildable.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Association

--- a/lib/mongoid/association/referenced/belongs_to/eager.rb
+++ b/lib/mongoid/association/referenced/belongs_to/eager.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Association

--- a/lib/mongoid/association/referenced/belongs_to/proxy.rb
+++ b/lib/mongoid/association/referenced/belongs_to/proxy.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Association

--- a/lib/mongoid/association/referenced/counter_cache.rb
+++ b/lib/mongoid/association/referenced/counter_cache.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Association

--- a/lib/mongoid/association/referenced/eager.rb
+++ b/lib/mongoid/association/referenced/eager.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Association

--- a/lib/mongoid/association/referenced/has_and_belongs_to_many.rb
+++ b/lib/mongoid/association/referenced/has_and_belongs_to_many.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require 'mongoid/association/referenced/has_and_belongs_to_many/binding'
 require 'mongoid/association/referenced/has_and_belongs_to_many/buildable'

--- a/lib/mongoid/association/referenced/has_and_belongs_to_many/binding.rb
+++ b/lib/mongoid/association/referenced/has_and_belongs_to_many/binding.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Association

--- a/lib/mongoid/association/referenced/has_and_belongs_to_many/buildable.rb
+++ b/lib/mongoid/association/referenced/has_and_belongs_to_many/buildable.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Association

--- a/lib/mongoid/association/referenced/has_and_belongs_to_many/eager.rb
+++ b/lib/mongoid/association/referenced/has_and_belongs_to_many/eager.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Association

--- a/lib/mongoid/association/referenced/has_and_belongs_to_many/proxy.rb
+++ b/lib/mongoid/association/referenced/has_and_belongs_to_many/proxy.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Association

--- a/lib/mongoid/association/referenced/has_many.rb
+++ b/lib/mongoid/association/referenced/has_many.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require 'mongoid/association/referenced/has_many/binding'
 require 'mongoid/association/referenced/has_many/buildable'

--- a/lib/mongoid/association/referenced/has_many/binding.rb
+++ b/lib/mongoid/association/referenced/has_many/binding.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Association

--- a/lib/mongoid/association/referenced/has_many/buildable.rb
+++ b/lib/mongoid/association/referenced/has_many/buildable.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Association

--- a/lib/mongoid/association/referenced/has_many/eager.rb
+++ b/lib/mongoid/association/referenced/has_many/eager.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Association

--- a/lib/mongoid/association/referenced/has_many/enumerable.rb
+++ b/lib/mongoid/association/referenced/has_many/enumerable.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Association

--- a/lib/mongoid/association/referenced/has_many/proxy.rb
+++ b/lib/mongoid/association/referenced/has_many/proxy.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Association

--- a/lib/mongoid/association/referenced/has_one.rb
+++ b/lib/mongoid/association/referenced/has_one.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require 'mongoid/association/referenced/has_one/binding'
 require 'mongoid/association/referenced/has_one/buildable'

--- a/lib/mongoid/association/referenced/has_one/binding.rb
+++ b/lib/mongoid/association/referenced/has_one/binding.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Association

--- a/lib/mongoid/association/referenced/has_one/buildable.rb
+++ b/lib/mongoid/association/referenced/has_one/buildable.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Association

--- a/lib/mongoid/association/referenced/has_one/eager.rb
+++ b/lib/mongoid/association/referenced/has_one/eager.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Association

--- a/lib/mongoid/association/referenced/has_one/nested_builder.rb
+++ b/lib/mongoid/association/referenced/has_one/nested_builder.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Association

--- a/lib/mongoid/association/referenced/has_one/proxy.rb
+++ b/lib/mongoid/association/referenced/has_one/proxy.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Association

--- a/lib/mongoid/association/referenced/syncable.rb
+++ b/lib/mongoid/association/referenced/syncable.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Association

--- a/lib/mongoid/association/reflections.rb
+++ b/lib/mongoid/association/reflections.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Association

--- a/lib/mongoid/association/relatable.rb
+++ b/lib/mongoid/association/relatable.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require 'mongoid/association/constrainable'
 require 'mongoid/association/options'

--- a/lib/mongoid/atomic.rb
+++ b/lib/mongoid/atomic.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "mongoid/atomic/modifiers"
 require "mongoid/atomic/paths"

--- a/lib/mongoid/atomic/modifiers.rb
+++ b/lib/mongoid/atomic/modifiers.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Atomic

--- a/lib/mongoid/atomic/paths.rb
+++ b/lib/mongoid/atomic/paths.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "mongoid/atomic/paths/embedded"
 require "mongoid/atomic/paths/root"

--- a/lib/mongoid/atomic/paths/embedded.rb
+++ b/lib/mongoid/atomic/paths/embedded.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "mongoid/atomic/paths/embedded/one"
 require "mongoid/atomic/paths/embedded/many"

--- a/lib/mongoid/atomic/paths/embedded/many.rb
+++ b/lib/mongoid/atomic/paths/embedded/many.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Atomic

--- a/lib/mongoid/atomic/paths/embedded/one.rb
+++ b/lib/mongoid/atomic/paths/embedded/one.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Atomic

--- a/lib/mongoid/atomic/paths/root.rb
+++ b/lib/mongoid/atomic/paths/root.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Atomic

--- a/lib/mongoid/attributes.rb
+++ b/lib/mongoid/attributes.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "active_model/attribute_methods"
 require "mongoid/attributes/dynamic"

--- a/lib/mongoid/attributes/dynamic.rb
+++ b/lib/mongoid/attributes/dynamic.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Attributes

--- a/lib/mongoid/attributes/nested.rb
+++ b/lib/mongoid/attributes/nested.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Attributes

--- a/lib/mongoid/attributes/processing.rb
+++ b/lib/mongoid/attributes/processing.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Attributes

--- a/lib/mongoid/attributes/projector.rb
+++ b/lib/mongoid/attributes/projector.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Attributes

--- a/lib/mongoid/attributes/readonly.rb
+++ b/lib/mongoid/attributes/readonly.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Attributes

--- a/lib/mongoid/cacheable.rb
+++ b/lib/mongoid/cacheable.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
 

--- a/lib/mongoid/changeable.rb
+++ b/lib/mongoid/changeable.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
 

--- a/lib/mongoid/clients.rb
+++ b/lib/mongoid/clients.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "mongoid/clients/factory"
 require "mongoid/clients/validators"

--- a/lib/mongoid/clients/factory.rb
+++ b/lib/mongoid/clients/factory.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Clients

--- a/lib/mongoid/clients/options.rb
+++ b/lib/mongoid/clients/options.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Clients

--- a/lib/mongoid/clients/sessions.rb
+++ b/lib/mongoid/clients/sessions.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Clients

--- a/lib/mongoid/clients/storage_options.rb
+++ b/lib/mongoid/clients/storage_options.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Clients

--- a/lib/mongoid/clients/validators.rb
+++ b/lib/mongoid/clients/validators.rb
@@ -1,4 +1,3 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "mongoid/clients/validators/storage"

--- a/lib/mongoid/clients/validators/storage.rb
+++ b/lib/mongoid/clients/validators/storage.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Clients

--- a/lib/mongoid/composable.rb
+++ b/lib/mongoid/composable.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "mongoid/changeable"
 require "mongoid/findable"

--- a/lib/mongoid/config.rb
+++ b/lib/mongoid/config.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "mongoid/config/environment"
 require "mongoid/config/options"

--- a/lib/mongoid/config/environment.rb
+++ b/lib/mongoid/config/environment.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Config

--- a/lib/mongoid/config/options.rb
+++ b/lib/mongoid/config/options.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Config

--- a/lib/mongoid/config/validators.rb
+++ b/lib/mongoid/config/validators.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "mongoid/config/validators/option"
 require "mongoid/config/validators/client"

--- a/lib/mongoid/config/validators/client.rb
+++ b/lib/mongoid/config/validators/client.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Config

--- a/lib/mongoid/config/validators/option.rb
+++ b/lib/mongoid/config/validators/option.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Config

--- a/lib/mongoid/contextual.rb
+++ b/lib/mongoid/contextual.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "mongoid/contextual/queryable"
 require "mongoid/contextual/mongo"

--- a/lib/mongoid/contextual/aggregable/memory.rb
+++ b/lib/mongoid/contextual/aggregable/memory.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Contextual

--- a/lib/mongoid/contextual/aggregable/mongo.rb
+++ b/lib/mongoid/contextual/aggregable/mongo.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Contextual

--- a/lib/mongoid/contextual/atomic.rb
+++ b/lib/mongoid/contextual/atomic.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Contextual

--- a/lib/mongoid/contextual/command.rb
+++ b/lib/mongoid/contextual/command.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Contextual

--- a/lib/mongoid/contextual/geo_near.rb
+++ b/lib/mongoid/contextual/geo_near.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Contextual

--- a/lib/mongoid/contextual/map_reduce.rb
+++ b/lib/mongoid/contextual/map_reduce.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Contextual

--- a/lib/mongoid/contextual/memory.rb
+++ b/lib/mongoid/contextual/memory.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "mongoid/contextual/aggregable/memory"
 require "mongoid/association/eager_loadable"

--- a/lib/mongoid/contextual/mongo.rb
+++ b/lib/mongoid/contextual/mongo.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "mongoid/contextual/atomic"
 require "mongoid/contextual/aggregable/mongo"

--- a/lib/mongoid/contextual/none.rb
+++ b/lib/mongoid/contextual/none.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Contextual

--- a/lib/mongoid/contextual/queryable.rb
+++ b/lib/mongoid/contextual/queryable.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Contextual

--- a/lib/mongoid/copyable.rb
+++ b/lib/mongoid/copyable.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
 

--- a/lib/mongoid/criteria.rb
+++ b/lib/mongoid/criteria.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "mongoid/criteria/findable"
 require "mongoid/criteria/includable"

--- a/lib/mongoid/criteria/findable.rb
+++ b/lib/mongoid/criteria/findable.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   class Criteria

--- a/lib/mongoid/criteria/includable.rb
+++ b/lib/mongoid/criteria/includable.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   class Criteria

--- a/lib/mongoid/criteria/inspectable.rb
+++ b/lib/mongoid/criteria/inspectable.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   class Criteria

--- a/lib/mongoid/criteria/marshalable.rb
+++ b/lib/mongoid/criteria/marshalable.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   class Criteria

--- a/lib/mongoid/criteria/modifiable.rb
+++ b/lib/mongoid/criteria/modifiable.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   class Criteria

--- a/lib/mongoid/criteria/options.rb
+++ b/lib/mongoid/criteria/options.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   class Criteria

--- a/lib/mongoid/criteria/permission.rb
+++ b/lib/mongoid/criteria/permission.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   class Criteria

--- a/lib/mongoid/criteria/queryable.rb
+++ b/lib/mongoid/criteria/queryable.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "mongoid/criteria/queryable/expandable"
 require "mongoid/criteria/queryable/extensions"

--- a/lib/mongoid/criteria/queryable/aggregable.rb
+++ b/lib/mongoid/criteria/queryable/aggregable.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   class Criteria

--- a/lib/mongoid/criteria/queryable/expandable.rb
+++ b/lib/mongoid/criteria/queryable/expandable.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   class Criteria

--- a/lib/mongoid/criteria/queryable/extensions.rb
+++ b/lib/mongoid/criteria/queryable/extensions.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 if defined?(ActiveSupport)
   unless defined?(ActiveSupport::TimeWithZone)

--- a/lib/mongoid/criteria/queryable/extensions/array.rb
+++ b/lib/mongoid/criteria/queryable/extensions/array.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   class Criteria

--- a/lib/mongoid/criteria/queryable/extensions/big_decimal.rb
+++ b/lib/mongoid/criteria/queryable/extensions/big_decimal.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "bigdecimal"
 

--- a/lib/mongoid/criteria/queryable/extensions/boolean.rb
+++ b/lib/mongoid/criteria/queryable/extensions/boolean.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   class Criteria

--- a/lib/mongoid/criteria/queryable/extensions/date.rb
+++ b/lib/mongoid/criteria/queryable/extensions/date.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   class Criteria

--- a/lib/mongoid/criteria/queryable/extensions/date_time.rb
+++ b/lib/mongoid/criteria/queryable/extensions/date_time.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   class Criteria

--- a/lib/mongoid/criteria/queryable/extensions/hash.rb
+++ b/lib/mongoid/criteria/queryable/extensions/hash.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   class Criteria

--- a/lib/mongoid/criteria/queryable/extensions/nil_class.rb
+++ b/lib/mongoid/criteria/queryable/extensions/nil_class.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   class Criteria

--- a/lib/mongoid/criteria/queryable/extensions/numeric.rb
+++ b/lib/mongoid/criteria/queryable/extensions/numeric.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   class Criteria

--- a/lib/mongoid/criteria/queryable/extensions/object.rb
+++ b/lib/mongoid/criteria/queryable/extensions/object.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   class Criteria

--- a/lib/mongoid/criteria/queryable/extensions/range.rb
+++ b/lib/mongoid/criteria/queryable/extensions/range.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   class Criteria

--- a/lib/mongoid/criteria/queryable/extensions/regexp.rb
+++ b/lib/mongoid/criteria/queryable/extensions/regexp.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   class Criteria

--- a/lib/mongoid/criteria/queryable/extensions/set.rb
+++ b/lib/mongoid/criteria/queryable/extensions/set.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "set"
 

--- a/lib/mongoid/criteria/queryable/extensions/string.rb
+++ b/lib/mongoid/criteria/queryable/extensions/string.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   class Criteria

--- a/lib/mongoid/criteria/queryable/extensions/symbol.rb
+++ b/lib/mongoid/criteria/queryable/extensions/symbol.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   class Criteria

--- a/lib/mongoid/criteria/queryable/extensions/time.rb
+++ b/lib/mongoid/criteria/queryable/extensions/time.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   class Criteria

--- a/lib/mongoid/criteria/queryable/extensions/time_with_zone.rb
+++ b/lib/mongoid/criteria/queryable/extensions/time_with_zone.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   class Criteria

--- a/lib/mongoid/criteria/queryable/key.rb
+++ b/lib/mongoid/criteria/queryable/key.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   class Criteria

--- a/lib/mongoid/criteria/queryable/macroable.rb
+++ b/lib/mongoid/criteria/queryable/macroable.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   class Criteria

--- a/lib/mongoid/criteria/queryable/mergeable.rb
+++ b/lib/mongoid/criteria/queryable/mergeable.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   class Criteria

--- a/lib/mongoid/criteria/queryable/optional.rb
+++ b/lib/mongoid/criteria/queryable/optional.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   class Criteria

--- a/lib/mongoid/criteria/queryable/options.rb
+++ b/lib/mongoid/criteria/queryable/options.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   class Criteria

--- a/lib/mongoid/criteria/queryable/pipeline.rb
+++ b/lib/mongoid/criteria/queryable/pipeline.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   class Criteria

--- a/lib/mongoid/criteria/queryable/selectable.rb
+++ b/lib/mongoid/criteria/queryable/selectable.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   class Criteria

--- a/lib/mongoid/criteria/queryable/selector.rb
+++ b/lib/mongoid/criteria/queryable/selector.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   class Criteria

--- a/lib/mongoid/criteria/queryable/smash.rb
+++ b/lib/mongoid/criteria/queryable/smash.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   class Criteria

--- a/lib/mongoid/criteria/queryable/storable.rb
+++ b/lib/mongoid/criteria/queryable/storable.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   class Criteria

--- a/lib/mongoid/criteria/scopable.rb
+++ b/lib/mongoid/criteria/scopable.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   class Criteria

--- a/lib/mongoid/document.rb
+++ b/lib/mongoid/document.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "mongoid/positional"
 require "mongoid/evolvable"

--- a/lib/mongoid/equality.rb
+++ b/lib/mongoid/equality.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
 

--- a/lib/mongoid/errors.rb
+++ b/lib/mongoid/errors.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "mongoid/errors/mongoid_error"
 require "mongoid/errors/ambiguous_relationship"

--- a/lib/mongoid/errors/ambiguous_relationship.rb
+++ b/lib/mongoid/errors/ambiguous_relationship.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Errors

--- a/lib/mongoid/errors/callback.rb
+++ b/lib/mongoid/errors/callback.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Errors

--- a/lib/mongoid/errors/criteria_argument_required.rb
+++ b/lib/mongoid/errors/criteria_argument_required.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Errors

--- a/lib/mongoid/errors/delete_restriction.rb
+++ b/lib/mongoid/errors/delete_restriction.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Errors

--- a/lib/mongoid/errors/document_not_destroyed.rb
+++ b/lib/mongoid/errors/document_not_destroyed.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Errors

--- a/lib/mongoid/errors/document_not_found.rb
+++ b/lib/mongoid/errors/document_not_found.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Errors

--- a/lib/mongoid/errors/eager_load.rb
+++ b/lib/mongoid/errors/eager_load.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Errors

--- a/lib/mongoid/errors/in_memory_collation_not_supported.rb
+++ b/lib/mongoid/errors/in_memory_collation_not_supported.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Errors

--- a/lib/mongoid/errors/invalid_collection.rb
+++ b/lib/mongoid/errors/invalid_collection.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Errors

--- a/lib/mongoid/errors/invalid_config_option.rb
+++ b/lib/mongoid/errors/invalid_config_option.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Errors

--- a/lib/mongoid/errors/invalid_dependent_strategy.rb
+++ b/lib/mongoid/errors/invalid_dependent_strategy.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Errors

--- a/lib/mongoid/errors/invalid_discriminator_key_target.rb
+++ b/lib/mongoid/errors/invalid_discriminator_key_target.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Errors

--- a/lib/mongoid/errors/invalid_elem_match_operator.rb
+++ b/lib/mongoid/errors/invalid_elem_match_operator.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Errors

--- a/lib/mongoid/errors/invalid_estimated_count_criteria.rb
+++ b/lib/mongoid/errors/invalid_estimated_count_criteria.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Errors

--- a/lib/mongoid/errors/invalid_expression_operator.rb
+++ b/lib/mongoid/errors/invalid_expression_operator.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Errors

--- a/lib/mongoid/errors/invalid_field.rb
+++ b/lib/mongoid/errors/invalid_field.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Errors

--- a/lib/mongoid/errors/invalid_field_operator.rb
+++ b/lib/mongoid/errors/invalid_field_operator.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Errors

--- a/lib/mongoid/errors/invalid_field_option.rb
+++ b/lib/mongoid/errors/invalid_field_option.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Errors

--- a/lib/mongoid/errors/invalid_find.rb
+++ b/lib/mongoid/errors/invalid_find.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Errors

--- a/lib/mongoid/errors/invalid_includes.rb
+++ b/lib/mongoid/errors/invalid_includes.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Errors

--- a/lib/mongoid/errors/invalid_index.rb
+++ b/lib/mongoid/errors/invalid_index.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Errors

--- a/lib/mongoid/errors/invalid_options.rb
+++ b/lib/mongoid/errors/invalid_options.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Errors

--- a/lib/mongoid/errors/invalid_path.rb
+++ b/lib/mongoid/errors/invalid_path.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Errors

--- a/lib/mongoid/errors/invalid_persistence_option.rb
+++ b/lib/mongoid/errors/invalid_persistence_option.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Errors

--- a/lib/mongoid/errors/invalid_query.rb
+++ b/lib/mongoid/errors/invalid_query.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Errors

--- a/lib/mongoid/errors/invalid_relation.rb
+++ b/lib/mongoid/errors/invalid_relation.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Errors

--- a/lib/mongoid/errors/invalid_relation_option.rb
+++ b/lib/mongoid/errors/invalid_relation_option.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Errors

--- a/lib/mongoid/errors/invalid_scope.rb
+++ b/lib/mongoid/errors/invalid_scope.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Errors

--- a/lib/mongoid/errors/invalid_session_use.rb
+++ b/lib/mongoid/errors/invalid_session_use.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Errors

--- a/lib/mongoid/errors/invalid_set_polymorphic_relation.rb
+++ b/lib/mongoid/errors/invalid_set_polymorphic_relation.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Errors

--- a/lib/mongoid/errors/invalid_storage_options.rb
+++ b/lib/mongoid/errors/invalid_storage_options.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Errors

--- a/lib/mongoid/errors/invalid_storage_parent.rb
+++ b/lib/mongoid/errors/invalid_storage_parent.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Errors

--- a/lib/mongoid/errors/invalid_time.rb
+++ b/lib/mongoid/errors/invalid_time.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Errors

--- a/lib/mongoid/errors/invalid_value.rb
+++ b/lib/mongoid/errors/invalid_value.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Errors

--- a/lib/mongoid/errors/inverse_not_found.rb
+++ b/lib/mongoid/errors/inverse_not_found.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Errors

--- a/lib/mongoid/errors/mixed_client_configuration.rb
+++ b/lib/mongoid/errors/mixed_client_configuration.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Errors

--- a/lib/mongoid/errors/mixed_relations.rb
+++ b/lib/mongoid/errors/mixed_relations.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Errors

--- a/lib/mongoid/errors/mongoid_error.rb
+++ b/lib/mongoid/errors/mongoid_error.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Errors

--- a/lib/mongoid/errors/nested_attributes_metadata_not_found.rb
+++ b/lib/mongoid/errors/nested_attributes_metadata_not_found.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Errors

--- a/lib/mongoid/errors/no_client_config.rb
+++ b/lib/mongoid/errors/no_client_config.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Errors

--- a/lib/mongoid/errors/no_client_database.rb
+++ b/lib/mongoid/errors/no_client_database.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Errors

--- a/lib/mongoid/errors/no_client_hosts.rb
+++ b/lib/mongoid/errors/no_client_hosts.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Errors

--- a/lib/mongoid/errors/no_clients_config.rb
+++ b/lib/mongoid/errors/no_clients_config.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Errors

--- a/lib/mongoid/errors/no_default_client.rb
+++ b/lib/mongoid/errors/no_default_client.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Errors

--- a/lib/mongoid/errors/no_environment.rb
+++ b/lib/mongoid/errors/no_environment.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Errors

--- a/lib/mongoid/errors/no_map_reduce_output.rb
+++ b/lib/mongoid/errors/no_map_reduce_output.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Errors

--- a/lib/mongoid/errors/no_metadata.rb
+++ b/lib/mongoid/errors/no_metadata.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Errors

--- a/lib/mongoid/errors/no_parent.rb
+++ b/lib/mongoid/errors/no_parent.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Errors

--- a/lib/mongoid/errors/readonly_attribute.rb
+++ b/lib/mongoid/errors/readonly_attribute.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Errors

--- a/lib/mongoid/errors/readonly_document.rb
+++ b/lib/mongoid/errors/readonly_document.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Errors

--- a/lib/mongoid/errors/scope_overwrite.rb
+++ b/lib/mongoid/errors/scope_overwrite.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Errors

--- a/lib/mongoid/errors/too_many_nested_attribute_records.rb
+++ b/lib/mongoid/errors/too_many_nested_attribute_records.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Errors

--- a/lib/mongoid/errors/unknown_attribute.rb
+++ b/lib/mongoid/errors/unknown_attribute.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Errors

--- a/lib/mongoid/errors/unknown_model.rb
+++ b/lib/mongoid/errors/unknown_model.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Errors

--- a/lib/mongoid/errors/unsaved_document.rb
+++ b/lib/mongoid/errors/unsaved_document.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Errors

--- a/lib/mongoid/errors/unsupported_javascript.rb
+++ b/lib/mongoid/errors/unsupported_javascript.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Errors

--- a/lib/mongoid/errors/validations.rb
+++ b/lib/mongoid/errors/validations.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Errors

--- a/lib/mongoid/evolvable.rb
+++ b/lib/mongoid/evolvable.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
 

--- a/lib/mongoid/extensions.rb
+++ b/lib/mongoid/extensions.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class BSON::ObjectId
   def as_json(options = nil)

--- a/lib/mongoid/extensions/array.rb
+++ b/lib/mongoid/extensions/array.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Extensions

--- a/lib/mongoid/extensions/big_decimal.rb
+++ b/lib/mongoid/extensions/big_decimal.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Extensions

--- a/lib/mongoid/extensions/boolean.rb
+++ b/lib/mongoid/extensions/boolean.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   class Boolean

--- a/lib/mongoid/extensions/date.rb
+++ b/lib/mongoid/extensions/date.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Extensions

--- a/lib/mongoid/extensions/date_time.rb
+++ b/lib/mongoid/extensions/date_time.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Extensions

--- a/lib/mongoid/extensions/decimal128.rb
+++ b/lib/mongoid/extensions/decimal128.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Extensions

--- a/lib/mongoid/extensions/false_class.rb
+++ b/lib/mongoid/extensions/false_class.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Extensions

--- a/lib/mongoid/extensions/float.rb
+++ b/lib/mongoid/extensions/float.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Extensions

--- a/lib/mongoid/extensions/hash.rb
+++ b/lib/mongoid/extensions/hash.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Extensions

--- a/lib/mongoid/extensions/integer.rb
+++ b/lib/mongoid/extensions/integer.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Extensions

--- a/lib/mongoid/extensions/module.rb
+++ b/lib/mongoid/extensions/module.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Extensions

--- a/lib/mongoid/extensions/nil_class.rb
+++ b/lib/mongoid/extensions/nil_class.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Extensions

--- a/lib/mongoid/extensions/object.rb
+++ b/lib/mongoid/extensions/object.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Extensions

--- a/lib/mongoid/extensions/object_id.rb
+++ b/lib/mongoid/extensions/object_id.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Extensions

--- a/lib/mongoid/extensions/range.rb
+++ b/lib/mongoid/extensions/range.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Extensions

--- a/lib/mongoid/extensions/regexp.rb
+++ b/lib/mongoid/extensions/regexp.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Extensions

--- a/lib/mongoid/extensions/set.rb
+++ b/lib/mongoid/extensions/set.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Extensions

--- a/lib/mongoid/extensions/string.rb
+++ b/lib/mongoid/extensions/string.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Extensions

--- a/lib/mongoid/extensions/symbol.rb
+++ b/lib/mongoid/extensions/symbol.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Extensions

--- a/lib/mongoid/extensions/time.rb
+++ b/lib/mongoid/extensions/time.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Extensions

--- a/lib/mongoid/extensions/time_with_zone.rb
+++ b/lib/mongoid/extensions/time_with_zone.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Extensions

--- a/lib/mongoid/extensions/true_class.rb
+++ b/lib/mongoid/extensions/true_class.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Extensions

--- a/lib/mongoid/factory.rb
+++ b/lib/mongoid/factory.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
 

--- a/lib/mongoid/fields.rb
+++ b/lib/mongoid/fields.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "mongoid/fields/standard"
 require "mongoid/fields/foreign_key"

--- a/lib/mongoid/fields/foreign_key.rb
+++ b/lib/mongoid/fields/foreign_key.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Fields

--- a/lib/mongoid/fields/localized.rb
+++ b/lib/mongoid/fields/localized.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Fields

--- a/lib/mongoid/fields/standard.rb
+++ b/lib/mongoid/fields/standard.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Fields

--- a/lib/mongoid/fields/validators.rb
+++ b/lib/mongoid/fields/validators.rb
@@ -1,4 +1,3 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "mongoid/fields/validators/macro"

--- a/lib/mongoid/fields/validators/macro.rb
+++ b/lib/mongoid/fields/validators/macro.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Fields

--- a/lib/mongoid/findable.rb
+++ b/lib/mongoid/findable.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
 

--- a/lib/mongoid/indexable.rb
+++ b/lib/mongoid/indexable.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "mongoid/indexable/specification"
 require "mongoid/indexable/validators/options"

--- a/lib/mongoid/indexable/specification.rb
+++ b/lib/mongoid/indexable/specification.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Indexable

--- a/lib/mongoid/indexable/validators/options.rb
+++ b/lib/mongoid/indexable/validators/options.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Indexable

--- a/lib/mongoid/inspectable.rb
+++ b/lib/mongoid/inspectable.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
 

--- a/lib/mongoid/interceptable.rb
+++ b/lib/mongoid/interceptable.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
 

--- a/lib/mongoid/loggable.rb
+++ b/lib/mongoid/loggable.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
 

--- a/lib/mongoid/matchable.rb
+++ b/lib/mongoid/matchable.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
 

--- a/lib/mongoid/persistable.rb
+++ b/lib/mongoid/persistable.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "mongoid/persistable/creatable"
 require "mongoid/persistable/deletable"

--- a/lib/mongoid/persistable/creatable.rb
+++ b/lib/mongoid/persistable/creatable.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Persistable

--- a/lib/mongoid/persistable/deletable.rb
+++ b/lib/mongoid/persistable/deletable.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Persistable

--- a/lib/mongoid/persistable/destroyable.rb
+++ b/lib/mongoid/persistable/destroyable.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Persistable

--- a/lib/mongoid/persistable/incrementable.rb
+++ b/lib/mongoid/persistable/incrementable.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Persistable

--- a/lib/mongoid/persistable/logical.rb
+++ b/lib/mongoid/persistable/logical.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Persistable

--- a/lib/mongoid/persistable/poppable.rb
+++ b/lib/mongoid/persistable/poppable.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Persistable

--- a/lib/mongoid/persistable/pullable.rb
+++ b/lib/mongoid/persistable/pullable.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Persistable

--- a/lib/mongoid/persistable/pushable.rb
+++ b/lib/mongoid/persistable/pushable.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Persistable

--- a/lib/mongoid/persistable/renamable.rb
+++ b/lib/mongoid/persistable/renamable.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Persistable

--- a/lib/mongoid/persistable/savable.rb
+++ b/lib/mongoid/persistable/savable.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Persistable

--- a/lib/mongoid/persistable/settable.rb
+++ b/lib/mongoid/persistable/settable.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Persistable

--- a/lib/mongoid/persistable/unsettable.rb
+++ b/lib/mongoid/persistable/unsettable.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Persistable

--- a/lib/mongoid/persistable/updatable.rb
+++ b/lib/mongoid/persistable/updatable.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Persistable

--- a/lib/mongoid/persistable/upsertable.rb
+++ b/lib/mongoid/persistable/upsertable.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Persistable

--- a/lib/mongoid/persistence_context.rb
+++ b/lib/mongoid/persistence_context.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
 

--- a/lib/mongoid/positional.rb
+++ b/lib/mongoid/positional.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
 

--- a/lib/mongoid/query_cache.rb
+++ b/lib/mongoid/query_cache.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
 

--- a/lib/mongoid/railtie.rb
+++ b/lib/mongoid/railtie.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "rails"
 require "rails/mongoid"

--- a/lib/mongoid/railties/controller_runtime.rb
+++ b/lib/mongoid/railties/controller_runtime.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Railties

--- a/lib/mongoid/reloadable.rb
+++ b/lib/mongoid/reloadable.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
 

--- a/lib/mongoid/scopable.rb
+++ b/lib/mongoid/scopable.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
 

--- a/lib/mongoid/selectable.rb
+++ b/lib/mongoid/selectable.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
 

--- a/lib/mongoid/serializable.rb
+++ b/lib/mongoid/serializable.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
 

--- a/lib/mongoid/shardable.rb
+++ b/lib/mongoid/shardable.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
 

--- a/lib/mongoid/stateful.rb
+++ b/lib/mongoid/stateful.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
 

--- a/lib/mongoid/stringified_symbol.rb
+++ b/lib/mongoid/stringified_symbol.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 # A class which sends values to the database as Strings but returns them to the user as Symbols.
 module Mongoid

--- a/lib/mongoid/tasks/database.rb
+++ b/lib/mongoid/tasks/database.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Tasks

--- a/lib/mongoid/threaded.rb
+++ b/lib/mongoid/threaded.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "mongoid/threaded/lifecycle"
 

--- a/lib/mongoid/threaded/lifecycle.rb
+++ b/lib/mongoid/threaded/lifecycle.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Threaded

--- a/lib/mongoid/timestamps.rb
+++ b/lib/mongoid/timestamps.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "mongoid/timestamps/timeless"
 require "mongoid/timestamps/created"

--- a/lib/mongoid/timestamps/created.rb
+++ b/lib/mongoid/timestamps/created.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "mongoid/timestamps/created/short"
 

--- a/lib/mongoid/timestamps/created/short.rb
+++ b/lib/mongoid/timestamps/created/short.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Timestamps

--- a/lib/mongoid/timestamps/short.rb
+++ b/lib/mongoid/timestamps/short.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Timestamps

--- a/lib/mongoid/timestamps/timeless.rb
+++ b/lib/mongoid/timestamps/timeless.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Timestamps

--- a/lib/mongoid/timestamps/updated.rb
+++ b/lib/mongoid/timestamps/updated.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "mongoid/timestamps/updated/short"
 

--- a/lib/mongoid/timestamps/updated/short.rb
+++ b/lib/mongoid/timestamps/updated/short.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Timestamps

--- a/lib/mongoid/touchable.rb
+++ b/lib/mongoid/touchable.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Touchable

--- a/lib/mongoid/traversable.rb
+++ b/lib/mongoid/traversable.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "mongoid/fields/validators/macro"
 

--- a/lib/mongoid/validatable.rb
+++ b/lib/mongoid/validatable.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "mongoid/validatable/macros"
 require "mongoid/validatable/localizable"

--- a/lib/mongoid/validatable/associated.rb
+++ b/lib/mongoid/validatable/associated.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Validatable

--- a/lib/mongoid/validatable/format.rb
+++ b/lib/mongoid/validatable/format.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Validatable

--- a/lib/mongoid/validatable/length.rb
+++ b/lib/mongoid/validatable/length.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Validatable

--- a/lib/mongoid/validatable/localizable.rb
+++ b/lib/mongoid/validatable/localizable.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Validatable

--- a/lib/mongoid/validatable/macros.rb
+++ b/lib/mongoid/validatable/macros.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Validatable

--- a/lib/mongoid/validatable/presence.rb
+++ b/lib/mongoid/validatable/presence.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Validatable

--- a/lib/mongoid/validatable/queryable.rb
+++ b/lib/mongoid/validatable/queryable.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Validatable

--- a/lib/mongoid/validatable/uniqueness.rb
+++ b/lib/mongoid/validatable/uniqueness.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Validatable

--- a/lib/mongoid/version.rb
+++ b/lib/mongoid/version.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   VERSION = "7.3.0"

--- a/lib/rails/generators/mongoid/config/config_generator.rb
+++ b/lib/rails/generators/mongoid/config/config_generator.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require 'rails/generators/mongoid_generator'
 

--- a/lib/rails/generators/mongoid/model/model_generator.rb
+++ b/lib/rails/generators/mongoid/model/model_generator.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "rails/generators/mongoid_generator"
 

--- a/lib/rails/generators/mongoid_generator.rb
+++ b/lib/rails/generators/mongoid_generator.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "rails/generators/named_base"
 require "rails/generators/active_model"

--- a/lib/rails/mongoid.rb
+++ b/lib/rails/mongoid.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Rails
   module Mongoid

--- a/lib/support/ruby_version.rb
+++ b/lib/support/ruby_version.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 # Go ahead and fail if not using Ruby 1.9.3, no since in letting people
 # squarm for answers

--- a/mongoid.gemspec
+++ b/mongoid.gemspec
@@ -1,4 +1,5 @@
-# encoding: utf-8
+# frozen_string_literal: true
+
 lib = File.expand_path('../lib/', __FILE__)
 $:.unshift lib unless $:.include?(lib)
 

--- a/perf/benchmark.rb
+++ b/perf/benchmark.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "benchmark"
 require "mongoid"

--- a/perf/benchmark_ips.rb
+++ b/perf/benchmark_ips.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "benchmark/ips"
 require "mongoid"

--- a/perf/benchmark_ips_iteration_cases.rb
+++ b/perf/benchmark_ips_iteration_cases.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "benchmark/ips"
 require "mongoid"

--- a/perf/gc_suite.rb
+++ b/perf/gc_suite.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class GCSuite
   def warming(*)

--- a/perf/models.rb
+++ b/perf/models.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Person
   include Mongoid::Document

--- a/perf/profile.rb
+++ b/perf/profile.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "perftools"
 require "mongoid"

--- a/spec/integration/app_spec.rb
+++ b/spec/integration/app_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require 'spec_helper'
 

--- a/spec/integration/associations/belongs_to_spec.rb
+++ b/spec/integration/associations/belongs_to_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require 'spec_helper'
 require_relative '../../mongoid/association/referenced/has_one_models'

--- a/spec/integration/associations/embedded_spec.rb
+++ b/spec/integration/associations/embedded_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require 'spec_helper'
 require_relative '../../mongoid/association/embedded/embeds_many_models'

--- a/spec/integration/associations/embeds_many_spec.rb
+++ b/spec/integration/associations/embeds_many_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require 'spec_helper'
 

--- a/spec/integration/associations/embeds_one_spec.rb
+++ b/spec/integration/associations/embeds_one_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require 'spec_helper'
 

--- a/spec/integration/associations/foreign_key_spec.rb
+++ b/spec/integration/associations/foreign_key_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require 'spec_helper'
 require_relative './foreign_key_spec_models'

--- a/spec/integration/associations/foreign_key_spec_models.rb
+++ b/spec/integration/associations/foreign_key_spec_models.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module ForeignKeySpec
   class Company

--- a/spec/integration/associations/has_many_spec.rb
+++ b/spec/integration/associations/has_many_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require 'spec_helper'
 require 'mongoid/association/referenced/has_many_models'

--- a/spec/integration/associations/has_one_spec.rb
+++ b/spec/integration/associations/has_one_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require 'spec_helper'
 require 'mongoid/association/referenced/has_one_models'

--- a/spec/integration/associations/nested_attributes_assignment_spec.rb
+++ b/spec/integration/associations/nested_attributes_assignment_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require 'spec_helper'
 

--- a/spec/integration/associations/reverse_population_spec.rb
+++ b/spec/integration/associations/reverse_population_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require 'spec_helper'
 require_relative './reverse_population_spec_models'

--- a/spec/integration/associations/reverse_population_spec_models.rb
+++ b/spec/integration/associations/reverse_population_spec_models.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module ReversePopulationSpec
   class Company

--- a/spec/integration/atomic/modifiers_spec.rb
+++ b/spec/integration/atomic/modifiers_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/integration/bson_regexp_raw_spec.rb
+++ b/spec/integration/bson_regexp_raw_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require 'spec_helper'
 

--- a/spec/integration/callbacks_spec.rb
+++ b/spec/integration/callbacks_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require 'spec_helper'
 require_relative './callbacks_models'

--- a/spec/integration/criteria/date_field_spec.rb
+++ b/spec/integration/criteria/date_field_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require 'spec_helper'
 

--- a/spec/integration/criteria/time_with_zone_spec.rb
+++ b/spec/integration/criteria/time_with_zone_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require 'spec_helper'
 

--- a/spec/integration/discriminator_key_spec.rb
+++ b/spec/integration/discriminator_key_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require 'spec_helper'
 

--- a/spec/integration/discriminator_value_spec.rb
+++ b/spec/integration/discriminator_value_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require 'spec_helper'
 

--- a/spec/integration/document_spec.rb
+++ b/spec/integration/document_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require 'spec_helper'
 

--- a/spec/integration/i18n_fallbacks_spec.rb
+++ b/spec/integration/i18n_fallbacks_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require 'spec_helper'
 

--- a/spec/integration/matcher_examples_spec.rb
+++ b/spec/integration/matcher_examples_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require 'spec_helper'
 

--- a/spec/integration/matcher_operator_spec.rb
+++ b/spec/integration/matcher_operator_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require 'spec_helper'
 

--- a/spec/integration/matcher_spec.rb
+++ b/spec/integration/matcher_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require 'spec_helper'
 

--- a/spec/integration/server_query_spec.rb
+++ b/spec/integration/server_query_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require 'spec_helper'
 

--- a/spec/integration/shardable_spec.rb
+++ b/spec/integration/shardable_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require 'spec_helper'
 require_relative '../mongoid/shardable_models'

--- a/spec/mongoid/association/accessors_spec.rb
+++ b/spec/mongoid/association/accessors_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/association/auto_save_spec.rb
+++ b/spec/mongoid/association/auto_save_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/association/builders_spec.rb
+++ b/spec/mongoid/association/builders_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/association/constrainable_spec.rb
+++ b/spec/mongoid/association/constrainable_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/association/counter_cache_spec.rb
+++ b/spec/mongoid/association/counter_cache_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/association/depending_spec.rb
+++ b/spec/mongoid/association/depending_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/association/eager_spec.rb
+++ b/spec/mongoid/association/eager_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/association/embedded/cyclic_spec.rb
+++ b/spec/mongoid/association/embedded/cyclic_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/association/embedded/dirty_spec.rb
+++ b/spec/mongoid/association/embedded/dirty_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require 'spec_helper'
 

--- a/spec/mongoid/association/embedded/embedded_in/binding_spec.rb
+++ b/spec/mongoid/association/embedded/embedded_in/binding_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/association/embedded/embedded_in/buildable_spec.rb
+++ b/spec/mongoid/association/embedded/embedded_in/buildable_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/association/embedded/embedded_in/proxy_spec.rb
+++ b/spec/mongoid/association/embedded/embedded_in/proxy_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/association/embedded/embedded_in_spec.rb
+++ b/spec/mongoid/association/embedded/embedded_in_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 require_relative './embeds_one_models'

--- a/spec/mongoid/association/embedded/embeds_many/binding_spec.rb
+++ b/spec/mongoid/association/embedded/embeds_many/binding_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/association/embedded/embeds_many/buildable_spec.rb
+++ b/spec/mongoid/association/embedded/embeds_many/buildable_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/association/embedded/embeds_many/proxy_spec.rb
+++ b/spec/mongoid/association/embedded/embeds_many/proxy_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/association/embedded/embeds_many_models.rb
+++ b/spec/mongoid/association/embedded/embeds_many_models.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class EmmCongress
   include Mongoid::Document

--- a/spec/mongoid/association/embedded/embeds_many_query_spec.rb
+++ b/spec/mongoid/association/embedded/embeds_many_query_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 require_relative './embeds_many_models'

--- a/spec/mongoid/association/embedded/embeds_many_spec.rb
+++ b/spec/mongoid/association/embedded/embeds_many_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/association/embedded/embeds_one/binding_spec.rb
+++ b/spec/mongoid/association/embedded/embeds_one/binding_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/association/embedded/embeds_one/buildable_spec.rb
+++ b/spec/mongoid/association/embedded/embeds_one/buildable_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/association/embedded/embeds_one/proxy_spec.rb
+++ b/spec/mongoid/association/embedded/embeds_one/proxy_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/association/embedded/embeds_one_dnl_models.rb
+++ b/spec/mongoid/association/embedded/embeds_one_dnl_models.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 # This file is added as an autoload target, but should never be actually
 # processed.

--- a/spec/mongoid/association/embedded/embeds_one_models.rb
+++ b/spec/mongoid/association/embedded/embeds_one_models.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class EomParent
   include Mongoid::Document

--- a/spec/mongoid/association/embedded/embeds_one_query_spec.rb
+++ b/spec/mongoid/association/embedded/embeds_one_query_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 require_relative './embeds_one_models'

--- a/spec/mongoid/association/embedded/embeds_one_spec.rb
+++ b/spec/mongoid/association/embedded/embeds_one_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 require_relative './embeds_one_models'

--- a/spec/mongoid/association/macros_spec.rb
+++ b/spec/mongoid/association/macros_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/association/nested/many_spec.rb
+++ b/spec/mongoid/association/nested/many_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/association/nested/one_spec.rb
+++ b/spec/mongoid/association/nested/one_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/association/options_spec.rb
+++ b/spec/mongoid/association/options_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/association/polymorphic_spec.rb
+++ b/spec/mongoid/association/polymorphic_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/association/referenced/belongs_to/binding_spec.rb
+++ b/spec/mongoid/association/referenced/belongs_to/binding_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/association/referenced/belongs_to/buildable_spec.rb
+++ b/spec/mongoid/association/referenced/belongs_to/buildable_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/association/referenced/belongs_to/eager_spec.rb
+++ b/spec/mongoid/association/referenced/belongs_to/eager_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 require_relative '../has_many_models'

--- a/spec/mongoid/association/referenced/belongs_to/proxy_spec.rb
+++ b/spec/mongoid/association/referenced/belongs_to/proxy_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/association/referenced/belongs_to_query_spec.rb
+++ b/spec/mongoid/association/referenced/belongs_to_query_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 require_relative './has_many_models'

--- a/spec/mongoid/association/referenced/belongs_to_spec.rb
+++ b/spec/mongoid/association/referenced/belongs_to_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 require_relative './has_one_models'

--- a/spec/mongoid/association/referenced/has_and_belongs_to_many/binding_spec.rb
+++ b/spec/mongoid/association/referenced/has_and_belongs_to_many/binding_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/association/referenced/has_and_belongs_to_many/buildable_spec.rb
+++ b/spec/mongoid/association/referenced/has_and_belongs_to_many/buildable_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/association/referenced/has_and_belongs_to_many/eager_spec.rb
+++ b/spec/mongoid/association/referenced/has_and_belongs_to_many/eager_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 require_relative '../has_and_belongs_to_many_models'

--- a/spec/mongoid/association/referenced/has_and_belongs_to_many/proxy_persistence_spec.rb
+++ b/spec/mongoid/association/referenced/has_and_belongs_to_many/proxy_persistence_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 require_relative '../has_and_belongs_to_many_models'

--- a/spec/mongoid/association/referenced/has_and_belongs_to_many/proxy_spec.rb
+++ b/spec/mongoid/association/referenced/has_and_belongs_to_many/proxy_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/association/referenced/has_and_belongs_to_many_models.rb
+++ b/spec/mongoid/association/referenced/has_and_belongs_to_many_models.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class HabtmmCompany
   include Mongoid::Document

--- a/spec/mongoid/association/referenced/has_and_belongs_to_many_query_spec.rb
+++ b/spec/mongoid/association/referenced/has_and_belongs_to_many_query_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 require_relative './has_and_belongs_to_many_models'

--- a/spec/mongoid/association/referenced/has_and_belongs_to_many_spec.rb
+++ b/spec/mongoid/association/referenced/has_and_belongs_to_many_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/association/referenced/has_many/binding_spec.rb
+++ b/spec/mongoid/association/referenced/has_many/binding_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/association/referenced/has_many/buildable_spec.rb
+++ b/spec/mongoid/association/referenced/has_many/buildable_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/association/referenced/has_many/eager_spec.rb
+++ b/spec/mongoid/association/referenced/has_many/eager_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/association/referenced/has_many/enumerable_spec.rb
+++ b/spec/mongoid/association/referenced/has_many/enumerable_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/association/referenced/has_many/proxy_query_spec.rb
+++ b/spec/mongoid/association/referenced/has_many/proxy_query_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 require_relative '../has_many_models'

--- a/spec/mongoid/association/referenced/has_many/proxy_spec.rb
+++ b/spec/mongoid/association/referenced/has_many/proxy_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/association/referenced/has_many_models.rb
+++ b/spec/mongoid/association/referenced/has_many_models.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class HmmCompany
   include Mongoid::Document

--- a/spec/mongoid/association/referenced/has_many_query_spec.rb
+++ b/spec/mongoid/association/referenced/has_many_query_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 require_relative './has_many_models'

--- a/spec/mongoid/association/referenced/has_many_spec.rb
+++ b/spec/mongoid/association/referenced/has_many_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/association/referenced/has_one/binding_spec.rb
+++ b/spec/mongoid/association/referenced/has_one/binding_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/association/referenced/has_one/buildable_spec.rb
+++ b/spec/mongoid/association/referenced/has_one/buildable_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/association/referenced/has_one/eager_spec.rb
+++ b/spec/mongoid/association/referenced/has_one/eager_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/association/referenced/has_one/proxy_spec.rb
+++ b/spec/mongoid/association/referenced/has_one/proxy_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/association/referenced/has_one_models.rb
+++ b/spec/mongoid/association/referenced/has_one_models.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class HomCollege
   include Mongoid::Document

--- a/spec/mongoid/association/referenced/has_one_query_spec.rb
+++ b/spec/mongoid/association/referenced/has_one_query_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 require_relative './has_one_models'

--- a/spec/mongoid/association/referenced/has_one_spec.rb
+++ b/spec/mongoid/association/referenced/has_one_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 require_relative './has_one_models'

--- a/spec/mongoid/association/reflections_spec.rb
+++ b/spec/mongoid/association/reflections_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/association/syncable_spec.rb
+++ b/spec/mongoid/association/syncable_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/association_spec.rb
+++ b/spec/mongoid/association_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/atomic/modifiers_spec.rb
+++ b/spec/mongoid/atomic/modifiers_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/atomic/paths/embedded/many_spec.rb
+++ b/spec/mongoid/atomic/paths/embedded/many_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/atomic/paths/embedded/one_spec.rb
+++ b/spec/mongoid/atomic/paths/embedded/one_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/atomic/paths/root_spec.rb
+++ b/spec/mongoid/atomic/paths/root_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/atomic/paths_spec.rb
+++ b/spec/mongoid/atomic/paths_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/atomic_spec.rb
+++ b/spec/mongoid/atomic_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/attributes/dynamic_spec.rb
+++ b/spec/mongoid/attributes/dynamic_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/attributes/nested_spec.rb
+++ b/spec/mongoid/attributes/nested_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/attributes/projector_spec.rb
+++ b/spec/mongoid/attributes/projector_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/attributes/readonly_spec.rb
+++ b/spec/mongoid/attributes/readonly_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/attributes_spec.rb
+++ b/spec/mongoid/attributes_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/cacheable_spec.rb
+++ b/spec/mongoid/cacheable_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/changeable_spec.rb
+++ b/spec/mongoid/changeable_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/clients/factory_spec.rb
+++ b/spec/mongoid/clients/factory_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/clients/options_spec.rb
+++ b/spec/mongoid/clients/options_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/clients/sessions_spec.rb
+++ b/spec/mongoid/clients/sessions_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/clients/transactions_spec.rb
+++ b/spec/mongoid/clients/transactions_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/clients_spec.rb
+++ b/spec/mongoid/clients_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/composable_spec.rb
+++ b/spec/mongoid/composable_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/config/environment_spec.rb
+++ b/spec/mongoid/config/environment_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/config/options_spec.rb
+++ b/spec/mongoid/config/options_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/config_spec.rb
+++ b/spec/mongoid/config_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/contextual/aggregable/memory_spec.rb
+++ b/spec/mongoid/contextual/aggregable/memory_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/contextual/aggregable/mongo_spec.rb
+++ b/spec/mongoid/contextual/aggregable/mongo_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/contextual/atomic_spec.rb
+++ b/spec/mongoid/contextual/atomic_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/contextual/geo_near_spec.rb
+++ b/spec/mongoid/contextual/geo_near_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/contextual/map_reduce_spec.rb
+++ b/spec/mongoid/contextual/map_reduce_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/contextual/memory_spec.rb
+++ b/spec/mongoid/contextual/memory_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/contextual/mongo_spec.rb
+++ b/spec/mongoid/contextual/mongo_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/contextual/none_spec.rb
+++ b/spec/mongoid/contextual/none_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/copyable_spec.rb
+++ b/spec/mongoid/copyable_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/copyable_spec_models.rb
+++ b/spec/mongoid/copyable_spec_models.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module CopyableSpec
   class A

--- a/spec/mongoid/criteria/findable_spec.rb
+++ b/spec/mongoid/criteria/findable_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/criteria/inspectable_spec.rb
+++ b/spec/mongoid/criteria/inspectable_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/criteria/marshalable_spec.rb
+++ b/spec/mongoid/criteria/marshalable_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/criteria/modifiable_spec.rb
+++ b/spec/mongoid/criteria/modifiable_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/criteria/options_spec.rb
+++ b/spec/mongoid/criteria/options_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/criteria/queryable/aggregable_spec.rb
+++ b/spec/mongoid/criteria/queryable/aggregable_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/criteria/queryable/expandable_spec.rb
+++ b/spec/mongoid/criteria/queryable/expandable_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/criteria/queryable/extensions/array_spec.rb
+++ b/spec/mongoid/criteria/queryable/extensions/array_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/criteria/queryable/extensions/big_decimal_spec.rb
+++ b/spec/mongoid/criteria/queryable/extensions/big_decimal_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/criteria/queryable/extensions/bignum_spec.rb
+++ b/spec/mongoid/criteria/queryable/extensions/bignum_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/criteria/queryable/extensions/boolean_spec.rb
+++ b/spec/mongoid/criteria/queryable/extensions/boolean_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/criteria/queryable/extensions/date_spec.rb
+++ b/spec/mongoid/criteria/queryable/extensions/date_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/criteria/queryable/extensions/date_time_spec.rb
+++ b/spec/mongoid/criteria/queryable/extensions/date_time_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/criteria/queryable/extensions/fixnum_spec.rb
+++ b/spec/mongoid/criteria/queryable/extensions/fixnum_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/criteria/queryable/extensions/float_spec.rb
+++ b/spec/mongoid/criteria/queryable/extensions/float_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/criteria/queryable/extensions/hash_spec.rb
+++ b/spec/mongoid/criteria/queryable/extensions/hash_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/criteria/queryable/extensions/integer_spec.rb
+++ b/spec/mongoid/criteria/queryable/extensions/integer_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/criteria/queryable/extensions/nil_class_spec.rb
+++ b/spec/mongoid/criteria/queryable/extensions/nil_class_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/criteria/queryable/extensions/numeric_spec.rb
+++ b/spec/mongoid/criteria/queryable/extensions/numeric_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/criteria/queryable/extensions/object_spec.rb
+++ b/spec/mongoid/criteria/queryable/extensions/object_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/criteria/queryable/extensions/range_spec.rb
+++ b/spec/mongoid/criteria/queryable/extensions/range_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/criteria/queryable/extensions/regexp_raw_spec.rb
+++ b/spec/mongoid/criteria/queryable/extensions/regexp_raw_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/criteria/queryable/extensions/regexp_spec.rb
+++ b/spec/mongoid/criteria/queryable/extensions/regexp_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/criteria/queryable/extensions/set_spec.rb
+++ b/spec/mongoid/criteria/queryable/extensions/set_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/criteria/queryable/extensions/string_spec.rb
+++ b/spec/mongoid/criteria/queryable/extensions/string_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/criteria/queryable/extensions/symbol_spec.rb
+++ b/spec/mongoid/criteria/queryable/extensions/symbol_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/criteria/queryable/extensions/time_spec.rb
+++ b/spec/mongoid/criteria/queryable/extensions/time_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "lite_spec_helper"
 

--- a/spec/mongoid/criteria/queryable/extensions/time_with_zone_spec.rb
+++ b/spec/mongoid/criteria/queryable/extensions/time_with_zone_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/criteria/queryable/key_spec.rb
+++ b/spec/mongoid/criteria/queryable/key_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/criteria/queryable/mergeable_spec.rb
+++ b/spec/mongoid/criteria/queryable/mergeable_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/criteria/queryable/optional_spec.rb
+++ b/spec/mongoid/criteria/queryable/optional_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/criteria/queryable/options_spec.rb
+++ b/spec/mongoid/criteria/queryable/options_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/criteria/queryable/pipeline_spec.rb
+++ b/spec/mongoid/criteria/queryable/pipeline_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/criteria/queryable/queryable_spec.rb
+++ b/spec/mongoid/criteria/queryable/queryable_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/criteria/queryable/selectable_logical_spec.rb
+++ b/spec/mongoid/criteria/queryable/selectable_logical_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/criteria/queryable/selectable_shared_examples.rb
+++ b/spec/mongoid/criteria/queryable/selectable_shared_examples.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 shared_examples_for "returns a cloned query" do
 

--- a/spec/mongoid/criteria/queryable/selectable_spec.rb
+++ b/spec/mongoid/criteria/queryable/selectable_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 require_relative './selectable_shared_examples'

--- a/spec/mongoid/criteria/queryable/selectable_where_spec.rb
+++ b/spec/mongoid/criteria/queryable/selectable_where_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 require_relative './selectable_shared_examples'

--- a/spec/mongoid/criteria/queryable/selector_spec.rb
+++ b/spec/mongoid/criteria/queryable/selector_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/criteria/queryable/smash_spec.rb
+++ b/spec/mongoid/criteria/queryable/smash_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/criteria/queryable/storable_spec.rb
+++ b/spec/mongoid/criteria/queryable/storable_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/criteria/scopable_spec.rb
+++ b/spec/mongoid/criteria/scopable_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/criteria_projection_spec.rb
+++ b/spec/mongoid/criteria_projection_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/criteria_spec.rb
+++ b/spec/mongoid/criteria_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/document_fields_spec.rb
+++ b/spec/mongoid/document_fields_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/document_persistence_context_spec.rb
+++ b/spec/mongoid/document_persistence_context_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/document_query_spec.rb
+++ b/spec/mongoid/document_query_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/document_spec.rb
+++ b/spec/mongoid/document_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/equality_spec.rb
+++ b/spec/mongoid/equality_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/errors/ambiguous_relationship_spec.rb
+++ b/spec/mongoid/errors/ambiguous_relationship_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require 'spec_helper'
 

--- a/spec/mongoid/errors/callback_spec.rb
+++ b/spec/mongoid/errors/callback_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/errors/delete_restriction_spec.rb
+++ b/spec/mongoid/errors/delete_restriction_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/errors/document_not_destroyed_spec.rb
+++ b/spec/mongoid/errors/document_not_destroyed_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/errors/document_not_found_spec.rb
+++ b/spec/mongoid/errors/document_not_found_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/errors/eager_load_spec.rb
+++ b/spec/mongoid/errors/eager_load_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/errors/invalid_collection_spec.rb
+++ b/spec/mongoid/errors/invalid_collection_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/errors/invalid_config_option_spec.rb
+++ b/spec/mongoid/errors/invalid_config_option_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/errors/invalid_field_option_spec.rb
+++ b/spec/mongoid/errors/invalid_field_option_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/errors/invalid_field_spec.rb
+++ b/spec/mongoid/errors/invalid_field_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/errors/invalid_find_spec.rb
+++ b/spec/mongoid/errors/invalid_find_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/errors/invalid_includes_spec.rb
+++ b/spec/mongoid/errors/invalid_includes_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/errors/invalid_index_spec.rb
+++ b/spec/mongoid/errors/invalid_index_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/errors/invalid_options_spec.rb
+++ b/spec/mongoid/errors/invalid_options_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/errors/invalid_path_spec.rb
+++ b/spec/mongoid/errors/invalid_path_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require 'spec_helper'
 

--- a/spec/mongoid/errors/invalid_relation_spec.rb
+++ b/spec/mongoid/errors/invalid_relation_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/errors/invalid_scope_spec.rb
+++ b/spec/mongoid/errors/invalid_scope_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/errors/invalid_set_polymorphic_relation_spec.rb
+++ b/spec/mongoid/errors/invalid_set_polymorphic_relation_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/errors/invalid_storage_options_spec.rb
+++ b/spec/mongoid/errors/invalid_storage_options_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/errors/invalid_time_spec.rb
+++ b/spec/mongoid/errors/invalid_time_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/errors/inverse_not_found_spec.rb
+++ b/spec/mongoid/errors/inverse_not_found_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/errors/mixed_client_configuration_spec.rb
+++ b/spec/mongoid/errors/mixed_client_configuration_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/errors/mixed_relations_spec.rb
+++ b/spec/mongoid/errors/mixed_relations_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/errors/mongoid_error_spec.rb
+++ b/spec/mongoid/errors/mongoid_error_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require 'spec_helper'
 

--- a/spec/mongoid/errors/nested_attributes_metadata_not_found_spec.rb
+++ b/spec/mongoid/errors/nested_attributes_metadata_not_found_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/errors/no_client_config_spec.rb
+++ b/spec/mongoid/errors/no_client_config_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/errors/no_client_database_spec.rb
+++ b/spec/mongoid/errors/no_client_database_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/errors/no_client_hosts_spec.rb
+++ b/spec/mongoid/errors/no_client_hosts_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/errors/no_clients_config_spec.rb
+++ b/spec/mongoid/errors/no_clients_config_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/errors/no_environment_spec.rb
+++ b/spec/mongoid/errors/no_environment_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/errors/no_map_reduce_output_spec.rb
+++ b/spec/mongoid/errors/no_map_reduce_output_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/errors/no_metadata_spec.rb
+++ b/spec/mongoid/errors/no_metadata_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require 'spec_helper'
 

--- a/spec/mongoid/errors/no_parent_spec.rb
+++ b/spec/mongoid/errors/no_parent_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/errors/readonly_attribute_spec.rb
+++ b/spec/mongoid/errors/readonly_attribute_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/errors/readonly_document_spec.rb
+++ b/spec/mongoid/errors/readonly_document_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/errors/scope_overwrite_spec.rb
+++ b/spec/mongoid/errors/scope_overwrite_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/errors/too_many_nested_attribute_records_spec.rb
+++ b/spec/mongoid/errors/too_many_nested_attribute_records_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/errors/unknown_attribute_spec.rb
+++ b/spec/mongoid/errors/unknown_attribute_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/errors/unsaved_document_spec.rb
+++ b/spec/mongoid/errors/unsaved_document_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/errors/unsupported_javascript_spec.rb
+++ b/spec/mongoid/errors/unsupported_javascript_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/errors/validations_spec.rb
+++ b/spec/mongoid/errors/validations_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/extensions/array_spec.rb
+++ b/spec/mongoid/extensions/array_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/extensions/big_decimal_spec.rb
+++ b/spec/mongoid/extensions/big_decimal_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/extensions/binary_spec.rb
+++ b/spec/mongoid/extensions/binary_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/extensions/boolean_spec.rb
+++ b/spec/mongoid/extensions/boolean_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/extensions/date_class_mongoize_spec.rb
+++ b/spec/mongoid/extensions/date_class_mongoize_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/extensions/date_spec.rb
+++ b/spec/mongoid/extensions/date_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/extensions/date_time_spec.rb
+++ b/spec/mongoid/extensions/date_time_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/extensions/decimal128_spec.rb
+++ b/spec/mongoid/extensions/decimal128_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/extensions/false_class_spec.rb
+++ b/spec/mongoid/extensions/false_class_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/extensions/float_spec.rb
+++ b/spec/mongoid/extensions/float_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/extensions/hash_spec.rb
+++ b/spec/mongoid/extensions/hash_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/extensions/integer_spec.rb
+++ b/spec/mongoid/extensions/integer_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/extensions/module_spec.rb
+++ b/spec/mongoid/extensions/module_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/extensions/nil_class_spec.rb
+++ b/spec/mongoid/extensions/nil_class_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/extensions/object_id_spec.rb
+++ b/spec/mongoid/extensions/object_id_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/extensions/object_spec.rb
+++ b/spec/mongoid/extensions/object_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/extensions/range_spec.rb
+++ b/spec/mongoid/extensions/range_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/extensions/regexp_spec.rb
+++ b/spec/mongoid/extensions/regexp_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/extensions/set_spec.rb
+++ b/spec/mongoid/extensions/set_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/extensions/string_spec.rb
+++ b/spec/mongoid/extensions/string_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/extensions/stringified_symbol_spec.rb
+++ b/spec/mongoid/extensions/stringified_symbol_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/extensions/symbol_spec.rb
+++ b/spec/mongoid/extensions/symbol_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/extensions/time_spec.rb
+++ b/spec/mongoid/extensions/time_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/extensions/time_with_zone_spec.rb
+++ b/spec/mongoid/extensions/time_with_zone_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/extensions/true_class_spec.rb
+++ b/spec/mongoid/extensions/true_class_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/extensions_spec.rb
+++ b/spec/mongoid/extensions_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/factory_spec.rb
+++ b/spec/mongoid/factory_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/fields/foreign_key_spec.rb
+++ b/spec/mongoid/fields/foreign_key_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/fields/localized_spec.rb
+++ b/spec/mongoid/fields/localized_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/fields/standard_spec.rb
+++ b/spec/mongoid/fields/standard_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/fields_spec.rb
+++ b/spec/mongoid/fields_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/findable_spec.rb
+++ b/spec/mongoid/findable_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/indexable/specification_spec.rb
+++ b/spec/mongoid/indexable/specification_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/indexable_spec.rb
+++ b/spec/mongoid/indexable_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/inspectable_spec.rb
+++ b/spec/mongoid/inspectable_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/interceptable_spec.rb
+++ b/spec/mongoid/interceptable_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 require_relative './interceptable_spec_models'

--- a/spec/mongoid/loggable_spec.rb
+++ b/spec/mongoid/loggable_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/matcher/extract_attribute_spec.rb
+++ b/spec/mongoid/matcher/extract_attribute_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require 'spec_helper'
 

--- a/spec/mongoid/persistable/creatable_spec.rb
+++ b/spec/mongoid/persistable/creatable_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/persistable/deletable_spec.rb
+++ b/spec/mongoid/persistable/deletable_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/persistable/destroyable_spec.rb
+++ b/spec/mongoid/persistable/destroyable_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/persistable/incrementable_spec.rb
+++ b/spec/mongoid/persistable/incrementable_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/persistable/logical_spec.rb
+++ b/spec/mongoid/persistable/logical_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/persistable/poppable_spec.rb
+++ b/spec/mongoid/persistable/poppable_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/persistable/pullable_spec.rb
+++ b/spec/mongoid/persistable/pullable_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/persistable/pushable_spec.rb
+++ b/spec/mongoid/persistable/pushable_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/persistable/renamable_spec.rb
+++ b/spec/mongoid/persistable/renamable_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/persistable/savable_spec.rb
+++ b/spec/mongoid/persistable/savable_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/persistable/settable_spec.rb
+++ b/spec/mongoid/persistable/settable_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/persistable/unsettable_spec.rb
+++ b/spec/mongoid/persistable/unsettable_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/persistable/updatable_spec.rb
+++ b/spec/mongoid/persistable/updatable_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/persistable/upsertable_spec.rb
+++ b/spec/mongoid/persistable/upsertable_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/persistable_spec.rb
+++ b/spec/mongoid/persistable_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/persistence_context_spec.rb
+++ b/spec/mongoid/persistence_context_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/positional_spec.rb
+++ b/spec/mongoid/positional_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/query_cache_middleware_spec.rb
+++ b/spec/mongoid/query_cache_middleware_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/query_cache_spec.rb
+++ b/spec/mongoid/query_cache_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/relations/proxy_spec.rb
+++ b/spec/mongoid/relations/proxy_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 # require "spec_helper"
 #

--- a/spec/mongoid/reloadable_spec.rb
+++ b/spec/mongoid/reloadable_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/scopable_spec.rb
+++ b/spec/mongoid/scopable_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/selectable_spec.rb
+++ b/spec/mongoid/selectable_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/serializable_spec.rb
+++ b/spec/mongoid/serializable_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/shardable_spec.rb
+++ b/spec/mongoid/shardable_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 require_relative './shardable_models'

--- a/spec/mongoid/stateful_spec.rb
+++ b/spec/mongoid/stateful_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/tasks/database_rake_spec.rb
+++ b/spec/mongoid/tasks/database_rake_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "rake"
 require "spec_helper"

--- a/spec/mongoid/tasks/database_spec.rb
+++ b/spec/mongoid/tasks/database_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/threaded_spec.rb
+++ b/spec/mongoid/threaded_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/timestamps/created/short_spec.rb
+++ b/spec/mongoid/timestamps/created/short_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/timestamps/created_spec.rb
+++ b/spec/mongoid/timestamps/created_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/timestamps/timeless_spec.rb
+++ b/spec/mongoid/timestamps/timeless_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/timestamps/updated/short_spec.rb
+++ b/spec/mongoid/timestamps/updated/short_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/timestamps/updated_spec.rb
+++ b/spec/mongoid/timestamps/updated_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/timestamps_spec.rb
+++ b/spec/mongoid/timestamps_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/touchable_spec.rb
+++ b/spec/mongoid/touchable_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 require_relative './touchable_spec_models'

--- a/spec/mongoid/touchable_spec_models.rb
+++ b/spec/mongoid/touchable_spec_models.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module TouchableSpec
   module Embedded

--- a/spec/mongoid/traversable_spec.rb
+++ b/spec/mongoid/traversable_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/validatable/associated_spec.rb
+++ b/spec/mongoid/validatable/associated_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/validatable/format_spec.rb
+++ b/spec/mongoid/validatable/format_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/validatable/length_spec.rb
+++ b/spec/mongoid/validatable/length_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/validatable/numericality_spec.rb
+++ b/spec/mongoid/validatable/numericality_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/validatable/presence_spec.rb
+++ b/spec/mongoid/validatable/presence_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/validatable/uniqueness_spec.rb
+++ b/spec/mongoid/validatable/uniqueness_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid/validatable_spec.rb
+++ b/spec/mongoid/validatable_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/mongoid_spec.rb
+++ b/spec/mongoid_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/rails/controller_extension/controller_runtime_spec.rb
+++ b/spec/rails/controller_extension/controller_runtime_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 require "mongoid/railties/controller_runtime"

--- a/spec/rails/mongoid_spec.rb
+++ b/spec/rails/mongoid_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "spec_helper"
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require 'lite_spec_helper'
 

--- a/spec/support/authorization.rb
+++ b/spec/support/authorization.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 # Set up a root user so we can set up authentication on a database level.
 MONGOID_ROOT_USER = Mongo::Auth::User.new(

--- a/spec/support/constraints.rb
+++ b/spec/support/constraints.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Constraints
   RAILS_VERSION = ActiveSupport.version.to_s.split('.')[0..1].join('.').freeze

--- a/spec/support/expectations.rb
+++ b/spec/support/expectations.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Expectations

--- a/spec/support/macros.rb
+++ b/spec/support/macros.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Mongoid
   module Macros

--- a/spec/support/models/account.rb
+++ b/spec/support/models/account.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Account
   include Mongoid::Document

--- a/spec/support/models/acolyte.rb
+++ b/spec/support/models/acolyte.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Acolyte
   include Mongoid::Document

--- a/spec/support/models/actor.rb
+++ b/spec/support/models/actor.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Actor
   include Mongoid::Document

--- a/spec/support/models/actress.rb
+++ b/spec/support/models/actress.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Actress < Actor
 end

--- a/spec/support/models/address.rb
+++ b/spec/support/models/address.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Address
   include Mongoid::Document

--- a/spec/support/models/address_component.rb
+++ b/spec/support/models/address_component.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class AddressComponent
   include Mongoid::Document

--- a/spec/support/models/address_number.rb
+++ b/spec/support/models/address_number.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class AddressNumber
   include Mongoid::Document

--- a/spec/support/models/agency.rb
+++ b/spec/support/models/agency.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Agency
   include Mongoid::Document

--- a/spec/support/models/agent.rb
+++ b/spec/support/models/agent.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Agent
   include Mongoid::Document

--- a/spec/support/models/album.rb
+++ b/spec/support/models/album.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Album
   include Mongoid::Document

--- a/spec/support/models/alert.rb
+++ b/spec/support/models/alert.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Alert
   include Mongoid::Document

--- a/spec/support/models/animal.rb
+++ b/spec/support/models/animal.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Animal
   include Mongoid::Document

--- a/spec/support/models/answer.rb
+++ b/spec/support/models/answer.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Answer
   include Mongoid::Document

--- a/spec/support/models/appointment.rb
+++ b/spec/support/models/appointment.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Appointment
   include Mongoid::Document

--- a/spec/support/models/armrest.rb
+++ b/spec/support/models/armrest.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Armrest
   include Mongoid::Document

--- a/spec/support/models/array_field.rb
+++ b/spec/support/models/array_field.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class ArrayField
   include Mongoid::Document

--- a/spec/support/models/article.rb
+++ b/spec/support/models/article.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Article
   include Mongoid::Document

--- a/spec/support/models/artist.rb
+++ b/spec/support/models/artist.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Artist
   include Mongoid::Document

--- a/spec/support/models/artwork.rb
+++ b/spec/support/models/artwork.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Artwork
   include Mongoid::Document

--- a/spec/support/models/audio.rb
+++ b/spec/support/models/audio.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Audio
   include Mongoid::Document

--- a/spec/support/models/augmentation.rb
+++ b/spec/support/models/augmentation.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Augmentation
   include Mongoid::Document

--- a/spec/support/models/author.rb
+++ b/spec/support/models/author.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Author
   include Mongoid::Document

--- a/spec/support/models/baby.rb
+++ b/spec/support/models/baby.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Baby
   include Mongoid::Document

--- a/spec/support/models/band.rb
+++ b/spec/support/models/band.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Band
   include Mongoid::Document

--- a/spec/support/models/bar.rb
+++ b/spec/support/models/bar.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Bar
   include Mongoid::Document

--- a/spec/support/models/basic.rb
+++ b/spec/support/models/basic.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Basic
   include Mongoid::Document

--- a/spec/support/models/bed.rb
+++ b/spec/support/models/bed.rb
@@ -1,4 +1,3 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Bed; end

--- a/spec/support/models/big_palette.rb
+++ b/spec/support/models/big_palette.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class BigPalette < Palette
 end

--- a/spec/support/models/birthday.rb
+++ b/spec/support/models/birthday.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Birthday
   include Mongoid::Document

--- a/spec/support/models/bolt.rb
+++ b/spec/support/models/bolt.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Bolt
   include Mongoid::Document

--- a/spec/support/models/bomb.rb
+++ b/spec/support/models/bomb.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Bomb
   include Mongoid::Document

--- a/spec/support/models/book.rb
+++ b/spec/support/models/book.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Book
   include Mongoid::Document

--- a/spec/support/models/breed.rb
+++ b/spec/support/models/breed.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Breed
   include Mongoid::Document

--- a/spec/support/models/browser.rb
+++ b/spec/support/models/browser.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Browser < Canvas
   field :version, type: Integer

--- a/spec/support/models/building.rb
+++ b/spec/support/models/building.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Building
   include Mongoid::Document

--- a/spec/support/models/building_address.rb
+++ b/spec/support/models/building_address.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class BuildingAddress
   include Mongoid::Document

--- a/spec/support/models/bus.rb
+++ b/spec/support/models/bus.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Bus
   include Mongoid::Document

--- a/spec/support/models/business.rb
+++ b/spec/support/models/business.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Business
   include Mongoid::Document

--- a/spec/support/models/callback_test.rb
+++ b/spec/support/models/callback_test.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class CallbackTest
   include Mongoid::Document

--- a/spec/support/models/canvas.rb
+++ b/spec/support/models/canvas.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Canvas
   include Mongoid::Document

--- a/spec/support/models/car.rb
+++ b/spec/support/models/car.rb
@@ -1,4 +1,3 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Car < Vehicle; end

--- a/spec/support/models/cat.rb
+++ b/spec/support/models/cat.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Cat
   include Mongoid::Document

--- a/spec/support/models/category.rb
+++ b/spec/support/models/category.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Category
   include Mongoid::Document

--- a/spec/support/models/child.rb
+++ b/spec/support/models/child.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Child
   include Mongoid::Document

--- a/spec/support/models/child_doc.rb
+++ b/spec/support/models/child_doc.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class ChildDoc
   include Mongoid::Document

--- a/spec/support/models/church.rb
+++ b/spec/support/models/church.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Church
   include Mongoid::Document

--- a/spec/support/models/circle.rb
+++ b/spec/support/models/circle.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Circle < Shape
   field :radius, type: Integer, default: 0

--- a/spec/support/models/circuit.rb
+++ b/spec/support/models/circuit.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Circuit
   include Mongoid::Document

--- a/spec/support/models/circus.rb
+++ b/spec/support/models/circus.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Circus
   include Mongoid::Document

--- a/spec/support/models/code.rb
+++ b/spec/support/models/code.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Code
   include Mongoid::Document

--- a/spec/support/models/coding.rb
+++ b/spec/support/models/coding.rb
@@ -1,4 +1,3 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require 'support/models/coding/pull_request'

--- a/spec/support/models/coding/pull_request.rb
+++ b/spec/support/models/coding/pull_request.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Coding
   class PullRequest

--- a/spec/support/models/comment.rb
+++ b/spec/support/models/comment.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Comment
   include Mongoid::Document

--- a/spec/support/models/company.rb
+++ b/spec/support/models/company.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Company
   include Mongoid::Document

--- a/spec/support/models/consumption_period.rb
+++ b/spec/support/models/consumption_period.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class ConsumptionPeriod
   include Mongoid::Document

--- a/spec/support/models/contextable_item.rb
+++ b/spec/support/models/contextable_item.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class ContextableItem
   include Mongoid::Document

--- a/spec/support/models/contractor.rb
+++ b/spec/support/models/contractor.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Contractor
   include Mongoid::Document

--- a/spec/support/models/cookie.rb
+++ b/spec/support/models/cookie.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Cookie
   include Mongoid::Document

--- a/spec/support/models/country_code.rb
+++ b/spec/support/models/country_code.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class CountryCode
   include Mongoid::Document

--- a/spec/support/models/courier_job.rb
+++ b/spec/support/models/courier_job.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class CourierJob
   include Mongoid::Document

--- a/spec/support/models/crate.rb
+++ b/spec/support/models/crate.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Crate
   include Mongoid::Document

--- a/spec/support/models/customer.rb
+++ b/spec/support/models/customer.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Customer
   include Mongoid::Document

--- a/spec/support/models/customer_address.rb
+++ b/spec/support/models/customer_address.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class CustomerAddress
   include Mongoid::Document

--- a/spec/support/models/deed.rb
+++ b/spec/support/models/deed.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Deed
   include Mongoid::Document

--- a/spec/support/models/definition.rb
+++ b/spec/support/models/definition.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Definition
   include Mongoid::Document

--- a/spec/support/models/delegating_patient.rb
+++ b/spec/support/models/delegating_patient.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class DelegatingPatient
   include Mongoid::Document

--- a/spec/support/models/description.rb
+++ b/spec/support/models/description.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Description
   include Mongoid::Document

--- a/spec/support/models/dictionary.rb
+++ b/spec/support/models/dictionary.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Dictionary
   include Mongoid::Document

--- a/spec/support/models/division.rb
+++ b/spec/support/models/division.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Division
   include Mongoid::Document

--- a/spec/support/models/doctor.rb
+++ b/spec/support/models/doctor.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Doctor < Person
   field :specialty, as: :spec

--- a/spec/support/models/dog.rb
+++ b/spec/support/models/dog.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Dog
   include Mongoid::Document

--- a/spec/support/models/dokument.rb
+++ b/spec/support/models/dokument.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Dokument
   include Mongoid::Document

--- a/spec/support/models/draft.rb
+++ b/spec/support/models/draft.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Draft
   include Mongoid::Document

--- a/spec/support/models/dragon.rb
+++ b/spec/support/models/dragon.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Dragon
   include Mongoid::Document

--- a/spec/support/models/driver.rb
+++ b/spec/support/models/driver.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Driver
   include Mongoid::Document

--- a/spec/support/models/drug.rb
+++ b/spec/support/models/drug.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Drug
   include Mongoid::Document

--- a/spec/support/models/dungeon.rb
+++ b/spec/support/models/dungeon.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Dungeon
   include Mongoid::Document

--- a/spec/support/models/edit.rb
+++ b/spec/support/models/edit.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Edit
   include Mongoid::Document

--- a/spec/support/models/email.rb
+++ b/spec/support/models/email.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Email
   include Mongoid::Document

--- a/spec/support/models/employer.rb
+++ b/spec/support/models/employer.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Employer
   def id

--- a/spec/support/models/entry.rb
+++ b/spec/support/models/entry.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Entry
   include Mongoid::Document

--- a/spec/support/models/eraser.rb
+++ b/spec/support/models/eraser.rb
@@ -1,4 +1,3 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Eraser < Tool; end

--- a/spec/support/models/even.rb
+++ b/spec/support/models/even.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Even
   include Mongoid::Document

--- a/spec/support/models/event.rb
+++ b/spec/support/models/event.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Event
   include Mongoid::Document

--- a/spec/support/models/exhibition.rb
+++ b/spec/support/models/exhibition.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Exhibition
   include Mongoid::Document

--- a/spec/support/models/exhibitor.rb
+++ b/spec/support/models/exhibitor.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Exhibitor
   include Mongoid::Document

--- a/spec/support/models/explosion.rb
+++ b/spec/support/models/explosion.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Explosion
   include Mongoid::Document

--- a/spec/support/models/eye.rb
+++ b/spec/support/models/eye.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Eye
   include Mongoid::Document

--- a/spec/support/models/eye_bowl.rb
+++ b/spec/support/models/eye_bowl.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class EyeBowl
   include Mongoid::Document

--- a/spec/support/models/face.rb
+++ b/spec/support/models/face.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Face
   include Mongoid::Document

--- a/spec/support/models/favorite.rb
+++ b/spec/support/models/favorite.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Favorite
   include Mongoid::Document

--- a/spec/support/models/filesystem.rb
+++ b/spec/support/models/filesystem.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Filesystem
   include Mongoid::Document

--- a/spec/support/models/fire_hydrant.rb
+++ b/spec/support/models/fire_hydrant.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class FireHydrant
   include Mongoid::Document

--- a/spec/support/models/firefox.rb
+++ b/spec/support/models/firefox.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Firefox < Browser
   field :user_agent

--- a/spec/support/models/fish.rb
+++ b/spec/support/models/fish.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Fish
   include Mongoid::Document

--- a/spec/support/models/folder.rb
+++ b/spec/support/models/folder.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Folder
   include Mongoid::Document

--- a/spec/support/models/folder_item.rb
+++ b/spec/support/models/folder_item.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class FolderItem
 

--- a/spec/support/models/fruits.rb
+++ b/spec/support/models/fruits.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Fruits
   class Apple

--- a/spec/support/models/game.rb
+++ b/spec/support/models/game.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Game
   include Mongoid::Document

--- a/spec/support/models/ghost.rb
+++ b/spec/support/models/ghost.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Ghost
   include Mongoid::Document

--- a/spec/support/models/guitar.rb
+++ b/spec/support/models/guitar.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Guitar < Instrument
 end

--- a/spec/support/models/hole.rb
+++ b/spec/support/models/hole.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Hole
   include Mongoid::Document

--- a/spec/support/models/home.rb
+++ b/spec/support/models/home.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Home
   include Mongoid::Document

--- a/spec/support/models/house.rb
+++ b/spec/support/models/house.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class House
   include Mongoid::Document

--- a/spec/support/models/html_writer.rb
+++ b/spec/support/models/html_writer.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class HtmlWriter < Writer
   def write; end

--- a/spec/support/models/id_key.rb
+++ b/spec/support/models/id_key.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class IdKey
   include Mongoid::Document

--- a/spec/support/models/idnodef.rb
+++ b/spec/support/models/idnodef.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Idnodef
   include Mongoid::Document

--- a/spec/support/models/image.rb
+++ b/spec/support/models/image.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Image
   attr_reader :name

--- a/spec/support/models/implant.rb
+++ b/spec/support/models/implant.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Implant
   include Mongoid::Document

--- a/spec/support/models/instrument.rb
+++ b/spec/support/models/instrument.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Instrument
   include Mongoid::Document

--- a/spec/support/models/item.rb
+++ b/spec/support/models/item.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Item
   include Mongoid::Document

--- a/spec/support/models/jar.rb
+++ b/spec/support/models/jar.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Jar
   include Mongoid::Document

--- a/spec/support/models/kaleidoscope.rb
+++ b/spec/support/models/kaleidoscope.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Kaleidoscope
   include Mongoid::Document

--- a/spec/support/models/kangaroo.rb
+++ b/spec/support/models/kangaroo.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Kangaroo
   include Mongoid::Document

--- a/spec/support/models/label.rb
+++ b/spec/support/models/label.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Label
   include Mongoid::Document

--- a/spec/support/models/language.rb
+++ b/spec/support/models/language.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Language
   include Mongoid::Document

--- a/spec/support/models/lat_lng.rb
+++ b/spec/support/models/lat_lng.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class LatLng
   attr_accessor :lat, :lng

--- a/spec/support/models/league.rb
+++ b/spec/support/models/league.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class League
   include Mongoid::Document

--- a/spec/support/models/learner.rb
+++ b/spec/support/models/learner.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Learner < Driver
 end

--- a/spec/support/models/line_item.rb
+++ b/spec/support/models/line_item.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class LineItem
   include Mongoid::Document

--- a/spec/support/models/location.rb
+++ b/spec/support/models/location.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Location
   include Mongoid::Document

--- a/spec/support/models/login.rb
+++ b/spec/support/models/login.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Login
   include Mongoid::Document

--- a/spec/support/models/manufacturer.rb
+++ b/spec/support/models/manufacturer.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Manufacturer
   include Mongoid::Document

--- a/spec/support/models/meat.rb
+++ b/spec/support/models/meat.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Meat
   include Mongoid::Document

--- a/spec/support/models/membership.rb
+++ b/spec/support/models/membership.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Membership
   include Mongoid::Document

--- a/spec/support/models/message.rb
+++ b/spec/support/models/message.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Message
   include Mongoid::Document

--- a/spec/support/models/minim.rb
+++ b/spec/support/models/minim.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 # Minimal model, do not add any fields
 class Minim

--- a/spec/support/models/mixed_drink.rb
+++ b/spec/support/models/mixed_drink.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class MixedDrink
   include Mongoid::Document

--- a/spec/support/models/mop.rb
+++ b/spec/support/models/mop.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 # This class is used for embedded matcher testing.
 class Mop

--- a/spec/support/models/movie.rb
+++ b/spec/support/models/movie.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Movie
   include Mongoid::Document

--- a/spec/support/models/my_hash.rb
+++ b/spec/support/models/my_hash.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class MyHash < ::Hash
 end

--- a/spec/support/models/name.rb
+++ b/spec/support/models/name.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Name
   include Mongoid::Document

--- a/spec/support/models/name_only.rb
+++ b/spec/support/models/name_only.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 # Model with one field called name
 class NameOnly

--- a/spec/support/models/node.rb
+++ b/spec/support/models/node.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Node
   include Mongoid::Document

--- a/spec/support/models/note.rb
+++ b/spec/support/models/note.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Note
   include Mongoid::Document

--- a/spec/support/models/nut.rb
+++ b/spec/support/models/nut.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Nut
   include Mongoid::Document

--- a/spec/support/models/odd.rb
+++ b/spec/support/models/odd.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Odd
   include Mongoid::Document

--- a/spec/support/models/order.rb
+++ b/spec/support/models/order.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Order
   include Mongoid::Document

--- a/spec/support/models/ordered_post.rb
+++ b/spec/support/models/ordered_post.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class OrderedPost
   include Mongoid::Document

--- a/spec/support/models/ordered_preference.rb
+++ b/spec/support/models/ordered_preference.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class OrderedPreference
   include Mongoid::Document

--- a/spec/support/models/oscar.rb
+++ b/spec/support/models/oscar.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Oscar
   include Mongoid::Document

--- a/spec/support/models/other_owner_object.rb
+++ b/spec/support/models/other_owner_object.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class OtherOwnerObject
 end

--- a/spec/support/models/override.rb
+++ b/spec/support/models/override.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Override
   include Mongoid::Document

--- a/spec/support/models/ownable.rb
+++ b/spec/support/models/ownable.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Ownable
   extend ActiveSupport::Concern

--- a/spec/support/models/owner.rb
+++ b/spec/support/models/owner.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Owner
   include Mongoid::Document

--- a/spec/support/models/pack.rb
+++ b/spec/support/models/pack.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Pack
   include Mongoid::Document

--- a/spec/support/models/page.rb
+++ b/spec/support/models/page.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Page
   include Mongoid::Document

--- a/spec/support/models/page_question.rb
+++ b/spec/support/models/page_question.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class PageQuestion
   include Mongoid::Document

--- a/spec/support/models/palette.rb
+++ b/spec/support/models/palette.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Palette
   include Mongoid::Document

--- a/spec/support/models/parent.rb
+++ b/spec/support/models/parent.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Parent
   include Mongoid::Document

--- a/spec/support/models/parent_doc.rb
+++ b/spec/support/models/parent_doc.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class ParentDoc
   include Mongoid::Document

--- a/spec/support/models/passport.rb
+++ b/spec/support/models/passport.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Passport
   include Mongoid::Document

--- a/spec/support/models/patient.rb
+++ b/spec/support/models/patient.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Patient
   include Mongoid::Document

--- a/spec/support/models/pdf_writer.rb
+++ b/spec/support/models/pdf_writer.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class PdfWriter < Writer
   def write; end

--- a/spec/support/models/pencil.rb
+++ b/spec/support/models/pencil.rb
@@ -1,4 +1,3 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Pencil < Tool; end

--- a/spec/support/models/person.rb
+++ b/spec/support/models/person.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Person
   include Mongoid::Document

--- a/spec/support/models/pet.rb
+++ b/spec/support/models/pet.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Pet
   include Mongoid::Document

--- a/spec/support/models/pet_owner.rb
+++ b/spec/support/models/pet_owner.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class PetOwner
   include Mongoid::Document

--- a/spec/support/models/phone.rb
+++ b/spec/support/models/phone.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Phone
   include Mongoid::Document

--- a/spec/support/models/piano.rb
+++ b/spec/support/models/piano.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Piano < Instrument
 end

--- a/spec/support/models/pizza.rb
+++ b/spec/support/models/pizza.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Pizza
   include Mongoid::Document

--- a/spec/support/models/player.rb
+++ b/spec/support/models/player.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Player
   include Mongoid::Document

--- a/spec/support/models/post.rb
+++ b/spec/support/models/post.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Post
   include Mongoid::Document

--- a/spec/support/models/post_genre.rb
+++ b/spec/support/models/post_genre.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class PostGenre
   include Mongoid::Document

--- a/spec/support/models/powerup.rb
+++ b/spec/support/models/powerup.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Powerup
   include Mongoid::Document

--- a/spec/support/models/preference.rb
+++ b/spec/support/models/preference.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Preference
   include Mongoid::Document

--- a/spec/support/models/princess.rb
+++ b/spec/support/models/princess.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Princess
   include Mongoid::Document

--- a/spec/support/models/product.rb
+++ b/spec/support/models/product.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Product
   include Mongoid::Document

--- a/spec/support/models/profile.rb
+++ b/spec/support/models/profile.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Profile
   include Mongoid::Document

--- a/spec/support/models/pronunciation.rb
+++ b/spec/support/models/pronunciation.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Pronunciation
   include Mongoid::Document

--- a/spec/support/models/pub.rb
+++ b/spec/support/models/pub.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Pub
   include Mongoid::Document

--- a/spec/support/models/publication.rb
+++ b/spec/support/models/publication.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require 'support/models/publication/encyclopedia'
 require 'support/models/publication/review'

--- a/spec/support/models/publication/encyclopedia.rb
+++ b/spec/support/models/publication/encyclopedia.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Publication
   class Encyclopedia

--- a/spec/support/models/publication/review.rb
+++ b/spec/support/models/publication/review.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 module Publication
   class Review

--- a/spec/support/models/purchase.rb
+++ b/spec/support/models/purchase.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Purchase
   include Mongoid::Document

--- a/spec/support/models/question.rb
+++ b/spec/support/models/question.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Question
   include Mongoid::Document

--- a/spec/support/models/quiz.rb
+++ b/spec/support/models/quiz.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Quiz
   include Mongoid::Document

--- a/spec/support/models/rating.rb
+++ b/spec/support/models/rating.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Rating
   include Mongoid::Document

--- a/spec/support/models/record.rb
+++ b/spec/support/models/record.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Record
   include Mongoid::Document

--- a/spec/support/models/registry.rb
+++ b/spec/support/models/registry.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Registry
   include Mongoid::Document

--- a/spec/support/models/role.rb
+++ b/spec/support/models/role.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Role
   include Mongoid::Document

--- a/spec/support/models/root_category.rb
+++ b/spec/support/models/root_category.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class RootCategory
   include Mongoid::Document

--- a/spec/support/models/sandwich.rb
+++ b/spec/support/models/sandwich.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Sandwich
   include Mongoid::Document

--- a/spec/support/models/scheduler.rb
+++ b/spec/support/models/scheduler.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Scheduler
   include Mongoid::Document

--- a/spec/support/models/scribe.rb
+++ b/spec/support/models/scribe.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Scribe
   include Mongoid::Document

--- a/spec/support/models/sealer.rb
+++ b/spec/support/models/sealer.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Sealer
   include Mongoid::Document

--- a/spec/support/models/seat.rb
+++ b/spec/support/models/seat.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Seat
   include Mongoid::Document

--- a/spec/support/models/seo.rb
+++ b/spec/support/models/seo.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Seo
   include Mongoid::Document

--- a/spec/support/models/series.rb
+++ b/spec/support/models/series.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Series
   include Mongoid::Document

--- a/spec/support/models/server.rb
+++ b/spec/support/models/server.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Server
   include Mongoid::Document

--- a/spec/support/models/service.rb
+++ b/spec/support/models/service.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Service
   include Mongoid::Document

--- a/spec/support/models/shape.rb
+++ b/spec/support/models/shape.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Shape
   include Mongoid::Document

--- a/spec/support/models/shelf.rb
+++ b/spec/support/models/shelf.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Shelf
   include Mongoid::Document

--- a/spec/support/models/shipment_address.rb
+++ b/spec/support/models/shipment_address.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class ShipmentAddress < Address
   field :shipping_name, localize: true

--- a/spec/support/models/shipping_container.rb
+++ b/spec/support/models/shipping_container.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class ShippingContainer
   include Mongoid::Document

--- a/spec/support/models/shipping_pack.rb
+++ b/spec/support/models/shipping_pack.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class ShippingPack < Pack
   belongs_to :subscription, counter_cache: true

--- a/spec/support/models/shirt.rb
+++ b/spec/support/models/shirt.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Shirt
   include Mongoid::Document

--- a/spec/support/models/shop.rb
+++ b/spec/support/models/shop.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Shop
   include Mongoid::Document

--- a/spec/support/models/short_agent.rb
+++ b/spec/support/models/short_agent.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class ShortAgent
   include Mongoid::Document

--- a/spec/support/models/short_quiz.rb
+++ b/spec/support/models/short_quiz.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class ShortQuiz
   include Mongoid::Document

--- a/spec/support/models/simple.rb
+++ b/spec/support/models/simple.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Simple
   include Mongoid::Document

--- a/spec/support/models/slave.rb
+++ b/spec/support/models/slave.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Slave
   include Mongoid::Document

--- a/spec/support/models/song.rb
+++ b/spec/support/models/song.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Song
   include Mongoid::Document

--- a/spec/support/models/sound.rb
+++ b/spec/support/models/sound.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Sound
   include Mongoid::Document

--- a/spec/support/models/spacer.rb
+++ b/spec/support/models/spacer.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Spacer
   include Mongoid::Document

--- a/spec/support/models/square.rb
+++ b/spec/support/models/square.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Square < Shape
   field :width, type: Integer, default: 0

--- a/spec/support/models/staff.rb
+++ b/spec/support/models/staff.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Staff
   include Mongoid::Document

--- a/spec/support/models/store_as_dup_test1.rb
+++ b/spec/support/models/store_as_dup_test1.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class StoreAsDupTest1
   include Mongoid::Document

--- a/spec/support/models/store_as_dup_test2.rb
+++ b/spec/support/models/store_as_dup_test2.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class StoreAsDupTest2
   include Mongoid::Document

--- a/spec/support/models/store_as_dup_test3.rb
+++ b/spec/support/models/store_as_dup_test3.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class StoreAsDupTest3
   include Mongoid::Document

--- a/spec/support/models/store_as_dup_test4.rb
+++ b/spec/support/models/store_as_dup_test4.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class StoreAsDupTest4
   include Mongoid::Document

--- a/spec/support/models/strategy.rb
+++ b/spec/support/models/strategy.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Strategy
   include Mongoid::Document

--- a/spec/support/models/sub_item.rb
+++ b/spec/support/models/sub_item.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class SubItem < Item
   embedded_in :parent

--- a/spec/support/models/subscription.rb
+++ b/spec/support/models/subscription.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Subscription
   include Mongoid::Document

--- a/spec/support/models/survey.rb
+++ b/spec/support/models/survey.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Survey
   include Mongoid::Document

--- a/spec/support/models/symptom.rb
+++ b/spec/support/models/symptom.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Symptom
   include Mongoid::Document

--- a/spec/support/models/tag.rb
+++ b/spec/support/models/tag.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Tag
   include Mongoid::Document

--- a/spec/support/models/target.rb
+++ b/spec/support/models/target.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Target
   include Mongoid::Document

--- a/spec/support/models/template.rb
+++ b/spec/support/models/template.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Template
   include Mongoid::Document

--- a/spec/support/models/thing.rb
+++ b/spec/support/models/thing.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Thing
   include Mongoid::Document

--- a/spec/support/models/threadlocker.rb
+++ b/spec/support/models/threadlocker.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Threadlocker
   include Mongoid::Document

--- a/spec/support/models/title.rb
+++ b/spec/support/models/title.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Title
   include Mongoid::Document

--- a/spec/support/models/tool.rb
+++ b/spec/support/models/tool.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Tool
   include Mongoid::Document

--- a/spec/support/models/topping.rb
+++ b/spec/support/models/topping.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Topping
   include Mongoid::Document

--- a/spec/support/models/toy.rb
+++ b/spec/support/models/toy.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Toy
   include Mongoid::Document

--- a/spec/support/models/track.rb
+++ b/spec/support/models/track.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Track
   include Mongoid::Document

--- a/spec/support/models/translation.rb
+++ b/spec/support/models/translation.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Translation
   include Mongoid::Document

--- a/spec/support/models/tree.rb
+++ b/spec/support/models/tree.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Tree
   include Mongoid::Document

--- a/spec/support/models/truck.rb
+++ b/spec/support/models/truck.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Truck < Vehicle
   embeds_one :bed

--- a/spec/support/models/updatable.rb
+++ b/spec/support/models/updatable.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Updatable
   include Mongoid::Document

--- a/spec/support/models/user.rb
+++ b/spec/support/models/user.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class User
   include Mongoid::Document

--- a/spec/support/models/user_account.rb
+++ b/spec/support/models/user_account.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class UserAccount
   include Mongoid::Document

--- a/spec/support/models/validation_callback.rb
+++ b/spec/support/models/validation_callback.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class ValidationCallback
   include Mongoid::Document

--- a/spec/support/models/vehicle.rb
+++ b/spec/support/models/vehicle.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Vehicle
   include Mongoid::Document

--- a/spec/support/models/version.rb
+++ b/spec/support/models/version.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Version
   include Mongoid::Document

--- a/spec/support/models/vertex.rb
+++ b/spec/support/models/vertex.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Vertex
   include Mongoid::Document

--- a/spec/support/models/vet_visit.rb
+++ b/spec/support/models/vet_visit.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class VetVisit
   include Mongoid::Document

--- a/spec/support/models/video.rb
+++ b/spec/support/models/video.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Video
   include Mongoid::Document

--- a/spec/support/models/video_game.rb
+++ b/spec/support/models/video_game.rb
@@ -1,4 +1,3 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class VideoGame < Game; end

--- a/spec/support/models/washer.rb
+++ b/spec/support/models/washer.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Washer
   include Mongoid::Document

--- a/spec/support/models/weapon.rb
+++ b/spec/support/models/weapon.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Weapon
   include Mongoid::Document

--- a/spec/support/models/wiki_page.rb
+++ b/spec/support/models/wiki_page.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class WikiPage
   include Mongoid::Document

--- a/spec/support/models/word.rb
+++ b/spec/support/models/word.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Word
   include Mongoid::Document

--- a/spec/support/models/word_origin.rb
+++ b/spec/support/models/word_origin.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class WordOrigin
   include Mongoid::Document

--- a/spec/support/models/writer.rb
+++ b/spec/support/models/writer.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 class Writer
   include Mongoid::Document

--- a/spec/support/shared/time.rb
+++ b/spec/support/shared/time.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 shared_context 'using AS time zone' do
   before do

--- a/spec/support/spec_config.rb
+++ b/spec/support/spec_config.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
 require 'singleton'
 


### PR DESCRIPTION
Fixes MONGOID-5143

It has not had any affect since Ruby 2.1, as that version made UTF-8 the default encoding. Min ruby we support is 2.3, so this is fine to remove.