### PR TITLE
Fix MONGOID-5089 HABTM inconsistencies

### DIFF
--- a/lib/mongoid/association/macros.rb
+++ b/lib/mongoid/association/macros.rb
@@ -12,8 +12,28 @@ module Mongoid
         class_attribute :embedded, instance_reader: false
         class_attribute :embedded_relations
         class_attribute :relations
+
+        # A hash that maps aliases to their associations. This is used when
+        # associations specify the `as` option, or on a referenced association.
+        # On a referenced association, this is used to map the foreign key to
+        # the association's name. For example, if we had the following
+        # relationship:
+        #
+        #   User has_many Accounts
+        #
+        # User will have an entry in the aliased associations hash:
+        #
+        #   account_ids => accounts
+        #
+        # Note that on the belongs_to associations, the mapping from
+        # foreign key => name is not in the aliased_associations hash, but a
+        # mapping from name => foreign key is in the aliased_fields hash.
+        #
+        # @return [ Hash<String, String> ] The aliased associations hash.
+        #
         # @api private
         class_attribute :aliased_associations
+
         self.embedded = false
         self.embedded_relations = BSON::Document.new
         self.relations = BSON::Document.new

--- a/lib/mongoid/association/referenced/has_and_belongs_to_many.rb
+++ b/lib/mongoid/association/referenced/has_and_belongs_to_many.rb
@@ -230,6 +230,7 @@ module Mongoid
         end
 
         def create_foreign_key_field!
+          inverse_class.aliased_associations[foreign_key] = name.to_s
           @owner_class.field(
               foreign_key,
               type: FOREIGN_KEY_FIELD_TYPE,

--- a/lib/mongoid/attributes/processing.rb
+++ b/lib/mongoid/attributes/processing.rb
@@ -43,7 +43,13 @@ module Mongoid
       # @return [ true, false ] True if pending, false if not.
       def pending_attribute?(key, value)
         name = key.to_s
-        aliased = aliased_associations[name] if aliased_associations.key?(name)
+
+        aliased = if aliased_associations.key?(name)
+          aliased_associations[name]
+        else
+          name
+        end
+
         if relations.has_key?(aliased)
           pending_relations[name] = value
           return true

--- a/spec/mongoid/association/referenced/has_and_belongs_to_many/proxy_spec.rb
+++ b/spec/mongoid/association/referenced/has_and_belongs_to_many/proxy_spec.rb
@@ -3789,4 +3789,11 @@ describe Mongoid::Association::Referenced::HasAndBelongsToMany::Proxy do
       expect(signature.contracts.first.signature_ids).to eq([signature.id])
     end
   end
+
+  context "when there is a foreign key in the aliased associations" do
+    it "has the correct aliases" do
+      expect(Dog.aliased_associations["breed_ids"]).to eq("breeds")
+      expect(Breed.aliased_associations["dog_ids"]).to eq("dogs")
+    end
+  end
 end

--- a/spec/mongoid/association/referenced/has_many/proxy_spec.rb
+++ b/spec/mongoid/association/referenced/has_many/proxy_spec.rb
@@ -4114,4 +4114,12 @@ describe Mongoid::Association::Referenced::HasMany::Proxy do
       expect(person2.posts_count).to eq 0
     end
   end
+
+  context "when there is a foreign key in the aliased associations" do
+    it "has the correct aliases" do
+      expect(Band.aliased_associations["artist_ids"]).to eq("artists")
+      expect(Artist.aliased_associations.key?("band_id")).to be false
+      expect(Artist.aliased_fields["band"]).to eq("band_id")
+    end
+  end
 end

--- a/spec/mongoid/association/referenced/has_one/proxy_spec.rb
+++ b/spec/mongoid/association/referenced/has_one/proxy_spec.rb
@@ -1139,4 +1139,13 @@ describe Mongoid::Association::Referenced::HasOne::Proxy do
       end
     end
   end
+
+  context "when there is a foreign key in the aliased associations" do
+    it "has the correct aliases" do
+      # Instances of Driver do not respond to vehicle_id.
+      expect(Driver.aliased_associations.key?("vehicle_id")).to be false
+      expect(Vehicle.aliased_associations.key?("driver_id")).to be false
+      expect(Vehicle.aliased_fields["driver"]).to eq("driver_id")
+    end
+  end
 end


### PR DESCRIPTION
MONGOID-5089 fixed the aliased_associations hash to include the foreign key field. For example if a `Bag` has_many `Tag`s, there would be an aliased association from `tag_ids => tag`. Before that PR the aliased associations hash would have `nil => tag`. However, this was only done for has_one and has_many associations. This PR fixes this for HABTM associations.

## Post fix results

Take the following models:
```
User HABTM Addresses 
User has_many Accounts
User has_one Pet
```
- HABTM: `User.aliased_associations` has `address_ids => addresses`, `Address.aliased_associations` has `user_ids => users`
- has_many: `User.aliased_associations` has `account_ids => accounts`, `Account.aliased_associations`  does not have `user_id`. `Account.aliased_fields` has `user => user_id`.
- has_one: `User.aliased_associations` does not have `pet_id`, `Pet.aliased_associations`  does not have `user_id`. `Pet.aliased_fields` has `user => user_id`.

Is this working as intended? Or should I add the `user_id => user` aliased_association for the belongs_to association as well?