### PR TITLE
MONGOID-5098 Bug fix: Range.mongoize should mongoize its members

### DIFF
--- a/lib/mongoid/extensions/range.rb
+++ b/lib/mongoid/extensions/range.rb
@@ -60,9 +60,9 @@ module Mongoid
         # @return [ Hash ] The object mongoized.
         def mongoize(object)
           return nil if object.nil?
-          return object if object.is_a?(::Hash)
-          return object if object.is_a?(String)
-          hash = { "min" => object.first, "max" => object.last }
+          return object.mongoize if object.is_a?(::Hash)
+          return object.mongoize if object.is_a?(String)
+          hash = { "min" => object.first&.mongoize, "max" => object.last&.mongoize }
           if object.respond_to?(:exclude_end?) && object.exclude_end?
             hash.merge!("exclude_end" => true)
           end

--- a/spec/integration/persistence/range_field_spec.rb
+++ b/spec/integration/persistence/range_field_spec.rb
@@ -1,0 +1,302 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'Range field persistence' do
+  let!(:person) { Person.create!(field => value).reload }
+  subject { person.send(field) }
+  let(:now_utc) { Time.now }
+  let(:later_utc) { now_utc + 10.minutes }
+  let(:now_in_zone) { now_utc.in_time_zone('Asia/Tokyo') }
+  let(:later_in_zone) { later_utc.in_time_zone('Asia/Tokyo') }
+
+  context 'static field' do
+    let(:field) { :range }
+
+    context 'when Integer' do
+      let(:value) { 1..3 }
+      it do
+        expect(subject).to eq(1..3)
+      end
+    end
+
+    context 'when Integer exclude_end' do
+      let(:value) { 1...3 }
+      it { expect(subject).to eq(1...3) }
+    end
+
+    context 'when Hash<String, Integer>' do
+      let(:value) { { 'min' => 1, 'max' => 3 } }
+      it { expect(subject).to eq(1..3) }
+    end
+
+    context 'when Hash<String, Integer> exclude_end' do
+      let(:value) { { 'min' => 1, 'max' => 3, 'exclude_end' => true } }
+      it { expect(subject).to eq(1...3) }
+    end
+
+    context 'when Hash<Symbol, Integer>' do
+      let(:value) { { min: 1, max: 3 } }
+      it { expect(subject).to eq(1..3) }
+    end
+
+    context 'when Hash<Symbol, Integer> exclude_end' do
+      let(:value) { { min: 1, max: 3, exclude_end: true } }
+      it { expect(subject).to eq(1...3) }
+    end
+
+    context 'when Time' do
+      let(:value) { now_utc..later_utc }
+
+      it do
+        expect(subject).to be_a Range
+        expect(subject.exclude_end?).to eq false
+        expect(subject.first).to be_within(0.01.second).of(now_utc)
+        expect(subject.last).to be_within(0.01.second).of(later_utc)
+        expect(subject.first.class).to eq Time
+        expect(subject.last.class).to eq Time
+      end
+    end
+
+    context 'when Time exclude_end' do
+      let(:value) { now_utc...later_utc }
+
+      it do
+        expect(subject).to be_a Range
+        expect(subject.exclude_end?).to eq true
+        expect(subject.first).to be_within(0.01.second).of(now_utc)
+        expect(subject.last).to be_within(0.01.second).of(later_utc)
+        expect(subject.first.class).to eq Time
+        expect(subject.last.class).to eq Time
+      end
+    end
+
+    context 'when Hash<String, Time>' do
+      let(:value) { { 'min' => now_utc, 'max' => later_utc } }
+
+      it do
+        expect(subject).to be_a Range
+        expect(subject.exclude_end?).to eq false
+        expect(subject.first).to be_within(0.01.second).of(now_utc)
+        expect(subject.last).to be_within(0.01.second).of(later_utc)
+        expect(subject.first.class).to eq Time
+        expect(subject.last.class).to eq Time
+      end
+    end
+
+    context 'when Hash<String, Time> exclude_end' do
+      let(:value) { { 'min' => now_utc, 'max' => later_utc, 'exclude_end' => true } }
+
+      it do
+        expect(subject).to be_a Range
+        expect(subject.exclude_end?).to eq true
+        expect(subject.first).to be_within(0.01.second).of(now_utc)
+        expect(subject.last).to be_within(0.01.second).of(later_utc)
+        expect(subject.first.class).to eq Time
+        expect(subject.last.class).to eq Time
+      end
+    end
+
+    context 'when ActiveSupport::TimeWithZone' do
+      let(:value) { now_in_zone..later_in_zone }
+
+      it do
+        expect(subject).to be_a Range
+        expect(subject.exclude_end?).to eq false
+        expect(subject.first).to be_within(0.01.second).of(now_utc)
+        expect(subject.last).to be_within(0.01.second).of(later_utc)
+        expect(subject.first.class).to eq Time
+        expect(subject.last.class).to eq Time
+      end
+    end
+
+    context 'when ActiveSupport::TimeWithZone exclude_end' do
+      let(:value) { now_in_zone...later_in_zone }
+
+      it do
+        expect(subject).to be_a Range
+        expect(subject.exclude_end?).to eq true
+        expect(subject.first).to be_within(0.01.second).of(now_utc)
+        expect(subject.last).to be_within(0.01.second).of(later_utc)
+        expect(subject.first.class).to eq Time
+        expect(subject.last.class).to eq Time
+      end
+    end
+
+    context 'when Hash<String, ActiveSupport::TimeWithZone>' do
+      let(:value) { { 'min' => now_in_zone, 'max' => later_in_zone } }
+
+      it do
+        expect(subject).to be_a Range
+        expect(subject.exclude_end?).to eq false
+        expect(subject.first).to be_within(0.01.second).of(now_utc)
+        expect(subject.last).to be_within(0.01.second).of(later_utc)
+        expect(subject.first.class).to eq Time
+        expect(subject.last.class).to eq Time
+      end
+    end
+
+    context 'when Hash<String, ActiveSupport::TimeWithZone> exclude_end' do
+      let(:value) { { 'min' => now_in_zone, 'max' => later_in_zone, 'exclude_end' => true } }
+
+      it do
+        expect(subject).to be_a Range
+        expect(subject.exclude_end?).to eq true
+        expect(subject.first).to be_within(0.01.second).of(now_utc)
+        expect(subject.last).to be_within(0.01.second).of(later_utc)
+        expect(subject.first.class).to eq Time
+        expect(subject.last.class).to eq Time
+      end
+    end
+  end
+
+  context 'dynamic field' do
+    let(:field) { :dynamic }
+
+    context 'when Integer' do
+      let(:value) { 1..3 }
+      it do
+        expect(subject).to eq('max' => 3, 'min' => 1)
+      end
+    end
+
+    context 'when Integer exclude_end' do
+      let(:value) { 1...3 }
+      it { expect(subject).to eq('max' => 3, 'min' => 1, 'exclude_end' => true) }
+    end
+
+    context 'when descending' do
+      let(:value) { 3..1 }
+      it { expect(subject).to eq('max' => 1, 'min' => 3) }
+    end
+
+    context 'when descending exclude_end' do
+      let(:value) { 3...1 }
+      it { expect(subject).to eq('max' => 1, 'min' => 3, 'exclude_end' => true) }
+    end
+
+    context 'when Hash<String, Integer>' do
+      let(:value) { { 'min' => 1, 'max' => 3 } }
+      it { expect(subject).to eq('max' => 3, 'min' => 1) }
+    end
+
+    context 'when Hash<String, Integer> exclude_end' do
+      let(:value) { { 'min' => 1, 'max' => 3, 'exclude_end' => true } }
+      it { expect(subject).to eq('max' => 3, 'min' => 1, 'exclude_end' => true) }
+    end
+
+    context 'when Hash<Symbol, Integer>' do
+      let(:value) { { min: 1, max: 3 } }
+      it { expect(subject).to eq('max' => 3, 'min' => 1) }
+    end
+
+    context 'when Hash<Symbol, Integer> exclude_end' do
+      let(:value) { { min: 1, max: 3, exclude_end: true } }
+      it { expect(subject).to eq('max' => 3, 'min' => 1, 'exclude_end' => true) }
+    end
+
+    context 'when Time' do
+      let(:value) { now_utc..later_utc }
+
+      it do
+        expect(subject).to be_a Hash
+        expect(subject['exclude_end']).to eq nil
+        expect(subject['min']).to be_within(0.01.second).of(now_utc)
+        expect(subject['max']).to be_within(0.01.second).of(later_utc)
+        expect(subject['min'].class).to eq Time
+        expect(subject['max'].class).to eq Time
+      end
+    end
+
+    context 'when Time exclude_end' do
+      let(:value) { now_utc...later_utc }
+
+      it do
+        expect(subject).to be_a Hash
+        expect(subject['exclude_end']).to eq true
+        expect(subject['min']).to be_within(0.01.second).of(now_utc)
+        expect(subject['max']).to be_within(0.01.second).of(later_utc)
+        expect(subject['min'].class).to eq Time
+        expect(subject['max'].class).to eq Time
+      end
+    end
+
+    context 'when Hash<String, Time>' do
+      let(:value) { { 'min' => now_utc, 'max' => later_utc } }
+
+      it do
+        expect(subject).to be_a Hash
+        expect(subject['exclude_end']).to eq nil
+        expect(subject['min']).to be_within(0.01.second).of(now_utc)
+        expect(subject['max']).to be_within(0.01.second).of(later_utc)
+        expect(subject['min'].class).to eq Time
+        expect(subject['max'].class).to eq Time
+      end
+    end
+
+    context 'when Hash<String, Time> exclude_end' do
+      let(:value) { { 'min' => now_utc, 'max' => later_utc, 'exclude_end' => true } }
+
+      it do
+        expect(subject).to be_a Hash
+        expect(subject['exclude_end']).to eq true
+        expect(subject['min']).to be_within(0.01.second).of(now_utc)
+        expect(subject['max']).to be_within(0.01.second).of(later_utc)
+        expect(subject['min'].class).to eq Time
+        expect(subject['max'].class).to eq Time
+      end
+    end
+
+    context 'when ActiveSupport::TimeWithZone' do
+      let(:value) { now_in_zone..later_in_zone }
+
+      it do
+        expect(subject).to be_a Hash
+        expect(subject['exclude_end']).to eq nil
+        expect(subject['min']).to be_within(0.01.second).of(now_utc)
+        expect(subject['max']).to be_within(0.01.second).of(later_utc)
+        expect(subject['min'].class).to eq Time
+        expect(subject['max'].class).to eq Time
+      end
+    end
+
+    context 'when ActiveSupport::TimeWithZone exclude_end' do
+      let(:value) { now_in_zone...later_in_zone }
+
+      it do
+        expect(subject).to be_a Hash
+        expect(subject['exclude_end']).to eq true
+        expect(subject['min']).to be_within(0.01.second).of(now_utc)
+        expect(subject['max']).to be_within(0.01.second).of(later_utc)
+        expect(subject['min'].class).to eq Time
+        expect(subject['max'].class).to eq Time
+      end
+    end
+
+    context 'when Hash<String, ActiveSupport::TimeWithZone>' do
+      let(:value) { { 'min' => now_in_zone, 'max' => later_in_zone } }
+
+      it do
+        expect(subject).to be_a Hash
+        expect(subject['exclude_end']).to eq nil
+        expect(subject['min']).to be_within(0.01.second).of(now_utc)
+        expect(subject['max']).to be_within(0.01.second).of(later_utc)
+        expect(subject['min'].class).to eq Time
+        expect(subject['max'].class).to eq Time
+      end
+    end
+
+    context 'when Hash<String, ActiveSupport::TimeWithZone> exclude_end' do
+      let(:value) { { 'min' => now_in_zone, 'max' => later_in_zone, 'exclude_end' => true } }
+
+      it do
+        expect(subject).to be_a Hash
+        expect(subject['exclude_end']).to eq true
+        expect(subject['min']).to be_within(0.01.second).of(now_utc)
+        expect(subject['max']).to be_within(0.01.second).of(later_utc)
+        expect(subject['min'].class).to eq Time
+        expect(subject['max'].class).to eq Time
+      end
+    end
+  end
+end

