### PR TITLE
MONGOID-5308: [WIP] `ActionController::Parameters` are not properly sanitized in all cases (*not a security issue)

### DIFF
--- a/docs/release-notes/mongoid-8.1.txt
+++ b/docs/release-notes/mongoid-8.1.txt
@@ -116,3 +116,38 @@ from the ``_translations`` hash:
 
 See the section on :ref:`Localize :present Field Option <present-fields>` for
 more details on how these are used.
+
+
+Support for Assignment of Nested ``ActionController::Parameters``
+-----------------------------------------------------------------
+
+Prior to Mongoid 8.0, attempting to instantiate or assign nested
+``ActionController::Parameters`` to a document would raise a
+``MethodMissing`` error. The following now works as expected.
+
+.. code-block:: ruby
+
+  class Company
+    include Mongoid::Document
+
+    field :name, type: String, localized: true
+    field :data, type: Hash
+
+    has_many :shops
+    accepts_nested_attributes_for :shops
+  end
+
+  params = ActionController::Parameters.new({
+    name: { 'en' => 'ACME Co.' },
+    data: { key: [:value1, { key2: :value2 }] }
+    shops_attributes: { ... }
+  }).permit!
+
+  Company.new(params) #=> raises MethodMissing error prior to Mongoid 8.0
+
+If you are using the `Protected Attributes Continued gem
+<https://github.com/westonganger/protected_attributes_continued>`_
+to preserve legacy Rails 4 ``attr_accessible`` functionality, please note
+that it will only protect document root-level field assignment and will
+not protect ``accepts_nested_attributes_for`` nested assignment.
+Please use Strong Parameters (``permit!``, etc.) in this case.

--- a/docs/release-notes/mongoid-8.1.txt
+++ b/docs/release-notes/mongoid-8.1.txt
@@ -121,9 +121,15 @@ more details on how these are used.
 Support for Assignment of Nested ``ActionController::Parameters``
 -----------------------------------------------------------------
 
-Prior to Mongoid 8.0, attempting to instantiate or assign nested
-``ActionController::Parameters`` to a document would raise a
-``MethodMissing`` error. The following now works as expected.
+Mass assignment of nested ``ActionController::Parameters`` to a document now
+works as expected for the following cases:
+
+- Localized fields
+- Array and Hash fields, including deeply nested Arrays and Hashes
+- ``accepts_nested_attributes_for``
+
+As usual, you must ``permit`` parameters before doing so; any unpermitted
+parameters will be ignored.
 
 .. code-block:: ruby
 
@@ -138,16 +144,28 @@ Prior to Mongoid 8.0, attempting to instantiate or assign nested
   end
 
   params = ActionController::Parameters.new({
-    name: { 'en' => 'ACME Co.' },
+    name: { "en" => "ACME Co." },
     data: { key: [:value1, { key2: :value2 }] }
-    shops_attributes: { ... }
+    shops_attributes: [{ name: "Gadgets R Us" }]
   }).permit!
 
-  Company.new(params) #=> raises MethodMissing error prior to Mongoid 8.0
+  company = Company.new(params)
+  company.name_translations  #=> { "en" => "ACME Co." }
+  company.data               #=> { key: [:value1, { key2: :value2 }] }
+  company.shops.first.name   #=> "Gadgets R Us"
 
-If you are using the `Protected Attributes Continued gem
-<https://github.com/westonganger/protected_attributes_continued>`_
-to preserve legacy Rails 4 ``attr_accessible`` functionality, please note
-that it will only protect document root-level field assignment and will
-not protect ``accepts_nested_attributes_for`` nested assignment.
-Please use Strong Parameters (``permit!``, etc.) in this case.
+In prior Mongoid versions, given the above example, attempting to mass-assign
+nested ``ActionController::Parameters`` would raise a ``MethodMissing`` error.
+
+.. code-block:: ruby
+
+  Company.new(params) #=> raises MethodMissing error
+
+.. note::
+
+  If you are using the `Protected Attributes Continued gem
+  <https://github.com/westonganger/protected_attributes_continued>`_
+  to preserve legacy Rails 4 ``attr_accessible`` functionality, please note
+  that it will only protect document root-level field assignment and will
+  not protect ``accepts_nested_attributes_for`` nested assignment.
+  Please use Strong Parameters (``permit!``, etc.) in this case.

--- a/lib/mongoid/attributes/processing.rb
+++ b/lib/mongoid/attributes/processing.rb
@@ -149,7 +149,7 @@ module Mongoid
       # instead of #sanitize_for_mass_assignment. The former only resolves
       # Strong Parameters permitted attributes.
       def sanitize_nested_forbidden_attributes(attrs)
