### PR TITLE
move to mongodb.com/docs

### DIFF
--- a/docs/additional-resources.txt
+++ b/docs/additional-resources.txt
@@ -13,7 +13,7 @@ Additional Resources
 This page lists some of the third-party guides and blog posts about Mongoid,
 as well as sample Mongoid applications. Additional resources for the driver
 are listed on the `respective driver page
-<https://docs.mongodb.com/ruby-driver/current/reference/additional-resources/>`_.
+<https://mongodb.com/docs/ruby-driver/current/reference/additional-resources/>`_.
 
 
 Screencasts
@@ -22,15 +22,15 @@ Screencasts
 - `RailsCasts: Mongoid (revised)
   <https://www.youtube.com/watch?v=L0RqU2MdqXU>`_
 
-  An overview of Mongoid, by Ryan Bates including the basics 
-  of setting up an app, querying for records, adding embedded 
+  An overview of Mongoid, by Ryan Bates including the basics
+  of setting up an app, querying for records, adding embedded
   associations, overriding the id, and more.
 
 - `Ruby on Rails Web Services and Integration with MongoDB, Week 3: Mongoid
   <https://www.youtube.com/watch?v=9LylgiMYsUM>`_
 
   A detailed introduction to Mongoid and Ruby on Rails web services.
-  
+
 - `Create a search bar in Rails with Mongoid
   <https://www.youtube.com/watch?v=zusWR8jS5-A>`_
 
@@ -51,7 +51,7 @@ Articles
 - `Converting an existing Ruby on Rails application to MongoDB <https://ibraheem.ca/posts/convert-rails-to-mongodb>`_
 
   How to Convert an existing Ruby on Rails application to use MongoDB and Mongoid.
-  
+
 
 Sample Applications
 ===================

--- a/docs/index.txt
+++ b/docs/index.txt
@@ -16,7 +16,7 @@ for MongoDB in Ruby.
   tutorials
   schema-configuration
   working-with-data
-  API <https://docs.mongodb.com/mongoid/master/api/>
+  API <https://mongodb.com/docs/mongoid/master/api/>
   release-notes
   additional-resources
   ecosystem

--- a/docs/reference/associations.txt
+++ b/docs/reference/associations.txt
@@ -554,7 +554,7 @@ often a good idea to use embedded associations.
 
 Using embedded associations allows using MongoDB tools like the
 `aggregation pipeline
-<https://docs.mongodb.com/manual/core/aggregation-pipeline/>`_ to query
+<https://mongodb.com/docs/manual/core/aggregation-pipeline/>`_ to query
 these documents in a powerful way.
 
 Because embedded documents are stored as part of their parent top-level
@@ -696,8 +696,8 @@ is not implemented for :ref:`text search <text-search>`, :manual:`geospatial que
 operators </reference/operator/query-geospatial/>`,
 operators that execute JavaScript code (:manual:`$where </reference/operator/query/where/>`)
 and operators that are implemented via other server functionality such as
-:manual:`$expr <https://docs.mongodb.com/manual/reference/operator/query/expr/>`
-and :manual:`$jsonSchema <https://docs.mongodb.com/manual/reference/operator/query/jsonSchema/>`.
+:manual:`$expr <https://mongodb.com/docs/manual/reference/operator/query/expr/>`
+and :manual:`$jsonSchema <https://mongodb.com/docs/manual/reference/operator/query/jsonSchema/>`.
 
 The following operators are supported:
 
@@ -1635,9 +1635,9 @@ Mongoid provides limited support for constructing the aggregation pipeline
 itself using a high-level DSL. The following aggregation pipeline operators
 are supported:
 
-- `$group <https://docs.mongodb.com/manual/reference/operator/aggregation/group/>`_
-- `$project <https://docs.mongodb.com/manual/reference/operator/aggregation/project/>`_
-- `$unwind <https://docs.mongodb.com/manual/reference/operator/aggregation/unwind/>`_
+- `$group <https://mongodb.com/docs/manual/reference/operator/aggregation/group/>`_
+- `$project <https://mongodb.com/docs/manual/reference/operator/aggregation/project/>`_
+- `$unwind <https://mongodb.com/docs/manual/reference/operator/aggregation/unwind/>`_
 
 To construct a pipeline, call the corresponding aggregation pipeline methods
 on a ``Criteria`` instance. Aggregation pipeline operations are added to the
