### PR TITLE
MONGOID-5260 Add _translations fields and dot-navigation to pluck and distinct

### DIFF
--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -99,7 +99,7 @@ set +e
 if test -n "$TEST_CMD"; then
   eval $TEST_CMD
 elif test -n "$TEST_I18N_FALLBACKS"; then
-  bundle exec rspec spec/integration/i18n_fallbacks_spec.rb
+  bundle exec rspec spec/integration/i18n_fallbacks_spec.rb spec/mongoid/criteria_spec.rb spec/mongoid/contextual/mongo_spec.rb
 elif test -n "$APP_TESTS"; then
   # Need recent node for rails
   export N_PREFIX=$HOME/.n

--- a/docs/reference/configuration.txt
+++ b/docs/reference/configuration.txt
@@ -373,7 +373,7 @@ for details on driver options.
       # and will return embedded values themselves (i.e. without putting them
       # in a hash).
       # (default: true in Mongoid 7, will change to false in Mongoid 8)
-      legacy_pluck_distinct: true
+      #legacy_pluck_distinct: true
 
       # Maintain legacy behavior of === on Mongoid document classes, which
       # returns true in a number of cases where Ruby's === implementation would

--- a/docs/reference/configuration.txt
+++ b/docs/reference/configuration.txt
@@ -368,9 +368,10 @@ for details on driver options.
 
       # Maintain legacy behavior of pluck and distinct, which does not demongoize
       # values on returning them. Setting this option to false will cause
-      # pluck and distinct to return demongoized values. This will also allow
-      # passing _translations fields to pluck and distinct and will return
-      # embedded values themselves (i.e. without putting them in a hash).
+      # pluck and distinct to return demongoized values. Setting this option to
+      # false will also allow passing _translations fields to pluck and distinct
+      # and will return embedded values themselves (i.e. without putting them
+      # in a hash).
       # (default: true in Mongoid 7, will change to false in Mongoid 8)
       legacy_pluck_distinct: true
 

--- a/docs/reference/configuration.txt
+++ b/docs/reference/configuration.txt
@@ -369,10 +369,10 @@ for details on driver options.
       # Maintain legacy behavior of pluck and distinct, which does not demongoize
       # values on returning them. Setting this option to false will cause
       # pluck and distinct to return demongoized values. Setting this option to
-      # false will also allow passing _translations fields to pluck and distinct
-      # and will return embedded values themselves (i.e. without putting them
-      # in a hash).
-      # (default: true in Mongoid 7, will change to false in Mongoid 8)
+      # false will also allow retrieving *_translations fields from pluck and
+      # distinct and will return embedded values themselves (i.e. without
+      # putting them in a hash).
+      # (default: false)
       #legacy_pluck_distinct: true
 
       # Maintain legacy behavior of === on Mongoid document classes, which

--- a/docs/reference/configuration.txt
+++ b/docs/reference/configuration.txt
@@ -368,9 +368,11 @@ for details on driver options.
 
       # Maintain legacy behavior of pluck and distinct, which does not demongoize
       # values on returning them. Setting this option to false will cause
-      # pluck and distinct to return demongoized values.
-      # (default: false)
-      #legacy_pluck_distinct: true
+      # pluck and distinct to return demongoized values. This will also allow
+      # passing _translations fields to pluck and distinct and will return
+      # embedded values themselves (i.e. without putting them in a hash).
+      # (default: true in Mongoid 7, will change to false in Mongoid 8)
+      legacy_pluck_distinct: true
 
       # Maintain legacy behavior of === on Mongoid document classes, which
       # returns true in a number of cases where Ruby's === implementation would

--- a/docs/release-notes/mongoid-7.4.txt
+++ b/docs/release-notes/mongoid-7.4.txt
@@ -56,7 +56,7 @@ Mongoid 7.4 with ``Mongoid.legacy_triple_equals`` set to ``false`` behavior:
 
   class Band
     include Mongoid::Document
-    
+
     has_many :members
   end
 
@@ -65,7 +65,7 @@ Mongoid 7.4 with ``Mongoid.legacy_triple_equals`` set to ``false`` behavior:
 
   class Member
     include Mongoid::Document
-    
+
     belongs_to :band
   end
 
@@ -83,10 +83,10 @@ Mongoid 7.4 with ``Mongoid.legacy_triple_equals`` set to ``false`` behavior:
 
   CoverBand === Band
   # => false
-  
+
   band.members === Array
   # => false
-  
+
   band.members === Mongoid::Association::Referenced::HasMany::Enumerable
   # => false
 
@@ -106,10 +106,10 @@ behavior:
 
   CoverBand === Band
   # => true
-  
+
   band.members === Array
   # => true
-  
+
   band.members === Mongoid::Association::Referenced::HasMany::Enumerable
   # => true
 
@@ -198,55 +198,6 @@ top-level models.
 The ``Mongoid.compare_time_by_ms`` option is set to ``false`` by default
 in Mongoid 7.4 for backwards compatibility. In Mongoid 8 the default value
 will change to ``true``.