--- a/spec/mongoid/extensions/range_spec.rb
+++ b/spec/mongoid/extensions/range_spec.rb
@@ -16,142 +16,167 @@ describe Mongoid::Extensions::Range do
   end
 
   describe ".demongoize" do
+    subject { Range.demongoize(hash) }
 
     context "when the range is ascending" do
-
-      let(:hash) do
-        { "min" => 1, "max" => 3 }
-      end
+      let(:hash) { { "min" => 1, "max" => 3 } }
 
       it "returns an ascending range" do
-        expect(Range.demongoize(hash)).to eq(1..3)
+        is_expected.to eq(1..3)
       end
     end
 
     context "when the range is ascending with exclude end" do
-
-      let(:hash) do
-        { "min" => 1, "max" => 3, "exclude_end" => true }
-      end
+      let(:hash) { { "min" => 1, "max" => 3, "exclude_end" => true } }
 
       it "returns an ascending range" do
-        expect(Range.demongoize(hash)).to eq(1...3)
+        is_expected.to eq(1...3)
       end
     end
 
     context "when the range is descending" do
-
-      let(:hash) do
-        { "min" => 5, "max" => 1 }
-      end
+      let(:hash) { { "min" => 5, "max" => 1 } }
 
       it "returns an descending range" do
-        expect(Range.demongoize(hash)).to eq(5..1)
+        is_expected.to eq(5..1)
       end
     end
 
     context "when the range is descending with exclude end" do
