### PR TITLE
MONGOID-5360 Warn when defining field types of BSON::Int64/Decimal128 and other unsupported types

### DIFF
--- a/docs/reference/fields.txt
+++ b/docs/reference/fields.txt
@@ -89,6 +89,13 @@ Mongoid also recognizes the string ``"Boolean"`` as an alias for the
 
 To define custom field types, refer to :ref:`Custom Field Types <custom-field-types>` below.
 
+.. note::
+
+  Using the other ``BSON::*`` types as field types is unsupported. Saving these
+  types to the database will work as expected, however, querying them will
+  return the corresponding native Ruby types. Querying fields
+  of type ``BSON::Decimal128`` will return values of type ``BSON::Decimal128`` in
+  BSON <=4 and values of type ``BigDecimal`` in BSON 5+.
 
 .. _omitting-field-type-definition:
 


### PR DESCRIPTION
Here are the warnings that are generated:
```
W, [2022-05-26T12:38:31.842319 #88974]  WARN -- : Using BSON classes, like BSON::Decimal128, as the field type is not supported. In 
BSON <=4, the BSON::Decimal128 type will work as expected for both storing and querying, but will return a BigDecimal on query in 
BSON 5+.
W, [2022-05-26T12:38:31.842455 #88974]  WARN -- : Using BSON classes, like BSON::Int64, as the field type is not supported. Saving 
these types to the database will work as expected, however, querying them will return the corresponding native Ruby types.
``` 
# ------------------------ >8 ------------------------ # Do not modify or remove the line above.
# Everything below it will be ignored.

Requesting a pull to mongodb:master from Neilshweky:MONGOID-5360

Write a message for this pull request. The first block
of text is the title and the rest is the description.