### PR TITLE
MONGOID-5199 Reloadable#reload_embedded_document doesn't respect session

### DIFF
--- a/lib/mongoid/reloadable.rb
+++ b/lib/mongoid/reloadable.rb
@@ -67,7 +67,7 @@ module Mongoid
     # @return [ Hash ] The reloaded attributes.
     def reload_embedded_document
       extract_embedded_attributes({}.merge(
-        collection(_root).find(_root.atomic_selector).read(mode: :primary).first
+        collection(_root).find(_root.atomic_selector, session: _session).read(mode: :primary).first
       ))
     end
 

--- a/spec/mongoid/clients/transactions_spec.rb
+++ b/spec/mongoid/clients/transactions_spec.rb
@@ -189,6 +189,27 @@ describe Mongoid::Clients::Sessions do
           end
         end
       end
+
+      context 'When reloading an embedded document created inside a transaction' do
+        it 'does not raise an error and has the correct document' do
+          Canvas.with_session do |s|
+            s.start_transaction
+
+            p = Palette.new
+            c = Canvas.new(palette: p)
+            c.save!
+
+            expect do
+              p.reload
+            end.to_not raise_error
+
+            expect(c.palette).to eq(p)
+
+            s.commit_transaction
+          end
+
+        end
+      end
     end
 
     context 'when sessions are supported but transactions are not' do

--- a/spec/mongoid/clients/transactions_spec.rb
+++ b/spec/mongoid/clients/transactions_spec.rb
@@ -62,8 +62,10 @@ describe Mongoid::Clients::Sessions do
         Mongoid::Clients.with_name(:other).command(create: :people)
         Mongoid::Clients.with_name(:other).command(create: :posts)
         subscriber.clear_events!
-        Person.with(client: :other) do
-          example.run
+        Canvas.with(client: :other) do
+          Person.with(client: :other) do
+            example.run
+          end
         end
         Mongoid::Clients.with_name(:other).database.collections.each(&:drop)
       end
@@ -207,7 +209,6 @@ describe Mongoid::Clients::Sessions do
 
             s.commit_transaction
           end
-
         end
       end
     end

--- a/spec/mongoid/clients/transactions_spec.rb
+++ b/spec/mongoid/clients/transactions_spec.rb
@@ -61,6 +61,7 @@ describe Mongoid::Clients::Sessions do
         Mongoid::Clients.with_name(:other).database.collections.each(&:drop)
         Mongoid::Clients.with_name(:other).command(create: :people)
         Mongoid::Clients.with_name(:other).command(create: :posts)
+        Mongoid::Clients.with_name(:other).command(create: :canvases)
         subscriber.clear_events!
         Canvas.with(client: :other) do
           Person.with(client: :other) do


### PR DESCRIPTION
The error occurs on the following code: 
```
Band.with_session do |s|
  s.start_transaction
 
  label = Label.new(name: "Neil")
  b = Band.new(label: label)
  b.save!
  label.reload
  puts b.label # error
 
  s.commit_transaction
end
```
Full class code is in the [MONGOID-5199](https://jira.mongodb.org/browse/MONGOID-5199) ticket.

While investigating this I also noticed another issue:
```
Canvas.with_session do |s|
  s.start_transaction

  p = Palette.new
  c = Canvas.new(palette: p)
  c.save!
  c.palette = nil
  c.palette = p
  c.save!
  c.reload

  expect(c.palette).to_not be_nil # fails

  s.commit_transaction
end