-        if attrs.is_a?(Array)
+        if attrs.is_a?(Array) || attrs.is_a?(Set)
           attrs.map(&method(:sanitize_forbidden_attributes))
         else
           sanitize_forbidden_attributes(attrs)

--- a/lib/mongoid/extensions.rb
+++ b/lib/mongoid/extensions.rb
@@ -32,6 +32,7 @@ class BSON::Document
   end
 end
 
+require "mongoid/extensions/action_controller_parameters"
 require "mongoid/extensions/array"
 require "mongoid/extensions/big_decimal"
 require "mongoid/extensions/binary"

--- a/lib/mongoid/extensions/action_controller_parameters.rb
+++ b/lib/mongoid/extensions/action_controller_parameters.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Mongoid
+  module Extensions
+    module ActionControllerParameters
+
+      # Turn the object from the Ruby type into a Mongo-friendly type.
+      #
+      # @example Mongoize the object.
+      #   object.mongoize
+      #
+      # @return [ Object ] The object.
+      def mongoize
+        ::Hash.mongoize(self)
+      end
+
+      module ClassMethods
+
+        # Turn the object from the Ruby type into a Mongo-friendly type.
+        #
+        # @example Mongoize the object.
+        #   ActionController::Parameters.mongoize([ 1, 2, 3 ])
+        #
+        # @param [ Object ] object The object to mongoize.
+        #
+        # @return [ Hash ] The object mongoized.
+        def mongoize(object)
+          ::Hash.mongoize(object)
+        end
+      end
+    end
+  end
+end
+
+if defined?(::ActionController::Parameters)
+  ::ActionController::Parameters.__send__(:include, Mongoid::Extensions::ActionControllerParameters)
+  ::ActionController::Parameters.extend(Mongoid::Extensions::ActionControllerParameters::ClassMethods)
+end

--- a/lib/mongoid/extensions/hash.rb
+++ b/lib/mongoid/extensions/hash.rb
@@ -224,7 +224,26 @@ module Mongoid
             # Need to use transform_values! which maintains the BSON::Document
             # instead of transform_values which always returns a hash. To do this,
             # we first need to dup the hash.
-            object.dup.transform_values!(&:mongoize)
+            evolve(object.dup).transform_values!(&:mongoize)
+          end
+        end
+
+        # Evolve the object when the serializer is defined as a hash.
+        #
+        # @example Evolve the object.
+        #   Hash.evolve([[:foo, :bar]])
+        #
+        # @param [ Object ] object The object to evolve.
+        #
+        # @return [ Object ] The evolved object.
+        def evolve(object)
+          return if object.nil?
+          if object.is_a?(::Hash)
+            object
+          elsif object.respond_to?(:to_h)
+            object.to_h
+          else
+            object
           end
         end
 