@@ -1686,7 +1686,7 @@ group
 `````
 
 The ``group`` method adds a `$group aggregation pipeline stage
-<https://docs.mongodb.com/manual/reference/operator/aggregation/group/>`_.
+<https://mongodb.com/docs/manual/reference/operator/aggregation/group/>`_.
 
 The field expressions support Mongoid symbol-operator syntax:
 
@@ -1706,7 +1706,7 @@ project
 ```````
 
 The ``project`` method adds a `$project aggregation pipeline stage
-<https://docs.mongodb.com/manual/reference/operator/aggregation/project/>`_.
+<https://mongodb.com/docs/manual/reference/operator/aggregation/project/>`_.
 
 The argument should be a Hash specifying the projection:
 
@@ -1722,7 +1722,7 @@ unwind
 ``````
 
 The ``unwind`` method adds an `$unwind aggregation pipeline stage
-<https://docs.mongodb.com/manual/reference/operator/aggregation/unwind/>`_.
+<https://mongodb.com/docs/manual/reference/operator/aggregation/unwind/>`_.
 
 The argument can be a field name, specifiable as a symbol or a string, or
 a Hash or a ``BSON::Document`` instance:

--- a/docs/reference/compatibility.txt
+++ b/docs/reference/compatibility.txt
@@ -14,7 +14,7 @@ Ruby MongoDB Driver Compatibility
 =================================
 
 The following compatibility table specifies the versions of `Ruby driver for
-MongoDB <https://docs.mongodb.com/ruby-driver/current/>`_
+MongoDB <https://mongodb.com/docs/ruby-driver/current/>`_
 (the ``mongo`` gem) supported by the most recent patch releases of the
 specified Mongoid versions.
 
@@ -182,7 +182,7 @@ version(s) of Mongoid for use with a specific version of MongoDB server.
 Note that in order to use features of a particular MongoDB server version,
 both the driver and Mongoid must support that server version.
 Please refer to `the driver compatibility page
-<https://docs.mongodb.com/ruby-driver/current/reference/driver-compatibility/>`_
+<https://mongodb.com/docs/ruby-driver/current/reference/driver-compatibility/>`_
 for driver compatibility matrices.
 
 "D" in a column means support for that MongoDB server version is deprecated

--- a/docs/reference/configuration.txt
+++ b/docs/reference/configuration.txt
@@ -117,7 +117,7 @@ The following annotated example ``mongoid.yml`` demonstrates how Mongoid
 can be configured.
 
 Mongoid delegates to the Ruby driver for client configuration. Please review
-`the driver documentation <https://docs.mongodb.com/ruby-driver/current/reference/create-client/>`_
+`the driver documentation <https://mongodb.com/docs/ruby-driver/current/reference/create-client/>`_
 for details on driver options.
 
 .. code-block:: yaml
@@ -143,7 +143,7 @@ for details on driver options.
           - myhost3.mydomain.com:27017
         options:
           # These options are Ruby driver options, documented in
-          # https://docs.mongodb.com/ruby-driver/current/reference/create-client/
+          # https://mongodb.com/docs/ruby-driver/current/reference/create-client/
 
           # Change the default write concern. (default = { w: 1 })
           write:
@@ -177,10 +177,10 @@ for details on driver options.
           # Specify the auth source, i.e. the database or other source which
           # contains the user's login credentials. Allowed values for auth source
           # depend on the authentication mechanism, as explained in the server documentation:
-          # https://docs.mongodb.com/manual/reference/connection-string/#mongodb-urioption-urioption.authSource
+          # https://mongodb.com/docs/manual/reference/connection-string/#mongodb-urioption-urioption.authSource
           # If no auth source is specified, the default auth source as
           # determined by the driver will be used. Please refer to:
