### PR TITLE
ActiveRecord parity: Prefer #sanitize_forbidden_attributes over #sanitize_for_mass_assignment

### DIFF
--- a/lib/mongoid/attributes/processing.rb
+++ b/lib/mongoid/attributes/processing.rb
@@ -18,7 +18,7 @@ module Mongoid
       def process_attributes(attrs = nil)
         attrs ||= {}
         if !attrs.empty?
-          attrs = sanitize_for_mass_assignment(attrs)
+          attrs = sanitize_forbidden_attributes(attrs)
           attrs.each_pair do |key, value|
             next if pending_attribute?(key, value)
             process_attribute(key, value)

--- a/spec/mongoid/attributes_spec.rb
+++ b/spec/mongoid/attributes_spec.rb
@@ -949,7 +949,7 @@ describe Mongoid::Attributes do
       end
     end
 
-    context "when providing tainted parameters" do
+    context "when providing unpermitted parameters" do
 
       let(:params) do
         ActionController::Parameters.new(title: "sir")
@@ -961,24 +961,80 @@ describe Mongoid::Attributes do
         }.to raise_error(ActiveModel::ForbiddenAttributesError)
       end
     end
+
+    context "when providing permitted parameters" do
+
+      let(:params) do
+        ActionController::Parameters.new(title: "sir").permit!
+      end
+
+      let(:person) do
+        Person.new(params)
+      end
+
+      it "assigns the attributes" do
+        expect(person.title).to eq("sir")
+      end
+    end
   end
 
   context "updating when attributes already exist" do
-
     let(:person) do
       Person.new(title: "Sir")
     end
 
-    let(:attributes) do
-      { dob: "2000-01-01" }
+    context 'when attribute not overwritten' do
+      let(:attributes) do
+        { dob: "2000-01-01" }
+      end
+
+      before do
+        person.process_attributes(attributes)
+      end
+
+      it "does not change existing attributes" do
+        expect(person.title).to eq("Sir")
+      end
     end
 
-    before do
-      person.process_attributes(attributes)
+    context 'when attribute overwritten' do
+      let(:attributes) do
+        { title: 'Mister', dob: "2000-01-01" }
+      end
+
+      before do
+        person.process_attributes(attributes)
+      end
+
+      it "overwrites supplied attributes" do
+        expect(person.title).to eq("Mister")
+      end
     end
 
-    it "only overwrites supplied attributes" do
-      expect(person.title).to eq("Sir")
+    context "when providing unpermitted parameters" do
+      let(:attributes) do
+        ActionController::Parameters.new(title: 'Mister')
+      end
+
+      it "raises an error" do
+        expect {
+          person.process_attributes(attributes)
+        }.to raise_error(ActiveModel::ForbiddenAttributesError)
+      end
+    end
+
+    context "when providing permitted parameters" do
+      let(:attributes) do
+        ActionController::Parameters.new(title: 'Mister').permit!
+      end
+
+      before do
+        person.process_attributes(attributes)
+      end
+
+      it "assigns the attributes" do
+        expect(person.title).to eq('Mister')
+      end
     end
   end
 


### PR DESCRIPTION
Converts the current single usage of #sanitize_for_mass_assignment to #sanitize_forbidden_attributes. **The two methods are aliased in ActiveModel**, and ActiveRecord uses the latter only and never the former. There are some gems, for example ProtectedAttributesContinued that work with the latter only.

Although this PR does NOT change any behavior, I've also added more robust test coverage in the affected area.
