### PR TITLE
MONGOID-3267 Allow associations to be used inside defaults

### DIFF
--- a/lib/mongoid/association/referenced/has_and_belongs_to_many/proxy.rb
+++ b/lib/mongoid/association/referenced/has_and_belongs_to_many/proxy.rb
@@ -84,9 +84,9 @@ module Mongoid
           # @return [ Document ] The new document.
           def build(attributes = {}, type = nil)
             doc = Factory.execute_build(type || klass, attributes, execute_callbacks: false)
-            _base.public_send(foreign_key).push(doc.public_send(_association.primary_key))
             append(doc)
             doc.apply_post_processed_defaults
+            _base.public_send(foreign_key).push(doc.public_send(_association.primary_key))
             unsynced(doc, inverse_foreign_key)
             yield(doc) if block_given?
             doc.run_pending_callbacks

--- a/lib/mongoid/document.rb
+++ b/lib/mongoid/document.rb
@@ -331,7 +331,7 @@ module Mongoid
           doc.run_callbacks(:initialize) unless doc._initialize_callbacks.empty?
         else
           yield(doc) if block_given?
-          doc.pending_callbacks.push(:apply_defaults, :find, :initialize)
+          doc.pending_callbacks += [:apply_defaults, :find, :initialize]
         end
 
         doc

--- a/lib/mongoid/document.rb
+++ b/lib/mongoid/document.rb
@@ -234,11 +234,12 @@ module Mongoid
         process_attributes(attrs) do
           yield(self) if block_given?
         end
-        apply_post_processed_defaults
 
         if execute_callbacks
+          apply_post_processed_defaults
           run_callbacks(:initialize) unless _initialize_callbacks.empty?
         else
+          pending_callbacks << :apply_post_processed_defaults
           pending_callbacks << :initialize
         end
       end

--- a/lib/mongoid/fields.rb
+++ b/lib/mongoid/fields.rb
@@ -156,6 +156,7 @@ module Mongoid
     #
     # @return [ Array<String ] The names of the proc defaults.
     def apply_post_processed_defaults
+      pending_callbacks.delete(:apply_post_processed_defaults)
       post_processed_defaults.each do |name|
         apply_default(name)
       end
@@ -184,6 +185,7 @@ module Mongoid
     # @example Apply all the defaults.
     #   model.apply_defaults
     def apply_defaults
+      pending_callbacks.delete(:apply_defaults)
       apply_pre_processed_defaults
       apply_post_processed_defaults
     end

--- a/lib/mongoid/interceptable.rb
+++ b/lib/mongoid/interceptable.rb
@@ -164,6 +164,11 @@ module Mongoid
       @pending_callbacks ||= [].to_set
     end
 
+    def pending_callbacks=(value)
+      @pending_callbacks = value
+    end
+
+
     # Run the pending callbacks. If the callback is :apply_defaults, we will apply
     # the defaults for this document. Otherwise, the callback is passed to the
     # run_callbacks function.

--- a/lib/mongoid/interceptable.rb
+++ b/lib/mongoid/interceptable.rb
@@ -171,8 +171,8 @@ module Mongoid
     # @api private
     def run_pending_callbacks
       pending_callbacks.each do |cb|
-        if cb == :apply_defaults
-          self.apply_defaults
+        if [:apply_defaults, :apply_post_processed_defaults].include? cb
+          send(cb)
         else
           self.run_callbacks(cb, with_children: false)
         end

--- a/lib/mongoid/interceptable.rb
+++ b/lib/mongoid/interceptable.rb
@@ -164,6 +164,7 @@ module Mongoid
       @pending_callbacks ||= [].to_set
     end
 
+    # @api private
     def pending_callbacks=(value)
       @pending_callbacks = value
     end
@@ -175,7 +176,7 @@ module Mongoid
     # @api private
     def run_pending_callbacks
       pending_callbacks.each do |cb|
-        if [:apply_defaults, :apply_post_processed_defaults].include? cb
+        if [:apply_defaults, :apply_post_processed_defaults].include?(cb)
           send(cb)
         else
           self.run_callbacks(cb, with_children: false)

