### PR TITLE
Fix documentation of index method

### DIFF
--- a/lib/mongoid/indexable.rb
+++ b/lib/mongoid/indexable.rb
@@ -88,7 +88,7 @@ module Mongoid
       #     index({ name: 1 }, { background: true })
       #   end
       #
-      # @param [ Symbol ] spec The index spec.
+      # @param [ Hash ] spec The index spec.
       # @param [ Hash ] options The index options.
       #
       # @return [ Hash ] The index options.


### PR DESCRIPTION
The `spec` argument of the `index` method is a Hash. The example is `index({ name: 1 }, { background: true })` which is a hash. The `spec` argument is directly passed as the 2nd argument to the `Specification` constructor which is [already documented as a Hash](https://github.com/mongodb/mongoid/blob/f863870a53ef9fd8d74cb8702557045d7de635a7/lib/mongoid/indexable/specification.rb#L41)