### PR TITLE
MONGOID-???? - Aggregable::Mongo should only pipeline the operators each method needs.

### DIFF
--- a/lib/mongoid/contextual/aggregable/memory.rb
+++ b/lib/mongoid/contextual/aggregable/memory.rb
@@ -16,11 +16,9 @@ module Mongoid
         #   If no documents are present, then returned Hash will have
         #   count, sum of 0 and max, min, avg of nil.
         def aggregates(field)
-          { "count" => count(field),
-            "sum" => sum(field),
-            "avg" => avg(field),
-            "min" => min(field),
-            "max" => max(field) }
+          %w(count sum avg min max).each_with_object({}) do |method, hash|
+            hash[method] = send(method, field)
+          end
         end
 
         # Get the average value of the provided field.

--- a/lib/mongoid/contextual/aggregable/memory.rb
+++ b/lib/mongoid/contextual/aggregable/memory.rb
@@ -11,13 +11,19 @@ module Mongoid
         # Provided for interface consistency with Aggregable::Mongo.
         #
         # @param [ String, Symbol ] field The field name.
+        # @param [ Array<String|Symbol> ] operators The aggregable operations to perform.
         #
-        # @return [ Hash ] A Hash containing the aggregate values.
-        #   If no documents are present, then returned Hash will have
-        #   count, sum of 0 and max, min, avg of nil.
-        def aggregates(field)
-          %w(count sum avg min max).each_with_object({}) do |method, hash|
-            hash[method] = send(method, field)
+        # @return [ Integer | Float | Hash ] A Hash containing the aggregate values.
+        #   If a single operator is specified, the aggregate value for the given
+        #   operator only will be returned.
+        def aggregates(field, *operators)
+          operators = operators.map(&:to_s)
+          keys = %w(count sum avg min max)
+          keys.slice!(*operators) if (operators & keys).present?
+          if keys.size == 1
+            send(method, field)
+          else
+            keys.each_with_object({}) { |method, hash| hash[method] = send(method, field) }
           end
         end
 

--- a/lib/mongoid/contextual/aggregable/memory.rb
+++ b/lib/mongoid/contextual/aggregable/memory.rb
@@ -7,6 +7,22 @@ module Mongoid
       # Contains behavior for aggregating values in memory.
       module Memory
 
+        # Get all the aggregate values for the provided field.
+        # Provided for interface consistency with Aggregable::Mongo.
+        #
+        # @param [ String, Symbol ] field The field name.
+        #
+        # @return [ Hash ] A Hash containing the aggregate values.
+        #   If no documents are present, then returned Hash will have
+        #   count, sum of 0 and max, min, avg of nil.
+        def aggregates(field)
+          { "count" => count(field),
+            "sum" => sum(field),
+            "avg" => avg(field),
+            "min" => min(field),
+            "max" => max(field) }
+        end
+
         # Get the average value of the provided field.
         #
         # @example Get the average of a single field.

--- a/lib/mongoid/contextual/aggregable/mongo.rb
+++ b/lib/mongoid/contextual/aggregable/mongo.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
-# encoding: utf-8
+
+require "mongoid/contextual/aggregable/none"
 
 module Mongoid
   module Contextual
@@ -21,15 +22,15 @@ module Mongoid
         #
         # @param [ String, Symbol ] field The field name.
         #
-        # @return [ Hash ] count is a number of documents with the provided
-        #   field. If there're none, then count is 0 and max, min, sum, avg
-        #   are nil.
+        # @return [ Hash ] A Hash containing the aggregate values.
+        #   If no documents are found, then returned Hash will have
+        #   count, sum of 0 and max, min, avg of nil.
         #
         # @since 3.0.0
         def aggregates(field)
           result = collection.find.aggregate(pipeline(field), session: _session).to_a
           if result.empty?
-            { "count" => 0, "sum" => nil, "avg" => nil, "min" => nil, "max" => nil }
+            Mongoid::Contextual::Aggregable::None::AGGREGATES.dup
           else
             result.first
           end

--- a/lib/mongoid/contextual/aggregable/none.rb
+++ b/lib/mongoid/contextual/aggregable/none.rb
@@ -11,10 +11,18 @@ module Mongoid
         # Provided for interface consistency with Aggregable::Mongo.
         #
         # @param [ String, Symbol ] _field The field name.