--- a/lib/mongoid/interceptable.rb
+++ b/lib/mongoid/interceptable.rb
@@ -168,7 +168,6 @@ module Mongoid
       @pending_callbacks = value
     end
 
-
     # Run the pending callbacks. If the callback is :apply_defaults, we will apply
     # the defaults for this document. Otherwise, the callback is passed to the
     # run_callbacks function.

--- a/lib/mongoid/interceptable.rb
+++ b/lib/mongoid/interceptable.rb
@@ -161,7 +161,7 @@ module Mongoid
     #
     # @api private
     def pending_callbacks
-      @pending_callbacks ||= []
+      @pending_callbacks ||= [].to_set
     end
 
     # Run the pending callbacks. If the callback is :apply_defaults, we will apply

--- a/spec/mongoid/association/referenced/has_and_belongs_to_many/proxy_spec.rb
+++ b/spec/mongoid/association/referenced/has_and_belongs_to_many/proxy_spec.rb
@@ -1996,7 +1996,7 @@ describe Mongoid::Association::Referenced::HasAndBelongsToMany::Proxy do
           end
 
           let!(:account) do
-            agent.accounts.send(method, name: "test again")
+            agent.accounts.send(method, name: "test again", execute_default: true)
           end
 
           it "does not convert the string key to an object id" do

--- a/spec/mongoid/association/referenced/has_and_belongs_to_many/proxy_spec.rb
+++ b/spec/mongoid/association/referenced/has_and_belongs_to_many/proxy_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+require_relative "../has_and_belongs_to_many_models"
 
 describe Mongoid::Association::Referenced::HasAndBelongsToMany::Proxy do
 
@@ -1995,16 +1996,12 @@ describe Mongoid::Association::Referenced::HasAndBelongsToMany::Proxy do
             Agent.create!(number: "007")
           end
 
-          let!(:account) do
-            agent.accounts.send(method, name: "test again", execute_default: true)
+          before do
+            agent.accounts.send(method, name: "test again")
           end
 
           it "does not convert the string key to an object id" do
             expect(agent.account_ids).to eq([ "test-again" ])
-          end
-
-          it "the parent does not have the childs _id at the time of the default" do
-            expect(account.primary_account_id).to be nil
           end
         end
 
@@ -3772,6 +3769,15 @@ describe Mongoid::Association::Referenced::HasAndBelongsToMany::Proxy do
       d2.projects << p2
       expect(d2.p_ids).to match_array([p2.id])
       expect(p2.d_ids).to match_array([d2.id])
+    end
+  end
+
+  context "when accesing own _id from parent's foreign key in default" do
+    let!(:contract) { HabtmmContract.create! }
+    let!(:signature) { contract.signatures.create! }
+
+    it "is nil" do
+      expect(signature.favorite_signature).to be nil
     end
   end
 end

--- a/spec/mongoid/association/referenced/has_and_belongs_to_many/proxy_spec.rb
+++ b/spec/mongoid/association/referenced/has_and_belongs_to_many/proxy_spec.rb
@@ -1995,12 +1995,16 @@ describe Mongoid::Association::Referenced::HasAndBelongsToMany::Proxy do
             Agent.create!(number: "007")
           end
 
-          before do
+          let!(:account) do
             agent.accounts.send(method, name: "test again")
           end
 
           it "does not convert the string key to an object id" do
             expect(agent.account_ids).to eq([ "test-again" ])
+          end
+
+          it "the parent does not have the childs _id at the time of the default" do
+            expect(account.primary_account_id).to be nil
           end
         end
 

--- a/spec/mongoid/association/referenced/has_and_belongs_to_many_models.rb
+++ b/spec/mongoid/association/referenced/has_and_belongs_to_many_models.rb
@@ -32,6 +32,8 @@ end
 class HabtmmSignature
   include Mongoid::Document
 
+  field :favorite_signature, default: ->{ contracts.first.signature_ids.first if contracts.first }
+
   has_and_belongs_to_many :contracts, class_name: 'HabtmmContract'
 
   field :name, type: String