-          # https://docs.mongodb.com/ruby-driver/current/reference/authentication/#auth-source
+          # https://mongodb.com/docs/ruby-driver/current/reference/authentication/#auth-source
           auth_source: admin
 
           # Connect directly to and perform all operations on the specified
@@ -723,7 +723,7 @@ be executed sequentially during socket creation.
   in an application.
 
 For more information about TLS context hooks, including best practices for
-assigning and removing them, see `the Ruby driver documentation <https://docs.mongodb.com/ruby-driver/current/reference/create-client/#modifying-sslcontext>`_.
+assigning and removing them, see `the Ruby driver documentation <https://mongodb.com/docs/ruby-driver/current/reference/create-client/#modifying-sslcontext>`_.
 
 Usage with Forking Servers
 ==========================

--- a/docs/reference/fields.txt
+++ b/docs/reference/fields.txt
@@ -19,7 +19,7 @@ Field Types
 ===========
 
 MongoDB stores underlying document data using
-`BSON types <https://docs.mongodb.com/manual/reference/bson-types/>`_, and
+`BSON types <https://mongodb.com/docs/manual/reference/bson-types/>`_, and
 Mongoid converts BSON types to Ruby types at runtime in your application.
 For example, a field defined with `type: :float` will use the Ruby ``Float``
 class in-memory and will persist in the database as the the BSON ``double`` type.
@@ -1327,7 +1327,7 @@ names containing the dot and dollar characters, however it is recommended to
 avoid these characters for ease of querying.
 
 MongoDB 5.0 adds `special operators
-<https://docs.mongodb.com/manual/core/dot-dollar-considerations/#std-label-crud-concepts-dot-dollar-considerations>`_
+<https://mongodb.com/docs/manual/core/dot-dollar-considerations/#std-label-crud-concepts-dot-dollar-considerations>`_
 for querying and modifying documents using field names containing dots and
 dollars. Previous MongoDB versions do not provide a mechanism for querying
 documents on fields whose names contain dots and dollars, though such documents

--- a/docs/reference/indexes.txt
+++ b/docs/reference/indexes.txt
@@ -24,7 +24,7 @@ second options hash parameter:
     class Person
       include Mongoid::Document
       field :ssn
-   
+
       index({ ssn: 1 }, { unique: true, name: "ssn_index" })
     end
 
@@ -46,7 +46,7 @@ You can index on multiple fields and provide direction:
       include Mongoid::Document
       field :first_name
       field :last_name
-  
+
       index({ first_name: 1, last_name: 1 }, { unique: true })
     end
 
@@ -57,7 +57,7 @@ Indexes can be sparse:
     class Person
       include Mongoid::Document
       field :ssn
-  
+
       index({ ssn: -1 }, { sparse: true })
     end
 
@@ -89,7 +89,7 @@ already have duplicate values by specifying the ``drop_dups`` option:
     end
 
 The ``drop_dups`` option has been `removed as of MongoDB 3.0
-<https://docs.mongodb.com/manual/release-notes/3.0-compatibility/#remove-dropdups-option>`_.
+<https://mongodb.com/docs/manual/release-notes/3.0-compatibility/#remove-dropdups-option>`_.
 
 For geospatial indexes, make sure the field being indexed is of type Array:
 
@@ -98,7 +98,7 @@ For geospatial indexes, make sure the field being indexed is of type Array:
     class Person
       include Mongoid::Document
       field :location, type: Array
- 
+
       index({ location: "2d" }, { min: -200, max: 200 })
     end
 
@@ -150,7 +150,7 @@ in Rails console:
 
     # Create indexes for Model
     Model.create_indexes
-   
+
     # Remove indexes for Model
     Model.remove_indexes
 
@@ -165,10 +165,10 @@ providing an ``:environment`` task to load your application's models:
 .. code-block:: ruby
 
     # Rakefile
-    
+
     require 'mongoid'
     load 'mongoid/tasks/database.rake'
-    
+
     task :environment do
       # Require/load your application's models here
     end
