### PR TITLE
Prefer field :type as Symbol + custom field type symbols

### DIFF
--- a/docs/reference/fields.txt
+++ b/docs/reference/fields.txt
@@ -13,15 +13,21 @@ Field Definition
    :class: singlecol
 
 
+.. _field-types:
+
 Field Types
 ===========
 
-Even though MongoDB is a schemaless database and allows data to be stored
-as strings, Mongoid permits the application to declare the type of data
-stored in the various fields of a document. Field type declarations affect
-the following:
+MongoDB stores underlying document data using
+`BSON types <https://docs.mongodb.com/manual/reference/bson-types/>`_, and
+Mongoid converts BSON types to Ruby types at runtime in your application.
+For example, a field defined with `type: :float` will use the Ruby ``Float``
+class in-memory and will persist in the database as the the BSON ``double`` type.
 
-1. When assigning values to fields, the values are converted to the
+Field type definitions determine how Mongoid behaves when constructing queries
+and retrieving/writing fields from/to the database. Specifically:
+
+1. When assigning values to fields at runtime, the values are converted to the
 specified type.
 
 2. When persisting data to MongoDB, the data is sent in an appropriate
@@ -34,9 +40,7 @@ type before being sent to MongoDB.
 4. When retrieving documents from the database, field values are converted
 to the specified type.
 
-Field type definitions determine how Mongoid behaves when constructing the
-queries, retrieving and writing fields from the database. Changing the field
-definitions in a model class does not alter data already stored in
+Changing the field definitions in a model class does not alter data already stored in
 MongoDB. To update type or contents of fields of existing documents,
 the field must be re-saved to the database. Note that, due to Mongoid
 tracking which attributes on a model change and only saving the changed ones,
@@ -44,38 +48,51 @@ it may be necessary to explicitly write a field value when changing the
 type of an existing field without changing the stored values.
 
 Consider a simple class for modeling a person in an application. A person may
-have a first name, last name, and middle name. We can define these attributes
+have a name, date_of_birth, and weight. We can define these attributes
 on a person by using the ``field`` macro.
 
 .. code-block:: ruby
 
    class Person
      include Mongoid::Document
-     field :first_name, type: String
-     field :middle_name, type: String
-     field :last_name, type: String
+     field :name, type: :string
+     field :date_of_birth, type: :date
+     field :weight, type: :float
    end
 
 Below is a list of valid types for fields.
 
-- ``Array``
-- ``BigDecimal``
-- ``Boolean``
-- ``Date``
-- ``DateTime``
-- ``Float``
-- ``Hash``
-- ``Integer``
-- ``BSON::ObjectId``
-- ``BSON::Binary``
-- ``Range``
-- ``Regexp``
-- ``Set``
-- ``String``
-- ``StringifiedSymbol``
-- ``Symbol``
-- ``Time``
-- ``TimeWithZone``
+- ``:array``
+- ``:big_decimal``
+- ``:boolean``
+- ``:date``
+- ``:date_time``
+- ``:decimal128`` (``BSON::Decimal128``)
+- ``:float``
+- ``:hash``
+- ``:integer``
+- ``:object_id`` (``BSON::ObjectID``)
+- ``:binary`` (``BSON::Binary``)
+- ``:range``
+- ``:regexp``
+- ``:set``
+- ``:string``
+- ``:stringified_symbol`` (see below)
+- ``:symbol``
+- ``:time``
+- ``:time_with_zone``
+
+To define custom field types, refer to :ref:`Custom Field Types <custom-field-types>` below.
+
+As of Mongoid 7.5, ``field :type`` should be specified as a ``Symbol``.
+Specifying as a ``Class`` is deprecated and will be no longer supported in Mongoid 8.0.
+Unrecognized field type symbols will result in an `InvalidFieldType` error when the model class is loaded.
+
+
+.. _omitting-field-type-definition:
+
+Omitting Field Type Definition
+------------------------------
 
 If you decide not to specify the type of field with the definition, Mongoid will treat
 it as an object and not try to typecast it when sending the values to the database.
@@ -103,18 +120,18 @@ Types that are not supported as dynamic attributes since they cannot be cast are
 - ``Range``
 
 
-.. _stringified-symbol:
+.. _field-type-stringified-symbol:
 
-The StringifiedSymbol Type
---------------------------
+Field Type :stringified_symbol
+------------------------------
 
-The ``StringifiedSymbol`` field type is the recommended field type for storing
-values that should be exposed as symbols to Ruby applications. When using the ``Symbol`` field type,
+The ``:stringified_symbol`` field type is the recommended field type for storing
+values that should be exposed as symbols to Ruby applications. When using the ``:symbol`` field type,
 Mongoid defaults to storing values as BSON symbols. For more information on the
