### PR TITLE
MONGOID-5330 Operator methods overwrite previous conditions

### DIFF
--- a/docs/reference/configuration.txt
+++ b/docs/reference/configuration.txt
@@ -258,7 +258,7 @@ for details on driver options.
       # feature flag to true will cause those operators to be combined using an
       # and. Setting this feature flag to false will cause the later chained
       # operators to overwrite the earlier ones. (default: false)
-      and_chained_operators: false
+      #and_chained_operators: true
 
       # Application name that is printed to the MongoDB logs upon establishing
       # a connection in server versions 3.4 or greater. Note that the name

--- a/docs/reference/configuration.txt
+++ b/docs/reference/configuration.txt
@@ -254,12 +254,6 @@ for details on driver options.
 
     # Configure Mongoid-specific options. (optional)
     options:
-      # When chaining the same operators that use the same field, setting this
-      # feature flag to true will cause those operators to be combined using an
-      # and. Setting this feature flag to false will cause the later chained
-      # operators to overwrite the earlier ones. (default: false)
-      #and_chained_operators: true
-
       # Application name that is printed to the MongoDB logs upon establishing
       # a connection in server versions 3.4 or greater. Note that the name
       # cannot exceed 128 bytes in length. It is also used as the database name
@@ -400,6 +394,12 @@ for details on driver options.
       # is used, the return value will be the hexadecimal ObjectId string only.
       # (default: false)
       #object_id_as_json_oid: true
+
+      # When chaining the same operators that use the same field, setting this
+      # feature flag to false will cause those operators to be combined using an
+      # and. Setting this feature flag to true will cause the later chained
+      # operators to overwrite the earlier ones. (default: false)
+      #overwrite_chained_operators: false
 
       # Preload all models in development, needed when models use
       # inheritance. (default: false)

--- a/docs/reference/configuration.txt
+++ b/docs/reference/configuration.txt
@@ -254,6 +254,12 @@ for details on driver options.
 
     # Configure Mongoid-specific options. (optional)
     options:
+      # When chaining the same operators that use the same field, setting this
+      # feature flag to true will cause those operators to be combined using an
+      # and. Setting this feature flag to false will cause the later chained
+      # operators to overwrite the earlier ones. (default: false)
+      and_chained_operators: false
+
       # Application name that is printed to the MongoDB logs upon establishing
       # a connection in server versions 3.4 or greater. Note that the name
       # cannot exceed 128 bytes in length. It is also used as the database name

