### PR TITLE
MONGOID-5207 Use YAML.safe_load in specs

### DIFF
--- a/spec/integration/matcher_operator_spec.rb
+++ b/spec/integration/matcher_operator_spec.rb
@@ -14,7 +14,28 @@ end
 describe 'Matcher operators' do
   Dir[File.join(File.dirname(__FILE__), 'matcher_operator_data', '*.yml')].sort.each do |path|
     context File.basename(path) do
-      specs = YAML.load(File.read(path))
+      permitted_classes = [ BigDecimal,
+                            Date,
+                            Time,
+                            Range,
+                            Regexp,
+                            Symbol,
+                            BSON::Binary,
+                            BSON::Code,
+                            BSON::CodeWithScope,
+                            BSON::DbPointer,
+                            BSON::Decimal128,
+                            BSON::Int32,
+                            BSON::Int64,
+                            BSON::MaxKey,
+                            BSON::MinKey,
+                            BSON::ObjectId,
+                            BSON::Regexp::Raw,
+                            BSON::Symbol::Raw,
+                            BSON::Timestamp,
+                            BSON::Undefined ]
+
+      specs = YAML.safe_load(File.read(path), permitted_classes, [], true)
 
       specs.each do |spec|
         context spec['name'] do

--- a/spec/integration/matcher_operator_spec.rb
+++ b/spec/integration/matcher_operator_spec.rb
@@ -36,11 +36,10 @@ describe 'Matcher operators' do
                             BSON::Undefined ]
 
       specs = if RUBY_VERSION.start_with?("2.5")
-        YAML.safe_load(File.read(path), permitted_classes, [], true)
-      else
-        # Here we have Ruby 2.6+ that supports the new syntax of `safe_load`.
-        YAML.safe_load(File.read(path), permitted_classes: permitted_classes, aliases: true)
-      end
+                YAML.safe_load(File.read(path), permitted_classes, [], true)
+              else
+                YAML.safe_load(File.read(path), permitted_classes: permitted_classes, aliases: true)
+              end
 
       specs.each do |spec|
         context spec['name'] do

--- a/spec/integration/matcher_operator_spec.rb
+++ b/spec/integration/matcher_operator_spec.rb
@@ -35,7 +35,12 @@ describe 'Matcher operators' do
                             BSON::Timestamp,
                             BSON::Undefined ]
 
-      specs = YAML.safe_load(File.read(path), permitted_classes, [], true)
+      specs = if RUBY_VERSION.start_with?("2.5")
+        YAML.safe_load(File.read(path), permitted_classes, [], true)
+      else
+        # Here we have Ruby 2.6+ that supports the new syntax of `safe_load`.
+        YAML.safe_load(File.read(path), permitted_classes: permitted_classes, aliases: true)
+      end
 
       specs.each do |spec|
         context spec['name'] do

--- a/spec/mongoid/attributes/projector_spec.rb
+++ b/spec/mongoid/attributes/projector_spec.rb
@@ -5,7 +5,11 @@ require "spec_helper"
 describe Mongoid::Attributes::Projector do
   Dir[File.join(File.dirname(__FILE__), 'projector_data', '*.yml')].sort.each do |path|
     context File.basename(path) do
-      specs = YAML.safe_load(File.read(path), [], [], true)
+      specs = if RUBY_VERSION.start_with?("2.5")
+                YAML.safe_load(File.read(path), [], [], true)
+              else
+                YAML.safe_load(File.read(path), aliases: true)
+              end
 
       specs.each do |spec|
         context spec['name'] do

--- a/spec/mongoid/attributes/projector_spec.rb
+++ b/spec/mongoid/attributes/projector_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 describe Mongoid::Attributes::Projector do
   Dir[File.join(File.dirname(__FILE__), 'projector_data', '*.yml')].sort.each do |path|
     context File.basename(path) do
-      specs = YAML.load(File.read(path))
+      specs = YAML.safe_load(File.read(path), [], [], true)
 
       specs.each do |spec|
         context spec['name'] do

--- a/spec/mongoid/matcher/extract_attribute_spec.rb
+++ b/spec/mongoid/matcher/extract_attribute_spec.rb
@@ -5,7 +5,11 @@ require 'spec_helper'
 describe 'Matcher.extract_attribute' do
   Dir[File.join(File.dirname(__FILE__), 'extract_attribute_data', '*.yml')].sort.each do |path|
     context File.basename(path) do
-      specs = YAML.safe_load(File.read(path), [], [], true)
+      specs = if RUBY_VERSION.start_with?("2.5")
+                YAML.safe_load(File.read(path), [], [], true)
+              else
+                YAML.safe_load(File.read(path), aliases: true)
+              end
 
       specs.each do |spec|
         context spec['name'] do

--- a/spec/mongoid/matcher/extract_attribute_spec.rb
+++ b/spec/mongoid/matcher/extract_attribute_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 describe 'Matcher.extract_attribute' do
   Dir[File.join(File.dirname(__FILE__), 'extract_attribute_data', '*.yml')].sort.each do |path|
     context File.basename(path) do
-      specs = YAML.load(File.read(path))
+      specs = YAML.safe_load(File.read(path), [], [], true)
 
       specs.each do |spec|
         context spec['name'] do


### PR DESCRIPTION
Change YAML.load to YAML.safe_load as it is the default in Ruby 3.1+. This change only affects specs.