@@ -179,10 +179,10 @@ explicitly requiring ``mongoid``:
 .. code-block:: ruby
 
     # Rakefile
-    
+
     require 'bundler/setup'
     load 'mongoid/tasks/database.rake'
-    
+
     task :environment do
       # Require/load your application's models here
     end

--- a/docs/reference/queries.txt
+++ b/docs/reference/queries.txt
@@ -488,7 +488,7 @@ an ``{'$and' => [{'$nor' => ...}]}`` construct:
 
 If using ``not`` with arrays or regular expressions, please note the
 caveats/limitations of ``$not`` `stated in the MongoDB server documentation
-<https://docs.mongodb.com/manual/reference/operator/query/not/>`_.
+<https://mongodb.com/docs/manual/reference/operator/query/not/>`_.
 
 
 Incremental Query Construction
@@ -1038,7 +1038,7 @@ to be combined with :ref:`ordering <ordering>` to ensure consistent results.
 
 When executing large queries, or when iterating over query results with an enumerator method such as
 ``Criteria#each``, Mongoid automatically uses the `MongoDB getMore command
-<https://docs.mongodb.com/manual/reference/command/getMore/>`_ to load results in batches.
+<https://mongodb.com/docs/manual/reference/command/getMore/>`_ to load results in batches.
 The default ``batch_size`` is 1000, however you may set it explicitly:
 
 .. code-block:: ruby
@@ -2017,7 +2017,7 @@ with driver versions 2.13.x and earlier, Mongoid utilizes its own, legacy,
 query cache implementation.
 
 Please review the `driver query cache documentation
-<https://docs.mongodb.com/ruby-driver/current/reference/query-cache/>`_
+<https://mongodb.com/docs/ruby-driver/current/reference/query-cache/>`_
 for details about the driver's query cache behavior.
 
 .. warning::

--- a/docs/reference/sharding.txt
+++ b/docs/reference/sharding.txt
@@ -41,7 +41,7 @@ advantage of.
 
 Mongoid supports two syntaxes for declaring shard keys. The standard syntax
 follows the format of MongoDB `shardCollection shell helper
-<https://docs.mongodb.com/manual/reference/method/sh.shardCollection/#sh.shardCollection>`_
+<https://mongodb.com/docs/manual/reference/method/sh.shardCollection/#sh.shardCollection>`_
 and allows specifying ranged and hashed shard keys, compound shard keys and
 collection sharding options:
 
@@ -125,5 +125,5 @@ sharding collections:
   sharding collections as described in this document, or creating or dropping
   collections or databases, cluster nodes may end up with out of date local
   configuration-related cache data. Execute the `flushRouterConfig
-  <https://docs.mongodb.com/manual/reference/command/flushRouterConfig/>`_
+  <https://mongodb.com/docs/manual/reference/command/flushRouterConfig/>`_
   command on each ``mongos`` node to clear these caches.

--- a/docs/reference/text-search.txt
+++ b/docs/reference/text-search.txt
@@ -37,7 +37,7 @@ Defining Text Search Index
 
 Index definition through Mongoid is described in detail on the `indexes
 <indexes>`_ page. Text search indexes are described in detail
-under `text indexes <https://docs.mongodb.com/manual/core/index-text/>`_
+under `text indexes <https://mongodb.com/docs/manual/core/index-text/>`_
 in the MongoDB manual. Below is an example definition of a Band model with
 a text index utilizing the description field:
 
@@ -69,7 +69,7 @@ Querying Using Text Index
 -------------------------
 
 To find bands whose description contains "ounces" or its variations, use the
-`$text operator <https://docs.mongodb.com/manual/reference/operator/query/text/#op._S_text>`_:
+`$text operator <https://mongodb.com/docs/manual/reference/operator/query/text/#op._S_text>`_:
 
 .. code-block:: ruby
 

--- a/docs/reference/transactions.txt
+++ b/docs/reference/transactions.txt
@@ -13,7 +13,7 @@ Transactions
    :class: singlecol
 
 Version 4.0 of the MongoDB server introduces