-
-
-Respect Field Aliases In Embedded Documents When Using ``distinct`` And ``pluck``
----------------------------------------------------------------------------------
-
-When ``distinct`` and ``pluck`` are used with aliased fields in embedded
-documents, the aliases can be expanded if the ``Mongoid.broken_alias_handling``
-option is set to ``false``. By default, for backwards compatibility, in
-Mongoid 7.4 this option is set to true, yielding Mongoid 7.3 and earlier
-behavior. Given the following definitions:
-
-.. code-block:: ruby
-
-  class Band
-    include Mongoid::Document
-    embeds_many :managers
-  end
-
-  class Manager
-    include Mongoid::Document
-    embedded_in :band
-
-    field :name, as: :n
-  end
-
-Mongoid 7.4 behavior with ``Mongoid.broken_alias_handling`` set to ``false``:
-
-.. code-block:: ruby
-
-  # Expands out to "managers.name" in the query:
-  Band.distinct('managers.n')
-  Band.pluck('managers.n')
-
-Mongoid 7.3 and 7.4 with ``Mongoid.broken_alias_handling`` set to ``true`` behavior:
-
-.. code-block:: ruby
-
-  # Sends "managers.n" without expanding the alias:
-  Band.distinct('managers.n')
-  Band.pluck('managers.n')
-
-.. note::
-
-  The alias expansion for top-level fields has already been done by Mongoid 7.3.
-
-.. note::
-
-  The value of ``Mongoid.broken_alias_handling`` option will change to ``false``
-  by default in Mongoid 8.0.
 
 
 ``count``, ``sum``, ``avg``, ``min``, ``max`` Ignore Sort If Not Limiting/Skipping
@@ -390,12 +341,64 @@ all scopes are cleared:
   by default in Mongoid 8.0.
 
 