-BSON symbol type, see :ref:`here <bson-symbol>`.
+BSON symbol type, see :ref:`here <field-type-symbol>`.
 However, the BSON symbol type is deprecated and is difficult to work with in programming languages
-without native symbol types, so the ``StringifiedSymbol`` type allows the use of symbols
-while ensuring interoperability with other drivers. The ``StringifiedSymbol`` type stores all data
+without native symbol types, so the ``:stringified_symbol`` type allows the use of symbols
+while ensuring interoperability with other drivers. The ``:stringified_symbol`` type stores all data
 on the database as strings, while exposing values to the application as symbols.
 
 An example usage is shown below:
@@ -157,12 +174,12 @@ migration from fields that currently store either strings or BSON symbols in the
 ``StringifiedSymbol`` field type.
 
 
-.. _bson-symbol:
+.. _field-type-symbol:
 
-BSON Symbol Type
-----------------
+Field Type :symbol
+------------------
 
-New applications should use the :ref:`StringifiedSymbol field type <stringified-symbol>`
+New applications should use the :ref:`StringifiedSymbol field type <field-type-stringified-symbol>`
 to store Ruby symbols in the database. The ``StringifiedSymbol`` field type
 provides maximum compatibility with other applications and programming languages
 and has the same behavior in all circumstances.
@@ -188,8 +205,10 @@ snippet in your project:
   end
 
 
-Hash Fields
------------
+.. _field-type-hash:
+
+Field Type :hash
+----------------
 
 When using a field of type Hash, be wary of adhering to the
 `legal key names for mongoDB <http://docs.mongodb.org/manual/reference/limits/#naming-restrictions>`_,
@@ -218,8 +237,10 @@ or else the values will not store properly.
    end
 
 
-Time Fields
------------
+.. _field-type-time:
+
+Field Type :time
+----------------
 
 ``Time`` fields store values as ``Time`` instances in the :ref:`configured
 time zone <time-zones>`.
@@ -242,8 +263,10 @@ In the above example, the value was interpreted as the beginning of today in
 local time, because the application was not configured to use UTC times.
 
 
-Date Fields
------------
+.. _field-type-date:
+
+Field Type :date
+----------------
 
 Mongoid allows assignment of values of several types to ``Date`` fields:
 
@@ -265,11 +288,14 @@ recommended to explicitly convert ``String``, ``Time`` and ``DateTime``
 objects to ``Date`` objects before assigning the values to fields of type
 ``Date``.
 
-DateTime Fields
----------------
+
+.. _field-type-date-time:
+
+Field Type :date_time
+---------------------
 
 MongoDB stores all times as UTC timestamps. When assigning a value to a
-``DateTime`` field, or when querying a ``DateTime`` field, Mongoid
+``:date_time`` field, or when querying a ``:date_time`` field, Mongoid
 converts the passed in value to a UTC ``Time`` before sending it to the
 MongoDB server.
 
@@ -332,13 +358,13 @@ If a time zone is specified, it is respected:
     # => Sun, 04 Mar 2018 09:00:00 +0000
 
 
-.. _regular-expression-fields:
+.. _field-type-regexp:
 
-Regular Expression Fields
--------------------------
+Field Type :regexp
+------------------
 
 MongoDB supports storing regular expressions in documents, and querying using
-regular expressions. Of note for Ruby applications, MongoDB uses
+regular expressions. Note that MongoDB uses
 `Perl-compatible regular expressions (PCRE) <http://pcre.org/>`_
 and Ruby uses `Onigmo <https://github.com/k-takata/Onigmo>`_, which is a
 fork of `Oniguruma regular expression engine <https://github.com/kkos/oniguruma>`_.
@@ -396,8 +422,10 @@ This is because the meaning of ``$`` is different between PCRE and Ruby
 regular expressions.
 
 
-Defaults
---------
+.. _field-default-values:
+
+Specifying Field Default Values
+-------------------------------
 
 A field can be configured to have a default value. The default value can be
 fixed, as in the following example:
@@ -587,7 +615,7 @@ To define the field anyway, use the ``overwrite: true`` option:
 
 .. _custom-id:
 
-Custom Ids
+Custom IDs
 ----------
 
 By default, Mongoid defines the ``_id`` field on documents to contain a
