### PR TITLE
MONGOID-5219 Uniqueness validation for StringifiedSymbol field in an embedded document fails

### DIFF
--- a/lib/mongoid/stringified_symbol.rb
+++ b/lib/mongoid/stringified_symbol.rb
@@ -9,7 +9,7 @@ module Mongoid
       # Convert the object from its mongo friendly ruby type to this type.
       #
       # @example Demongoize the object.
-      #   Symbol.demongoize(object)
+      #   Mongoid::StringifiedSymbol.demongoize(object)
       #
       # @param [ Object ] object The object to demongoize.
       #
@@ -28,7 +28,7 @@ module Mongoid
       # type.
       #
       # @example Mongoize the object.
-      #   Symbol.mongoize("123.11")
+      #   Mongoid::StringifiedSymbol.mongoize("123.11")
       #
       # @param [ Object ] object The object to mongoize.
       #

--- a/lib/mongoid/validatable/uniqueness.rb
+++ b/lib/mongoid/validatable/uniqueness.rb
@@ -94,9 +94,8 @@ module Mongoid
       # @return [ Criteria ] The criteria.
       def create_criteria(base, document, attribute, value)
         criteria = scope(base.unscoped, document, attribute)
-        field_name = document.aliased_fields[attribute.to_s] || attribute.to_s
-        field = document.fields[field_name]
-        mongoized = field&.localized? ? value.mongoize : field.mongoize(value) 
+        field = document.fields[document.database_field_name(attribute)]
+        mongoized = field.try(:localized?) ? value.mongoize : field.mongoize(value) 
         criteria.selector.update(criterion(document, attribute, mongoized))
         criteria
       end

--- a/lib/mongoid/validatable/uniqueness.rb
+++ b/lib/mongoid/validatable/uniqueness.rb
@@ -100,12 +100,13 @@ module Mongoid
         # would call Object's mongoize method. This is a problem for StringifiedSymbol,
         # because a Symbol should mongoize to a String, but calling .mongoize
         # on a Symbol mongoizes it to a Symbol.
-        # Therefore, we call the field's mongoize in all cases except when the field is
-        # localized, because by the time we arrive at this code, the value is already
-        # in the form of { lang => translation } and calling the fields mongoize will
-        # nest that further into { lang => "\{ lang => translation \}"} (assuming the
-        # field type is a string). Therefore, we just call object's mongoize so it
-        # returns the hash as it is.
+        # Therefore, we call the field's mongoize in all cases except when the
+        # field is localized, because by the time we arrive at this code, the
+        # value is already in the form of { lang => translation } and calling
+        # the field's mongoize will nest that further into { lang =>
+        # "\{ lang => translation \}"} (assuming the field type is a string).
+        # Therefore, we call Object's mongoize method so it returns the hash as
+        # it is.
         mongoized = field.try(:localized?) ? value.mongoize : field.mongoize(value)
         criteria.selector.update(criterion(document, attribute, mongoized))
         criteria

--- a/lib/mongoid/validatable/uniqueness.rb
+++ b/lib/mongoid/validatable/uniqueness.rb
@@ -95,19 +95,18 @@ module Mongoid
       def create_criteria(base, document, attribute, value)
         criteria = scope(base.unscoped, document, attribute)
         field = document.fields[document.database_field_name(attribute)]
-        
+
         # In the past, we were calling value.mongoize in all cases, which
-        # would call Object's mongoize method. This is a problem for StringifiedSymbol, 
-        # because a symbol should mongoize to a string, but calling .mongoize on a 
-        # Symbol mongoizes it to a Symbol, when StringifiedSymbol's mongoize should 
-        # mongoize it to a string. 
+        # would call Object's mongoize method. This is a problem for StringifiedSymbol,
+        # because a Symbol should mongoize to a String, but calling .mongoize
+        # on a Symbol mongoizes it to a Symbol.
         # Therefore, we call the field's mongoize in all cases except when the field is
         # localized, because by the time we arrive at this code, the value is already
         # in the form of { lang => translation } and calling the fields mongoize will
         # nest that further into { lang => "\{ lang => translation \}"} (assuming the
-        # field type is a string). Therefore, we just call object's mongoize so it 
-        # returns the hash as it is. 
-        mongoized = field.try(:localized?) ? value.mongoize : field.mongoize(value) 
+        # field type is a string). Therefore, we just call object's mongoize so it
+        # returns the hash as it is.
+        mongoized = field.try(:localized?) ? value.mongoize : field.mongoize(value)
         criteria.selector.update(criterion(document, attribute, mongoized))
         criteria
       end

--- a/lib/mongoid/validatable/uniqueness.rb
+++ b/lib/mongoid/validatable/uniqueness.rb
@@ -94,7 +94,8 @@ module Mongoid
       # @return [ Criteria ] The criteria.
       def create_criteria(base, document, attribute, value)
         criteria = scope(base.unscoped, document, attribute)