-Demongoize Values Returned from Pluck and Distinct
---------------------------------------------------
+Changes to ``distinct`` and ``pluck``
+-------------------------------------
+
+Respect Field Aliases In Embedded Documents When Using ``distinct`` and ``pluck``
+`````````````````````````````````````````````````````````````````````````````````
+
+When ``distinct`` and ``pluck`` are used with aliased fields in embedded
+documents, the aliases can be expanded if the ``Mongoid.broken_alias_handling``
+option is set to ``false``. By default, for backwards compatibility, in
+Mongoid 7.4 this option is set to true, yielding Mongoid 7.3 and earlier
+behavior. Given the following definitions:
+
+.. code-block:: ruby
+
+  class Band
+    include Mongoid::Document
+    embeds_many :managers
+  end
+
+  class Manager
+    include Mongoid::Document
+    embedded_in :band
+
+    field :name, as: :n
+  end
+
+Mongoid 7.4 behavior with ``Mongoid.broken_alias_handling`` set to ``false``:
+
+.. code-block:: ruby
+
+  # Expands out to "managers.name" in the query:
+  Band.distinct('managers.n')
+  Band.pluck('managers.n')
+
+Mongoid 7.3 and 7.4 with ``Mongoid.broken_alias_handling`` set to ``true`` behavior:
+
+.. code-block:: ruby
+
+  # Sends "managers.n" without expanding the alias:
+  Band.distinct('managers.n')
+  Band.pluck('managers.n')
+
+.. note::
+
+  The alias expansion for top-level fields has already been done by Mongoid 7.3.
+
+.. note::
+
+  The value of ``Mongoid.broken_alias_handling`` option will change to ``false``
+  by default in Mongoid 8.0.
+
+
+Demongoize Values Returned from ``pluck`` and ``distinct``
+``````````````````````````````````````````````````````````
 
 Mongoid 7.4 with the ``Mongoid.legacy_pluck_distinct`` option set to ``false``
-will demongoize values returned from the pluck and distinct methods.
-For example:
+will demongoize values returned from the ``pluck`` and ``distinct`` methods.
+Given the following definitions:
 
 .. code-block:: ruby
 
@@ -407,6 +410,11 @@ For example:
 
   Band.create!(sales: "1E2")
   Band.create!(sales: "2E2")
+
+Mongoid 7.4 behavior with ``Mongoid.legacy_pluck_distinct`` set to ``false``:
+
+.. code-block:: ruby
+
   Band.pluck(:sales)
   # => [0.1e3, 0.2e3]
   Band.distinct(:sales)
@@ -428,3 +436,95 @@ distinct methods will not be demongoized. For example:
 
   The value of ``Mongoid.legacy_pluck_distinct`` option will change to ``false``
   by default in Mongoid 8.0.
+
+Localized Fields with ``pluck`` and ``distinct``
+````````````````````````````````````````````````
+Mongoid 7.4 with the ``Mongoid.legacy_pluck_distinct`` option set to ``false``
+changes the behavior of using ``pluck`` and ``distinct`` with localized fields.
+Now when inputting a localized field into these functions, the translation for
+the current locale will be returned. To get the full translations hash the
+``_translations`` field can be used. Given the following definitions:
+
+.. code-block:: ruby
+
+  class Band
+    include Mongoid::Document
+
+    field :name, localize: true
+  end
+
+  I18n.locale = :en
+  band = Band.create!(name: 'english-name')
+  I18n.locale = :de
+  band.name = 'deutsch-name'
+  band.save!
+
+Mongoid 7.4 behavior with ``Mongoid.legacy_pluck_distinct`` set to ``false``:
+
+.. code-block:: ruby
+
+  Band.pluck(:name)
+  # => ["deutsch-name"]
+  Band.pluck(:name_translations)
+  # => [{"en"=>"english-name", "de"=>"deutsch-name"}, {"en"=>"english-name", "de"=>"deutsch-name"}]
+
+In Mongoid 7.3 and earlier, and in 7.4 with the ``Mongoid.legacy_pluck_distinct``
+option set to ``true`` (the default), inputting a localized field returns the
+full translations hash. Inputting the ``_translations`` field will return ``nil``.
+For example:
+
+.. code-block:: ruby
+
+  Band.pluck(:name)
+  # => [{"en"=>"english-name", "de"=>"deutsch-name"}, {"en"=>"english-name", "de"=>"deutsch-name"}]
+  Band.pluck(:name_translations)
+  # => [nil, nil]
+
+.. note::
+
+  The value of ``Mongoid.legacy_pluck_distinct`` option will change to ``false``
+  by default in Mongoid 8.0.
+
+
+Embedded Fields with ``pluck``
+``````````````````````````````
+Mongoid 7.4 with the ``Mongoid.legacy_pluck_distinct`` option set to ``false``
+returns the embedded values themselves, i.e. not inside a hash. Given the
+following definitions:
+
+.. code-block:: ruby
+
+  class Band
+    include Mongoid::Document
+
+    embeds_one :label
+  end
+
+  class Label
+    include Mongoid::Document
+
+    embedded_in :band
+    field :sales, type: BigDecimal
+  end
+
+Mongoid 7.4 behavior with ``Mongoid.legacy_pluck_distinct`` set to ``false``:
+
+.. code-block:: ruby
+
+  Band.pluck("label.sales")
+  # => [0.1e3]
+
+In Mongoid 7.3 and earlier, and in 7.4 with the ``Mongoid.legacy_pluck_distinct``
+option set to ``true`` (the default), plucking embedded attributes returns them
+inside a hash. For example:
+
+.. code-block:: ruby
+
+  Band.pluck("label.sales")
+  # => [{"sales"=>"1E2"}]
+
+.. note::
+
+  The value of ``Mongoid.legacy_pluck_distinct`` option will change to ``false``
+  by default in Mongoid 8.0.
+

--- a/docs/release-notes/mongoid-7.4.txt
+++ b/docs/release-notes/mongoid-7.4.txt
@@ -371,17 +371,17 @@ Mongoid 7.4 behavior with ``Mongoid.broken_alias_handling`` set to ``false``:
 
 .. code-block:: ruby
 
-  # Expands out to "managers.name" in the query:
-  Band.distinct('managers.n')
-  Band.pluck('managers.n')
+  # Expands out to "managers.n" in the query:
+  Band.distinct('managers.name')
+  Band.pluck('managers.name')
 
 Mongoid 7.3 and 7.4 with ``Mongoid.broken_alias_handling`` set to ``true`` behavior:
 
 .. code-block:: ruby
 
-  # Sends "managers.n" without expanding the alias:
-  Band.distinct('managers.n')
-  Band.pluck('managers.n')
+  # Sends "managers.name" without expanding the alias:
+  Band.distinct('managers.name')
+  Band.pluck('managers.name')
 
 .. note::
 
@@ -441,7 +441,7 @@ Localized Fields with ``pluck`` and ``distinct``
 ````````````````````````````````````````````````
 Mongoid 7.4 with the ``Mongoid.legacy_pluck_distinct`` option set to ``false``
 changes the behavior of using ``pluck`` and ``distinct`` with localized fields.
-Now when inputting a localized field into these functions, the translation for
+Now, when retrieving a localized field using these methods, the translation for
 the current locale will be returned. To get the full translations hash the
 ``_translations`` field can be used. Given the following definitions:
 

--- a/lib/mongoid/contextual/mongo.rb
+++ b/lib/mongoid/contextual/mongo.rb
@@ -696,9 +696,7 @@ module Mongoid
       end
 
       # Extracts the value for the given field name from the given attribute
-      # hash. Note, this is assuming the attributes were just retrieved from
-      # the database. The after_find and after_initialize callbacks are not
-      # called.
+      # hash.
       #
       # @param [ Hash ] attrs The attributes hash.
       # @param [ String ] field_name The name of the field to extract.

--- a/lib/mongoid/contextual/mongo.rb
+++ b/lib/mongoid/contextual/mongo.rb
@@ -428,7 +428,11 @@ module Mongoid
           db_fn = klass.database_field_name(f)
           normalized_field_names.push(db_fn)
 
-          hash[klass.cleanse_localized_field_names(f)] = 1
+          if Mongoid.legacy_pluck_distinct
+            hash[db_fn] = 1
+          else
+            hash[klass.cleanse_localized_field_names(f)] = 1
+          end
           hash
         end
 

--- a/lib/mongoid/contextual/mongo.rb
+++ b/lib/mongoid/contextual/mongo.rb
@@ -428,8 +428,7 @@ module Mongoid
           db_fn = klass.database_field_name(f)
           normalized_field_names.push(db_fn)
 
-          field_name = klass.get_field(f)&.name || db_fn
-          hash[field_name] = 1
+          hash[klass.cleanse_localized_field_names(f)] = 1
           hash
         end
 
@@ -442,10 +441,10 @@ module Mongoid
               # splits up the method and calls them in succession on the document
               n.split('.').inject(d) do |curr, meth|
                 if curr.is_a? Array
-                  res = curr.map { |x| x.try(meth) }
+                  res = curr.map { |x| x.try(meth) || x.try(:fetch, meth) }
                   res.empty? ? nil : res
                 else
-                  curr.try(meth)
+                  curr.try(meth) || curr.try(:fetch, meth)
                 end
               end
             end

--- a/lib/mongoid/contextual/mongo.rb
+++ b/lib/mongoid/contextual/mongo.rb
@@ -705,7 +705,7 @@ module Mongoid
       #
       # @param [ Any ] The value for the given field name
       def extract_value(attrs, field_name)
-        d = Factory.execute_from_db(klass, attrs, defer_callbacks: false)
+        d = Factory.execute_from_db(klass, attrs, execute_callbacks: false)
         d.pending_callbacks.clear
 
         # splits up the method and calls them in succession on the document

--- a/lib/mongoid/contextual/mongo.rb
+++ b/lib/mongoid/contextual/mongo.rb
@@ -697,14 +697,17 @@ module Mongoid
 
       # Extracts the value for the given field name from the given attribute
       # hash. Note, this is assuming the attributes were just retrieved from
-      # the database, and will trigger the appropriate callbacks.
+      # the database. The after_find and after_initialize callbacks are not
+      # called
       #
       # @param [ Hash ] attrs The attributes hash.
       # @param [ String ] field_name The name of the field to extract.
       #
       # @param [ Any ] The value for the given field name
       def extract_value(attrs, field_name)
-        d = Factory.from_db(klass, attrs)
+        d = Factory.execute_from_db(klass, attrs, defer_callbacks: false)
+        d.pending_callbacks.clear
+
         # splits up the method and calls them in succession on the document
         field_name.split('.').inject(d) do |curr, meth|
           if curr.is_a? Array

--- a/lib/mongoid/fields.rb
+++ b/lib/mongoid/fields.rb
@@ -76,6 +76,25 @@ module Mongoid
         end
         nil
       end
+
+      # Retrieves the field for the given klass and field_name.
+      #
+      # If the field ends in _translations and that field does not exist on the
+      # given klass, get the field for the string without _translations.
+      #
+      # @param [ String | Symbol ] name The name of the field to retrieve.
+      #
+      # @return [ Field ] The field retrieved from the klass
+      def get_field(name)
+        name = database_field_name(name.to_s)
+
+        unless fields.has_key?(name)
+          if tr = name.match(/(.*)_translations\z/).captures&.first
+            name = tr
+          end
+        end
+        fields[name]
+      end
     end
 
     included do

--- a/lib/mongoid/fields.rb
+++ b/lib/mongoid/fields.rb
@@ -93,7 +93,7 @@ module Mongoid
           ar = name.split('.')
           ar.each_with_index do |fn, i|
             key = fn
-            unless klass.fields.has_key?(fn) || klass.relations.has_key?(fn)
+            unless klass.fields.key?(fn) || klass.relations.key?(fn)
               if tr = fn.match(/(.*)_translations\z/)&.captures&.first
                 key = tr
               else
@@ -101,12 +101,12 @@ module Mongoid
               end
 
             end
-            res.push("#{key}")
+            res.push(key)
 
-            if klass.fields.has_key?(fn)
+            if klass.fields.key?(fn)
               res.push(ar.drop(i+1).join('.')) unless i == ar.length - 1
               break
-            elsif klass.relations.has_key?(fn)
+            elsif klass.relations.key?(fn)
               klass = klass.relations[key].klass
             end
           end

--- a/lib/mongoid/fields.rb
+++ b/lib/mongoid/fields.rb
@@ -89,7 +89,7 @@ module Mongoid
         name = database_field_name(name.to_s)
 
         unless fields.has_key?(name)
-          if tr = name.match(/(.*)_translations\z/).captures&.first
+          if tr = name.match(/(.*)_translations\z/)&.captures&.first
             name = tr
           end
         end

--- a/spec/integration/criteria/alias_query_spec.rb
+++ b/spec/integration/criteria/alias_query_spec.rb
@@ -114,7 +114,7 @@ describe 'pluck on aliased fields' do
       it 'expands the alias' do
         query
 
-        command['projection'].should == {'t' => 1}
+        command['projection'].should == {'t' => true}
       end
     end
 
@@ -126,7 +126,7 @@ describe 'pluck on aliased fields' do
       it 'expands the alias' do
         query
 
-        command['projection'].should == {'phone_numbers.ext' => 1}
+        command['projection'].should == {'phone_numbers.ext' => true}
       end
     end
   end
@@ -142,7 +142,7 @@ describe 'pluck on aliased fields' do
       it 'expands the alias' do
         query
 
-        command['projection'].should == {'t' => 1}
+        command['projection'].should == {'t' => true}
       end
     end
 
@@ -154,7 +154,7 @@ describe 'pluck on aliased fields' do
       it 'does not expand the alias' do
         query
 
-        command['projection'].should == {'phone_numbers.extension' => 1}
+        command['projection'].should == {'phone_numbers.extension' => true}
       end
     end
   end

--- a/spec/mongoid/contextual/mongo_spec.rb
+++ b/spec/mongoid/contextual/mongo_spec.rb
@@ -689,13 +689,11 @@ describe Mongoid::Contextual::Mongo do
       end
 
       context 'when fallbacks are enabled with a locale list' do
-        before(:all) do
-          puts "I18n version: #{I18n::VERSION}"
-
-          require "i18n/backend/fallbacks"
-          I18n::Backend::Simple.send(:include, I18n::Backend::Fallbacks)
-
+        around(:all) do |example|
+          prev_fallbacks = I18n.fallbacks.dup
           I18n.fallbacks[:he] = [ :en ]
+          example.run
+          I18n.fallbacks = prev_fallbacks
         end
 
         let(:distinct) do

--- a/spec/mongoid/contextual/mongo_spec.rb
+++ b/spec/mongoid/contextual/mongo_spec.rb
@@ -796,6 +796,8 @@ describe Mongoid::Contextual::Mongo do
 
       context "when legacy_pluck_distinct is set" do
         config_override :legacy_pluck_distinct, true
+        config_override :map_big_decimal_to_decimal128, true
+
         it "returns the distinct matching fields" do
           expect(context.distinct("label.sales")).to eq([ BSON::Decimal128.new('1E+2') ])
         end

--- a/spec/mongoid/contextual/mongo_spec.rb
+++ b/spec/mongoid/contextual/mongo_spec.rb
@@ -708,12 +708,6 @@ describe Mongoid::Contextual::Mongo do
         it "returns the distinct matching fields" do
           expect(context.distinct("label.sales")).to eq([ BigDecimal("1E2") ])
         end
-
-        it "the parent is available in the callbacks" do
-          label.reload
-          expect(label.after_find_called).to be true
-          expect(label.after_initialize_called).to be true
-        end
       end
     end
   end

--- a/spec/mongoid/contextual/mongo_spec.rb
+++ b/spec/mongoid/contextual/mongo_spec.rb
@@ -695,7 +695,7 @@ describe Mongoid::Contextual::Mongo do
           require "i18n/backend/fallbacks"
           I18n::Backend::Simple.send(:include, I18n::Backend::Fallbacks)
 
-          I18n.fallbacks[:fr] = [ :en ]
+          I18n.fallbacks[:he] = [ :en ]
         end
 
         let(:distinct) do
@@ -716,7 +716,7 @@ describe Mongoid::Contextual::Mongo do
           it "correctly uses the fallback" do
             I18n.locale = :en
             d = Dictionary.create!(description: 'english-text')
-            I18n.locale = :fr
+            I18n.locale = :he
             distinct.should == "english-text"
           end
         end

--- a/spec/mongoid/contextual/mongo_spec.rb
+++ b/spec/mongoid/contextual/mongo_spec.rb
@@ -689,6 +689,8 @@ describe Mongoid::Contextual::Mongo do
       end
 
       context 'when fallbacks are enabled with a locale list' do
+        require_fallbacks
+
         around(:all) do |example|
           prev_fallbacks = I18n.fallbacks.dup
           I18n.fallbacks[:he] = [ :en ]

--- a/spec/mongoid/contextual/mongo_spec.rb
+++ b/spec/mongoid/contextual/mongo_spec.rb
@@ -797,7 +797,7 @@ describe Mongoid::Contextual::Mongo do
       context "when legacy_pluck_distinct is set" do
         config_override :legacy_pluck_distinct, true
         it "returns the distinct matching fields" do
-          expect(context.distinct("label.sales")).to eq([ "1E2" ])
+          expect(context.distinct("label.sales")).to eq([ BSON::Decimal128.new('1E+2') ])
         end
       end
 

--- a/spec/mongoid/criteria_spec.rb
+++ b/spec/mongoid/criteria_spec.rb
@@ -3174,13 +3174,11 @@ describe Mongoid::Criteria do
       end
 
       context 'when fallbacks are enabled with a locale list' do
-        before(:all) do
-          puts "I18n version: #{I18n::VERSION}"
-
-          require "i18n/backend/fallbacks"
-          I18n::Backend::Simple.send(:include, I18n::Backend::Fallbacks)
-
+        around(:all) do |example|
+          prev_fallbacks = I18n.fallbacks.dup
           I18n.fallbacks[:he] = [ :en ]
+          example.run
+          I18n.fallbacks = prev_fallbacks
         end
 
         let(:plucked) do

--- a/spec/mongoid/criteria_spec.rb
+++ b/spec/mongoid/criteria_spec.rb
@@ -3145,7 +3145,7 @@ describe Mongoid::Criteria do
           config_override :legacy_pluck_distinct, false
 
           it 'returns the specific translations' do
-            expect(plucked.first).to eq(nil)
+            expect(plucked.first).to eq('deutsch-text')
           end
         end
       end

--- a/spec/mongoid/criteria_spec.rb
+++ b/spec/mongoid/criteria_spec.rb
@@ -3323,9 +3323,10 @@ describe Mongoid::Criteria do
 
       context "when legacy_pluck_distinct is set" do
         config_override :legacy_pluck_distinct, true
+        config_override :map_big_decimal_to_decimal128, true
 
         it "returns a hash with a non-demongoized field" do
-          expect(plucked.first).to eq({ 'sales' => "1E2" })
+          expect(plucked.first).to eq({ 'sales' => BSON::Decimal128.new('1E+2') })
         end
       end
 
@@ -3346,9 +3347,10 @@ describe Mongoid::Criteria do
 
       context "when legacy_pluck_distinct is set" do
         config_override :legacy_pluck_distinct, true
+        config_override :map_big_decimal_to_decimal128, true
 
         it "returns a hash with a non-demongoized field" do
-          expect(plucked.first).to eq([{ 'sales' => "1E2" }])
+          expect(plucked.first).to eq([{ 'sales' => BSON::Decimal128.new('1E+2') }])
         end
       end
 

--- a/spec/mongoid/criteria_spec.rb
+++ b/spec/mongoid/criteria_spec.rb
@@ -3038,6 +3038,10 @@ describe Mongoid::Criteria do
           Dictionary.all.pluck(:description_translations)
         end
 
+        let(:plucked_translations_both) do
+          Dictionary.all.pluck(:description_translations)
+        end
+
         context "when legacy_pluck_distinct is set" do
           config_override :legacy_pluck_distinct, true
 
@@ -3046,8 +3050,11 @@ describe Mongoid::Criteria do
           end
 
           it 'returns the full translations hash to _translations' do
-            pending "MONGOID-5260"
             expect(plucked_translations.first).to eq({"de"=>"deutsch-text", "en"=>"english-text"})
+          end
+
+          it 'returns both' do
+            expect(plucked_translations_both.first).to eq([{"de"=>"deutsch-text", "en"=>"english-text"}, {"de"=>"deutsch-text", "en"=>"english-text"}])
           end
         end
 
@@ -3059,7 +3066,6 @@ describe Mongoid::Criteria do
           end
 
           it 'returns the full translations hash to _translations' do
-            pending "MONGOID-5260"
             expect(plucked_translations.first).to eq({"de"=>"deutsch-text", "en"=>"english-text"})
           end
         end

--- a/spec/mongoid/criteria_spec.rb
+++ b/spec/mongoid/criteria_spec.rb
@@ -3180,7 +3180,7 @@ describe Mongoid::Criteria do
           require "i18n/backend/fallbacks"
           I18n::Backend::Simple.send(:include, I18n::Backend::Fallbacks)
 
-          I18n.fallbacks[:fr] = [ :en ]
+          I18n.fallbacks[:he] = [ :en ]
         end
 
         let(:plucked) do
@@ -3201,7 +3201,7 @@ describe Mongoid::Criteria do
           it "correctly uses the fallback" do
             I18n.locale = :en
             d = Dictionary.create!(description: 'english-text')
-            I18n.locale = :fr
+            I18n.locale = :he
             plucked.should == "english-text"
           end
         end

--- a/spec/mongoid/criteria_spec.rb
+++ b/spec/mongoid/criteria_spec.rb
@@ -3149,6 +3149,29 @@ describe Mongoid::Criteria do
           end
         end
       end
+
+      context 'when plucking a specific locale from _translations field' do
+
+        let(:plucked) do
+          Dictionary.all.pluck(:'description_translations.de')
+        end
+
+        context "when legacy_pluck_distinct is set" do
+          config_override :legacy_pluck_distinct, true
+
+          it 'returns the specific translations' do
+            expect(plucked.first).to eq(nil)
+          end
+        end
+
+        context "when legacy_pluck_distinct is not set" do
+          config_override :legacy_pluck_distinct, false
+
+          it 'returns the specific translations' do
+            expect(plucked.first).to eq('deutsch-text')
+          end
+        end
+      end
     end
 
     context 'when plucking a field to be demongoized' do

--- a/spec/mongoid/criteria_spec.rb
+++ b/spec/mongoid/criteria_spec.rb
@@ -3222,6 +3222,12 @@ describe Mongoid::Criteria do
         it "demongoizes the field" do
           expect(plucked.first).to eq(BigDecimal("1E2"))
         end
+
+        it "the parent is available in the callbacks" do
+          label.reload
+          expect(label.after_find_called).to be true
+          expect(label.after_initialize_called).to be true
+        end
       end
     end
 

--- a/spec/mongoid/criteria_spec.rb
+++ b/spec/mongoid/criteria_spec.rb
@@ -3336,6 +3336,29 @@ describe Mongoid::Criteria do
       end
     end
 
+    context "when plucking an embeds_many field" do
+      let(:label) { Label.new(sales: "1E2") }
+      let!(:band) { Band.create!(labels: [label]) }
+
+      let(:plucked) { Band.where(_id: band.id).pluck("labels.sales") }
+
+      context "when legacy_pluck_distinct is set" do
+        config_override :legacy_pluck_distinct, true
+
+        it "returns a hash with a non-demongoized field" do
+          expect(plucked.first).to eq([{ 'sales' => "1E2" }])
+        end
+      end
+
+      context "when legacy_pluck_distinct is not set" do
+        config_override :legacy_pluck_distinct, false
+
+        it "demongoizes the field" do
+          expect(plucked.first).to eq([BigDecimal("1E2")])
+        end
+      end
+    end
+
     context "when plucking a nonexistent embedded field" do
       let(:label) { Label.new(sales: "1E2") }
       let!(:band) { Band.create!(label: label) }

--- a/spec/mongoid/criteria_spec.rb
+++ b/spec/mongoid/criteria_spec.rb
@@ -3034,11 +3034,20 @@ describe Mongoid::Criteria do
           Dictionary.all.pluck(:description)
         end
 
+        let(:plucked_translations) do
+          Dictionary.all.pluck(:description_translations)
+        end
+
         context "when legacy_pluck_distinct is set" do
           config_override :legacy_pluck_distinct, true
 
           it 'returns the non-demongoized translations' do
             expect(plucked.first).to eq({"de"=>"deutsch-text", "en"=>"english-text"})
+          end
+
+          it 'returns the full translations hash to _translations' do
+            pending "MONGOID-5260"
+            expect(plucked_translations.first).to eq({"de"=>"deutsch-text", "en"=>"english-text"})
           end
         end
 
@@ -3047,6 +3056,11 @@ describe Mongoid::Criteria do
 
           it 'returns the demongoized translations' do
             expect(plucked.first).to eq('deutsch-text')
+          end
+
+          it 'returns the full translations hash to _translations' do
+            pending "MONGOID-5260"
+            expect(plucked_translations.first).to eq({"de"=>"deutsch-text", "en"=>"english-text"})
           end
         end
       end

--- a/spec/mongoid/criteria_spec.rb
+++ b/spec/mongoid/criteria_spec.rb
@@ -3174,6 +3174,8 @@ describe Mongoid::Criteria do
       end
 
       context 'when fallbacks are enabled with a locale list' do
+        require_fallbacks
+
         around(:all) do |example|
           prev_fallbacks = I18n.fallbacks.dup
           I18n.fallbacks[:he] = [ :en ]

--- a/spec/mongoid/criteria_spec.rb
+++ b/spec/mongoid/criteria_spec.rb
@@ -3245,12 +3245,6 @@ describe Mongoid::Criteria do
         it "demongoizes the field" do
           expect(plucked.first).to eq(BigDecimal("1E2"))
         end
-
-        it "the parent is available in the callbacks" do
-          label.reload
-          expect(label.after_find_called).to be true
-          expect(label.after_initialize_called).to be true
-        end
       end
     end
 

--- a/spec/mongoid/fields_spec.rb
+++ b/spec/mongoid/fields_spec.rb
@@ -1745,10 +1745,24 @@ describe Mongoid::Fields do
       end
     end
 
+    context "when cleansing dotted translation field as a symbol" do
+      let(:field_name) { "passport.name_translations.asd".to_sym }
+      it "returns the correct field name" do
+        expect(field).to eq("passport.name.asd")
+      end
+    end
+
     context "when cleansing dotted existing translation field" do
       let(:field_name) { "passport.localized_translations.asd" }
       it "returns the correct field name" do
         expect(field).to eq("passport.localized_translations.asd")
+      end
+    end
+
+    context "when cleansing aliased dotted translation field" do
+      let(:field_name) { "pass.name_translations.asd" }
+      it "returns the correct field name" do
+        expect(field).to eq("pass.name.asd")
       end
     end
   end

--- a/spec/mongoid/fields_spec.rb
+++ b/spec/mongoid/fields_spec.rb
@@ -1701,41 +1701,54 @@ describe Mongoid::Fields do
   describe "#get_field" do
 
     let(:klass) { Person }
-    let(:field) { klass.get_field(field_name) }
+    let(:field) { klass.cleanse_localized_field_names(field_name) }
 
-    context "when getting a field" do
+    context "when cleansing a field" do
       let(:field_name) { "employer_id" }
-      it "returns the correct field" do
-        expect(field).to eq(klass.fields[field_name])
+      it "returns the correct field name" do
+        expect(field).to eq(field_name)
       end
     end
 
-    context "when getting a localized field" do
+    context "when cleansing a localized field" do
       let(:field_name) { "desc" }
-      it "returns the correct field" do
-        expect(field).to eq(klass.fields[field_name])
+      it "returns the correct field name" do
+        expect(field).to eq(field_name)
       end
     end
 
-    context "when getting a translation field" do
+    context "when cleansing a translation field" do
       let(:field_name) { "desc_translations" }
-      it "returns the correct field" do
-        expect(field).to eq(klass.fields["desc"])
+      it "returns the correct field name" do
+        expect(field).to eq("desc")
       end
     end
 
-    context "when getting an existing translation field" do
+    context "when cleansing an existing translation field" do
       let(:field_name) { "localized_translations" }
-      it "returns the correct field" do
-        byebug
-        expect(field).to eq(klass.fields[field_name])
+      it "returns the correct field name" do
+        expect(field).to eq(field_name)
       end
     end
 
-    context "when getting an existing translation field with a _translations" do
+    context "when cleansing an existing translation field with a _translations" do
       let(:field_name) { "localized_translations_translations" }
-      it "returns the correct field" do
-        expect(field).to eq(klass.fields["localized_translations"])
+      it "returns the correct field name" do
+        expect(field).to eq("localized_translations")
+      end
+    end
+
+    context "when cleansing dotted translation field" do
+      let(:field_name) { "passport.name_translations.asd" }
+      it "returns the correct field name" do
+        expect(field).to eq("passport.name.asd")
+      end
+    end
+
+    context "when cleansing dotted existing translation field" do
+      let(:field_name) { "passport.localized_translations.asd" }
+      it "returns the correct field name" do
+        expect(field).to eq("passport.localized_translations.asd")
       end
     end
   end

--- a/spec/mongoid/fields_spec.rb
+++ b/spec/mongoid/fields_spec.rb
@@ -1739,23 +1739,26 @@ describe Mongoid::Fields do
     end
 
     context "when cleansing dotted translation field" do
+      config_override :broken_alias_handling, false
       let(:field_name) { "passport.name_translations.asd" }
       it "returns the correct field name" do
-        expect(field).to eq("passport.name.asd")
+        expect(field).to eq("pass.name.asd")
       end
     end
 
     context "when cleansing dotted translation field as a symbol" do
+      config_override :broken_alias_handling, false
       let(:field_name) { "passport.name_translations.asd".to_sym }
       it "returns the correct field name" do
-        expect(field).to eq("passport.name.asd")
+        expect(field).to eq("pass.name.asd")
       end
     end
 
     context "when cleansing dotted existing translation field" do
+      config_override :broken_alias_handling, false
       let(:field_name) { "passport.localized_translations.asd" }
       it "returns the correct field name" do
-        expect(field).to eq("passport.localized_translations.asd")
+        expect(field).to eq("pass.localized_translations.asd")
       end
     end
 

--- a/spec/mongoid/fields_spec.rb
+++ b/spec/mongoid/fields_spec.rb
@@ -1697,4 +1697,46 @@ describe Mongoid::Fields do
       end
     end
   end
+
+  describe "#get_field" do
+
+    let(:klass) { Person }
+    let(:field) { klass.get_field(field_name) }
+
+    context "when getting a field" do
+      let(:field_name) { "employer_id" }
+      it "returns the correct field" do
+        expect(field).to eq(klass.fields[field_name])
+      end
+    end
+
+    context "when getting a localized field" do
+      let(:field_name) { "desc" }
+      it "returns the correct field" do
+        expect(field).to eq(klass.fields[field_name])
+      end
+    end
+
+    context "when getting a translation field" do
+      let(:field_name) { "desc_translations" }
+      it "returns the correct field" do
+        expect(field).to eq(klass.fields["desc"])
+      end
+    end
+
+    context "when getting an existing translation field" do
+      let(:field_name) { "localized_translations" }
+      it "returns the correct field" do
+        byebug
+        expect(field).to eq(klass.fields[field_name])
+      end
+    end
+
+    context "when getting an existing translation field with a _translations" do
+      let(:field_name) { "localized_translations_translations" }
+      it "returns the correct field" do
+        expect(field).to eq(klass.fields["localized_translations"])
+      end
+    end
+  end
 end

--- a/spec/mongoid/interceptable_spec.rb
+++ b/spec/mongoid/interceptable_spec.rb
@@ -5,6 +5,14 @@ require_relative './interceptable_spec_models'
 
 describe Mongoid::Interceptable do
 
+  before do
+    # The find and initialize callbacks I added were causing failures
+    # because they were causing updates when we were asserting no updates
+    # happened.
+    Label.reset_callbacks(:initialize)
+    Label.reset_callbacks(:find)
+  end
+
   class TestClass
     include Mongoid::Interceptable
 

--- a/spec/support/models/label.rb
+++ b/spec/support/models/label.rb
@@ -7,8 +7,6 @@ class Label
   field :name, type: String
   field :sales, type: BigDecimal
   field :after_create_called, type: Mongoid::Boolean, default: false
-  field :after_find_called, type: Mongoid::Boolean, default: false
-  field :after_initialize_called, type: Mongoid::Boolean, default: false
   field :after_save_called, type: Mongoid::Boolean, default: false
   field :after_update_called, type: Mongoid::Boolean, default: false
   field :after_validation_called, type: Mongoid::Boolean, default: false
@@ -24,8 +22,6 @@ class Label
   after_update :after_update_stub
   after_validation :after_validation_stub
   before_validation :cleanup
-  after_find :after_find_stub
-  after_initialize :after_initialize_stub
 
   def before_save_stub
     self.before_save_count += 1
@@ -45,14 +41,6 @@ class Label
 
   def after_validation_stub
     self.after_validation_called = true
-  end
-
-  def after_find_stub
-    self.update_attributes!(after_find_called: true) if band
-  end
-
-  def after_initialize_stub
-    self.update_attributes!(after_initialize_called: true) if band
   end
 
   private

--- a/spec/support/models/label.rb
+++ b/spec/support/models/label.rb
@@ -5,7 +5,10 @@ class Label
   include Mongoid::Timestamps::Updated::Short
 
   field :name, type: String
+  field :sales, type: BigDecimal
   field :after_create_called, type: Mongoid::Boolean, default: false
+  field :after_find_called, type: Mongoid::Boolean, default: false
+  field :after_initialize_called, type: Mongoid::Boolean, default: false
   field :after_save_called, type: Mongoid::Boolean, default: false
   field :after_update_called, type: Mongoid::Boolean, default: false
   field :after_validation_called, type: Mongoid::Boolean, default: false
@@ -21,6 +24,8 @@ class Label
   after_update :after_update_stub
   after_validation :after_validation_stub
   before_validation :cleanup
+  after_find :after_find_stub
+  after_initialize :after_initialize_stub
 
   def before_save_stub
     self.before_save_count += 1
@@ -40,6 +45,14 @@ class Label
 
   def after_validation_stub
     self.after_validation_called = true
+  end
+
+  def after_find_stub
+    self.update_attributes!(after_find_called: true) if band
+  end
+
+  def after_initialize_stub
+    self.update_attributes!(after_initialize_called: true) if band
   end
 
   private

--- a/spec/support/models/passport.rb
+++ b/spec/support/models/passport.rb
@@ -6,6 +6,8 @@ class Passport
   field :number, type: String
   field :country, type: String
   field :exp, as: :expiration_date, type: Date
+  field :name, localize: true
+  field :localized_translations, localize: true
 
   embedded_in :person, autobuild: true
 end

--- a/spec/support/models/person.rb
+++ b/spec/support/models/person.rb
@@ -34,6 +34,7 @@ class Person
   field :i, as: :inte, type: Integer
   field :a, as: :array, type: Array
   field :desc, localize: true
+  field :localized_translations, localize: true
   field :test_array, type: Array
   field :overridden_setter, type: String
   field :arrays, type: Array


### PR DESCRIPTION
I have not written the release notes or docs yet but I'm going to use this as scratch space:

Difference between new and old pluck and distinct:

|                                              | new                                                    | old                                          |
|----------------------------------------------|--------------------------------------------------------|----------------------------------------------|
| callbacks                                    | none                                     | none                                         |
| plucking a localized field                   | "deutsch-text"                                         | {"de"=>"deutsch-text", "en"=>"english-text"} |
| plucking an _translations                    | {"de"=>"deutsch-text", "en"=>"english-text"}           | nil                                          |
| plucking a dotted field (records.name)       | "the name"                                             | { name => "the name" }                       |
| plucking dotted localized field (:'desc.de') | 'deutsch-text' | {'de' => 'deutsch-text'}                     |
| plucking dotted translation field (:'desc_transaltions.de') | 'deutsch-text' | nil             |

I've decided not to call the find/initialize callbacks in pluck/distinct for the following reasons: 
1. distinct only gets one value so we don't actually initialize an object to call the callbacks on. I would like pluck/distinct to behave the same in this regard
2. Neither pluck or distinct return the actually objects that we're initializing, and I think that's the reason the callbacks weren't called in the first place.

I am open to having those callbacks called (I don't think I could on distinct, though), but I don't think it's necessary.