-`multi-document transactions <https://docs.mongodb.com/manual/core/transactions/>`_.
+`multi-document transactions <https://mongodb.com/docs/manual/core/transactions/>`_.
 (Updates to multiple fields within a single document are atomic in all
 versions of MongoDB). Transactions require Mongoid version 6.4 or higher and Ruby driver version
 2.6 or higher.
@@ -67,9 +67,9 @@ A transaction may be committed or aborted. The corresponding methods to do so ar
   end
 
 If a session ends with an open transaction,
-`the transaction is aborted <https://docs.mongodb.com/manual/core/transactions/#transactions-and-sessions>`_.
+`the transaction is aborted <https://mongodb.com/docs/manual/core/transactions/#transactions-and-sessions>`_.
 
-The transaction commit `can be retried <https://docs.mongodb.com/manual/core/transactions/#retry-commit-operation>`_
+The transaction commit `can be retried <https://mongodb.com/docs/manual/core/transactions/#retry-commit-operation>`_
 if it fails. Here is the Ruby code to do so:
 
 .. code-block:: ruby

--- a/docs/release-notes/mongoid-7.2.txt
+++ b/docs/release-notes/mongoid-7.2.txt
@@ -402,7 +402,7 @@ Mongoid query cache. If you plan to use the query cache, it is recommended
 that you upgrade to driver version 2.14.
 
 To read more about the query cache improvements made in the driver, see
-`the Ruby driver documentation <https://docs.mongodb.com/ruby-driver/current/reference/query-cache/>`_.
+`the Ruby driver documentation <https://mongodb.com/docs/ruby-driver/current/reference/query-cache/>`_.
 
 To read more about using the query cache with Mongoid and the limitations
 of the legacy query cache, see :ref:`the query cache documentation <query-cache>`.
@@ -424,13 +424,13 @@ Example Mongoid 7.2 behavior:
 
   class Offer
     include Mongoid::Document
-    
+
     field :constraint, type: Regexp
   end
-  
+
   offer = Offer.create!(constraint: /foo/)
   # => #<Offer _id: 6082df412c97a66be6ba9970, constraint: /foo/>