-
-      let(:hash) do
-        { "min" => 5, "max" => 1, "exclude_end" => true }
-      end
+      let(:hash) { { "min" => 5, "max" => 1, "exclude_end" => true } }
 
       it "returns an descending range" do
-        expect(Range.demongoize(hash)).to eq(5...1)
+        is_expected.to eq(5...1)
       end
     end
 
     context "when the range is letters" do
-
-      let(:hash) do
-        { "min" => "a", "max" => "z" }
-      end
+      let(:hash) { { "min" => "a", "max" => "z" } }
 
       it "returns an alphabetic range" do
-        expect(Range.demongoize(hash)).to eq("a".."z")
+        is_expected.to eq("a".."z")
       end
     end
 
     context "when the range is letters with exclude end" do
-
-      let(:hash) do
-        { "min" => "a", "max" => "z", "exclude_end" => true }
-      end
+      let(:hash) { { "min" => "a", "max" => "z", "exclude_end" => true } }
 
       it "returns an alphabetic range" do
-        expect(Range.demongoize(hash)).to eq("a"..."z")
+        is_expected.to eq("a"..."z")
       end
     end
   end
 
-  describe ".mongoize" do
+  shared_examples_for 'mongoize range' do
 
-    context "when the value is not nil" do
+    context 'given a normal range' do
+      let(:range) { 1..3 }
 
       it "returns the object hash" do
