### PR TITLE
MONGOID-5131 Use proper mdb <-> ubuntu versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     env:
       CI: true
       TESTOPTS: "-v"
-    runs-on: ubuntu-latest
+    runs-on: ${{matrix.os}}
     continue-on-error: "${{matrix.experimental}}"
     strategy:
       fail-fast: false
@@ -21,6 +21,7 @@ jobs:
         - mongodb: '5.0'
           ruby: ruby-3.0
           topology: server
+          os: ubuntu-20.04
           task: test
           driver: current
           rails:
@@ -30,6 +31,7 @@ jobs:
         - mongodb: '5.0'
           ruby: ruby-3.0
           topology: replica_set
+          os: ubuntu-20.04
           task: test
           driver: current
           rails:
@@ -39,6 +41,7 @@ jobs:
         - mongodb: '5.0'
           ruby: jruby-9.2
           topology: replica_set
+          os: ubuntu-20.04
           task: test
           driver: current
           rails:
@@ -48,6 +51,7 @@ jobs:
         - mongodb: '4.4'
           ruby: ruby-2.7
           topology: server
+          os: ubuntu-20.04
           task: test
           driver: current
           rails:
@@ -57,6 +61,7 @@ jobs:
         - mongodb: '4.4'
           ruby: ruby-2.7
           topology: replica_set
+          os: ubuntu-20.04
           task: test
           driver: current
           rails:
@@ -66,6 +71,7 @@ jobs:
         - mongodb: '4.0'
           ruby: ruby-2.6
           topology: server
+          os: ubuntu-18.04
           task: test
           driver: current
           rails:
@@ -75,6 +81,7 @@ jobs:
         - mongodb: '4.0'
           ruby: ruby-2.6
           topology: replica_set
+          os: ubuntu-18.04
           task: test
           driver: current
           rails:
@@ -84,6 +91,7 @@ jobs:
         - mongodb: '3.6'
           ruby: ruby-2.5
           topology: server
+          os: ubuntu-18.04
           task: test
           driver: current
           rails:
@@ -93,6 +101,7 @@ jobs:
         - mongodb: '3.6'
           ruby: ruby-2.5
           topology: replica_set
+          os: ubuntu-18.04
           task: test
           driver: current
           rails:
@@ -102,6 +111,7 @@ jobs:
         - mongodb: '5.0'
           ruby: ruby-3.0
           topology: replica_set
+          os: ubuntu-20.04
           task: test
           driver: master
           rails:
@@ -111,6 +121,7 @@ jobs:
         - mongodb: '5.0'
           ruby: ruby-3.0
           topology: replica_set
+          os: ubuntu-20.04
           task: test
           driver: stable
           rails:
@@ -120,6 +131,7 @@ jobs:
         - mongodb: '4.0'
           ruby: ruby-2.5
           topology: replica_set
+          os: ubuntu-18.04
           task: test
           driver: oldstable
           rails:
@@ -129,6 +141,7 @@ jobs:
         - mongodb: '4.0'
           ruby: ruby-2.5
           topology: replica_set
+          os: ubuntu-18.04
           task: test
           driver: min
           rails:
@@ -138,6 +151,7 @@ jobs:
         - mongodb: '3.6'
           ruby: ruby-2.5
           topology: server
+          os: ubuntu-18.04
           task: test
           driver: min
           rails:
@@ -147,6 +161,7 @@ jobs:
         - mongodb: '5.0'
           ruby: ruby-3.0
           topology: server
+          os: ubuntu-20.04
           task: test
           driver: current
           rails: '6.0'
@@ -156,6 +171,7 @@ jobs:
         - mongodb: '4.0'
           ruby: ruby-2.7
           topology: server
+          os: ubuntu-18.04
           task: test
           driver: current
           rails: '5.1'
@@ -165,6 +181,7 @@ jobs:
         - mongodb: '4.0'
           ruby: ruby-2.7
           topology: server
+          os: ubuntu-18.04
           task: test
           driver: current
           rails: '5.2'
@@ -174,6 +191,7 @@ jobs:
         - mongodb: '4.4'
           ruby: ruby-2.5
           topology: server
+          os: ubuntu-20.04
           task: test
           driver: current
           rails:
@@ -183,6 +201,7 @@ jobs:
         - mongodb: '4.2'
           ruby: ruby-2.6
           topology: server
+          os: ubuntu-18.04
           task: test
           driver: current
           rails:
@@ -192,6 +211,7 @@ jobs:
         - mongodb: '4.2'
           ruby: ruby-2.6
           topology: server
+          os: ubuntu-18.04
           task: test
           driver: current
           rails:
@@ -201,6 +221,7 @@ jobs:
         - mongodb: '5.0'
           ruby: ruby-2.7
           topology: server
+          os: ubuntu-20.04
           task: test
           driver: current
           rails: '5.1'
@@ -210,6 +231,7 @@ jobs:
         - mongodb: '5.0'
           ruby: ruby-2.7
           topology: server
+          os: ubuntu-20.04
           task: test
           driver: current
           rails: '5.2'
@@ -219,6 +241,7 @@ jobs:
         - mongodb: '5.0'
           ruby: jruby-9.2
           topology: server
+          os: ubuntu-20.04
           task: test
           driver: current
           rails: '6.0'


### PR DESCRIPTION
Proposed changed are based on https://github.com/mongodb-labs/drivers-evergreen-tools/blob/master/.evergreen/download-mongodb.sh with an exception for 3.6 (it is available for 18.04, even though not listed in the script).

Unfortunately, we do not have builds of all mongodb versions for all ubuntu versions. So we should not run everything on latest, but be explicit about version.