### PR TITLE
MONGOID-3624 read_attribute_for_validation uses getter

### DIFF
--- a/lib/mongoid/validatable.rb
+++ b/lib/mongoid/validatable.rb
@@ -69,7 +69,7 @@ module Mongoid
       elsif fields[attribute].try(:localized?)
         attributes[attribute]
       else
-        send(attr)
+        read_attribute(attr)
       end
     end
 

--- a/spec/mongoid/validatable_spec.rb
+++ b/spec/mongoid/validatable_spec.rb
@@ -62,6 +62,21 @@ describe Mongoid::Validatable do
         expect(value).to be_empty
       end
     end
+
+    context "when validating a mongoizable field" do
+
+      let(:princess) do
+        Princess.new(family: :fam)
+      end
+
+      let(:value) do
+        princess.read_attribute_for_validation(:family)
+      end
+
+      it "validates the demongoized value" do
+        expect(value).to eq(:fam)
+      end
+    end
   end
 
   describe "#valid?" do

--- a/spec/support/models/princess.rb
+++ b/spec/support/models/princess.rb
@@ -4,6 +4,8 @@ class Princess
   include Mongoid::Document
   field :primary_color
   field :name, type: String
+  field :family, type: StringifiedSymbol
+
   def color
     primary_color.to_s
   end


### PR DESCRIPTION
The user's issue in this case was that `read_attribute_for_validation` uses the getter, and they were suggesting a work around. I misunderstood this to mean that they wanted this method to work with mongoized instead of demongoized values, whereas they just didn't want us to use the getter, so that they can override it.

In this PR, I change `read_attribute_for_validation` to not use the getter, but still validate on the demongoized value.