### PR TITLE
fixes errors where getlocal is unrecognized

### DIFF
--- a/lib/mongoid/extensions/time.rb
+++ b/lib/mongoid/extensions/time.rb
@@ -54,7 +54,9 @@ module Mongoid
         # @return [ Time ] The object as a date.
         def demongoize(object)
           return nil if object.blank?
-          object = object.getlocal unless Mongoid::Config.use_utc?
+          if object.respond_to?(:getlocal) && !Mongoid::Config.use_utc?
+            object = object.getlocal
+          end
           if Mongoid::Config.use_activesupport_time_zone?
             object = object.in_time_zone(Mongoid.time_zone)
           end


### PR DESCRIPTION
fixes the following issue
```
caught error of type NoMethodError in after callback inside Grape::Middleware::Formatter : undefined method `getlocal' for "2022-04-20T17:20:04.75-07:00":String
NoMethodError: undefined method `getlocal' for "2022-04-20T17:20:04.75-07:00":String
	/Users/aronlilland/.rvm/gems/ruby-2.6.5/gems/mongoid-6.4.8/lib/mongoid/extensions/time.rb:52:in `demongoize'
	/Users/aronlilland/.rvm/gems/ruby-2.6.5/gems/mongoid-6.4.8/lib/mongoid/fields/standard.rb:10:in `demongoize'
	/Users/aronlilland/.rvm/gems/ruby-2.6.5/gems/mongoid-6.4.8/lib/mongoid/fields.rb:418:in `block (2 levels) in create_field_getter'
```