### PR TITLE
MONGOID-5284 Fix spec helper on Windows

### DIFF
--- a/spec/lite_spec_helper.rb
+++ b/spec/lite_spec_helper.rb
@@ -43,7 +43,7 @@ end
 
 require 'mongoid'
 
-if SpecConfig.instance.mri?
+if SpecConfig.instance.mri? && SpecConfig.instance.windows?
   require 'timeout_interrupt'
 else
   require 'timeout'

--- a/spec/lite_spec_helper.rb
+++ b/spec/lite_spec_helper.rb
@@ -43,7 +43,7 @@ end
 
 require 'mongoid'
 
-if SpecConfig.instance.mri? && SpecConfig.instance.windows?
+if SpecConfig.instance.mri? && !SpecConfig.instance.windows?
   require 'timeout_interrupt'
 else
   require 'timeout'

--- a/spec/support/spec_config.rb
+++ b/spec/support/spec_config.rb
@@ -34,6 +34,10 @@ class SpecConfig
     RUBY_PLATFORM =~ /\bjava\b/
   end
 
+  def windows?
+    ENV['OS'] == 'Windows_NT' && !RUBY_PLATFORM.match?(/cygwin/)
+  end
+
   def platform
     RUBY_PLATFORM
   end


### PR DESCRIPTION
Fixes MONGOID-5284

The logic `ENV['OS'] == 'Windows_NT' && !RUBY_PLATFORM.match?(/cygwin/)` is borrowed from the [OS gem](https://github.com/rdp/os/blob/master/lib/os.rb#L21).