--- a/spec/mongoid/interceptable_spec.rb
+++ b/spec/mongoid/interceptable_spec.rb
@@ -2213,15 +2213,6 @@ describe Mongoid::Interceptable do
 
         include_examples 'accesses the correct parent'
       end
-
-      context "when accessing the child directly" do
-        let(:band) { InterceptableBand.create(name: "Molejo") }
-        let(:song) { band.songs.create(name: "Cilada") }
-
-        it "assigns the default correctly" do
-          expect(song.band_name).to eq("Molejo")
-        end
-      end
     end
 
     context "when using build methods" do
@@ -2329,6 +2320,36 @@ describe Mongoid::Interceptable do
         end
 
         include_examples 'accesses the correct parent'
+      end
+    end
+  end
+
+  context "when accessing associations in defaults" do
+    context "when not using autobuilding" do
+      let(:band) { InterceptableBand.create(name: "Molejo") }
+      let(:song) { band.songs.create(name: "Cilada") }
+
+      it "assigns the default correctly" do
+        expect(song.band_name).to eq("Molejo")
+      end
+    end
+
+    context "when using autobuilding" do
+      before do
+        InterceptablePlane.create!.tap do |plane|
+          plane.wings.create!
+        end
+      end
+
+      let(:plane) { InterceptablePlane.first }
+      let(:wing) { InterceptableWing.first }
+      let(:engine) { wing.engine }
+
+      it "sets the defaults correctly" do
+        expect(wing._id).to eq("hello-wing")
+        expect(wing.p_id).to eq(plane._id.to_s)
+        expect(wing.e_id).to eq(engine._id.to_s)
+        expect(engine._id).to eq("hello-engine-#{wing.id}")
       end
     end
   end

--- a/spec/mongoid/interceptable_spec.rb
+++ b/spec/mongoid/interceptable_spec.rb
@@ -2106,6 +2106,7 @@ describe Mongoid::Interceptable do
     end
 
     context "when using create methods" do
+
       context "when the child is an embeds_many association" do
         let!(:player) do
           Player.create!.tap do |player|
@@ -2212,9 +2213,19 @@ describe Mongoid::Interceptable do
 
         include_examples 'accesses the correct parent'
       end
+
+      context "when accessing the child directly" do
+        let(:band) { InterceptableBand.create(name: "Molejo") }
+        let(:song) { band.songs.create(name: "Cilada") }
+
+        it "assigns the default correctly" do
+          expect(song.band_name).to eq("Molejo")
+        end
+      end
     end
 
     context "when using build methods" do
+
       context "when the child is an embeds_many association" do
         let!(:player) do
           Player.create!.tap do |player|

--- a/spec/mongoid/interceptable_spec_models.rb
+++ b/spec/mongoid/interceptable_spec_models.rb
@@ -241,3 +241,29 @@ class InterceptableSong
   field :band_name, default: -> { band.name }
   field :name
 end
+
+class InterceptablePlane
+  include Mongoid::Document
+
+  has_many :wings, class_name: "InterceptableWing"
+end
+
+class InterceptableWing
+  include Mongoid::Document
+
+  belongs_to :plane, class_name: "InterceptablePlane"
+  has_one :engine, autobuild: true, class_name: "InterceptableEngine"
+
+  field :_id, type: String, default: -> { 'hello-wing' }
+
+  field :p_id, type: String, default: -> { plane&.id }
+  field :e_id, type: String, default: -> { engine&.id }
+end
+
+class InterceptableEngine
+  include Mongoid::Document
+
+  belongs_to :wing, class_name: "InterceptableWing"
+
+  field :_id, type: String, default: -> { "hello-engine-#{wing&.id}" }
+end

--- a/spec/mongoid/interceptable_spec_models.rb
+++ b/spec/mongoid/interceptable_spec_models.rb
@@ -226,3 +226,18 @@ module InterceptableSpec
     include CallbackTracking
   end
 end
+
+class InterceptableBand
+  include Mongoid::Document
+
+  has_many :songs, class_name: "InterceptableSong"
+  field :name
+end
+
+class InterceptableSong
+  include Mongoid::Document
+
+  belongs_to :band, class_name: "InterceptableBand"
+  field :band_name, default: -> { band.name }
+  field :name
+end