-        expect(Range.mongoize(1..3)).to eq({ "min" => 1, "max" => 3 })
-      end
-
-      it "returns the object hash when passed an inverse range" do
-        expect(Range.mongoize(5..1)).to eq({ "min" => 5, "max" => 1 })
-      end
-
-      it "returns the object hash when passed a letter range" do
-        expect(Range.mongoize("a".."z")).to eq({ "min" => "a", "max" => "z" })
+        is_expected.to eq("min" => 1, "max" => 3)
       end
     end
 
-    context "when the value is not nil with exclude end" do
+    context 'given a normal range not inclusive' do
+      let(:range) { 1...3 }
 
       it "returns the object hash" do
-        expect(Range.mongoize(1...3)).to eq({ "min" => 1, "max" => 3, "exclude_end" => true })
+        is_expected.to eq("min" => 1, "max" => 3, "exclude_end" => true)
       end
-
-      it "returns the object hash when passed an inverse range" do
-        expect(Range.mongoize(5...1)).to eq({ "min" => 5, "max" => 1, "exclude_end" => true })
-      end
-
-      it "returns the object hash when passed a letter range" do
-        expect(Range.mongoize("a"..."z")).to eq({ "min" => "a", "max" => "z", "exclude_end" => true })
-      end
-
     end
 
