### PR TITLE
MONGOID-5352 assign_attributes is working incorrectly since 7.3.4

### DIFF
--- a/lib/mongoid/association/embedded/batchable.rb
+++ b/lib/mongoid/association/embedded/batchable.rb
@@ -248,9 +248,9 @@ module Mongoid
           end
         end
 
-        # Retrieve the path and invalidate the cache afterwards. This method
-        # is used for when the association has not been set on the document
-        # yet, which can cause path and atomic_paths to be calculated
+        # Clear the cache for path and atomic_paths. This method is used when
+        # the path method is used, and the association has not been set on the
+        # document yet, which can cause path and atomic_paths to be calculated
         # incorrectly later.
         #
         # @api private

--- a/lib/mongoid/association/embedded/batchable.rb
+++ b/lib/mongoid/association/embedded/batchable.rb
@@ -97,7 +97,7 @@ module Mongoid
             _base.delayed_atomic_sets.clear unless _assigning?
             docs = normalize_docs(docs).compact
             _target.clear and _unscoped.clear
-            _base.delayed_atomic_unsets.clear unless _assigning?
+            _base.delayed_atomic_unsets.delete(path)
             inserts = execute_batch_set(docs)
             add_atomic_sets(inserts)
           end

--- a/lib/mongoid/association/embedded/batchable.rb
+++ b/lib/mongoid/association/embedded/batchable.rb
@@ -239,10 +239,11 @@ module Mongoid
         #
         # @return [ String ] The atomic path.
         def path
-          @path ||= if _unscoped.empty?
+          return @path if @path
+          if _unscoped.empty?
             Mongoid::Atomic::Paths::Embedded::Many.position_without_document(_base, _association)
           else
-            _unscoped.first.atomic_path
+            @path = _unscoped.first.atomic_path
           end
         end
 

--- a/lib/mongoid/association/embedded/batchable.rb
+++ b/lib/mongoid/association/embedded/batchable.rb
@@ -85,7 +85,7 @@ module Mongoid
         def batch_replace(docs)
           if docs.blank?
             if _assigning? && !empty?
-              _base.delayed_atomic_sets.clear
+              _base.delayed_atomic_sets.clear unless _assigning?
               _base.add_atomic_unset(first)
               target_duplicate = _target.dup
               pre_process_batch_remove(target_duplicate, :delete)
@@ -97,7 +97,7 @@ module Mongoid
             _base.delayed_atomic_sets.clear unless _assigning?
             docs = normalize_docs(docs).compact
             _target.clear and _unscoped.clear
-            _base.delayed_atomic_unsets.clear
+            _base.delayed_atomic_unsets.clear unless _assigning?
             inserts = execute_batch_set(docs)
             add_atomic_sets(inserts)
           end

--- a/lib/mongoid/association/embedded/batchable.rb
+++ b/lib/mongoid/association/embedded/batchable.rb
@@ -85,7 +85,7 @@ module Mongoid
         def batch_replace(docs)
           if docs.blank?
             if _assigning? && !empty?
-              _base.delayed_atomic_sets.clear unless _assigning?
+              _base.delayed_atomic_sets.delete(path)
               _base.add_atomic_unset(first)
               target_duplicate = _target.dup
               pre_process_batch_remove(target_duplicate, :delete)

--- a/lib/mongoid/atomic/paths/embedded/many.rb
+++ b/lib/mongoid/atomic/paths/embedded/many.rb
@@ -50,10 +50,6 @@ module Mongoid
             # @return [ String ] The position string.
             def position_without_document(parent, association)
               pos = parent.atomic_position
-              # Clear the cache here since this method can be called before the
-              # associations are set, which can cause the atomic paths to be
-              # calculated incorrectly later.
-              parent.instance_variable_set("@atomic_paths", nil)
               "#{pos}#{"." unless pos.blank?}#{association.store_as}"
             end
           end

--- a/lib/mongoid/atomic/paths/embedded/many.rb
+++ b/lib/mongoid/atomic/paths/embedded/many.rb
@@ -50,6 +50,10 @@ module Mongoid
             # @return [ String ] The position string.
             def position_without_document(parent, association)
               pos = parent.atomic_position
+              # Clear the cache here since this method can be called before the
+              # associations are set, which can cause the atomic paths to be
+              # calculated incorrectly later.
+              parent.instance_variable_set("@atomic_paths", nil)
               "#{pos}#{"." unless pos.blank?}#{association.store_as}"
             end
           end

--- a/spec/mongoid/association/embedded/embeds_many/proxy_spec.rb
+++ b/spec/mongoid/association/embedded/embeds_many/proxy_spec.rb
@@ -4706,11 +4706,11 @@ describe Mongoid::Association::Embedded::EmbedsMany::Proxy do
     before do
       post.assign_attributes(company_tags: [{id: BSON::ObjectId.new, title: 'a'}],
         user_tags: [{id: BSON::ObjectId.new, title: 'b'}])
-      post.save
+      post.save!
       post.reload
       post.assign_attributes(company_tags: [{id: BSON::ObjectId.new, title: 'c'}],
         user_tags: [])
-      post.save
+      post.save!
       post.reload
     end
 

--- a/spec/mongoid/association/embedded/embeds_many/proxy_spec.rb
+++ b/spec/mongoid/association/embedded/embeds_many/proxy_spec.rb
@@ -4699,4 +4699,24 @@ describe Mongoid::Association::Embedded::EmbedsMany::Proxy do
       end
     end
   end
+
+  context "when using assign_attributes with an already populated array" do
+    let(:post) { EmmPost.create! }
+
+    before do
+      post.assign_attributes(company_tags: [{id: BSON::ObjectId.new, title: 'a'}],
+        user_tags: [{id: BSON::ObjectId.new, title: 'b'}])
+      post.save
+      post.reload
+      post.assign_attributes(company_tags: [{id: BSON::ObjectId.new, title: 'c'}],
+        user_tags: [])
+      post.save
+      post.reload
+    end
+
+    it "has the correct embedded documents" do
+      expect(post.company_tags.length).to eq(1)
+      expect(post.company_tags.first.title).to eq("c")
+    end
+  end
 end

--- a/spec/mongoid/association/embedded/embeds_many_models.rb
+++ b/spec/mongoid/association/embedded/embeds_many_models.rb
@@ -162,3 +162,29 @@ class EmmHatch
   # No :class_name option on this association intentionally.
   embedded_in :tank
 end
+
+class EmmPost
+  include Mongoid::Document
+
+  embeds_many :company_tags, class_name: "EmmCompanyTag"
+  embeds_many :user_tags, class_name: "EmmUserTag"
+end
+
+
+class EmmCompanyTag
+  include Mongoid::Document
+
+  field :title, type: String
+
+  embedded_in :post, class_name: "EmmPost"
+end
+
+
+class EmmUserTag
+  include Mongoid::Document
+
+  field :title, type: String
+
+  embedded_in :post, class_name: "EmmPost"
+end
+


### PR DESCRIPTION
MONGOID-5352

Should we backport this to 7.3-stable and 7.4-stable?

CI failure are unrelated and appear on other PRs