+        # @param [ Array<String|Symbol> ] operators The aggregable operations to perform.
+        #   If a single operator is specified, the aggregate value for the given
+        #   operator only will be returned.
         #
         # @return [ Hash ] A Hash with count, sum of 0 and max, min, avg of nil.
-        def aggregates(_field)
-          AGGREGATES.dup
+        #   If a single operator is specified, the aggregate value for the given
+        #   operator only will be returned.
+        def aggregates(_field, *operators)
+          operators = operators.map(&:to_s)
+          result = AGGREGATES.dup
+          result.slice!(*operators) if (operators & result.keys).present?
+          result.size == 1 ? result.values.first : result
         end
 
         # Always returns zero.

--- a/lib/mongoid/contextual/aggregable/none.rb
+++ b/lib/mongoid/contextual/aggregable/none.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module Mongoid
+  module Contextual
+    module Aggregable
+      # Contains behavior for aggregating values in null context.
+      module None
+        AGGREGATES = { "count" => 0, "sum" => 0, "avg" => nil, "min" => nil, "max" => nil }.freeze
+
+        # Get all the aggregate values for the provided field in null context.
+        # Provided for interface consistency with Aggregable::Mongo.
+        #
+        # @param [ String, Symbol ] _field The field name.
+        #
+        # @return [ Hash ] A Hash with count, sum of 0 and max, min, avg of nil.
+        def aggregates(_field)
+          AGGREGATES.dup
+        end
+
+        # Always returns zero.
+        #
+        # @example Get the sum of null context.
+        #
+        # @param [ Symbol ] _field The field to sum.
+        #
+        # @return [ Integer ] Always zero.
+        def sum(_field = nil)
+          0
+        end
+
+        # Always returns nil.
+        #
+        # @example Get the avg of null context.
+        #
+        # @param [ Symbol ] _field The field to avg.
+        #
+        # @return [ nil ] Always nil.
+        def avg(_field)
+          nil
+        end
+
+        # Always returns nil.
+        #
+        # @example Get the min of null context.
+        #
+        # @param [ Symbol ] _field The field to min.
+        #
+        # @return [ nil ] Always nil.
+        def min(_field = nil)
+          nil
+        end
+
+        # Always returns nil.
+        #
+        # @example Get the max of null context.
+        #
+        # @param [ Symbol ] _field The field to max.
+        #
+        # @return [ nil ] Always nil.
+        alias :max :min
+      end
+    end
+  end
+end

--- a/lib/mongoid/contextual/none.rb
+++ b/lib/mongoid/contextual/none.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
-# encoding: utf-8
+
+require "mongoid/contextual/aggregable/none"
 
 module Mongoid
   module Contextual
     class None
       include Enumerable
+      include Aggregable::None
       include Queryable
 
       attr_reader :criteria, :klass
@@ -23,22 +25,22 @@ module Mongoid
         other.is_a?(None)
       end
 
-      # Allow distinct for null context.
+      # Get the distinct field values in null context.
       #
-      # @example Get the distinct values.
+      # @example Get the distinct values in null context.
       #   context.distinct(:name)
       #
-      # @param [ String, Symbol ] field the name of the field.
+      # @param [ String, Symbol ] _field The name of the field.
       #
-      # @return [ Array ] Empty Array
-      def distinct(field)
+      # @return [ Array ] An empty Array.
+      def distinct(_field)
         []
       end
 
       # Iterate over the null context. There are no documents to iterate over
       # in this case.
       #
-      # @example Iterate over the context.
+      # @example Iterate over the null context.
       #   context.each do |doc|
       #     puts doc.name
       #   end
@@ -57,23 +59,22 @@ module Mongoid
 
       # Do any documents exist for the context.
       #
-      # @example Do any documents exist for the context.
+      # @example Do any documents exist in the null context.
       #   context.exists?
       #
-      # @return [ true, false ] If the count is more than zero.
+      # @return [ false ] Always false.
       #
       # @since 4.0.0
       def exists?; false; end
 
-
-      # Allow pluck for null context.
+      # Pluck the field values in null context.
       #
-      # @example Allow pluck for null context.
+      # @example Get the values for null context.
       #   context.pluck(:name)
       #
       # @param [ String, Symbol, Array ] args Field or fields to pluck.
       #
-      # @return [ Array ] Emtpy Array
+      # @return [ Array ] An empty Array.
       def pluck(*args)
         []
       end