--- a/docs/release-notes/mongoid-7.5.txt
+++ b/docs/release-notes/mongoid-7.5.txt
@@ -27,7 +27,7 @@ The ``Document#to_a`` method is deprecated in Mongoid 7.5.
 Combine Chained Operators Using ``and`` Instead of ``override``
 ```````````````````````````````````````````````````````````````
 
-Mongoid 7.5 with the ``Mongoid.and_chained_operators`` option set to ``true``
+Mongoid 7.5 with the ``Mongoid.overwrite_chained_operators`` option set to ``false``
 will combine conditions that use the same operator and field using an ``and``.
 For example, in the following query:
 
@@ -35,7 +35,7 @@ For example, in the following query:
 
   Band.ne(name: "The Rolling Stones").ne(name: "The Beatles")
 
-Mongoid 7.5 with the ``Mongoid.and_chained_operators`` option set to ``true``
+Mongoid 7.5 with the ``Mongoid.overwrite_chained_operators`` option set to ``false``
 will generate the following criteria:
 
 .. code-block:: ruby
@@ -46,9 +46,9 @@ will generate the following criteria:
     class:    Band
     embedded: false>
 
-In Mongoid 7.4 and earlier, and in 7.5 with the ``Mongoid.and_chained_operators``
-option set to ``false`` (the default), the following criteria would be
-generated instead which overwrites the first condition:
+In Mongoid 7.4 and earlier, and in 7.5 with the ``Mongoid.overwrite_chained_operators``
+option set to ``true``, the following criteria would be generated instead which
+overwrites the first condition:
 
 .. code-block:: ruby
 
@@ -73,10 +73,10 @@ The following functions are affected by this change:
 
 .. note::
 
-   In Mongoid 7.5 with the ``Mongoid.and_chained_operators`` option set to
-   ``true``, nested keys in the generated selector will always be strings,
+   In Mongoid 7.5 with the ``Mongoid.overwrite_chained_operators`` option set to
+   ``false``, nested keys in the generated selector will always be strings,
    whereas in Mongoid 7.4 and earlier, and in 7.5 with the
-   ``Mongoid.and_chained_operators`` option set to ``false``, nested keys in
+   ``Mongoid.overwrite_chained_operators`` option set to ``true``, nested keys in
    the selector can be strings or symbols, depending on what was passed to the
    operator.
 

--- a/docs/release-notes/mongoid-7.5.txt
+++ b/docs/release-notes/mongoid-7.5.txt
@@ -61,6 +61,7 @@ generated instead which overwrites the first condition:
 The following functions are affected by this change:
 
 - ``eq``
+- ``elem_match``
 - ``gt``
 - ``gte``
 - ``lt``
@@ -69,4 +70,13 @@ The following functions are affected by this change:
 - ``ne``
 - ``near``
 - ``near_sphere``
+
+.. note::
+
+   In Mongoid 7.5 with the ``Mongoid.and_chained_operators`` option set to
+   ``true``, nested keys in the generated selector will always be strings,
+   whereas in Mongoid 7.4 and earlier, and in 7.5 with the
+   ``Mongoid.and_chained_operators`` option set to ``false``, nested keys in
+   the selector can be strings or symbols, depending on what was passed to the
+   operator.
 

--- a/docs/release-notes/mongoid-7.5.txt
+++ b/docs/release-notes/mongoid-7.5.txt
@@ -1,0 +1,72 @@
+***********
+Mongoid 7.5
+***********
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+This page describes significant changes and improvements in Mongoid 7.5.
+The complete list of releases is available `on GitHub
+<https://github.com/mongodb/mongoid/releases>`_ and `in JIRA
+<https://jira.mongodb.org/projects/MONGOID?selectedItem=com.atlassian.jira.jira-projects-plugin:release-page>`_;
+please consult GitHub releases for detailed release notes and JIRA for
+the complete list of issues fixed in each release, including bug fixes.
+
+
+``Document#to_a`` deprecated
+````````````````````````````
+
+The ``Document#to_a`` method is deprecated in Mongoid 7.5.
+
+
+Combine Chained Operators Using ``and`` Instead of ``override``
+```````````````````````````````````````````````````````````````
+
+Mongoid 7.5 with the ``Mongoid.and_chained_operators`` option set to ``true``
+will combine conditions that use the same operator and field using an ``and``.
+For example, in the following query:
+
+.. code-block:: ruby
+
+  Band.ne(name: "The Rolling Stones").ne(name: "The Beatles")
+
+Mongoid 7.5 with the ``Mongoid.and_chained_operators`` option set to ``true``
+will generate the following criteria:
+
+.. code-block:: ruby
+
+  #<Mongoid::Criteria
+    selector: {"name"=>{"$ne"=>"The Rolling Stones"}, "$and"=>[{"name"=>{"$ne"=>"The Beatles"}}]}
+    options:  {}
+    class:    Band
+    embedded: false>
+
+In Mongoid 7.4 and earlier, and in 7.5 with the ``Mongoid.and_chained_operators``
+option set to ``false`` (the default), the following criteria would be
+generated instead which overwrites the first condition:
+
+.. code-block:: ruby
+
+  #<Mongoid::Criteria
+    selector: {"name"=>{"$ne"=>"The Beatles"}}
+    options:  {}
+    class:    Band
+    embedded: false>
+
+The following functions are affected by this change:
+
+- ``eq``
+- ``gt``
+- ``gte``
+- ``lt``
+- ``lte``
+- ``mod``
+- ``ne``
+- ``near``
+- ``near_sphere``
+

--- a/docs/release-notes/mongoid-8.0.txt
+++ b/docs/release-notes/mongoid-8.0.txt
@@ -31,6 +31,7 @@ Default Option Values Changed
 **Breaking change:** The following options have had their default values
 changed in Mongoid 8.0:
 
+- ``:and_chained_operators`` => ``true``
 - ``:broken_aggregables`` => ``false``
 - ``:broken_alias_handling`` => ``false``
 - ``:broken_and`` => ``false``
@@ -345,48 +346,3 @@ The previously deprecated ``Array#update_values`` and ``Hash#update_values``
 methods have been removed in Mongoid 8.
 
 
-Combine Chained Operators Using ``and`` Instead of ``override``
----------------------------------------------------------------
-
-Mongoid 8.0 with the ``Mongoid.and_chained_operators`` option set to ``true``
-will combine conditions that use the same operator and field using an ``and``.
-For example, in the following query:
-
-.. code-block:: ruby
-
-  Band.ne(name: "The Rolling Stones").ne(name: "The Beatles")
-
-Mongoid 8.0 with the ``Mongoid.and_chained_operators`` option set to ``true``
-will generate the following criteria:
-
-.. code-block:: ruby
-
-  #<Mongoid::Criteria
-    selector: {"name"=>{"$ne"=>"The Rolling Stones"}, "$and"=>[{"name"=>{"$ne"=>"The Beatles"}}]}
-    options:  {}
-    class:    Band
-    embedded: false>
-
-In Mongoid 7.5 and earlier, and in 8.0 with the ``Mongoid.and_chained_operators``
-option set to ``false`` (the default), the following criteria would be
-generated instead which overwrites the first condition:
-
-.. code-block:: ruby
-
-  #<Mongoid::Criteria
-    selector: {"name"=>{"$ne"=>"The Beatles"}}
-    options:  {}
-    class:    Band
-    embedded: false>
-
-The following functions are affected by this change:
-
-- ``eq``
-- ``gt``
-- ``gte``
-- ``lt``
-- ``lte``
-- ``mod``
-- ``ne``
-- ``near``
-- ``near_sphere``

--- a/docs/release-notes/mongoid-8.0.txt
+++ b/docs/release-notes/mongoid-8.0.txt
@@ -161,20 +161,20 @@ Mongoid 8.0 behavior:
 
 .. code-block:: ruby
 
-  Band.any_of({name: 'Rolling Stone'}, {founded: 1990}).
+  Band.any_of({name: 'The Rolling Stones'}, {founded: 1990}).
     any_of({members: 2}, {last_tour: 1995})
   # =>
   # #<Mongoid::Criteria
-  #   selector: {"$or"=>[{"name"=>"Rolling Stone"}, {"founded"=>1990}],
+  #   selector: {"$or"=>[{"name"=>"The Rolling Stones"}, {"founded"=>1990}],
   #     "$and"=>[{"$or"=>[{"members"=>2}, {"last_tour"=>1995}]}]}
   #   options:  {}
   #   class:    Band
   #   embedded: false>
 
-  Band.any_of({name: 'Rolling Stone'}, {founded: 1990}).any_of({members: 2})
+  Band.any_of({name: 'The Rolling Stones'}, {founded: 1990}).any_of({members: 2})
   # =>
   # #<Mongoid::Criteria
-  #   selector: {"$or"=>[{"name"=>"Rolling Stone"}, {"founded"=>1990}], "members"=>2}
+  #   selector: {"$or"=>[{"name"=>"The Rolling Stones"}, {"founded"=>1990}], "members"=>2}
   #   options:  {}
   #   class:    Band
   #   embedded: false>
@@ -183,20 +183,20 @@ Mongoid 7 behavior:
 
 .. code-block:: ruby
 
-  Band.any_of({name: 'Rolling Stone'}, {founded: 1990}).
+  Band.any_of({name: 'The Rolling Stones'}, {founded: 1990}).
     any_of({members: 2}, {last_tour: 1995})
   # =>
   # #<Mongoid::Criteria
-  #   selector: {"$or"=>[{"name"=>"Rolling Stone"}, {"founded"=>1990},
+  #   selector: {"$or"=>[{"name"=>"The Rolling Stones"}, {"founded"=>1990},
   #     {"members"=>2}, {"last_tour"=>1995}]}
   #   options:  {}
   #   class:    Band
   #   embedded: false>
 
-  Band.any_of({name: 'Rolling Stone'}, {founded: 1990}).any_of({members: 2})
+  Band.any_of({name: 'The Rolling Stones'}, {founded: 1990}).any_of({members: 2})
   # =>
   # #<Mongoid::Criteria
-  #   selector: {"$or"=>[{"name"=>"Rolling Stone"}, {"founded"=>1990}], "members"=>2}
+  #   selector: {"$or"=>[{"name"=>"The Rolling Stones"}, {"founded"=>1990}], "members"=>2}
   #   options:  {}
   #   class:    Band
   #   embedded: false>
@@ -343,3 +343,50 @@ Removed ``Array#update_values`` and ``Hash#update_values`` methods
 
 The previously deprecated ``Array#update_values`` and ``Hash#update_values``
 methods have been removed in Mongoid 8.
+
+
+Combine Chained Operators Using ``and`` Instead of ``override``
+---------------------------------------------------------------
+
+Mongoid 8.0 with the ``Mongoid.and_chained_operators`` option set to ``true``
+will combine conditions that use the same operator and field using an ``and``.
+For example, in the following query:
+
+.. code-block:: ruby
+
+  Band.ne(name: "The Rolling Stones").ne(name: "The Beatles")
+
+Mongoid 8.0 with the ``Mongoid.and_chained_operators`` option set to ``true``
+will generate the following criteria:
+
+.. code-block:: ruby
+
+  #<Mongoid::Criteria
+    selector: {"name"=>{"$ne"=>"The Rolling Stones"}, "$and"=>[{"name"=>{"$ne"=>"The Beatles"}}]}
+    options:  {}
+    class:    Band
+    embedded: false>
+
+In Mongoid 7.5 and earlier, and in 8.0 with the ``Mongoid.and_chained_operators``
+option set to ``false`` (the default), the following criteria would be
+generated instead which overwrites the first condition:
+
+.. code-block:: ruby
+
+  #<Mongoid::Criteria
+    selector: {"name"=>{"$ne"=>"The Beatles"}}
+    options:  {}
+    class:    Band
+    embedded: false>
+
+The following functions are affected by this change:
+
+- ``eq``
+- ``gt``
+- ``gte``
+- ``lt``
+- ``lte``
+- ``mod``
+- ``ne``
+- ``near``
+- ``near_sphere``

--- a/docs/release-notes/mongoid-8.0.txt
+++ b/docs/release-notes/mongoid-8.0.txt
@@ -344,5 +344,3 @@ Removed ``Array#update_values`` and ``Hash#update_values`` methods
 
 The previously deprecated ``Array#update_values`` and ``Hash#update_values``
 methods have been removed in Mongoid 8.
-
-

--- a/docs/release-notes/mongoid-8.0.txt
+++ b/docs/release-notes/mongoid-8.0.txt
@@ -31,7 +31,7 @@ Default Option Values Changed
 **Breaking change:** The following options have had their default values
 changed in Mongoid 8.0:
 
-- ``:and_chained_operators`` => ``true``
+- ``:overwrite_chained_operators`` => ``false``
 - ``:broken_aggregables`` => ``false``
 - ``:broken_alias_handling`` => ``false``
 - ``:broken_and`` => ``false``

--- a/lib/mongoid/config.rb
+++ b/lib/mongoid/config.rb
@@ -117,7 +117,7 @@ module Mongoid
 
     # Combine chained operators, which use the same field and operator,
     # using and's instead of overwriting them.
-    option :and_chained_operators, default: false
+    option :and_chained_operators, default: true
 
     # Has Mongoid been configured? This is checking that at least a valid
     # client config exists.

--- a/lib/mongoid/config.rb
+++ b/lib/mongoid/config.rb
@@ -117,7 +117,7 @@ module Mongoid
 
     # Combine chained operators, which use the same field and operator,
     # using and's instead of overwriting them.
-    option :and_chained_operators, default: true
+    option :overwrite_chained_operators, default: false
 
     # Has Mongoid been configured? This is checking that at least a valid
     # client config exists.

--- a/lib/mongoid/config.rb
+++ b/lib/mongoid/config.rb
@@ -115,6 +115,10 @@ module Mongoid
     # demongoize the values on returning them.
     option :legacy_pluck_distinct, default: false
 
+    # Combine chained operators, which use the same field and operator,
+    # using and's instead of overwriting them.
+    option :and_chained_operators, default: false
+
     # Has Mongoid been configured? This is checking that at least a valid
     # client config exists.
     #

--- a/lib/mongoid/criteria/queryable/mergeable.rb
+++ b/lib/mongoid/criteria/queryable/mergeable.rb
@@ -52,6 +52,22 @@ module Mongoid
           self
         end
 
+        # Merge criteria with operators using the and function.
+        #
+        # @param [ Hash ] The criterion to add to the criteria.
+        # @param [ String ] operator The MongoDB operator.
+        #
+        # @return [ Criteria ] The resulting criteria.
+        def and_with_operator(criterion, operator)
+          crit = self
+          if criterion
+            criterion.each_pair do |field, value|
+              crit = crit.and(field => prepare(field, "$gt", value))
+            end
+          end
+          crit
+        end
+
         private
 
         # Adds the criterion to the existing selection.

--- a/lib/mongoid/criteria/queryable/mergeable.rb
+++ b/lib/mongoid/criteria/queryable/mergeable.rb
@@ -62,7 +62,7 @@ module Mongoid
           crit = self
           if criterion
             criterion.each_pair do |field, value|
-              crit = crit.and(field => prepare(field, "$gt", value))
+              crit = crit.and(field => prepare(field, operator, value))
             end
           end
           crit

--- a/lib/mongoid/criteria/queryable/mergeable.rb
+++ b/lib/mongoid/criteria/queryable/mergeable.rb
@@ -62,7 +62,12 @@ module Mongoid
           crit = self
           if criterion
             criterion.each_pair do |field, value|
-              crit = crit.and(field => prepare(field, operator, value))
+              val = prepare(field, operator, value)
+              # The prepare method already takes the negation into account. We
+              # set negating to false here so that ``and`` doesn't also apply
+              # negation and we have a double negative.
+              crit.negating = false
+              crit = crit.and(field => val)
             end
           end
           crit

--- a/lib/mongoid/criteria/queryable/selectable.rb
+++ b/lib/mongoid/criteria/queryable/selectable.rb
@@ -154,7 +154,7 @@ module Mongoid
             raise Errors::CriteriaArgumentRequired, :elem_match
           end
 
-          __override__(criterion, "$elemMatch")
+          and_or_override(criterion, "$elemMatch")
         end
         key :elem_match, :override, "$elemMatch"
 

--- a/lib/mongoid/criteria/queryable/selectable.rb
+++ b/lib/mongoid/criteria/queryable/selectable.rb
@@ -904,17 +904,17 @@ module Mongoid
 
         # Combine operator expessions onto a Criteria using either
         # an override or ands depending on the status of the
-        # Mongoid.and_chained_operators feature flag.
+        # Mongoid.overwrite_chained_operators feature flag.
         #
         # @param [ Hash ] The criterion to add to the criteria.
         # @param [ String ] operator The MongoDB operator.
         #
         # @return [ Criteria ] The resulting criteria.
         def and_or_override(criterion, operator)
-          if Mongoid.and_chained_operators
-            and_with_operator(criterion, operator)
-          else
+          if Mongoid.overwrite_chained_operators
             __override__(criterion, operator)
+          else
+            and_with_operator(criterion, operator)
           end
         end
 

--- a/lib/mongoid/criteria/queryable/selectable.rb
+++ b/lib/mongoid/criteria/queryable/selectable.rb
@@ -277,7 +277,7 @@ module Mongoid
             raise Errors::CriteriaArgumentRequired, :gt
           end
 
-          __override__(criterion, "$gt")
+          and_with_operator(criterion, "$gt")
         end
         key :gt, :override, "$gt"
 

--- a/lib/mongoid/criteria/queryable/selectable.rb
+++ b/lib/mongoid/criteria/queryable/selectable.rb
@@ -277,7 +277,7 @@ module Mongoid
             raise Errors::CriteriaArgumentRequired, :gt
           end
 
-          and_with_operator(criterion, "$gt")
+          and_or_override(criterion, "$gt")
         end
         key :gt, :override, "$gt"
 
@@ -297,7 +297,7 @@ module Mongoid
             raise Errors::CriteriaArgumentRequired, :gte
           end
 
-          __override__(criterion, "$gte")
+          and_or_override(criterion, "$gte")
         end
         key :gte, :override, "$gte"
 
@@ -353,7 +353,7 @@ module Mongoid
             raise Errors::CriteriaArgumentRequired, :lt
           end
 
-          __override__(criterion, "$lt")
+          and_or_override(criterion, "$lt")
         end
         key :lt, :override, "$lt"
 
@@ -373,7 +373,7 @@ module Mongoid
             raise Errors::CriteriaArgumentRequired, :lte
           end
 
-          __override__(criterion, "$lte")
+          and_or_override(criterion, "$lte")
         end
         key :lte, :override, "$lte"
 
@@ -410,7 +410,7 @@ module Mongoid
             raise Errors::CriteriaArgumentRequired, :mod
           end
 
-          __override__(criterion, "$mod")
+          and_or_override(criterion, "$mod")
         end
         key :mod, :override, "$mod"
 
@@ -430,7 +430,7 @@ module Mongoid
             raise Errors::CriteriaArgumentRequired, :ne
           end
 
-          __override__(criterion, "$ne")
+          and_or_override(criterion, "$ne")
         end
         alias :excludes :ne
         key :ne, :override, "$ne"
@@ -451,7 +451,7 @@ module Mongoid
             raise Errors::CriteriaArgumentRequired, :near
           end
 
-          __override__(criterion, "$near")
+          and_or_override(criterion, "$near")
         end
         key :near, :override, "$near"
 
@@ -471,7 +471,7 @@ module Mongoid
             raise Errors::CriteriaArgumentRequired, :near_sphere
           end
 
-          __override__(criterion, "$nearSphere")
+          and_or_override(criterion, "$nearSphere")
         end
         key :near_sphere, :override, "$nearSphere"
 
@@ -899,6 +899,22 @@ module Mongoid
               end
             end
             query.reset_strategies!
+          end
+        end
+
+        # Combine operator expessions onto a Criteria using either
+        # an override or ands depending on the status of the
+        # Mongoid.and_chained_operators feature flag.
+        #
+        # @param [ Hash ] The criterion to add to the criteria.
+        # @param [ String ] operator The MongoDB operator.
+        #
+        # @return [ Criteria ] The resulting criteria.
+        def and_or_override(criterion, operator)
+          if Mongoid.and_chained_operators
+            and_with_operator(criterion, operator)
+          else
+            __override__(criterion, operator)
           end
         end
 

--- a/lib/mongoid/criteria/queryable/selectable.rb
+++ b/lib/mongoid/criteria/queryable/selectable.rb
@@ -257,7 +257,7 @@ module Mongoid
             raise Errors::CriteriaArgumentRequired, :eq
           end
 
-          __override__(criterion, "$eq")
+          and_or_override(criterion, "$eq")
         end
         key :eq, :override, "$eq"
 

--- a/spec/mongoid/config_spec.rb
+++ b/spec/mongoid/config_spec.rb
@@ -335,9 +335,9 @@ describe Mongoid::Config do
     it_behaves_like "a config option"
   end
 
-  context 'when setting the and_chained_operators option in the config' do
-    let(:option) { :and_chained_operators }
-    let(:default) { true }
+  context 'when setting the overwrite_chained_operators option in the config' do
+    let(:option) { :overwrite_chained_operators }
+    let(:default) { false }
 
     it_behaves_like "a config option"
   end

--- a/spec/mongoid/config_spec.rb
+++ b/spec/mongoid/config_spec.rb
@@ -335,6 +335,12 @@ describe Mongoid::Config do
     it_behaves_like "a config option"
   end
 
+  context 'when setting the and_chained_operators option in the config' do
+    let(:option) { :and_chained_operators }
+    let(:default) { false }
+
+    it_behaves_like "a config option"
+  end
 
   describe "#load!" do
 

--- a/spec/mongoid/config_spec.rb
+++ b/spec/mongoid/config_spec.rb
@@ -337,7 +337,7 @@ describe Mongoid::Config do
 
   context 'when setting the and_chained_operators option in the config' do
     let(:option) { :and_chained_operators }
-    let(:default) { false }
+    let(:default) { true }
 
     it_behaves_like "a config option"
   end

--- a/spec/mongoid/criteria/queryable/selectable_spec.rb
+++ b/spec/mongoid/criteria/queryable/selectable_spec.rb
@@ -879,19 +879,40 @@ describe Mongoid::Criteria::Queryable::Selectable do
 
       context "when the criterion are on the same field" do
 
-        let(:selection) do
-          query.gt(first: 10).gt(first: 15)
+        context "when and_chained_operators is false" do
+          config_override :and_chained_operators, false
+
+          let(:selection) do
+            query.gt(first: 10).gt(first: 15)
+          end
+
+          it "overwrites the first $gt selector" do
+            expect(selection.selector).to eq({
+              "first" => { "$gt" => 15 },
+              })
+          end
+
+          it "returns a cloned query" do
+            expect(selection).to_not equal(query)
+          end
         end
 
-        it "overwrites the first $gt selector" do
-          expect(selection.selector).to eq({
-            "first" => { "$gt" => 10 },
-            "$and" => [{ "first" => { "$gt" => 15 } }]
-          })
-        end
+        context "when and_chained_operators is true" do
+          config_override :and_chained_operators, true
+          let(:selection) do
+            query.gt(first: 10).gt(first: 15)
+          end
 
-        it "returns a cloned query" do
-          expect(selection).to_not equal(query)
+          it "overwrites the first $gt selector" do
+            expect(selection.selector).to eq({
+              "first" => { "$gt" => 10 },
+              "$and" => [{ "first" => { "$gt" => 15 } }]
+              })
+          end
+
+          it "returns a cloned query" do
+            expect(selection).to_not equal(query)
+          end
         end
       end
     end

--- a/spec/mongoid/criteria/queryable/selectable_spec.rb
+++ b/spec/mongoid/criteria/queryable/selectable_spec.rb
@@ -2310,12 +2310,13 @@ describe Mongoid::Criteria::Queryable::Selectable do
   end
 
   describe "Mongoid.and_chained_operators" do
-    [ :eq, :gt, :gte, :lt, :lte, :mod, :ne, :near, :near_sphere ].each do |meth|
+    [ :eq, :elem_match, :gt, :gte, :lt, :lte, :mod, :ne, :near, :near_sphere ].each do |meth|
 
       context "when chaining the #{meth} method when using the same field" do
         let(:op) do
           {
             eq: "$eq",
+            elem_match: "$elemMatch",
             gt: "$gt",
             gte: "$gte",
             lt: "$lt",

--- a/spec/mongoid/criteria/queryable/selectable_spec.rb
+++ b/spec/mongoid/criteria/queryable/selectable_spec.rb
@@ -479,10 +479,24 @@ describe Mongoid::Criteria::Queryable::Selectable do
           query.elem_match(users: { name: "value" })
         end
 
-        it "adds the $elemMatch expression" do
-          expect(selection.selector).to eq({
-            "users" => { "$elemMatch" => { name: "value" }}
-          })
+        context "when and_chained_operators is true" do
+          config_override :and_chained_operators, true
+
+          it "adds the $elemMatch expression" do
+            expect(selection.selector).to eq({
+              "users" => { "$elemMatch" => { "name" => "value" }}
+            })
+          end
+        end
+
+        context "when and_chained_operators is false" do
+          config_override :and_chained_operators, false
+
+          it "adds the $elemMatch expression" do
+            expect(selection.selector).to eq({
+              "users" => { "$elemMatch" => { name: "value" }}
+            })
+          end
         end
 
         it "returns a cloned query" do
@@ -523,11 +537,26 @@ describe Mongoid::Criteria::Queryable::Selectable do
           )
         end
 
-        it "adds the $elemMatch expression" do
-          expect(selection.selector).to eq({
-            "users" => { "$elemMatch" => { name: "value" }},
-            "comments" => { "$elemMatch" => { text: "value" }}
-          })
+        context "when and_chained_operators is true" do
+          config_override :and_chained_operators, true
+
+          it "adds the $elemMatch expression" do
+            expect(selection.selector).to eq({
+              "users" => { "$elemMatch" => { "name" => "value" }},
+              "comments" => { "$elemMatch" => { "text" => "value" }}
+            })
+          end
+        end
+
+        context "when and_chained_operators is true" do
+          config_override :and_chained_operators, false
+
+          it "adds the $elemMatch expression" do
+            expect(selection.selector).to eq({
+              "users" => { "$elemMatch" => { name: "value" }},
+              "comments" => { "$elemMatch" => { text: "value" }}
+            })
+          end
         end
 
         it "returns a cloned query" do
@@ -548,8 +577,8 @@ describe Mongoid::Criteria::Queryable::Selectable do
 
         it "adds the $elemMatch expression" do
           expect(selection.selector).to eq({
-            "users" => { "$elemMatch" => { name: "value" }},
-            "comments" => { "$elemMatch" => { text: "value" }}
+            "users" => { "$elemMatch" => { "name" => "value" }},
+            "comments" => { "$elemMatch" => { "text" => "value" }}
           })
         end
 
@@ -566,10 +595,25 @@ describe Mongoid::Criteria::Queryable::Selectable do
             elem_match(users: { state: "new" })
         end
 
-        it "overrides the $elemMatch expression" do
-          expect(selection.selector).to eq({
-            "users" => { "$elemMatch" => { state: "new" }}
-          })
+        context "when and_chained_operators is true" do
+          config_override :and_chained_operators, true
+
+          it "adds an $elemMatch expression" do
+            expect(selection.selector).to eq({
+              "users" => { "$elemMatch" => { "name" => "value" } },
+              "$and" => [ { "users" => { "$elemMatch" => { "state" => "new" } } } ],
+            })
+          end
+        end
+
+        context "when and_chained_operators is false" do
+          config_override :and_chained_operators, false
+
+          it "overrides the $elemMatch expression" do
+            expect(selection.selector).to eq({
+              "users" => { "$elemMatch" => { state: "new" }}
+            })
+          end
         end
 
         it "returns a cloned query" do
@@ -989,10 +1033,25 @@ describe Mongoid::Criteria::Queryable::Selectable do
           query.gte(first: 10).gte(first: 15)
         end
 
-        it "overwrites the first $gte selector" do
-          expect(selection.selector).to eq({
-            "first" =>  { "$gte" => 15 }
-          })
+        context "when and_chained_operators is true" do
+          config_override :and_chained_operators, true
+
+          it "adds a second $gte selector" do
+            expect(selection.selector).to eq({
+              "first" =>  { "$gte" => 10 },
+              "$and" => [ { "first" => { "$gte" => 15 } } ]
+            })
+          end
+        end
+
+        context "when and_chained_operators is false" do
+          config_override :and_chained_operators, false
+
+          it "overwrites the first $gte selector" do
+            expect(selection.selector).to eq({
+              "first" =>  { "$gte" => 15 }
+            })
+          end
         end
 
         it "returns a cloned query" do
@@ -1166,10 +1225,25 @@ describe Mongoid::Criteria::Queryable::Selectable do
           query.lt(first: 10).lt(first: 15)
         end
 
-        it "overwrites the first $lt selector" do
-          expect(selection.selector).to eq({
-            "first" =>  { "$lt" => 15 }
-          })
+        context "when and_chained_operators is true" do
+          config_override :and_chained_operators, true
+
+          it "adds a second $lt selector" do
+            expect(selection.selector).to eq({
+              "first" =>  { "$lt" => 10 },
+              "$and" => [ { "first" => { "$lt" => 15 } } ]
+            })
+          end
+        end
+
+        context "when and_chained_operators is false" do
+          config_override :and_chained_operators, false
+
+          it "overwrites the first $lt selector" do
+            expect(selection.selector).to eq({
+              "first" =>  { "$lt" => 15 }
+            })
+          end
         end
 
         it "returns a cloned query" do
@@ -1250,10 +1324,25 @@ describe Mongoid::Criteria::Queryable::Selectable do
           query.lte(first: 10).lte(first: 15)
         end
 
-        it "overwrites the first $lte selector" do
-          expect(selection.selector).to eq({
-            "first" =>  { "$lte" => 15 }
-          })
+        context "when and_chained_operators is true" do
+          config_override :and_chained_operators, true
+
+          it "adds a second $lte selector" do
+            expect(selection.selector).to eq({
+              "first" =>  { "$lte" => 10 },
+              "$and" => [ { "first" => { "$lte" => 15 } } ]
+            })
+          end
+        end
+
+        context "when and_chained_operators is false" do
+          config_override :and_chained_operators, false
+
+          it "overwrites the first $lte selector" do
+            expect(selection.selector).to eq({
+              "first" =>  { "$lte" => 15 }
+            })
+          end
         end
 
         it "returns a cloned query" do

--- a/spec/mongoid/criteria/queryable/selectable_spec.rb
+++ b/spec/mongoid/criteria/queryable/selectable_spec.rb
@@ -575,11 +575,26 @@ describe Mongoid::Criteria::Queryable::Selectable do
             elem_match(comments: { text: "value" })
         end
 
-        it "adds the $elemMatch expression" do
-          expect(selection.selector).to eq({
-            "users" => { "$elemMatch" => { "name" => "value" }},
-            "comments" => { "$elemMatch" => { "text" => "value" }}
-          })
+        context "when and_chained_operators is, true" do
+          config_override :and_chained_operators, true
+
+          it "adds the $elemMatch expression" do
+            expect(selection.selector).to eq({
+              "users" => { "$elemMatch" => { "name" => "value" }},
+              "comments" => { "$elemMatch" => { "text" => "value" }}
+            })
+          end
+        end
+
+        context "when and_chained_operators is, false" do
+          config_override :and_chained_operators, false
+
+          it "adds the $elemMatch expression" do
+            expect(selection.selector).to eq({
+              "users" => { "$elemMatch" => { name: "value" }},
+              "comments" => { "$elemMatch" => { text: "value" }}
+            })
+          end
         end
 
         it "returns a cloned query" do

--- a/spec/mongoid/criteria/queryable/selectable_spec.rb
+++ b/spec/mongoid/criteria/queryable/selectable_spec.rb
@@ -479,8 +479,8 @@ describe Mongoid::Criteria::Queryable::Selectable do
           query.elem_match(users: { name: "value" })
         end
 
-        context "when and_chained_operators is true" do
-          config_override :and_chained_operators, true
+        context "when overwrite_chained_operators is false" do
+          config_override :overwrite_chained_operators, false
 
           it "adds the $elemMatch expression" do
             expect(selection.selector).to eq({
@@ -489,8 +489,8 @@ describe Mongoid::Criteria::Queryable::Selectable do
           end
         end
 
-        context "when and_chained_operators is false" do
-          config_override :and_chained_operators, false
+        context "when overwrite_chained_operators is true" do
+          config_override :overwrite_chained_operators, true
 
           it "adds the $elemMatch expression" do
             expect(selection.selector).to eq({
@@ -537,8 +537,8 @@ describe Mongoid::Criteria::Queryable::Selectable do
           )
         end
 
-        context "when and_chained_operators is true" do
-          config_override :and_chained_operators, true
+        context "when overwrite_chained_operators is false" do
+          config_override :overwrite_chained_operators, false
 
           it "adds the $elemMatch expression" do
             expect(selection.selector).to eq({
@@ -548,8 +548,8 @@ describe Mongoid::Criteria::Queryable::Selectable do
           end
         end
 
-        context "when and_chained_operators is true" do
-          config_override :and_chained_operators, false
+        context "when overwrite_chained_operators is true" do
+          config_override :overwrite_chained_operators, true
 
           it "adds the $elemMatch expression" do
             expect(selection.selector).to eq({
@@ -575,8 +575,8 @@ describe Mongoid::Criteria::Queryable::Selectable do
             elem_match(comments: { text: "value" })
         end
 
-        context "when and_chained_operators is, true" do
-          config_override :and_chained_operators, true
+        context "when overwrite_chained_operators is false" do
+          config_override :overwrite_chained_operators, false
 
           it "adds the $elemMatch expression" do
             expect(selection.selector).to eq({
@@ -586,8 +586,8 @@ describe Mongoid::Criteria::Queryable::Selectable do
           end
         end
 
-        context "when and_chained_operators is, false" do
-          config_override :and_chained_operators, false
+        context "when overwrite_chained_operators is true" do
+          config_override :overwrite_chained_operators, true
 
           it "adds the $elemMatch expression" do
             expect(selection.selector).to eq({
@@ -610,8 +610,8 @@ describe Mongoid::Criteria::Queryable::Selectable do
             elem_match(users: { state: "new" })
         end
 
-        context "when and_chained_operators is true" do
-          config_override :and_chained_operators, true
+        context "when overwrite_chained_operators is false" do
+          config_override :overwrite_chained_operators, false
 
           it "adds an $elemMatch expression" do
             expect(selection.selector).to eq({
@@ -621,8 +621,8 @@ describe Mongoid::Criteria::Queryable::Selectable do
           end
         end
 
-        context "when and_chained_operators is false" do
-          config_override :and_chained_operators, false
+        context "when overwrite_chained_operators is true" do
+          config_override :overwrite_chained_operators, true
 
           it "overrides the $elemMatch expression" do
             expect(selection.selector).to eq({
@@ -938,8 +938,8 @@ describe Mongoid::Criteria::Queryable::Selectable do
 
       context "when the criterion are on the same field" do
 
-        context "when and_chained_operators is false" do
-          config_override :and_chained_operators, false
+        context "when overwrite_chained_operators is true" do
+          config_override :overwrite_chained_operators, true
 
           let(:selection) do
             query.gt(first: 10).gt(first: 15)
@@ -956,8 +956,8 @@ describe Mongoid::Criteria::Queryable::Selectable do
           end
         end
 
-        context "when and_chained_operators is true" do
-          config_override :and_chained_operators, true
+        context "when overwrite_chained_operators is false" do
+          config_override :overwrite_chained_operators, false
           let(:selection) do
             query.gt(first: 10).gt(first: 15)
           end
@@ -1048,8 +1048,8 @@ describe Mongoid::Criteria::Queryable::Selectable do
           query.gte(first: 10).gte(first: 15)
         end
 
-        context "when and_chained_operators is true" do
-          config_override :and_chained_operators, true
+        context "when overwrite_chained_operators is false" do
+          config_override :overwrite_chained_operators, false
 
           it "adds a second $gte selector" do
             expect(selection.selector).to eq({
@@ -1059,8 +1059,8 @@ describe Mongoid::Criteria::Queryable::Selectable do
           end
         end
 
-        context "when and_chained_operators is false" do
-          config_override :and_chained_operators, false
+        context "when overwrite_chained_operators is true" do
+          config_override :overwrite_chained_operators, true
 
           it "overwrites the first $gte selector" do
             expect(selection.selector).to eq({
@@ -1240,8 +1240,8 @@ describe Mongoid::Criteria::Queryable::Selectable do
           query.lt(first: 10).lt(first: 15)
         end
 
-        context "when and_chained_operators is true" do
-          config_override :and_chained_operators, true
+        context "when overwrite_chained_operators is false" do
+          config_override :overwrite_chained_operators, false
 
           it "adds a second $lt selector" do
             expect(selection.selector).to eq({
@@ -1251,8 +1251,8 @@ describe Mongoid::Criteria::Queryable::Selectable do
           end
         end
 
-        context "when and_chained_operators is false" do
-          config_override :and_chained_operators, false
+        context "when overwrite_chained_operators is true" do
+          config_override :overwrite_chained_operators, true
 
           it "overwrites the first $lt selector" do
             expect(selection.selector).to eq({
@@ -1339,8 +1339,8 @@ describe Mongoid::Criteria::Queryable::Selectable do
           query.lte(first: 10).lte(first: 15)
         end
 
-        context "when and_chained_operators is true" do
-          config_override :and_chained_operators, true
+        context "when overwrite_chained_operators is false" do
+          config_override :overwrite_chained_operators, false
 
           it "adds a second $lte selector" do
             expect(selection.selector).to eq({
@@ -1350,8 +1350,8 @@ describe Mongoid::Criteria::Queryable::Selectable do
           end
         end
 
-        context "when and_chained_operators is false" do
-          config_override :and_chained_operators, false
+        context "when overwrite_chained_operators is true" do
+          config_override :overwrite_chained_operators, true
 
           it "overwrites the first $lte selector" do
             expect(selection.selector).to eq({
@@ -2413,7 +2413,7 @@ describe Mongoid::Criteria::Queryable::Selectable do
     end
   end
 
-  describe "Mongoid.and_chained_operators" do
+  describe "Mongoid.overwrite_chained_operators" do
     [ :eq, :elem_match, :gt, :gte, :lt, :lte, :mod, :ne, :near, :near_sphere ].each do |meth|
 
       context "when chaining the #{meth} method when using the same field" do
@@ -2436,8 +2436,8 @@ describe Mongoid::Criteria::Queryable::Selectable do
           Band.send(meth, {views: 1}).send(meth, {views:2})
         end
 
-        context "when and_chained_operators is false" do
-          config_override :and_chained_operators, false
+        context "when overwrite_chained_operators is true" do
+          config_override :overwrite_chained_operators, true
 
           it "overrides the previous operators" do
             expect(criteria.selector).to eq({
@@ -2446,8 +2446,8 @@ describe Mongoid::Criteria::Queryable::Selectable do
           end
         end
 
-        context "when and_chained_operators is true" do
-          config_override :and_chained_operators, true
+        context "when overwrite_chained_operators is false" do
+          config_override :overwrite_chained_operators, false
 
           it "overrides the previous operators" do
             expect(criteria.selector).to eq({

--- a/spec/mongoid/criteria/queryable/selectable_spec.rb
+++ b/spec/mongoid/criteria/queryable/selectable_spec.rb
@@ -2313,7 +2313,7 @@ describe Mongoid::Criteria::Queryable::Selectable do
     [ :eq, :gt, :gte, :lt, :lte, :mod, :ne, :near, :near_sphere ].each do |meth|
 
       context "when chaining the #{meth} method when using the same field" do
-        let(:operator_map) do
+        let(:op) do
           {
             eq: "$eq",
             gt: "$gt",
@@ -2324,14 +2324,12 @@ describe Mongoid::Criteria::Queryable::Selectable do
             ne: "$ne",
             near: "$near",
             near_sphere: "$nearSphere"
-          }
+          }[meth]
         end
 
         let(:criteria) do
           Band.send(meth, {views: 1}).send(meth, {views:2})
         end
-
-        let(:op) { operator_map[meth] }
 
         context "when and_chained_operators is false" do
           config_override :and_chained_operators, false

--- a/spec/mongoid/criteria/queryable/selectable_spec.rb
+++ b/spec/mongoid/criteria/queryable/selectable_spec.rb
@@ -885,7 +885,8 @@ describe Mongoid::Criteria::Queryable::Selectable do
 
         it "overwrites the first $gt selector" do
           expect(selection.selector).to eq({
-            "first" => { "$gt" => 15 }
+            "first" => { "$gt" => 10 },
+            "$and" => [{ "first" => { "$gt" => 15 } }]
           })
         end
 

--- a/spec/mongoid/criteria_spec.rb
+++ b/spec/mongoid/criteria_spec.rb
@@ -1107,18 +1107,6 @@ describe Mongoid::Criteria do
     it "returns the matching documents" do
       expect(criteria).to eq([ match ])
     end
-
-    context "when duplicating gt conditions with different values" do
-      let(:criteria) do
-        Person.gt(age: 2).gt(age: 1)
-      end
-
-      it 'does not duplicate criteria' do
-        expect(criteria.selector).to eq(
-          "age" => { "$gt" => 2 }, "$and" => [ { "age" => { "$gt" => 1 } } ]
-        )
-      end
-    end
   end
 
   describe "#gte" do

--- a/spec/mongoid/criteria_spec.rb
+++ b/spec/mongoid/criteria_spec.rb
@@ -1114,7 +1114,6 @@ describe Mongoid::Criteria do
       end
 
       it 'does not duplicate criteria' do
-        pending "MONGOID-5330"
         expect(criteria.selector).to eq(
           "age" => { "$gt" => 2 }, "$and" => [ { "age" => { "$gt" => 1 } } ]
         )

--- a/spec/mongoid/criteria_spec.rb
+++ b/spec/mongoid/criteria_spec.rb
@@ -1114,6 +1114,7 @@ describe Mongoid::Criteria do
       end
 
       it 'does not duplicate criteria' do
+        pending "MONGOID-5330"
         expect(criteria.selector).to eq(
           "age" => { "$gt" => 2 }, "$and" => [ { "age" => { "$gt" => 1 } } ]
         )

--- a/spec/mongoid/criteria_spec.rb
+++ b/spec/mongoid/criteria_spec.rb
@@ -1107,6 +1107,18 @@ describe Mongoid::Criteria do
     it "returns the matching documents" do
       expect(criteria).to eq([ match ])
     end
+
+    context "when duplicating gt conditions with different values" do
+      let(:criteria) do
+        Person.gt(age: 2).gt(age: 1)
+      end
+
+      it 'does not duplicate criteria' do
+        expect(criteria.selector).to eq(
+          "age" => { "$gt" => 2 }, "$and" => [ { "age" => { "$gt" => 1 } } ]
+        )
+      end
+    end
   end
 
   describe "#gte" do


### PR DESCRIPTION
This PR changes certain functions to combine using $and instead of replacement. For example, given the following query: 
```
Person.gt(age: 2).gt(age: 1)
```
We currently get:
```
{"age"=>{"$gt"=>1}}
```
And we should expect:
```
{"age"=>{"$gt"=>2}, "$and"=>[{"age"=>{"$gt"=>1}}]}
```
Now, I have enumerated the functions below that I believe require this change, and I have also added a list of functions that I believe should not get this change. 

Functions to fix:
- gt
- gte
- lt
- lte
- ne
- near 
- near_sphere 
- eq
- mod
- elem_match

Note that these functions all currently use the ``__override__`` strategy when adding to the criteria.

No longer doing: 

Previously, I thought to not make this change for `eq` and `mod` for the following reason:

> The logic behind the list of functions to _not_ fix is that, these functions don't make sense to combine with an `and`. For example, combining two `eq` clauses together with an `and` will almost always cause no results to be returned. (I'm trying to think of a situation were two `eq`s combined with an `and` return results, but I can't think of one).

Johnny has provided a use case for anding eq and mod below, so I have included them.