### PR TITLE
MONGOID-5274: Issues with #touch method

### DIFF
--- a/spec/mongoid/touchable_spec_models.rb
+++ b/spec/mongoid/touchable_spec_models.rb
@@ -1,6 +1,19 @@
 # frozen_string_literal: true
 
 module TouchableSpec
+  class NoTimestamps
+    include Mongoid::Document
+
+    field :last_used_at, as: :aliased_field, type: Time
+  end
+
+  class NoAssociations
+    include Mongoid::Document
+    include Mongoid::Timestamps
+
+    field :last_used_at, as: :aliased_field, type: Time
+  end
+
   module Embedded
     class Building
       include Mongoid::Document
@@ -24,6 +37,8 @@ module TouchableSpec
       include Mongoid::Timestamps
 
       embedded_in :building, touch: true
+
+      field :last_used_at, type: Time
     end
   end
 
@@ -41,6 +56,8 @@ module TouchableSpec
       include Mongoid::Timestamps
 
       belongs_to :building
+
+      field :last_used_at, type: Time
     end
 
     class Floor
@@ -48,6 +65,8 @@ module TouchableSpec
       include Mongoid::Timestamps
 
       belongs_to :building, touch: true
+
+      field :last_used_at, type: Time
     end
   end
 end

--- a/spec/support/models/updatable.rb
+++ b/spec/support/models/updatable.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-class Updatable
-  include Mongoid::Document
-
-  field :updated_at, type: BSON::Timestamp
-end


### PR DESCRIPTION
MONGOID-5274

**This PR only contains specs which demonstrate the issues.**

Please run spec/mongoid/touchable_spec.rb

1. On referenced relations with `touch: false`, calling `#touch` on document A will touch document B.

2. On embedded relations with `touch: false`, calling `#touch` on child document touches its parent (the root cause is different than #2)

3. On embedded relations with `touch: true`, there is strange behavior where in some cases calling #save! and #destroy on the child does not touch its parent. This works correctly on referenced relations.

I have raised a PR here https://github.com/mongodb/mongoid/pull/5045 that refactors the `Touchable` module. AFAIK my changes do not break/alter any behavior, but they eliminate unnecessary queries and make the code much easier to read, so I recommend you consider to try debugging with my #5045 version.

Note re: #2. When you investigate it, I believe you will find that on embedded childs, we need a way to know if the association with the parent has `touch: true/false`. Note that we have the following:

```ruby
child._parent #=> returns parent object itself
child._association #=> returns the EmbedsMany/EmbedsOne association of the parent

# suggest we add the following:
child._association_to_parent #=> returns the EmbeddedIn association

(_association should probably be renamed to _association_from_parent)
```

In order to permanently fix the issue, we should add specs to cover all possible relation cases:
- embeds_one (calling #touch on parent)
- embeds_one -> embedded_in (calling #touch on child)
- embeds_many (calling #touch on parent)
- referenced has_one
- referenced has_many
- referenced habtm