@@ -92,7 +93,7 @@ module Mongoid
 
       # Always returns nil.
       #
-      # @example Get the last document.
+      # @example Get the last document in null context.
       #   context.last
       #
       # @return [ nil ] Always nil.
@@ -102,14 +103,14 @@ module Mongoid
 
       # Always returns zero.
       #
-      # @example Get the length of matching documents.
+      # @example Get the length of null context.
       #   context.length
       #
       # @return [ Integer ] Always zero.
       #
       # @since 4.0.0
       def length
-        entries.length
+        0
       end
       alias :size :length
     end

--- a/spec/mongoid/contextual/aggregable/memory_spec.rb
+++ b/spec/mongoid/contextual/aggregable/memory_spec.rb
@@ -5,6 +5,46 @@ require "spec_helper"
 
 describe Mongoid::Contextual::Aggregable::Memory do
 
+  describe "#aggregates" do
+    let(:context) do
+      Mongoid::Contextual::Memory.new(criteria)
+    end
+
+    subject { context.aggregates(:likes) }
+
+    context 'when no documents found' do
+      let(:criteria) do
+        Band.all.tap do |crit|
+          crit.documents = []
+        end
+      end
+
+      it do
+        is_expected.to eq("count" => 0, "avg" => nil, "max" => nil, "min" => nil, "sum" => 0)
+      end
+    end
+
+    context 'when documents found' do
+      let(:criteria) do
+        Band.all.tap do |crit|
+          crit.documents = [ depeche, tool ]
+        end
+      end
+
+      let!(:depeche) do
+        Band.create(name: "Depeche Mode", likes: 1000)
+      end
+
+      let!(:tool) do
+        Band.create(name: "Tool", likes: 500)
+      end
+
+      it do
+        is_expected.to eq("count" => 0, "avg" => 750.0, "max" => 1000, "min" => 500, "sum" => 1500)
+      end
+    end
+  end
+
   describe "#avg" do
 
     context "when provided a single field" do

--- a/spec/mongoid/contextual/aggregable/mongo_spec.rb
+++ b/spec/mongoid/contextual/aggregable/mongo_spec.rb
@@ -168,7 +168,7 @@ describe Mongoid::Contextual::Aggregable::Mongo do
         end
 
         it "returns a sum" do
-          expect(aggregates["sum"]).to be_nil
+          expect(aggregates["sum"]).to eq 0
         end
       end
 
@@ -241,7 +241,7 @@ describe Mongoid::Contextual::Aggregable::Mongo do
         end
 
         it "returns nil" do
-          expect(aggregates).to eq({ "count" => 0, "sum" => nil, "avg" => nil, "min" => nil, "max" => nil })
+          expect(aggregates).to eq({ "count" => 0, "sum" => 0, "avg" => nil, "min" => nil, "max" => nil })
         end
       end
     end

--- a/spec/mongoid/contextual/aggregable/none_spec.rb
+++ b/spec/mongoid/contextual/aggregable/none_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+# encoding: utf-8
+
+require "spec_helper"
+
+describe Mongoid::Contextual::Aggregable::None do
+
+  before do
+    Band.create!(name: "Depeche Mode")
+  end
+
+  let(:context) do
+    Mongoid::Contextual::None.new(Band.where(name: "Depeche Mode"))
+  end
+
+  describe "#aggregates" do
+    it "returns fixed values" do
+      expect(context.aggregates(:likes)).to eq("count" => 0, "avg" => nil, "max" => nil, "min" => nil, "sum" => 0)
+    end
+  end
+
+  describe "#sum" do
+    it "returns zero" do
+      expect(context.sum).to eq(0)
+    end
+
+    it "returns zero when arg given" do
+      expect(context.sum(:likes)).to eq(0)
+    end
+  end
+
+  describe "#avg" do
+    it "returns nil" do
+      expect(context.avg(:likes)).to eq(nil)
+    end
+  end
+
+  describe "#min and #max" do
+    it "returns nil" do
+      expect(context.min).to eq(nil)
+      expect(context.max).to eq(nil)
+    end
+
+    it "returns nil when arg given" do
+      expect(context.min(:likes)).to eq(nil)
+      expect(context.max(:likes)).to eq(nil)
+    end
+  end
+end

--- a/spec/mongoid/contextual/none_spec.rb
+++ b/spec/mongoid/contextual/none_spec.rb
@@ -5,18 +5,17 @@ require "spec_helper"
 
 describe Mongoid::Contextual::None do
 
