### PR TITLE
MONGOID-5289 - Faster Regex for numeric mongoization + bug fixes

### DIFF
--- a/lib/mongoid/criteria/queryable/extensions/numeric.rb
+++ b/lib/mongoid/criteria/queryable/extensions/numeric.rb
@@ -51,7 +51,7 @@ module Mongoid
             #
             # @return [ Object ] The converted number.
             def __numeric__(object)
-              object.to_s =~ /(\A[-+]?[0-9]+\z)|(\.0+\z)|(\.\z)/ ? object.to_i : Float(object)
+              object.to_s.match?(/\A[-+]?[0-9]*[0-9.]0*\z/) ? object.to_i : Float(object)
             end
 
             # Evolve the object to an integer.

--- a/spec/mongoid/criteria/queryable/extensions/numeric_spec.rb
+++ b/spec/mongoid/criteria/queryable/extensions/numeric_spec.rb
@@ -49,5 +49,14 @@ describe Mongoid::Criteria::Queryable::Extensions::Numeric::ClassMethods do
         expect(actual).to eq(12)
       end
     end
+
+    context "when the string is non-numeric" do
+
+      let(:str) { 'foo' }
+
+      it "returns the value as integer" do
+        expect { actual }.to raise_error(ArgumentError)
+      end
+    end
   end
 end

--- a/spec/mongoid/criteria/queryable/extensions/numeric_spec.rb
+++ b/spec/mongoid/criteria/queryable/extensions/numeric_spec.rb
@@ -18,6 +18,7 @@ describe Mongoid::Criteria::Queryable::Extensions::Numeric::ClassMethods do
 
       it "returns the value as integer" do
         expect(actual).to eq(123)
+        expect(actual).to be_a Integer
       end
     end
 
@@ -26,6 +27,7 @@ describe Mongoid::Criteria::Queryable::Extensions::Numeric::ClassMethods do
 
       it "returns the value as a float" do
         expect(actual).to eq(123.45)
+        expect(actual).to be_a Float
       end
     end
 
@@ -34,6 +36,7 @@ describe Mongoid::Criteria::Queryable::Extensions::Numeric::ClassMethods do
 
       it "returns the value as a float" do
         expect(actual).to eq(0.45)
+        expect(actual).to be_a Float
       end
     end
 
@@ -42,6 +45,7 @@ describe Mongoid::Criteria::Queryable::Extensions::Numeric::ClassMethods do
 
       it "returns zero" do
         expect(actual).to eq(0)
+        expect(actual).to be_a Integer
       end
     end
 
@@ -50,6 +54,7 @@ describe Mongoid::Criteria::Queryable::Extensions::Numeric::ClassMethods do
 
       it "returns zero" do
         expect(actual).to eq(123)
+        expect(actual).to be_a Integer
       end
     end
 
@@ -58,6 +63,16 @@ describe Mongoid::Criteria::Queryable::Extensions::Numeric::ClassMethods do
 
       it "returns the value as integer" do
         expect(actual).to eq(12)
+        expect(actual).to be_a Integer
+      end
+    end
+
+    context "when the string is a number with leading dot then zeros" do
+      let(:str) { '.000' }
+
+      it "returns the value as integer" do
+        expect(actual).to eq(0)
+        expect(actual).to be_a Integer
       end
     end
 

--- a/spec/mongoid/criteria/queryable/extensions/numeric_spec.rb
+++ b/spec/mongoid/criteria/queryable/extensions/numeric_spec.rb
@@ -11,11 +11,9 @@ describe Mongoid::Criteria::Queryable::Extensions::Numeric::ClassMethods do
   end
 
   describe "#__numeric__" do
-
     let(:actual) { host.__numeric__(str) }
 
     context "when the string is a whole number" do
-
       let(:str) { '123' }
 
       it "returns the value as integer" do
@@ -24,7 +22,6 @@ describe Mongoid::Criteria::Queryable::Extensions::Numeric::ClassMethods do
     end
 
     context "when the string is a floating point number" do
-
       let(:str) { '123.45' }
 
       it "returns the value as a float" do
@@ -32,8 +29,15 @@ describe Mongoid::Criteria::Queryable::Extensions::Numeric::ClassMethods do
       end
     end
 
-    context "when the string is a dot only" do
+    context "when the string is a floating point number with a leading dot" do
+      let(:str) { '.45' }
 
+      it "returns the value as a float" do
+        expect(actual).to eq(0.45)
+      end
+    end
+
+    context "when the string is a dot only" do
       let(:str) { '.' }
 
       it "returns zero" do
@@ -41,8 +45,15 @@ describe Mongoid::Criteria::Queryable::Extensions::Numeric::ClassMethods do
       end
     end
 
-    context "when the string is a number with fractional part consisting of zeros" do
+    context "when the string is numeric with a trailing dot" do
+      let(:str) { '123.' }
 
+      it "returns zero" do
+        expect(actual).to eq(123)
+      end
+    end
+
+    context "when the string is a number with fractional part consisting of zeros" do
       let(:str) { '12.000' }
 
       it "returns the value as integer" do
@@ -51,8 +62,31 @@ describe Mongoid::Criteria::Queryable::Extensions::Numeric::ClassMethods do
     end
 
     context "when the string is non-numeric" do
