### PR TITLE
MONGOID-5204 default_scopes duplication, query scope inconsistency

### DIFF
--- a/lib/mongoid/criteria/queryable/storable.rb
+++ b/lib/mongoid/criteria/queryable/storable.rb
@@ -54,7 +54,7 @@ module Mongoid
               # adding them to the existing hash.
               new_value = selector[field].merge(value)
               selector.store(field, new_value)
-            else
+            elsif selector[field] != value
               add_operator_expression('$and', [{field => value}])
             end
           else

--- a/spec/mongoid/criteria_spec.rb
+++ b/spec/mongoid/criteria_spec.rb
@@ -3627,6 +3627,23 @@ describe Mongoid::Criteria do
           'foo' => 1, '$and' => [{'foo' => 2}], 'bar' => 3)
       end
     end
+    
+    context "when duplicating where conditions" do 
+      let(:criteria) { Sound.where(active: true).where(active: true) }
+      
+      it 'does not duplicate criteria' do
+        expect(criteria.selector).to eq('active' => true)
+      end
+    end
+    
+    context "when duplicating where conditions with different values" do 
+      let(:criteria) { Sound.where(active: true).where(active: false).where(active: true).where(active: false) }
+      
+      it 'does not duplicate criteria' do
+        expect(criteria.selector).to eq(
+          'active' => true, '$and' => [{'active' => false}])
+      end
+    end
   end
 
   describe "#for_js" do

--- a/spec/mongoid/criteria_spec.rb
+++ b/spec/mongoid/criteria_spec.rb
@@ -3627,18 +3627,18 @@ describe Mongoid::Criteria do
           'foo' => 1, '$and' => [{'foo' => 2}], 'bar' => 3)
       end
     end
-    
-    context "when duplicating where conditions" do 
+
+    context "when duplicating where conditions" do
       let(:criteria) { Sound.where(active: true).where(active: true) }
-      
+
       it 'does not duplicate criteria' do
         expect(criteria.selector).to eq('active' => true)
       end
     end
-    
-    context "when duplicating where conditions with different values" do 
+
+    context "when duplicating where conditions with different values" do
       let(:criteria) { Sound.where(active: true).where(active: false).where(active: true).where(active: false) }
-      
+
       it 'does not duplicate criteria' do
         expect(criteria.selector).to eq(
           'active' => true, '$and' => [{'active' => false}])

--- a/spec/mongoid/scopable_spec.rb
+++ b/spec/mongoid/scopable_spec.rb
@@ -110,6 +110,21 @@ describe Mongoid::Scopable do
         expect(Band).to be_default_scoping
       end
     end
+    
+    context "when parent class has default scope" do 
+      
+      before do 
+        Sound.send(:include, Ownable)
+      end
+      
+      let (:selector) do 
+        AudibleSound.all.selector
+      end
+      
+      it "the subclass doesn't duplicate the default scope in the selector" do
+        expect(selector).to eq({'active' => true})
+      end
+    end
   end
 
   describe ".default_scopable?" do

--- a/spec/mongoid/scopable_spec.rb
+++ b/spec/mongoid/scopable_spec.rb
@@ -110,13 +110,13 @@ describe Mongoid::Scopable do
         expect(Band).to be_default_scoping
       end
     end
-    
-    context "when parent class has default scope" do 
-      
-      let (:selector) do 
+
+    context "when parent class has default scope" do
+
+      let (:selector) do
         AudibleSound.all.selector
       end
-      
+
       it "the subclass doesn't duplicate the default scope in the selector" do
         expect(selector).to eq({'active' => true})
       end

--- a/spec/mongoid/scopable_spec.rb
+++ b/spec/mongoid/scopable_spec.rb
@@ -113,10 +113,6 @@ describe Mongoid::Scopable do
     
     context "when parent class has default scope" do 
       
-      before do 
-        Sound.send(:include, Ownable)
-      end
-      
       let (:selector) do 
         AudibleSound.all.selector
       end

--- a/spec/support/models/audible_sound.rb
+++ b/spec/support/models/audible_sound.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+class AudibleSound < Sound; end

--- a/spec/support/models/sound.rb
+++ b/spec/support/models/sound.rb
@@ -5,6 +5,3 @@ class Sound
   field :active, type: Mongoid::Boolean
   default_scope ->{ where(active: true) }
 end
-
-class AudibleSound < Sound
-end

--- a/spec/support/models/sound.rb
+++ b/spec/support/models/sound.rb
@@ -5,3 +5,6 @@ class Sound
   field :active, type: Mongoid::Boolean
   default_scope ->{ where(active: true) }
 end
+
+class AudibleSound < Sound
+end


### PR DESCRIPTION
Look at the following comment: https://jira.mongodb.org/browse/MONGOID-5204?focusedCommentId=4328701&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-4328701

The functionality after this PR is as follows: 
```
(byebug) Sound.where(active: true)
#<Mongoid::Criteria
  selector: {"active"=>true}
  options:  {}
  class:    Sound
  embedded: false>
(byebug) Sound.where(active: true).where(active: true)
#<Mongoid::Criteria
  selector: {"active"=>true}
  options:  {}
  class:    Sound
  embedded: false>
(byebug) Sound.where(active: true).where(active: true).where(active:false)
#<Mongoid::Criteria
  selector: {"active"=>true, "$and"=>[{"active"=>false}]}
  options:  {}
  class:    Sound
  embedded: false>
(byebug) Sound.where(active: true).where(active: true).where(active:false).where(active:true)
#<Mongoid::Criteria
  selector: {"active"=>true, "$and"=>[{"active"=>false}]}
  options:  {}
  class:    Sound
  embedded: false>
```
which makes sense to me. 