+  before do
+    Band.create!(name: "Depeche Mode")
+  end
+
+  let(:context) do
+    described_class.new(Band.where(name: "Depeche Mode"))
+  end
+
   describe "#==" do
 
-    let!(:band) do
-      Band.create(name: "Depeche Mode")
-    end
-
-    let(:context) do
-      described_class.new(Band.where(name: "Depeche Mode"))
-    end
-
     context "when the other is a none" do
-
       let(:other) do
         described_class.new(Band.where(name: "Depeche Mode"))
       end
@@ -27,7 +26,6 @@ describe Mongoid::Contextual::None do
     end
 
     context "when the other is not a none" do
-
       let(:other) do
         Mongoid::Contextual::Memory.new(Band.where(name: "Depeche Mode"))
       end
@@ -39,120 +37,48 @@ describe Mongoid::Contextual::None do
   end
 
   describe "#each" do
-
-    let!(:band) do
-      Band.create(name: "Depeche Mode")
-    end
-
-    let(:context) do
-      described_class.new(Band.where(name: "Depeche Mode"))
-    end
-
     it "iterates over no documents" do
       expect(context.each.entries).to be_empty
     end
   end
 
   describe "#exists?" do
-
-    let!(:band) do
-      Band.create(name: "Depeche Mode")
-    end
-
-    let(:context) do
-      described_class.new(Band.where(name: "Depeche Mode"))
-    end
-
     it "returns false" do
       expect(context).to_not be_exists
     end
   end
 
   describe "#distinct" do
-
-    let!(:band) do
-      Band.create(name: "Depeche Mode")
-    end
-
-    let(:context) do
-      described_class.new(Band.where(name: "Depeche Mode"))
-    end
-
     it "returns an empty array" do
       expect(context.distinct(:id)).to eq([])
     end
   end
 
   describe "#pluck" do
-
-    let!(:band) do
-      Band.create(name: "Depeche Mode")
-    end
-
-    let(:context) do
-      described_class.new(Band.where(name: "Depeche Mode"))
-    end
-
     it "returns an empty array" do
       expect(context.pluck(:id)).to eq([])
     end
   end
 
   describe "#first" do
-
-    let!(:band) do
-      Band.create(name: "Depeche Mode")
-    end
-
-    let(:context) do
-      described_class.new(Band.where(name: "Depeche Mode"))
-    end
-
     it "returns nil" do
       expect(context.first).to be_nil
     end
   end
 
   describe "#last" do
-
-    let!(:band) do
-      Band.create(name: "Depeche Mode")
-    end
-
-    let(:context) do
-      described_class.new(Band.where(name: "Depeche Mode"))
-    end
-
     it "returns nil" do
       expect(context.last).to be_nil
     end
   end
 
   describe "#length" do
-
-    let!(:band) do
-      Band.create(name: "Depeche Mode")
-    end
-
-    let(:context) do
-      described_class.new(Band.where(name: "Depeche Mode"))
-    end
-
     it "returns zero" do
       expect(context.length).to eq(0)
     end
   end
 
   describe "#size" do
-
-    let!(:band) do
-      Band.create(name: "Depeche Mode")
-    end
-
-    let(:context) do
-      described_class.new(Band.where(name: "Depeche Mode"))
-    end
-
     it "returns zero" do
       expect(context.size).to eq(0)
     end


### PR DESCRIPTION
To avoid conflicts, this PR includes the changes from https://github.com/mongodb/mongoid/pull/5036. Please review and merge that one first.

---

This PR improves `count`, `sum`, `avg`, `min`, and `max` performance.

Currently when any of the aforementioned methods are called, Mongoid creates an aggregation pipeline which calculates all 5 of them, even though a single value is actually returned.

In the vast majority of use cases, there is no point to calculating all 5 values in the aggregation pipeline. I believe result is can be cached if QueryCache is enabled, but in practice I have very few cases where I'm calling count then sum on a given field.

After the changes in this PR, users who wish to retrieve multiple values can still do so, with greater selectivity than before:

```
Band.aggregates(:likes) => { sum: 1082, count: 100, avg: 10.2, min: 0, max: 23 }

Band.aggregates(:likes, :sum, :count) => { sum: 1082, count: 100 }
```

## TODO

- Specs
