### PR TITLE
MONGOId-5185 Remove tests for _id serialization

### DIFF
--- a/spec/mongoid/document_spec.rb
+++ b/spec/mongoid/document_spec.rb
@@ -430,27 +430,6 @@ describe Mongoid::Document do
       Person.new(title: "Sir")
     end
 
-    describe 'id' do
-      context 'rails < 6' do
-        max_rails_version '5.2'
-
-        it 'is a BSON::ObjectId' do
-          id = person.as_json['_id']
-          expect(id).to be_a(BSON::ObjectId)
-        end
-      end
-
-      context 'rails >= 6' do
-        min_rails_version '6.0'
-
-        it 'is a hash with $oid' do
-          id = person.as_json['_id']
-          expect(id).to be_a(Hash)
-          expect(id['$oid']).to be_a(String)
-        end
-      end
-    end
-
     context "when no options are provided" do
 
       it "does not apply any options" do


### PR DESCRIPTION
I suggest removing these tests from Mongoid. There is no code that does something with `_id`. And we agreed that we rely on `bson-ruby` implementation of json serialisation.