### PR TITLE
MONGOID-5324 Remove deprecated EPOCH constant from Date and Time

### DIFF
--- a/docs/release-notes/mongoid-8.0.txt
+++ b/docs/release-notes/mongoid-8.0.txt
@@ -324,4 +324,6 @@ Removed Deprecated Constants
 Mongoid 8 removes the following deprecated constants that are not expected
 to have been used outside of Mongoid:
 
+- ``Mongoid::Extensions::Date::EPOCH``
+- ``Mongoid::Extensions::Time::EPOCH``
 - ``Mongoid::Factory::TYPE``

--- a/lib/mongoid/extensions/date.rb
+++ b/lib/mongoid/extensions/date.rb
@@ -4,12 +4,6 @@ module Mongoid
   module Extensions
     module Date
 
-      # Constant for epoch - used when passing invalid times.
-      #
-      # @deprecated No longer used as a return value from #mongoize passed
-      #   an invalid date string.
-      EPOCH = ::Date.new(1970, 1, 1)
-
       # Convert the date into a time.
       #
       # @example Convert the date to a time.

--- a/lib/mongoid/extensions/time.rb
+++ b/lib/mongoid/extensions/time.rb
@@ -14,12 +14,6 @@ module Mongoid
         self
       end
 
-      # Constant for epoch - used when passing invalid times.
-      #
-      # @deprecated No longer used as a return value from #mongoize passed
-      #   an invalid time string.
-      EPOCH = ::Time.utc(1970, 1, 1, 0, 0, 0)
-
       # Turn the object from the ruby type we deal with to a Mongo friendly
       # type.
       #


### PR DESCRIPTION
It is not used anywhere.

Don't think this needs to be added to release notes, but happy to add it if you'd like.