-
       let(:str) { 'foo' }
+
+      it "returns the value as integer" do
+        expect { actual }.to raise_error(ArgumentError)
+      end
+    end
+
+    context "when the string is non-numeric with leading dot" do
+      let(:str) { '.foo' }
+
+      it "returns the value as integer" do
+        expect { actual }.to raise_error(ArgumentError)
+      end
+    end
+
+    context "when the string is non-numeric with trailing dot" do
+      let(:str) { 'foo.' }
+
+      it "returns the value as integer" do
+        expect { actual }.to raise_error(ArgumentError)
+      end
+    end
+
+    context "when the string is non-numeric with trailing dot and zeroes" do
+      let(:str) { 'foo.000' }
 
       it "returns the value as integer" do
         expect { actual }.to raise_error(ArgumentError)

--- a/spec/mongoid/criteria/queryable/extensions/numeric_spec.rb
+++ b/spec/mongoid/criteria/queryable/extensions/numeric_spec.rb
@@ -49,7 +49,7 @@ describe Mongoid::Criteria::Queryable::Extensions::Numeric::ClassMethods do
       end
     end
 
-    context "when the string is numeric with a trailing dot" do
+    context "when the string is a number with a trailing dot" do
       let(:str) { '123.' }
 
       it "returns zero" do

--- a/spec/mongoid/criteria/queryable/extensions/numeric_spec.rb
+++ b/spec/mongoid/criteria/queryable/extensions/numeric_spec.rb
@@ -16,7 +16,7 @@ describe Mongoid::Criteria::Queryable::Extensions::Numeric::ClassMethods do
     context "when the string is a whole number" do
       let(:str) { '123' }
 
-      it "returns the value as integer" do
+      it "returns the value as an integer" do
         expect(actual).to eq(123)
         expect(actual).to be_a Integer
       end
@@ -61,7 +61,7 @@ describe Mongoid::Criteria::Queryable::Extensions::Numeric::ClassMethods do
     context "when the string is a number with fractional part consisting of zeros" do
       let(:str) { '12.000' }
 
-      it "returns the value as integer" do
+      it "returns the value as an integer" do
         expect(actual).to eq(12)
         expect(actual).to be_a Integer
       end
@@ -70,7 +70,7 @@ describe Mongoid::Criteria::Queryable::Extensions::Numeric::ClassMethods do
     context "when the string is a number with leading dot then zeros" do
       let(:str) { '.000' }
 
-      it "returns the value as integer" do
+      it "returns the value as an integer" do
         expect(actual).to eq(0)
         expect(actual).to be_a Integer
       end
@@ -79,7 +79,7 @@ describe Mongoid::Criteria::Queryable::Extensions::Numeric::ClassMethods do
     context "when the string is non-numeric" do
       let(:str) { 'foo' }
 
-      it "returns the value as integer" do
+      it "raises ArgumentError" do
         expect { actual }.to raise_error(ArgumentError)
       end
     end
@@ -87,7 +87,7 @@ describe Mongoid::Criteria::Queryable::Extensions::Numeric::ClassMethods do
     context "when the string is non-numeric with leading dot" do
       let(:str) { '.foo' }
 
-      it "returns the value as integer" do
+      it "raises ArgumentError" do
         expect { actual }.to raise_error(ArgumentError)
       end
     end
@@ -95,7 +95,7 @@ describe Mongoid::Criteria::Queryable::Extensions::Numeric::ClassMethods do
     context "when the string is non-numeric with trailing dot" do
       let(:str) { 'foo.' }
 
-      it "returns the value as integer" do
+      it "raises ArgumentError" do
         expect { actual }.to raise_error(ArgumentError)
       end
     end
@@ -103,7 +103,15 @@ describe Mongoid::Criteria::Queryable::Extensions::Numeric::ClassMethods do
     context "when the string is non-numeric with trailing dot and zeroes" do
       let(:str) { 'foo.000' }
 
-      it "returns the value as integer" do
+      it "raises ArgumentError" do
+        expect { actual }.to raise_error(ArgumentError)
+      end
+    end
+
+    context "when the string is empty" do
+      let(:str) { '' }
+
+      it "raises ArgumentError" do
         expect { actual }.to raise_error(ArgumentError)
       end
     end


### PR DESCRIPTION
Fixes MONGOID-5289

This PR contains two performance changes and a bug fix to `__numeric__` method used in Mongoization:
- `.match?` is faster than `=~`
- 50% faster regex which is functionally equivalent to the old one.
- Fixes bugs where `foo.` and `foo.000` both match the current regex.
- Empty string behavior is preserved from existing code.

```ruby
Benchmark.bm do |bm|
  bm.report { x.times { '21329.2328'.match?(/(\A[-+]?[0-9]+\z)|(\.0+\z)|(\.\z)/) } }
  bm.report { x.times { '21329.2328'.match?(/\A[-+]?[0-9]*[0-9.]0*\z/) } }
end
#       user     system      total        real
#   0.531000   0.000000   0.531000 (  0.538161)
#   0.282000   0.000000   0.282000 (  0.270321)
```

Note that `.` inside `[ ]` doesn't need to be escaped.