### PR TITLE
MONGOID-4734 Test: Updating an association value to object instance when the instance has multiple inverses changes the wrong field

### DIFF
--- a/spec/mongoid/association/embedded/embeds_one_models.rb
+++ b/spec/mongoid/association/embedded/embeds_one_models.rb
@@ -52,3 +52,22 @@ class EomDnlChild
   embedded_in :parent, class_name: 'EomDnlParent'
   embedded_in :missing_parent, class_name: 'EomDnlMissingParent'
 end
+
+class EomAddress
+  include Mongoid::Document
+
+  field :city, type: String
+
+  embedded_in :addressable, polymorphic: true
+end
+
+# app/models/company.rb
+class EomCompany
+  include Mongoid::Document
+
+  embeds_one :address, class_name: 'EomAddress', as: :addressable
+  accepts_nested_attributes_for :address
+
+  embeds_one :delivery_address, class_name: 'EomAddress', as: :addressable
+  accepts_nested_attributes_for :delivery_address
+end

--- a/spec/mongoid/association/embedded/embeds_one_spec.rb
+++ b/spec/mongoid/association/embedded/embeds_one_spec.rb
@@ -957,14 +957,28 @@ describe Mongoid::Association::Embedded::EmbedsOne do
   context "when multiple embeds_one associations reference the same class" do
     let(:acme) { EomCompany.create(address: { city: 'Gotham' }, delivery_address: { city: 'Parcelville' }) }
 
-    before do
-      acme.update(delivery_address: EomAddress.new(city: 'Bigville'))
-      acme.reload
+    context "when the first assignment is modified" do
+      before do
+        acme.update(address: EomAddress.new(city: 'Bigville'))
+        acme.reload
+      end
+
+      it "updates the correct association" do
+        expect(acme.address.city).to eq("Bigville")
+        expect(acme.delivery_address.city).to eq("Parcelville")
+      end
     end
 
-    it "updates the correct association" do
-      expect(acme.address.city).to eq("Gotham")
-      expect(acme.delivery_address.city).to eq("Bigville")
+    context "when the second assignment is modified" do
+      before do
+        acme.update(delivery_address: EomAddress.new(city: 'Bigville'))
+        acme.reload
+      end
+
+      it "updates the correct association" do
+        expect(acme.address.city).to eq("Gotham")
+        expect(acme.delivery_address.city).to eq("Bigville")
+      end
     end
   end
 end

--- a/spec/mongoid/association/embedded/embeds_one_spec.rb
+++ b/spec/mongoid/association/embedded/embeds_one_spec.rb
@@ -953,4 +953,18 @@ describe Mongoid::Association::Embedded::EmbedsOne do
       expect(association.create_relation(owner, target)).to be_a(EmbeddedObject)
     end
   end
+
+  context "when multiple embeds_one associations reference the same class" do
+    let(:acme) { EomCompany.create(address: { city: 'Gotham' }, delivery_address: { city: 'Parcelville' }) }
+
+    before do
+      acme.update(delivery_address: EomAddress.new(city: 'Bigville'))
+      acme.reload
+    end
+
+    it "updates the correct association" do
+      expect(acme.address.city).to eq("Gotham")
+      expect(acme.delivery_address.city).to eq("Bigville")
+    end
+  end
 end


### PR DESCRIPTION
MONGOID-4734 

This is working as intended. I added a test to document it.