### PR TITLE
GH Actions tests for Rails 7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -179,6 +179,46 @@ jobs:
           gemfile: gemfiles/driver_min.gemfile
           experimental: false
         - mongodb: '5.0'
+          ruby: ruby-3.1
+          topology: server
+          os: ubuntu-20.04
+          task: test
+          driver: current
+          rails: '7.0'
+          i18n:
+          gemfile: gemfiles/rails-7.0.gemfile
+          experimental: false
+        - mongodb: '5.0'
+          ruby: ruby-3.1
+          topology: server
+          os: ubuntu-20.04
+          task: test
+          driver: current
+          rails: '6.1'
+          i18n:
+          gemfile: gemfiles/rails-6.1.gemfile
+          experimental: false
+        - mongodb: '5.0'
+          ruby: ruby-3.0
+          topology: server
+          os: ubuntu-20.04
+          task: test
+          driver: current
+          rails: '7.0'
+          i18n:
+          gemfile: gemfiles/rails-7.0.gemfile
+          experimental: false
+        - mongodb: '5.0'
+          ruby: ruby-3.0
+          topology: server
+          os: ubuntu-20.04
+          task: test
+          driver: current
+          rails: '6.1'
+          i18n:
+          gemfile: gemfiles/rails-6.1.gemfile
+          experimental: false
+        - mongodb: '5.0'
           ruby: ruby-3.0
           topology: server
           os: ubuntu-20.04

--- a/gemfiles/rails-7.0.gemfile
+++ b/gemfiles/rails-7.0.gemfile
@@ -1,0 +1,10 @@
+source 'https://rubygems.org'
+
+gem 'actionpack', '~> 7.0'
+gem 'activemodel', '~> 7.0'
+
+gemspec path: '..'
+
+require_relative './standard'
+
+standard_dependencies

--- a/mongoid.gemspec
+++ b/mongoid.gemspec
@@ -33,17 +33,15 @@ Gem::Specification.new do |s|
   s.required_ruby_version     = ">= 2.5"
   s.required_rubygems_version = ">= 1.3.6"
 
-  if RUBY_VERSION.start_with?('2.')
-    s.add_dependency("activemodel", [">=5.1", "<6.2"])
-  elsif RUBY_VERSION.start_with?('3.')
-    s.add_dependency("activemodel", [">=6.0", "<6.2"])
-  end
+  # activemodel 7.0.0 cannot be used due to Class#descendants issue (see: https://github.com/rails/rails/pull/43951)
+  s.add_dependency("activemodel", ['>=5.1', '<7.1', '!= 7.0.0'])
   s.add_dependency("mongo", ['>=2.10.5', '<3.0.0'])
-  # Using this gem is recommended for handling argument delegation issues,
+
+  # The ruby2_keywords gem is recommended for handling argument delegation issues,
   # especially if support for 2.6 or prior is required.
   # See https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/#delegation
   #
-  # We have a bunch of complex delegation logic, including various method_missngs.
+  # We have a bunch of complex delegation logic, including various method_missings.
   # If we try to fix them "right", it will add too much logic. We will have to
   # handle different Ruby versions (including minor ones, Ruby 2.6 and 2.7
   # behave differently), hash key types (strings vs symbols), ways of passing

--- a/mongoid.gemspec
+++ b/mongoid.gemspec
@@ -33,7 +33,8 @@ Gem::Specification.new do |s|
   s.required_ruby_version     = ">= 2.5"
   s.required_rubygems_version = ">= 1.3.6"
 
-  # activemodel 7.0.0 cannot be used due to Class#descendants issue (see: https://github.com/rails/rails/pull/43951)
+  # activemodel 7.0.0 cannot be used due to Class#descendants issue
+  # See: https://github.com/rails/rails/pull/43951
   s.add_dependency("activemodel", ['>=5.1', '<7.1', '!= 7.0.0'])
   s.add_dependency("mongo", ['>=2.10.5', '<3.0.0'])
 


### PR DESCRIPTION
This PR adds GH Actions tests supports for Rails 7.

Currently, this PR is blocked for Ruby 3.1 + Rails 7.0.0 support due to a last-minute change (hence I've disallowed 7.0.0 as a version.) This will be fixed in Rails 7.0.1. See https://github.com/rails/rails/pull/43951.