### PR TITLE
MONGOID-5257 make === equivalent to ==

### DIFF
--- a/lib/mongoid/document.rb
+++ b/lib/mongoid/document.rb
@@ -272,22 +272,6 @@ module Mongoid
 
     module ClassMethods
 
-      # Performs class equality checking.
-      #
-      # @example Compare the classes.
-      #   document === other
-      #
-      # @param [ Document, Object ] other The other object to compare with.
-      #
-      # @return [ true, false ] True if the classes are equal, false if not.
-      def ===(other)
-        if Mongoid.legacy_triple_equals
-          other.class == Class ? self <= other : other.is_a?(self)
-        else
-          other.is_a?(self)
-        end
-      end
-
       # Instantiate a new object, only when loaded from the database or when
       # the attributes have already been typecast.
       #

--- a/lib/mongoid/equality.rb
+++ b/lib/mongoid/equality.rb
@@ -43,7 +43,7 @@ module Mongoid
     #
     # @return [ true, false ] True if the classes are equal, false if not.
     def ===(other)
-      if Mongoid.triple_equals_uses_is_a
+      if Mongoid.legacy_triple_equals
         super
       else
         other.class == Class ? self.class === other : self == other
@@ -72,7 +72,7 @@ module Mongoid
       #
       # @return [ true, false ] True if the classes are equal, false if not.
       def ===(other)
-        if Mongoid.triple_equals_uses_is_a
+        if Mongoid.legacy_triple_equals
           other.is_a?(self)
         else
           other.class == Class ? self <= other : other.is_a?(self)

--- a/lib/mongoid/equality.rb
+++ b/lib/mongoid/equality.rb
@@ -40,7 +40,11 @@ module Mongoid
     #
     # @return [ true, false ] True if the classes are equal, false if not.
     def ===(other)
-      other.class == Class ? self.class === other : self == other
+      if Mongoid.triple_equals_uses_is_a
+        super
+      else
+        other.class == Class ? self.class === other : self == other
+      end
     end
 
     # Delegates to ==. Used when needing checks in hashes.

--- a/lib/mongoid/equality.rb
+++ b/lib/mongoid/equality.rb
@@ -4,6 +4,9 @@ module Mongoid
 
   # This module contains the behavior of Mongoid's clone/dup of documents.
   module Equality
+    # Leave the current contents of this module outside of InstanceMethods
+    # to prevent cherry picking conflicts. For now...
+    extend ActiveSupport::Concern
 
     # Default comparison is via the string version of the id.
     #
@@ -57,6 +60,24 @@ module Mongoid
     # @return [ true, false ] True if equal, false if not.
     def eql?(other)
       self == (other)
+    end
+
+    module ClassMethods
+      # Performs class equality checking.
+      #
+      # @example Compare the classes.
+      #   document === other
+      #
+      # @param [ Document, Object ] other The other object to compare with.
+      #
+      # @return [ true, false ] True if the classes are equal, false if not.
+      def ===(other)
+        if Mongoid.triple_equals_uses_is_a
+          other.is_a?(self)
+        else
+          other.class == Class ? self <= other : other.is_a?(self)
+        end
+      end
     end
   end
 end

--- a/spec/mongoid/equality_spec.rb
+++ b/spec/mongoid/equality_spec.rb
@@ -85,114 +85,88 @@ describe Mongoid::Equality do
 
   describe ".===" do
 
-    context "when comparable is an instance of this document" do
+    context "when legacy_triple_equals is set" do
+      config_override :legacy_triple_equals, true
 
-      with_config_values :legacy_triple_equals, false, true do
+      context "when comparable is an instance of this document" do
+
         it "returns true" do
           expect(klass === person).to be true
         end
       end
-    end
 
-    context "when comparable is a relation of this document" do
+      context "when comparable is a relation of this document" do
 
-      let(:relation) do
-        Post.new(person: person).person
-      end
+        let(:relation) do
+          Post.new(person: person).person
+        end
 
-      with_config_values :legacy_triple_equals, false, true do
         it "returns true" do
           expect(klass === relation).to be true
         end
       end
-    end
 
-    context "when comparable is the same class" do
-
-      context "when legacy_triple_equals is not set" do
-        config_override :legacy_triple_equals, false
+      context "when comparable is the same class" do
 
         it "returns false" do
           expect(klass === Person).to be false
         end
       end
 
-      context "when legacy_triple_equals is set" do
-        config_override :legacy_triple_equals, true
+      context "when the comparable is a subclass" do
 
-        it "returns true" do
-          expect(klass === Person).to be true
-        end
-      end
-    end
-
-    context "when the comparable is a subclass" do
-
-      with_config_values :legacy_triple_equals, false, true do
         it "returns false" do
           expect(Person === Doctor).to be false
         end
       end
-    end
 
-    context "when the comparable is an instance of a subclass" do
+      context "when the comparable is an instance of a subclass" do
 
-      with_config_values :legacy_triple_equals, false, true do
         it "returns true" do
           expect(Person === Doctor.new).to be true
         end
       end
     end
 
-    context "when comparing to a class" do
+    context "when legacy_triple_equals is not set" do
+      config_override :legacy_triple_equals, false
 
