### PR TITLE
MONGOID-3999 Test: Assigning to a belongs_to association overwrites fields in previous association target

### DIFF
--- a/spec/integration/associations/has_one_spec.rb
+++ b/spec/integration/associations/has_one_spec.rb
@@ -255,4 +255,18 @@ describe 'has_one associations' do
       end
     end
   end
+
+  context "when overwriting an association" do
+    let(:post1) { HomPost.create!(title: "post 1") }
+    let(:post2) { HomPost.create!(title: "post 2") }
+    let(:comment) { HomComment.create(post: post1) }
+
+    it "does not overwrite the original value" do
+      pending "MONGOID-3999"
+      p1 = comment.post
+      expect(p1.title).to eq("post 1")
+      comment.post = post2
+      expect(p1.title).to eq("post 1")
+    end
+  end
 end


### PR DESCRIPTION
This PR is just for adding a failing test to this ticket for later use 