-        criteria.selector.update(criterion(document, attribute, value.mongoize))
+        field = document.fields[attribute.to_s]
+        criteria.selector.update(criterion(document, attribute, field.mongoize(value)))
         criteria
       end
 

--- a/lib/mongoid/validatable/uniqueness.rb
+++ b/lib/mongoid/validatable/uniqueness.rb
@@ -95,6 +95,18 @@ module Mongoid
       def create_criteria(base, document, attribute, value)
         criteria = scope(base.unscoped, document, attribute)
         field = document.fields[document.database_field_name(attribute)]
+        
+        # In the past, we were calling value.mongoize in all cases, which
+        # would call Object's mongoize method. This is a problem for StringifiedSymbol, 
+        # because a symbol should mongoize to a string, but calling .mongoize on a 
+        # Symbol mongoizes it to a Symbol, when StringifiedSymbol's mongoize should 
+        # mongoize it to a string. 
+        # Therefore, we call the field's mongoize in all cases except when the field is
+        # localized, because by the time we arrive at this code, the value is already
+        # in the form of { lang => translation } and calling the fields mongoize will
+        # nest that further into { lang => "\{ lang => translation \}"} (assuming the
+        # field type is a string). Therefore, we just call object's mongoize so it 
+        # returns the hash as it is. 
         mongoized = field.try(:localized?) ? value.mongoize : field.mongoize(value) 
         criteria.selector.update(criterion(document, attribute, mongoized))
         criteria

--- a/lib/mongoid/validatable/uniqueness.rb
+++ b/lib/mongoid/validatable/uniqueness.rb
@@ -94,8 +94,10 @@ module Mongoid
       # @return [ Criteria ] The criteria.
       def create_criteria(base, document, attribute, value)
         criteria = scope(base.unscoped, document, attribute)
-        field = document.fields[attribute.to_s]
-        criteria.selector.update(criterion(document, attribute, field.mongoize(value)))
+        field_name = document.aliased_fields[attribute.to_s] || attribute.to_s
+        field = document.fields[field_name]
+        mongoized = field&.localized? ? value.mongoize : field.mongoize(value) 
+        criteria.selector.update(criterion(document, attribute, mongoized))
         criteria
       end
 

--- a/spec/integration/stringified_symbol_field_spec.rb
+++ b/spec/integration/stringified_symbol_field_spec.rb
@@ -187,4 +187,17 @@ describe "StringifiedSymbol fields" do
       expect(event.command["updates"].first["u"]["$set"]["saved_status"]).to eq("[3, 4, 5]")
     end
   end
+  
+  context "when StringifiedSymbol is embedded" do 
+    
+    describe "When the embedded field is not unique" do
+      
+      it "should be invalid" do
+        order = Order.new
+        order.purchased_items.build(item_id: :foo)
+        order.purchased_items.build(item_id: :foo)
+        expect(order.invalid?).to be true
+      end
+    end
+  end
 end

--- a/spec/support/models/order.rb
+++ b/spec/support/models/order.rb
@@ -7,6 +7,6 @@ class Order
   # This is a dummy field that verifies the Mongoid::Fields::StringifiedSymbol
   # alias.
   field :saved_status, type: StringifiedSymbol
-  
+
   embeds_many :purchased_items
 end

--- a/spec/support/models/order.rb
+++ b/spec/support/models/order.rb
@@ -7,4 +7,6 @@ class Order
   # This is a dummy field that verifies the Mongoid::Fields::StringifiedSymbol
   # alias.
   field :saved_status, type: StringifiedSymbol
+  
+  embeds_many :purchased_items
 end

--- a/spec/support/models/purchased_item.rb
+++ b/spec/support/models/purchased_item.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class PurchasedItem
+  include Mongoid::Document
+  field :item_id, type: Mongoid::StringifiedSymbol
+  
+  validates_uniqueness_of :item_id
+
+  embedded_in :order
+end

--- a/spec/support/models/purchased_item.rb
+++ b/spec/support/models/purchased_item.rb
@@ -3,7 +3,7 @@
 class PurchasedItem
   include Mongoid::Document
   field :item_id, type: Mongoid::StringifiedSymbol
-  
+
   validates_uniqueness_of :item_id
 
   embedded_in :order


### PR DESCRIPTION
The changes here fix the mongoize in the `create_criteria` method for the uniqueness validator. Previously, the selector was `mongoize`d using `Object`'s `.mongoize` method. This was not type specific, so for the `StringifiedSymbol` type, a `Symbol` was not `mongoize`d into a string. These changes extract the field for the attribute we're trying to `mongoize` and `mongoize` based on the type of that field. 

There is a special case when reading the field from the document for a `localized` field. This field is already `mongoized` by the time it gets to the `create_criteria` function and so I have a special case for it.

MONGOID-5219