-    context "when the value is nil" do
+    context 'given a descending range' do
+      let(:range) { 5..1 }
+
+      it "returns the object hash" do
+        is_expected.to eq("min" => 5, "max" => 1)
+      end
+    end
+
+    context 'given a descending range not inclusive' do
+      let(:range) { 5...1 }
+
+      it "returns the object hash" do
+        is_expected.to eq("min" => 5, "max" => 1, "exclude_end" => true)
+      end
+    end
+
+    context 'given a letter range' do
+      let(:range) { 'a'..'z' }
+
+      it "returns the object hash" do
+        is_expected.to eq("min" => "a", "max" => "z")
+      end
+    end
+
+    context 'given a letter range not inclusive' do
+      let(:range) { 'a'...'z' }
+
+      it "returns the object hash" do
+        is_expected.to eq("min" => "a", "max" => "z", "exclude_end" => true)
+      end
+    end
+
+    context 'given a Time range' do
+      let(:range) { Time.at(0)..Time.at(1) }
+
+      it "returns the object hash" do
+        is_expected.to eq("min" => Time.at(0), "max" => Time.at(1))
+        expect(subject["min"].utc?).to be(true)
+        expect(subject["max"].utc?).to be(true)
+      end
+    end
+
+    context 'given an ActiveSupport::TimeWithZone range' do
+      let(:range) { Time.at(0)..Time.at(1) }
+
+      it "returns the object hash" do
+        is_expected.to eq("min" => Time.at(0).in_time_zone, "max" => Time.at(1).in_time_zone)
+        expect(subject["min"].utc?).to be(true)
+        expect(subject["max"].utc?).to be(true)
+      end
+    end
+
+    context 'given a Date range' do
+      let(:range) { Time.at(0).to_date..Time.at(1).to_date }
+
+      it "returns the object hash" do
+        is_expected.to eq("min" => Time.at(0).in_time_zone, "max" => Time.at(0).in_time_zone)
+        expect(subject["min"].utc?).to be(true)
+        expect(subject["max"].utc?).to be(true)
+      end
+    end
+
+    context 'given a String' do
+      let(:range) { '3' }
+
+      it 'returns a string' do
+        is_expected.to eq('3')
+      end
+    end
+
+    context "given nil" do
+      let(:range) { nil }
 
       it "returns nil" do
-        expect(Range.mongoize(nil)).to be_nil
+        is_expected.to be_nil
       end
     end
   end
 
   describe "#mongoize" do
+    subject { range.mongoize }
 
-    context "when the value is not nil" do
+    it_behaves_like 'mongoize range'
+  end
 
-      it "returns the object hash" do
-        expect((1..3).mongoize).to eq({ "min" => 1, "max" => 3 })
-      end
+  describe ".mongoize" do
+    subject { Range.mongoize(range) }
 
-      it "returns the object hash when passed an inverse range" do
-        expect((5..1).mongoize).to eq({ "min" => 5, "max" => 1 })
-      end
-
-      it "returns the object hash when passed a letter range" do
-        expect(("a".."z").mongoize).to eq({ "min" => "a", "max" => "z" })
-      end
-    end
-
-    context 'when the value is a string' do
-
-      it 'returns a string' do
-        expect(Range.mongoize('3')).to eq('3')
-      end
-    end
+    it_behaves_like 'mongoize range'
   end
 
   describe "#resizable?" do
-
     let(:range) do
       1...3
     end


### PR DESCRIPTION
Fixes MONGOID-5098 (along with #5023 and #5025 which were already merged.)

MongoDB supports `Range` as a storable field type. Currently, when storing a `Range` of `Time` objects, the `Range#mongoize` method does not call `Time#mongoize` on the inner objects.

In addition, this PR improves `Range.mongoize` handling of `Hash` as an input, by removing keys which are unrelated to `Range` and would be junk data in DB. This case is *highly unlikely* to be used in any real-world app, but the existing Mongoid code supports it so we should make it work properly.

(* This PR does NOT add support for endless/beginless ranges; that will be addressed in a separate PR.)