### PR TITLE
MONGOID-5324 Remove deprecated Mongoid::Factory::TYPE constant

### DIFF
--- a/docs/release-notes/mongoid-8.0.txt
+++ b/docs/release-notes/mongoid-8.0.txt
@@ -316,3 +316,12 @@ Replaced ``Mongoid::Criteria#geo_spacial`` with ``#geo_spatial``
 The previously deprecated ``Mongoid::Criteria#geo_spacial`` method has been
 removed in Mongoid 8. It has been replaced one-for-one with ``#geo_spatial``
 which was added in Mongoid 7.2.0.
+
+
+Removed Deprecated Constants
+----------------------------
+
+Mongoid 8 removes the following deprecated constants that are not expected
+to have been used outside of Mongoid:
+
+- ``Mongoid::Factory::TYPE``

--- a/lib/mongoid/factory.rb
+++ b/lib/mongoid/factory.rb
@@ -6,9 +6,6 @@ module Mongoid
   module Factory
     extend self
 
-    # @deprecated
-    TYPE = "_type".freeze
-
     # Builds a new +Document+ from the supplied attributes.
     #
     # This method either instantiates klass or a descendant of klass if the attributes include


### PR DESCRIPTION
It is not used in the code.

Don't think this one needs documentation in release notes but I'm happy to add it if you'd like.