--- a/spec/support/models/account.rb
+++ b/spec/support/models/account.rb
@@ -13,7 +13,7 @@ class Account
 
   field :overridden, type: String
 
-  field :primary_account_id, default: ->{ agents.first.account_ids.first }
+  field :primary_account_id, default: ->{ agents.first.account_ids.first if agents.first }
 
   embeds_many :memberships
   belongs_to :creator, class_name: "User", foreign_key: :creator_id

--- a/spec/support/models/account.rb
+++ b/spec/support/models/account.rb
@@ -13,6 +13,8 @@ class Account
 
   field :overridden, type: String
 
+  field :primary_account_id, default: ->{ agents.first.account_ids.first }
+
   embeds_many :memberships
   belongs_to :creator, class_name: "User", foreign_key: :creator_id
   belongs_to :person

--- a/spec/support/models/account.rb
+++ b/spec/support/models/account.rb
@@ -13,11 +13,6 @@ class Account
 
   field :overridden, type: String
 
-  field :execute_default, type: Boolean, default: false
-  # Executing these defaults messes up eager loading tests. Only execute them
-  # when we explicitly want to.
-  field :primary_account_id, default: ->{ execute_default && agents.first ? agents.first.account_ids.first : false }
-
   embeds_many :memberships
   belongs_to :creator, class_name: "User", foreign_key: :creator_id
   belongs_to :person

--- a/spec/support/models/account.rb
+++ b/spec/support/models/account.rb
@@ -18,7 +18,6 @@ class Account
   # when we explicitly want to.
   field :primary_account_id, default: ->{ execute_default && agents.first ? agents.first.account_ids.first : false }
 
-
   embeds_many :memberships
   belongs_to :creator, class_name: "User", foreign_key: :creator_id
   belongs_to :person

--- a/spec/support/models/account.rb
+++ b/spec/support/models/account.rb
@@ -13,7 +13,11 @@ class Account
 
   field :overridden, type: String
 
-  field :primary_account_id, default: ->{ agents.first.account_ids.first if agents.first }
+  field :execute_default, type: Boolean, default: false
+  # Executing these defaults messes up eager loading tests. Only execute them
+  # when we explicitly want to.
+  field :primary_account_id, default: ->{ execute_default && agents.first ? agents.first.account_ids.first : false }
+
 
   embeds_many :memberships
   belongs_to :creator, class_name: "User", foreign_key: :creator_id


### PR DESCRIPTION
MONGOID-3267

Optional reading: The latest change. After deferring the defaults we had the following case:
```
class Band
  include Mongoid::Document
  has_and_belongs_to_many :songs
  field :name
end

class Song
  include Mongoid::Document
  has_and_belongs_to_many :bands
  field :_id, type: String, overwrite: true, default: ->{ "#{name}-hello" }

  field :band_name, default: -> { bands.first.name if bands.first }
  field :favorite_song_id, default: -> { bands.first.song_ids.first if bands.first }
  field :name
end
band = Band.create(name: "Molejo")
song = band.songs.create(name: "Cilada")
``` 
The last command yielded the following order of operations:
1. Build a `song` object
2. Defer the callbacks and defaults
3. Push the `song._id` to the band's foreign key (`song_ids`). Note that `song._id` is being set in the default, therefore `nil` is being pushed here.
4. Set the association. Push song to the band's songs.
5. Apply the defaults
6. Call the pending callbacks
The problem here is evident. The `song._id` is not being set after it is being push to the band's foreign key. 

Solution:
Call song's defaults before pushing the song `_id` to the band's foreign key, i.e. move step 3 until after step 5. Don't change the time where we call the callbacks.

Problem: 
Now that the song._id is being pushed after the defaults are called, the song._id will not be available in the band's song_ids at the time that that song's defaults are called. I am **okay with this**. This is the current functionality in 7.4.x, so no functionality is lost. Also, if the user wants that `song_id`, they can access it using `_id` on the current song.