-      context "when legacy_triple_equals is not set" do
-        config_override :legacy_triple_equals, false
+      context "when comparable is an instance of this document" do
 
-        context "when the class is the same" do
-
-          it "returns false" do
-            expect(Person === Person).to be false
-          end
-        end
-
-        context "when the class is a subclass" do
-
-          it "returns false" do
-            expect(Person === Doctor).to be false
-          end
-        end
-
-        context "when the class is a superclass" do
-
-          it "returns false" do
-            expect(Doctor === Person).to be false
-          end
+        it "returns true" do
+          expect(klass === person).to be true
         end
       end
 
-      context "when legacy_triple_equals is set" do
-        config_override :legacy_triple_equals, true
+      context "when comparable is a relation of this document" do
 
-        context "when the class is the same" do
-
-          it "returns true" do
-            expect(Person === Person).to be true
-          end
+        let(:relation) do
+          Post.new(person: person).person
         end
 
-        context "when the class is a subclass" do
-
-          it "returns false" do
-            expect(Person === Doctor).to be false
-          end
+        it "returns true" do
+          expect(klass === relation).to be true
         end
+      end
 
-        context "when the class is a superclass" do
+      context "when comparable is the same class" do
 
-          it "returns true" do
-            expect(Doctor === Person).to be true
-          end
+        it "returns true" do
+          expect(klass === Person).to be true
+        end
+      end
+
+      context "when the comparable is a subclass" do
+
+        it "returns false" do
+          expect(Person === Doctor).to be false
+        end
+      end
+
+      context "when the comparable is an instance of a subclass" do
+
+        it "returns true" do
+          expect(Person === Doctor.new).to be true
         end
       end
     end
@@ -200,36 +174,34 @@ describe Mongoid::Equality do
 
   describe "#===" do
 
-    context "when comparable is the same type" do
+    context "when legacy_triple_equals is set" do
+      config_override :legacy_triple_equals, true
 
-      context "when the instance is different" do
+      context "when comparable is the same type" do
 
-        it "returns false" do
-          expect(person === Person.new).to be false
+        context "when the instance is different" do
+
+          it "returns false" do
+            expect(person === Person.new).to be false
+          end
+        end
+
+        context "when the instance is the same" do
+
+          it "returns true" do
+            expect(person === person).to be true
+          end
         end
       end
 
-      context "when the instance is the same" do
+      context "when the comparable is a subclass" do
 
-        it "returns true" do
-          expect(person === person).to be true
-        end
-      end
-    end
-
-    context "when the comparable is a subclass" do
-
-      with_config_values :legacy_triple_equals, false, true do
         it "returns false" do
           expect(person === Doctor.new).to be false
         end
       end
-    end
 
-    context "when comparing to a class" do
-
-      context "when legacy_triple_equals is not set" do
-        config_override :legacy_triple_equals, false
+      context "when comparing to a class" do
 
         context "when the class is the same" do
 
@@ -252,10 +224,36 @@ describe Mongoid::Equality do
           end
         end
       end
+    end
 
-      context "when legacy_triple_equals is set" do
-        config_override :legacy_triple_equals, true
+    context "when legacy_triple_equals is not set" do
+      config_override :legacy_triple_equals, false
 
+      context "when comparable is the same type" do
+
+        context "when the instance is different" do
+
+          it "returns false" do
+            expect(person === Person.new).to be false
+          end
+        end
+
+        context "when the instance is the same" do
+
+          it "returns true" do
+            expect(person === person).to be true
+          end
+        end
+      end
+
+      context "when the comparable is a subclass" do
+
+        it "returns false" do
+          expect(person === Doctor.new).to be false
+        end
+      end
+
+      context "when comparing to a class" do
         context "when the class is the same" do
 
           it "returns true" do


### PR DESCRIPTION
There are no additional tests for this change because this change does not have any changes to the functionality of the instance `===` in a practical sense, but changes how we think about it. 

Note that we have multiple `===` functions, one defined for when an instance of a class is on the left hand side (lhs), and one for when a class is on the lhs. I will refer to these as instance `===` and class `===` respectively. 

Previously, the instance `===` operator call `==` if the right hand side (rhs) was another instance, but would call the class `===` if the rhs was a class. Meaning, that if `other` was a class, then we would call `self.class === other`, and since MONGOID-5126, this executes: 
```
other.is_a?(self)
```
Now, since `other` is a class, and we call `===` on `self.class` we end up checking if a class is an instance of a class, which doesn't actually make sense, unless `self` is `Class`. However, it is impossible for self to be `Class` when traversing this code path via the instance `===`, since if the lhs was actually a class, then it wouldn't have called the instance `===`, rather the class `===`.

All of this is to say, we have the correct behavior on the technicality that a class `is_a?` class is always false (except for the impossible case that that class is `Class`), and this fix is intended to clarify and make explicit the behavior we want. 

EDIT: See comments on MONGOID-5257 for a longer explanation on why this decision was made.
EDIT: The tests in this PR were changed to test them with the feature flag both on and off. The functionality of ===, however, did not actually change.