### PR TITLE
MONGOID-5306 Use pluck instead of only to avoid projecting when referencing association _ids

### DIFF
--- a/lib/mongoid/association/accessors.rb
+++ b/lib/mongoid/association/accessors.rb
@@ -115,8 +115,6 @@ module Mongoid
         # during binding or when cascading callbacks. Whenever we retrieve
         # associations within the codebase, we use without_autobuild.
         if !without_autobuild? && association.embedded? && attribute_missing?(field_name)
-          byebug
-          attribute_missing?(field_name)
           raise ActiveModel::MissingAttributeError, "Missing attribute: '#{field_name}'"
         end
 

--- a/lib/mongoid/association/accessors.rb
+++ b/lib/mongoid/association/accessors.rb
@@ -115,6 +115,8 @@ module Mongoid
         # during binding or when cascading callbacks. Whenever we retrieve
         # associations within the codebase, we use without_autobuild.
         if !without_autobuild? && association.embedded? && attribute_missing?(field_name)
+          byebug
+          attribute_missing?(field_name)
           raise ActiveModel::MissingAttributeError, "Missing attribute: '#{field_name}'"
         end
 
@@ -319,7 +321,7 @@ module Mongoid
         ids_method = "#{association.name.to_s.singularize}_ids"
         association.inverse_class.tap do |klass|
           klass.re_define_method(ids_method) do
-            send(association.name).only(:_id).map(&:_id)
+            send(association.name).pluck(:_id)
           end
         end
       end

--- a/spec/mongoid/interceptable_spec.rb
+++ b/spec/mongoid/interceptable_spec.rb
@@ -2353,4 +2353,21 @@ describe Mongoid::Interceptable do
       end
     end
   end
+
+  # This case is rather niche. The _ids method used to use the `.only` method
+  # to get only the _ids for an association, which was causing a
+  # MissingAttributeError to be raised when accessing another association. This
+  # was fixed by using `.pluck` over `.only`. Look at MONGOID-5306 for a more
+  # detailed explanation.
+  context "when accessing _ids in validate and access an association in after_initialize" do
+    it "doesn't raise a MissingAttributeError" do
+      company = InterceptableCompany.create!
+      shop = InterceptableShop.create!(company: company)
+      user = InterceptableUser.new
+      user.company = company
+      expect do
+        user.save!
+      end.to_not raise_error(ActiveModel::MissingAttributeError)
+    end
+  end
 end

--- a/spec/mongoid/interceptable_spec_models.rb
+++ b/spec/mongoid/interceptable_spec_models.rb
@@ -267,3 +267,41 @@ class InterceptableEngine
 
   field :_id, type: String, default: -> { "hello-engine-#{wing&.id}" }
 end
+
+class InterceptableCompany
+  include Mongoid::Document
+
+  has_many :users, class_name: "InterceptableUser"
+  has_many :shops, class_name: "InterceptableShop"
+end
+
+class InterceptableShop
+  include Mongoid::Document
+
+  embeds_one :address, class_name: "InterceptableAddress"
+  belongs_to :company, class_name: "InterceptableCompany"
+
+  after_initialize :build_address1
+
+  def build_address1
+    self.address ||= Address.new
+  end
+end
+
+class InterceptableAddress
+  include Mongoid::Document
+  embedded_in :shop, class_name: "InterceptableShop"
+end
+
+class InterceptableUser
+  include Mongoid::Document
+
+  belongs_to :company, class_name: "InterceptableCompany"
+
+  validate :break_mongoid
+
+  def break_mongoid
+    company.shop_ids
+  end
+end
+


### PR DESCRIPTION
MONGOID-5306

The `_id`s method uses the `.only` method to get only the `_id`s for an association, which was causing a `MissingAttributeError` to be raised when accessing another association later in the `after_initialize` callback. This was fixed by using `.pluck` over `.only`.

The move from `only` to `pluck` should not have backwards breaking changes, as `pluck` still causes the documents to be "actualized." i.e. during the `pluck`, the `after_initialize` callback that was called (in which the error was raised) during `only`, will also be called during the `pluck`.