@@ -640,16 +668,20 @@ alias can :ref:`be removed <unalias-id>` if desired (such as to integrate
 with systems that use the ``id`` field to store value different from ``_id``.
 
 
+.. _customizing-field-behavior:
+
 Customizing Field Behavior
 ==========================
 
-Mongoid offers several options for customizing the behavior of fields.
+Mongoid offers several ways to customize the behavior of fields.
 
+
+.. _custom-getters-and-setters:
 
 Custom Getters And Setters
 --------------------------
 
-You can define custom getters and setters for fields to modify the values
+You may override getters and setters for fields to modify the values
 when they are being accessed or written. The getters and setters use the
 same name as the field. Use ``read_attribute`` and ``write_attribute``
 methods inside the getters and setters to operate on the raw attribute
@@ -707,19 +739,36 @@ may be implemented as follows:
   # => {"_id"=>BSON::ObjectId('613fa15aa15d5d617216104c'), "value"=>2.0, "unit"=>nil}
 
 
+.. _custom-field-types:
+
 Custom Field Types
 ------------------
 
 You can define custom types in Mongoid and determine how they are serialized
-and deserialized. You simply need to provide three methods on it for Mongoid
-to call to convert your object to and from MongoDB friendly values.
+and deserialized. In this example, we define a new field type ``Point``, which we
+can use in our model class as follows:
 
 .. code-block:: ruby
 
   class Profile
     include Mongoid::Document
-    field :location, type: Point
+    field :location, type: :point
   end
+
+First, declare the new field type mapping in an initializer:
+
+.. code-block:: ruby
+
+  # in /config/initializers/mongoid_custom_fields.rb
+
+  Mongoid::Fields.configure do
+    type :point, Point
+  end
+
+Then make a Ruby class to represent the type. This class must
+define ``mongoize`` and ``demongoize`` methods as per below:
+
+.. code-block:: ruby
 
   class Point
 
@@ -730,6 +779,7 @@ to call to convert your object to and from MongoDB friendly values.
     end
 
     # Converts an object of this instance into a database friendly value.
+    # In this example, we store the values in the database as array.
     def mongoize
       [ x, y ]
     end
@@ -795,10 +845,47 @@ Note that when accessing custom fields from the document, you will get a
 new instance of that object with each call to the getter. This is because
 Mongoid is generating a new object from the raw attributes on each access.
 
-We need the point object in the criteria to be transformed to a
+We need the ``Point`` object in the criteria to be transformed to a
 MongoDB-friendly value when it is not as well, ``evolve`` is the method
 that takes care of this. We check if the passed in object is a ``Point``
 first, in case we also want to be able to pass in ordinary arrays instead.
+
+
+.. _custom-field-options:
+
+Custom Field Options
+--------------------
+
+You may define custom options for the ``field`` macro function
+which extend its behavior at the your time model classes are loaded.
+
+As an example, we will define a ``:required`` option which will
+add a presence validator for the field. First, declare the new
+field option in an initializer:
+
+.. code-block:: ruby
+
+  # in /config/initializers/mongoid_custom_fields.rb
+
+  Mongoid::Fields.configure do
+    option :required do |model, field, value|
+      model.validates_presence_of field if value
+    end
+  end
+
+Then, use it your model class:
+
+.. code-block:: ruby
+
+  class Person
+    include Mongoid::Document
+
+    field :name, type: String, required: true
+  end
+
+No assumptions are made about the functionality the handler might
+perform. The handler will always be called whenever the option is used
+in the field definition, even if its value is false or nil.
 
 
 .. _dynamic-fields:

--- a/lib/config/locales/en.yml
+++ b/lib/config/locales/en.yml
@@ -84,7 +84,7 @@ en:
           message: "Empty configuration file: %{path}."
           summary: "Your mongoid.yml configuration file appears to be empty."
           resolution: "Ensure your configuration file contains the correct contents.
-            Please consult the following page with respect to Mongoid's configuration:
+            Refer to:
             https://docs.mongodb.com/mongoid/current/reference/configuration/"
         invalid_collection:
           message: "Access to the collection for %{klass} is not allowed."
@@ -105,7 +105,7 @@ en:
           summary: "Your mongoid.yml configuration file does not contain the
             correct file structure."
           resolution: "Ensure your configuration file contains the correct contents.
-            Please consult the following page with respect to Mongoid's configuration:
+            Refer to:
             https://docs.mongodb.com/mongoid/current/reference/configuration/"
         invalid_config_option:
           message: "Invalid configuration option: %{name}."
@@ -173,14 +173,34 @@ en:
             field definition in order to prevent unexpected behavior later on."
           resolution: "When defining the field :%{name} on '%{klass}', please provide
             valid options for the field. These are currently: %{valid}. If you
-            meant to define a custom field option, please do so first like so:\n\n
-            \_\_Mongoid::Fields.option :%{option} do |model, field, value|\n
-            \_\_\_\_# Your logic here...\n
+            meant to define a custom field option, please do so first as follows:\n\n
+            \_\_Mongoid::Fields.configure do\n
+            \_\_\_\_option :%{option} do |model, field, value|\n
+            \_\_\_\_\_\_# Your logic here...\n
+            \_\_\_\_end\n
             \_\_end\n
             \_\_class %{klass}\n
             \_\_\_\_include Mongoid::Document\n
             \_\_\_\_field :%{name}, %{option}: true\n
-            \_\_end\n\n"
+            \_\_end\n\n
+            Refer to:
+            https://docs.mongodb.com/mongoid/current/reference/fields/#custom-field-options"
+        invalid_field_type:
+          message: "Invalid field type :%{type} for field :%{field} on model '%{klass}'."
+          summary: "Model '%{klass}' defines a field :%{field} with an unknown :type value
+            '%{type}'. This value is neither present in Mongoid's default type mapping,
+            nor defined in a custom field type mapping."
+          resolution: "Please provide a valid :type value for the field. If you
+            meant to define a custom field type, please do so first as follows:\n\n
+            \_\_Mongoid::Fields.configure do\n
+            \_\_\_\_type :%{type}, YourTypeClass
+            \_\_end\n
+            \_\_class %{klass}\n
+            \_\_\_\_include Mongoid::Document\n
+            \_\_\_\_field :%{field}, type: :%{type}\n
+            \_\_end\n\n
+            Refer to:
+            https://docs.mongodb.com/mongoid/current/reference/fields/#custom-field-types"
         invalid_includes:
           message: "Invalid includes directive: %{klass}.includes(%{args})"
           summary: "Eager loading in Mongoid only supports providing arguments
@@ -564,12 +584,12 @@ en:
             Mongoid::Attributes::Dynamic in %{klass} if you intend to
             store values in fields that are not explicitly defined."
         unknown_model:
-          message: "Attempted to instantiate an object of the unknown Model '%{klass}'."
+          message: "Attempted to instantiate an object of the unknown model '%{klass}'."
           summary: "A document with the value '%{value}' at the key '_type' was used to
             instantiate a model object but Mongoid cannot find this Class."
           resolution: "The _type field is a reserved one used by Mongoid to determine the
             class for instantiating an object. Please don't save data in this field or ensure
-            that any values in this field correspond to valid Models."
+            that any values in this field correspond to valid models."
         unsaved_document:
           message: "Attempted to save %{document} before the parent %{base}."
           summary: "You cannot call create or create! through the

--- a/lib/mongoid/errors/invalid_field_type.rb
+++ b/lib/mongoid/errors/invalid_field_type.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Mongoid
+  module Errors
+
+    # This error is raised when trying to define a field using a :type option value
+    # that is not present in the field type mapping.
+    class InvalidFieldType < MongoidError
+
+      # Create the new error.
+      #
+      # @example Instantiate the error.
+      #   InvalidFieldType.new('Person', 'first_name', 'stringgy')
+      #
+      # @param [ String ] klass The model class.
+      # @param [ String ] field The field on which the invalid type is used.
+      # @param [ String ] type The value of the field :type option.
+      def initialize(klass, field, type)
+        super(
+          compose_message('invalid_field_type', { klass: klass, field: field, type: type })
+        )
+      end
+    end
+  end
+end

--- a/lib/mongoid/field_types.rb
+++ b/lib/mongoid/field_types.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module Mongoid
+
+  # Singleton module which contains a cache for field type definitions.
+  # Custom field types can be configured.
+  module FieldTypes
+    extend self
+
+    # For fields defined with symbols use the correct class.
+    DEFAULT_MAPPING = {
+      array: Array,
+      bigdecimal: BigDecimal,
+      big_decimal: BigDecimal,
+      binary: BSON::Binary,
+      boolean: Mongoid::Boolean,
+      date: Date,
+      datetime: DateTime,
+      date_time: DateTime,
+      decimal128: BSON::Decimal128,
+      double: Float,
+      float: Float,
+      hash: Hash,
+      integer: Integer,
+      object: Object,
+      object_id: BSON::ObjectId,
+      range: Range,
+      regexp: Regexp,
+      set: Set,
+      string: String,
+      stringified_symbol: Mongoid::StringifiedSymbol,
+      symbol: Symbol,
+      time: Time,
+      time_with_zone: ActiveSupport::TimeWithZone
+    }.with_indifferent_access.freeze
+
+    def get(value)
+      mapping[value] || handle_unmapped_type(value)
+    end
+
+    def define(symbol, klass)
+      mapping[symbol] = klass
+    end
+
+    delegate :delete, to: :mapping
+
+    def mapping
+      @mapping ||= DEFAULT_MAPPING.dup
+    end
+
+    def handle_unmapped_type(type)
+      return Object if type.nil?
+
+      if type.is_a?(Module)
+        Mongoid.logger.warn(FIELD_TYPE_IS_SYMBOL)
+        return Mongoid::Boolean if type.to_s == 'Boolean'
+        type
+      end
+
+      nil
+    end
+  end
+end

--- a/lib/mongoid/fields.rb
+++ b/lib/mongoid/fields.rb
@@ -11,30 +11,6 @@ module Mongoid
   module Fields
     extend ActiveSupport::Concern
 
-    StringifiedSymbol = Mongoid::StringifiedSymbol
-    Boolean = Mongoid::Boolean
-
-    # For fields defined with symbols use the correct class.
-    TYPE_MAPPINGS = {
-      array: Array,
-      big_decimal: BigDecimal,
-      binary: BSON::Binary,
-      boolean: Mongoid::Boolean,
-      date: Date,
-      date_time: DateTime,
-      float: Float,
-      hash: Hash,
-      integer: Integer,
-      object_id: BSON::ObjectId,
-      range: Range,
-      regexp: Regexp,
-      set: Set,
-      string: String,
-      stringified_symbol: StringifiedSymbol,
-      symbol: Symbol,
-      time: Time
-    }.with_indifferent_access
-
     # Constant for all names of the _id field in a document.
     #
     # This does not include aliases of _id field.
@@ -205,16 +181,39 @@ module Mongoid
 
     class << self
 
+      # DSL method used for configuration readability, typically in
+      # an initializer.
+      #
+      # @example
+      #   Mongoid::Fields.configure do
+      #     # do configuration
+      #   end
+      def configure(&block)
+        instance_exec(&block)
+      end
+
+      # Defines a field type mapping, for later use in field :type option.
+      #
+      # @example
+      #   Mongoid::Fields.configure do
+      #     type :point, Point
+      #   end
+      def type(symbol, klass)
+        Mongoid::FieldTypes.define(symbol, klass)
+      end
+
       # Stores the provided block to be run when the option name specified is
       # defined on a field.
       #
-      # No assumptions are made about what sort of work the handler might
+      # No assumptions are made about the functionality the handler might
       # perform, so it will always be called if the `option_name` key is
       # provided in the field definition -- even if it is false or nil.
       #
       # @example
-      #   Mongoid::Fields.option :required do |model, field, value|
-      #     model.validates_presence_of field if value
+      #   Mongoid::Fields.configure do
+      #     option :required do |model, field, value|
+      #       model.validates_presence_of field if value
+      #     end
       #   end
       #
       # @param [ Symbol ] option_name the option name to match against
@@ -569,19 +568,16 @@ module Mongoid
 
       def field_for(name, options)
         opts = options.merge(klass: self)
-        type_mapping = TYPE_MAPPINGS[options[:type]]
-        opts[:type] = type_mapping || unmapped_type(options)
+        opts[:type] = field_type_klass_for(name, options[:type])
         return Fields::Localized.new(name, opts) if options[:localize]
         return Fields::ForeignKey.new(name, opts) if options[:identity]
         Fields::Standard.new(name, opts)
       end
 
-      def unmapped_type(options)
-        if "Boolean" == options[:type].to_s
-          Mongoid::Boolean
-        else
-          options[:type] || Object
-        end
+      def field_type_klass_for(field, type)
+        klass = FieldTypes.get(type)
+        return klass if klass
+        raise Mongoid::Errors::InvalidFieldType.new(self.name, field, type)
       end
     end
   end


### PR DESCRIPTION
 **Prior to this PR**, Mongoid already supports defining field `:type` as a `Symbol` rather than a `Class`:

```ruby
  field :first_name, type: :string  # works today, even without this PR!
```

Generally speaking, it is much better to to use Symbol than Class, because Class uses autoloading etc.

This PR adds the following:
- Main documentation is updated to **prefer** using Symbol rather than Class. I haven't done this change in 100% of doc files; I plan to do that after this PR is merged in a separate PR.
- Usage of Class is **deprecated** and now logs a warning. Usage of Class is intended to be removed in Mongoid 8.0.
- It is now possible to define custom symbols using the following:

```ruby
  Mongoid::Fields.configure do
    type :point, Point
  end
```