### PR TITLE
MONGOID-5237 Add Feature Flag: _matches? should use millisecond precision when comparing Time objects

### DIFF
--- a/docs/reference/configuration.txt
+++ b/docs/reference/configuration.txt
@@ -260,9 +260,11 @@ for details on driver options.
       # error. (default: true)
       belongs_to_required_by_default: true
 
-      # In Mongoid 7.3.3 and earlier, the _matches? function does not use
-      # millisecond precision when comparing time objects. Turning on this
-      # feature flag enables this. (default: false)
+      # In Mongoid 7.3 and earlier, embedded matching performed time comparisons
+      # with full (microsecond) precision. However, MongoDB server is only
+      # capable of storing times with millisecond precision. Enabling this
+      # option makes Mongoid truncate times to millisecond precision for
+      # comparison purposes, to match the server behavior. (default: false)
       compare_time_by_ms: false
 
       # Set the global discriminator key. (default: "_type")

--- a/docs/reference/configuration.txt
+++ b/docs/reference/configuration.txt
@@ -260,6 +260,11 @@ for details on driver options.
       # error. (default: true)
       belongs_to_required_by_default: true
 
+      # In Mongoid 7.3.3 and earlier, the _matches? function does not use
+      # millisecond precision when comparing time objects. Turning on this
+      # feature flag enables this. (default: false)
+      compare_time_by_ms: false
+
       # Set the global discriminator key. (default: "_type")
       discriminator_key: "_type"
 

--- a/lib/mongoid/config.rb
+++ b/lib/mongoid/config.rb
@@ -99,6 +99,8 @@ module Mongoid
     # clauses that use the same operator on the same field.
     option :fix_multiple_ands, default: false
 
+    # Use millisecond precision when comparing Time objects with the _matches
+    # function.
     option :compare_time_by_ms, default: false
 
     # Has Mongoid been configured? This is checking that at least a valid

--- a/lib/mongoid/config.rb
+++ b/lib/mongoid/config.rb
@@ -99,7 +99,7 @@ module Mongoid
     # clauses that use the same operator on the same field.
     option :fix_multiple_ands, default: false
 
-    # Use millisecond precision when comparing Time objects with the _matches
+    # Use millisecond precision when comparing Time objects with the _matches?
     # function.
     option :compare_time_by_ms, default: false
 

--- a/lib/mongoid/config.rb
+++ b/lib/mongoid/config.rb
@@ -99,6 +99,8 @@ module Mongoid
     # clauses that use the same operator on the same field.
     option :fix_multiple_ands, default: false
 
+    option :compare_time_by_ms, default: false
+
     # Has Mongoid been configured? This is checking that at least a valid
     # client config exists.
     #

--- a/lib/mongoid/matcher/eq_impl.rb
+++ b/lib/mongoid/matcher/eq_impl.rb
@@ -24,19 +24,24 @@ module Mongoid
 =end
         else
           # When doing a comparison with Time objects, compare using millisecond precision
-          if value.kind_of?(Time) && condition.kind_of?(Time)
-            time_eq?(value, condition)
-          elsif value.is_a?(Array) && condition.kind_of?(Time)
-            value.map do |v|
-              if v.kind_of?(Time)
-                time_rounded_to_millis(v)
-              else
-                v
-              end
-            end.include?(time_rounded_to_millis(condition))
-          else
+          if Mongoid.compare_time_by_ms
             value == condition ||
             value.is_a?(Array) && value.include?(condition)
+          else
+            if value.kind_of?(Time) && condition.kind_of?(Time)
+              time_eq?(value, condition)
+            elsif value.is_a?(Array) && condition.kind_of?(Time)
+              value.map do |v|
+                if v.kind_of?(Time)
+                  time_rounded_to_millis(v)
+                else
+                  v
+                end
+              end.include?(time_rounded_to_millis(condition))
+            else
+              value == condition ||
+              value.is_a?(Array) && value.include?(condition)
+            end
           end
         end
       end

--- a/lib/mongoid/matcher/eq_impl_with_regexp.rb
+++ b/lib/mongoid/matcher/eq_impl_with_regexp.rb
@@ -13,7 +13,8 @@ module Mongoid
         when ::BSON::Regexp::Raw
           value =~ condition.compile
         else
-          if value.kind_of?(Time) && condition.kind_of?(Time)
+          if Mongoid.compare_time_by_ms &&
+            value.kind_of?(Time) && condition.kind_of?(Time)
             EqImpl.time_eq?(value, condition)
           else
             value == condition

--- a/spec/integration/matcher_spec.rb
+++ b/spec/integration/matcher_spec.rb
@@ -44,12 +44,46 @@ describe 'Matcher operators' do
         end
       end
 
-      context 'with $in' do
-        let(:query) do
-          {'started_at' => {:$in => [time_millis]}}
+      context "when compare_time_by_ms feature flag is set" do
+
+        around do |example|
+          saved_flag = Mongoid.compare_time_by_ms
+          Mongoid.compare_time_by_ms = true
+          begin
+            example.run
+          ensure
+            Mongoid.compare_time_by_ms = saved_flag
+          end
         end
 
-        it_behaves_like 'is true'
+        context 'with $in' do
+          let(:query) do
+            {'started_at' => {:$in => [time_millis]}}
+          end
+
+          it_behaves_like 'is true'
+        end
+      end
+
+      context "when compare_time_by_ms feature flag is not set" do
+
+        around do |example|
+          saved_flag = Mongoid.compare_time_by_ms
+          Mongoid.compare_time_by_ms = false
+          begin
+            example.run
+          ensure
+            Mongoid.compare_time_by_ms = saved_flag
+          end
+        end
+
+        context 'with $in' do
+          let(:query) do
+            {'started_at' => {:$in => [time_millis]}}
+          end
+
+          it_behaves_like 'is false'
+        end
       end
 
       context 'when matching an element in an array' do

--- a/spec/mongoid/config_spec.rb
+++ b/spec/mongoid/config_spec.rb
@@ -314,6 +314,13 @@ describe Mongoid::Config do
     it_behaves_like "a config option"
   end
 
+  context 'when setting the compare_time_by_ms option in the config' do
+    let(:option) { :compare_time_by_ms }
+    let(:default) { false }
+
+    it_behaves_like "a config option"
+  end
+
   describe "#load!" do
 
     before(:all) do


### PR DESCRIPTION
MONGOID-5237