--- a/spec/integration/action_controller_parameters_spec.rb
+++ b/spec/integration/action_controller_parameters_spec.rb
@@ -1,0 +1,336 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe ActionController::Parameters do
+
+  describe 'fields mass-assignment' do
+
+    context '#new' do
+
+      context 'parameters unpermitted' do
+
+      end
+
+      context 'parameters explicitly permitted' do
+
+      end
+
+      context 'parameters mass-permitted' do
+
+      end
+    end
+
+    context '#assign_attributes' do
+
+      context 'parameters unpermitted' do
+
+      end
+
+      context 'parameters explicitly permitted' do
+
+      end
+
+      context 'parameters mass-permitted' do
+
+      end
+    end
+  end
+
+  describe 'Hash field mass-assignment' do
+
+    context '#new' do
+
+      context 'parameters unpermitted' do
+
+      end
+
+      context 'parameters explicitly permitted' do
+
+      end
+
+      context 'parameters mass-permitted' do
+
+      end
+    end
+
+    context '#assign_attributes' do
+
+      context 'parameters unpermitted' do
+
+      end
+
+      context 'parameters explicitly permitted' do
+
+      end
+
+      context 'parameters mass-permitted' do
+
+      end
+    end
+  end
+
+  describe 'Hash field nested value mass-assignment' do
+
+    context '#new' do
+
+      context 'parameters unpermitted' do
+
+      end
+
+      context 'parameters explicitly permitted' do
+
+      end
+
+      context 'parameters mass-permitted' do
+
+      end
+    end
+
+    context '#assign_attributes' do
+
+      context 'parameters unpermitted' do
+
+      end
+
+      context 'parameters explicitly permitted' do
+
+      end
+
+      context 'parameters mass-permitted' do
+
+      end
+    end
+  end
+
+  describe 'Array field nested value mass-assignment' do
+
+    context '#new' do
+
+      context 'parameters unpermitted' do
+
+      end
+
+      context 'parameters explicitly permitted' do
+
+      end
+
+      context 'parameters mass-permitted' do
+
+      end
+    end
+
+    context '#assign_attributes' do
+
+      context 'parameters unpermitted' do
+
+      end
+
+      context 'parameters explicitly permitted' do
+
+      end
+
+      context 'parameters mass-permitted' do
+
+      end
+    end
+  end
+
+  describe 'Object field mass-assignment' do
+
+    context '#new' do
+
+      context 'parameters unpermitted' do
+
+      end
+
+      context 'parameters explicitly permitted' do
+
+      end
+
+      context 'parameters mass-permitted' do
+
+      end
+    end
+
+    context '#assign_attributes' do
+
+      context 'parameters unpermitted' do
+
+      end
+
+      context 'parameters explicitly permitted' do
+
+      end
+
+      context 'parameters mass-permitted' do
+
+      end
+    end
+  end
+
+  describe 'localized field mass-assignment' do
+
+    context '#new' do
+
+      context 'parameters unpermitted' do
+
+      end
+
+      context 'parameters explicitly permitted' do
+
+      end
+
+      context 'parameters mass-permitted' do
+
+      end
+    end
+
+    context '#assign_attributes' do
+
+      context 'parameters unpermitted' do
+
+      end
+
+      context 'parameters explicitly permitted' do
+
+      end
+
+      context 'parameters mass-permitted' do
+
+      end
+    end
+  end
+
+  describe 'embedded relation with accepts_nested_attributes_for' do
+
+    context '#new' do
+
+      context 'parameters unpermitted' do
+
+      end
+
+      context 'parameters explicitly permitted' do
+
+      end
+
+      context 'parameters mass-permitted' do
+
+      end
+    end
+
+    context '#assign_attributes' do
+
+      context 'parameters unpermitted' do
+
+      end
+
+      context 'parameters explicitly permitted' do
+
+      end
+
+      context 'parameters mass-permitted' do
+
+      end
+    end
+  end
+
+  describe 'double-nested embedded relations with accepts_nested_attributes_for' do
+
+    context '#new' do
+
+      context 'parameters unpermitted' do
+
+      end
+
+      context 'parameters explicitly permitted' do
+
+      end
+
+      context 'parameters mass-permitted' do
+
+      end
+    end
+
+    context '#assign_attributes' do
+
+      context 'parameters unpermitted' do
+
+      end
+
+      context 'parameters explicitly permitted' do
+
+      end
+
+      context 'parameters mass-permitted' do
+
+      end
+    end
+  end
+
+  describe 'referenced relation with accepts_nested_attributes_for' do
+
+    context '#new' do
+
+      context 'parameters unpermitted' do
+
+      end
+
+      context 'parameters explicitly permitted' do
+
+      end
+
+      context 'parameters mass-permitted' do
+
+      end
+    end
+
+    context '#assign_attributes' do
+
+      context 'parameters unpermitted' do
+
+      end
+
+      context 'parameters explicitly permitted' do
+
+      end
+
+      context 'parameters mass-permitted' do
+
+      end
+    end
+  end
+
+  describe 'double-nested referenced and embedded relation with accepts_nested_attributes_for' do
+
+    context '#new' do
+
+      context 'parameters unpermitted' do
+
+      end
+
+      context 'parameters explicitly permitted' do
+
+      end
+
+      context 'parameters mass-permitted' do
+
+      end
+    end
+
+    context '#assign_attributes' do
+
+      context 'parameters unpermitted' do
+
+      end
+
+      context 'parameters explicitly permitted' do
+
+      end
+
+      context 'parameters mass-permitted' do
+
+      end
+    end
+  end
+end


### PR DESCRIPTION
### TODO

* [ ] https://github.com/mongodb/mongoid/pull/5417 should be merged first, then this needs rebase.
* [ ] Tests for following cases
   - Localized fields
   - Array and Hash fields, including deeply nested Arrays and Hashes
   - ``accepts_nested_attributes_for`` (Was this working before?)

---

`ActionController::Parameters` are not properly sanitized when instantiating embedded/referenced relations and localized fields.

**Fortunately** the current behavior does **NOT** cause a security issue because an MethodMissing error happens in all cases (i.e. Mongoid chokes on processing the `ActionController::Parameters` when it expects a `Hash`)

This PR standardizes and tests the behavior.