### PR TITLE
MONGOID-5341: Remove :drop_dups option from index macro

### DIFF
--- a/docs/reference/indexes.txt
+++ b/docs/reference/indexes.txt
@@ -61,39 +61,6 @@ Indexes can be sparse:
       index({ ssn: -1 }, { sparse: true })
     end
 
-*Deprecated:* In MongoDB 4.0 and earlier, users could control whether to build indexes
-in the foreground (blocking) or background (non-blocking, but less efficient) using the
-``background`` option.
-
-.. code-block:: ruby
-
-    class Person
-      include Mongoid::Document
-      field :ssn
-      index({ ssn: 1 }, { unique: true, background: true })
-    end
-
-The default value of ``background`` is controlled by Mongoid's
-``background_indexing`` :ref:`configuration option <configuration-options>`.
-
-The ``background`` option has `no effect as of MongoDB 4.2
-<https://www.mongodb.com/docs/manual/core/index-creation/#comparison-to-foreground-and-background-builds>`_.
-
-*Deprecated:* When using MongoDB 2.6, you can drop the duplicate entries
-for unique indexes that are defined for a column that might
-already have duplicate values by specifying the ``drop_dups`` option:
-
-.. code-block:: ruby
-
-    class Person
-      include Mongoid::Document
-      field :ssn
-      index({ ssn: 1 }, { unique: true, drop_dups: true })
-    end
-
-The ``drop_dups`` option has been `removed as of MongoDB 3.0
-<https://mongodb.com/docs/manual/release-notes/3.0-compatibility/#remove-dropdups-option>`_.
-
 For geospatial indexes, make sure the field being indexed is of type Array:
 
 .. code-block:: ruby
@@ -125,6 +92,25 @@ This only works on the association macro that the foreign key is stored on:
       belongs_to :post, index: true
       has_and_belongs_to_many :preferences, index: true
     end
+
+*Deprecated:* In MongoDB 4.0 and earlier, users could control whether to build indexes
+in the foreground (blocking) or background (non-blocking, but less efficient) using the
+``background`` option.
+
+.. code-block:: ruby
+
+    class Person
+      include Mongoid::Document
+      field :ssn
+      index({ ssn: 1 }, { unique: true, background: true })
+    end
+
+The default value of ``background`` is controlled by Mongoid's
+``background_indexing`` :ref:`configuration option <configuration-options>`.
+
+The ``background`` option has `no effect as of MongoDB 4.2
+<https://www.mongodb.com/docs/manual/core/index-creation/#comparison-to-foreground-and-background-builds>`_.
+
 
 Index Management Rake Tasks
 ===========================

--- a/docs/release-notes/mongoid-8.0.txt
+++ b/docs/release-notes/mongoid-8.0.txt
@@ -303,6 +303,13 @@ Mongoid 7 behavior:
   end
 
 
+Removed ``:drop_dups`` Option from Indexes
+------------------------------------------
+
+The ``:drop_dups`` option has been removed from the ``index`` macro. This option
+was specific to MongoDB server 2.6 and earlier, which Mongoid no longer supports.
+
+
 Removed ``Document#to_a`` Method
 --------------------------------
 

--- a/lib/config/locales/en.yml
+++ b/lib/config/locales/en.yml
@@ -195,7 +195,6 @@ en:
             Valid options are:\n
             \_\_background: true|false\n
             \_\_database: 'database_name'\n
-            \_\_drop_dups: true|false\n
             \_\_name: 'index_name'\n
             \_\_sparse: true|false\n
             \_\_unique: true|false\n

--- a/lib/mongoid/indexable/specification.rb
+++ b/lib/mongoid/indexable/specification.rb
@@ -86,7 +86,7 @@ module Mongoid
       # @api private
       #
       # @example Normalize the index options.
-      #   specification.normalize_options(drop_dups: true)
+      #   specification.normalize_options(unique: true)
       #
       # @param [ Hash ] opts The index options.
       #

--- a/lib/mongoid/indexable/validators/options.rb
+++ b/lib/mongoid/indexable/validators/options.rb
@@ -13,7 +13,6 @@ module Mongoid
           :database,
           :default_language,
           :language_override,
-          :drop_dups,
           :name,
           :sparse,
           :unique,

--- a/spec/mongoid/indexable/specification_spec.rb
+++ b/spec/mongoid/indexable/specification_spec.rb
@@ -85,7 +85,7 @@ describe Mongoid::Indexable::Specification do
         Band,
         { name: 1, title: 1, years: -1 },
         background: true,
-        drop_dups: true
+        unique: true
       )
     end
 
@@ -98,7 +98,7 @@ describe Mongoid::Indexable::Specification do
     end
 
     it "normalizes the options" do
-      expect(spec.options).to eq(background: true, drop_dups: true)
+      expect(spec.options).to eq(background: true, unique: true)
     end
   end
 

--- a/spec/mongoid/indexable_spec.rb
+++ b/spec/mongoid/indexable_spec.rb
@@ -262,21 +262,6 @@ describe Mongoid::Indexable do
       end
     end
 
-    context "when providing a drop_dups option" do
-
-      before do
-        klass.index({ name: 1 }, drop_dups: true)
-      end
-
-      let(:options) do
-        klass.index_specification(name: 1).options
-      end
-
-      it "sets the index with drop_dups option" do
-        expect(options).to eq(drop_dups: true)
-      end
-    end
-
     context "when providing a sparse option" do
 
       before do


### PR DESCRIPTION
Mongoid 8.0 supports MongoDB server version 3.6+. `:drop_dups` was removed in MongoDB server version 3.0.