-  
+
   Offer.collection.aggregate([
     {'$match' => {_id: offer.id}},
     {'$set' => {type: {'$type' => '$constraint'}}},
@@ -441,7 +441,7 @@ Example Mongoid 7.2 behavior:
 
   offer = Offer.create!(constraint: 'foo')
   # => #<Offer _id: 6082df412c97a66be6ba9971, constraint: /foo/>
-  
+
   Offer.collection.aggregate([
     {'$match' => {_id: offer.id}},
     {'$set' => {type: {'$type' => '$constraint'}}},
@@ -456,7 +456,7 @@ Mongoid 7.1 behavior with the same model class:
 
   offer = Offer.create!(constraint: /foo/)
   # => #<Offer _id: 6082e0182c97a66c21e3f721, constraint: /foo/>
-  
+
   Offer.collection.aggregate([
     {'$match' => {_id: offer.id}},
     {'$set' => {type: {'$type' => '$constraint'}}},
@@ -467,7 +467,7 @@ Mongoid 7.1 behavior with the same model class:
 
   offer = Offer.create!(constraint: 'foo')
   # => #<Offer _id: 6082e05c2c97a66c21e3f723, constraint: "foo">
-  
+
   Offer.collection.aggregate([
     {'$match' => {_id: offer.id}},
     {'$set' => {type: {'$type' => '$constraint'}}},

--- a/docs/tutorials/getting-started-rails.txt
+++ b/docs/tutorials/getting-started-rails.txt
@@ -60,7 +60,7 @@ Use the ``rails`` command to create the application skeleton, as follows:
 
         Could not find gem 'puma (~> 3.11)' in any of the gem sources listed in your Gemfile.
         Run `bundle install` to install missing gems.
-        
+
     Disregard it as we will be taking care of gem installation
     in a moment.
 
@@ -133,7 +133,7 @@ Run MongoDB Locally
 The configuration created in the previous step is suitable when
 a MongoDB server is running locally. If you do not already have a
 local MongoDB server, `download and install MongoDB
-<https://docs.mongodb.com/manual/installation/>`_.
+<https://mongodb.com/docs/manual/installation/>`_.
 
 While the generated ``mongoid.yml`` will work without modifications,
 we recommend reducing the server selection timeout for development.
@@ -157,7 +157,7 @@ Use MongoDB Atlas
 
 Instead of downloading, installing and running MongoDB locally, you can create
 a free MongoDB Atlas account and create a `free MongoDB cluster in Atlas
-<https://docs.mongodb.com/manual/tutorial/atlas-free-tier-setup/>`_.
+<https://mongodb.com/docs/manual/tutorial/atlas-free-tier-setup/>`_.
 Once the cluster is created, follow the instructions in `connect to the cluster
 page <https://docs.atlas.mongodb.com/connect-to-cluster/#connect-to-a-cluster>`_
 to obtain the URI. Use the *Ruby driver 2.5 or later* format.
@@ -192,7 +192,7 @@ Finally, install webpacker:
 
 .. code-block:: sh
 
-    rails webpacker:install 
+    rails webpacker:install
 
 
 Run Application
@@ -247,7 +247,7 @@ association for the comments:
 
     class Post
       include Mongoid::Document
-      
+
       field :title, type: String
       field :body, type: String
 
@@ -263,7 +263,7 @@ generated ``embedded_in`` association to ``belongs_to``:
 
     class Comment
       include Mongoid::Document
-      
+
       field :name, type: String
       field :message, type: String
 
@@ -398,7 +398,7 @@ via ``require 'rails/all'``, change it to require individual frameworks:
 
   # Add this require instead of "rails/all":
   require "rails"
-  
+
   # Pick the frameworks you want:
   require "active_model/railtie"
   require "active_job/railtie"
@@ -410,7 +410,7 @@ via ``require 'rails/all'``, change it to require individual frameworks:
   require "action_cable/engine"
   require "sprockets/railtie"
   require "rails/test_unit/railtie"
-  
+
   # Remove or comment out ActiveRecord and ActiveStorage:
   # require "active_record/railtie"
   # require "active_storage/engine"
@@ -497,7 +497,7 @@ The same model may look like this in Mongoid:
 
   class Post
     include Mongoid::Document
-    
+
     field :title, type: String
     field :body, type: String
 
@@ -513,7 +513,7 @@ Or like this with dynamic fields:
   class Post
     include Mongoid::Document
     include Mongoid::Attributes::Dynamic
-    
+
     has_many :comments, dependent: :destroy
   end
 

--- a/docs/tutorials/getting-started-sinatra.txt
+++ b/docs/tutorials/getting-started-sinatra.txt
@@ -66,7 +66,7 @@ Run MongoDB Locally
 -------------------
 
 To develop locally with MongoDB, `download and install MongoDB
-<https://docs.mongodb.com/manual/installation/>`_.
+<https://mongodb.com/docs/manual/installation/>`_.
 
 Once MongoDB is installed and running, create a file named ``config/mongoid.yml``
 pointing to your deployment. For example, if you launched a standalone
@@ -89,7 +89,7 @@ Use MongoDB Atlas
 
 Instead of downloading, installing and running MongoDB locally, you can create
 a free MongoDB Atlas account and create a `free MongoDB cluster in Atlas
-<https://docs.mongodb.com/manual/tutorial/atlas-free-tier-setup/>`_.
+<https://mongodb.com/docs/manual/tutorial/atlas-free-tier-setup/>`_.
 Once the cluster is created, follow the instructions in `connect to the cluster
 page <https://docs.atlas.mongodb.com/connect-to-cluster/#connect-to-a-cluster>`_
 to obtain the URI. Use the *Ruby driver 2.5 or later* format.


### PR DESCRIPTION
We're moving the docs to `mongodb.com/docs`. This updates links found in the docs folder that point to `docs.mongodb.com`.