### PR TITLE
MONGOID-5077 DocumentNotFound message fails to account for shard key

### DIFF
--- a/lib/config/locales/en.yml
+++ b/lib/config/locales/en.yml
@@ -72,6 +72,17 @@ en:
           resolution: "Search for attributes that are in the database or set
             the Mongoid.raise_not_found_error configuration option to false,
             which will cause a nil to be returned instead of raising this error."
+        document_with_shard_key_not_found:
+          message: "Document not found for class %{klass} with id %{missing} and
+            shard key %{shard_key}."
+          summary: "When calling %{klass}.find with an id and a shard key, each
+            parameter must match a document in the database or this error will
+            be raised. The search was for the id: %{missing} with
+            shard_key: %{shard_key} and it was not found."
+          resolution: "Search for an id/shard key that is in the database or set
+            the Mongoid.raise_not_found_error configuration option to false,
+            which will cause a nil to be returned instead of raising this error when
+            searching for a single document."
         empty_config_file:
           message: "Empty configuration file: %{path}."
           summary: "Your mongoid.yml configuration file appears to be empty."

--- a/lib/config/locales/en.yml
+++ b/lib/config/locales/en.yml
@@ -81,8 +81,7 @@ en:
             shard_key: %{shard_key} and it was not found."
           resolution: "Search for an id/shard key that is in the database or set
             the Mongoid.raise_not_found_error configuration option to false,
-            which will cause a nil to be returned instead of raising this error when
-            searching for a single document."
+            which will cause a nil to be returned instead of raising this error."
         empty_config_file:
           message: "Empty configuration file: %{path}."
           summary: "Your mongoid.yml configuration file appears to be empty."

--- a/lib/mongoid/errors/document_not_found.rb
+++ b/lib/mongoid/errors/document_not_found.rb
@@ -74,8 +74,6 @@ module Mongoid
       def searched(params)
         if params.is_a?(::Array)
           params.take(3).join(", ") + " ..."
-        elsif params.is_a?(::Hash)
-          params[:_id] || params["_id"]
         else
           params
         end

--- a/lib/mongoid/errors/document_not_found.rb
+++ b/lib/mongoid/errors/document_not_found.rb
@@ -111,7 +111,7 @@ module Mongoid
 
       # Get the shard key from the unmatched hash.
       #
-      # @return [ String ] the shard key and value
+      # @return [ String ] the shard key and value.
       def shard_key(unmatched)
         if Hash === unmatched
           h = unmatched.dup

--- a/lib/mongoid/errors/document_not_found.rb
+++ b/lib/mongoid/errors/document_not_found.rb
@@ -20,7 +20,8 @@ module Mongoid
       #
       # @param [ Class ] klass The model class.
       # @param [ Hash, Array, Object ] params The attributes or ids.
-      # @param [ Array ] unmatched The unmatched ids, if appropriate
+      # @param [ Array, Hash ] unmatched The unmatched ids, if appropriate. If
+      #   there is a shard key this will be a hash.
       def initialize(klass, params, unmatched = nil)
         if !unmatched && !params.is_a?(Hash)
           unmatched = Array(params)
@@ -29,13 +30,14 @@ module Mongoid
         @klass, @params = klass, params
         super(
           compose_message(
-            message_key(params),
+            message_key(params, unmatched),
             {
               klass: klass.name,
               searched: searched(params),
               attributes: params,
               total: total(params),
-              missing: missing(unmatched)
+              missing: missing(unmatched),
+              shard_key: shard_key(unmatched)
             }
           )
         )
@@ -54,6 +56,8 @@ module Mongoid
       def missing(unmatched)
         if unmatched.is_a?(::Array)
           unmatched.join(", ")
+        elsif unmatched.is_a?(::Hash)
+          unmatched[:_id] || unmatched["_id"]
         else
           unmatched
         end
@@ -70,6 +74,8 @@ module Mongoid
       def searched(params)
         if params.is_a?(::Array)
           params.take(3).join(", ") + " ..."
+        elsif params.is_a?(::Hash)
+          params[:_id] || params["_id"]
         else
           params
         end
@@ -93,10 +99,25 @@ module Mongoid
       #   error.problem
       #
       # @return [ String ] The problem.
-      def message_key(params)
-        case params
-          when Hash then "document_with_attributes_not_found"
-          else "document_not_found"
+      def message_key(params, unmatched)
+        if Hash === params && !unmatched
+            "document_with_attributes_not_found"
+        elsif Hash === params && params.size >= 2
+          "document_with_shard_key_not_found"
+        else
+          "document_not_found"
+        end
+      end
+
+      # Get the shard key from the unmatched hash.
+      #
+      # @return [ String ] the shard key and value
+      def shard_key(unmatched)
+        if Hash === unmatched
+          h = unmatched.dup
+          h.delete("_id")
+          h.delete(:_id)
+          "#{h.keys.first}: #{h.values.first}"
         end
       end
     end

--- a/lib/mongoid/errors/document_not_found.rb
+++ b/lib/mongoid/errors/document_not_found.rb
@@ -100,9 +100,9 @@ module Mongoid
       #
       # @return [ String ] The problem.
       def message_key(params, unmatched)
-        if Hash === params && !unmatched
-            "document_with_attributes_not_found"
-        elsif Hash === params && params.size >= 2
+        if Hash === params
+          "document_with_attributes_not_found"
+        elsif Hash === unmatched && unmatched.size >= 2
           "document_with_shard_key_not_found"
         else
           "document_not_found"
@@ -117,7 +117,7 @@ module Mongoid
           h = unmatched.dup
           h.delete("_id")
           h.delete(:_id)
-          "#{h.keys.first}: #{h.values.first}"
+          h.map{|k,v| "#{k}: #{v}" }.join(", ")
         end
       end
     end

--- a/lib/mongoid/reloadable.rb
+++ b/lib/mongoid/reloadable.rb
@@ -23,7 +23,7 @@ module Mongoid
 
       reloaded = _reload
       if Mongoid.raise_not_found_error && (reloaded.nil? || reloaded.empty?)
-        raise Errors::DocumentNotFound.new(self.class, _id, _id)
+        raise Errors::DocumentNotFound.new(self.class, atomic_selector, atomic_selector)
       end
       @attributes = reloaded
       @attributes_before_type_cast = {}

--- a/lib/mongoid/reloadable.rb
+++ b/lib/mongoid/reloadable.rb
@@ -23,7 +23,8 @@ module Mongoid
 
       reloaded = _reload
       if Mongoid.raise_not_found_error && (reloaded.nil? || reloaded.empty?)
-        raise Errors::DocumentNotFound.new(self.class, atomic_selector, atomic_selector)
+        shard_keys = atomic_selector.with_indifferent_access.slice(*shard_key_fields, :_id)
+        raise Errors::DocumentNotFound.new(self.class, _id, shard_keys)
       end
       @attributes = reloaded
       @attributes_before_type_cast = {}

--- a/spec/mongoid/errors/document_not_found_spec.rb
+++ b/spec/mongoid/errors/document_not_found_spec.rb
@@ -86,7 +86,7 @@ describe Mongoid::Errors::DocumentNotFound do
       let(:id) { BSON::ObjectId.new }
       let(:doc) { { _id: id, a: "syd" } }
       let(:error) do
-        described_class.new(Person, doc, doc)
+        described_class.new(Person, id, doc)
       end
 
       it "contains the problem in the message" do
@@ -111,7 +111,7 @@ describe Mongoid::Errors::DocumentNotFound do
     context "when providing an id in a hash without a shard key" do
 
       let(:error) do
-        described_class.new(Person, { _id: 1 }, { _id: 1 })
+        described_class.new(Person, 1, { _id: 1 })
       end
 
       it "contains the problem in the message" do

--- a/spec/mongoid/errors/document_not_found_spec.rb
+++ b/spec/mongoid/errors/document_not_found_spec.rb
@@ -80,6 +80,58 @@ describe Mongoid::Errors::DocumentNotFound do
         )
       end
     end
+
+    context "when providing an _id and a shard key" do
+
+      let(:id) { BSON::ObjectId.new }
+      let(:doc) { { _id: id, a: "syd" } }
+      let(:error) do
+        described_class.new(Person, doc, doc)
+      end
+
+      it "contains the problem in the message" do
+        expect(error.message).to include(
+          "Document not found for class Person with id #{id.to_s} and shard key a: syd."
+        )
+      end
+
+      it "contains the summary in the message" do
+        expect(error.message).to include(
+          "When calling Person.find with an id and a shard key"
+        )
+      end
+
+      it "contains the resolution in the message" do
+        expect(error.message).to include(
+          "Search for an id/shard key that is in the database or set"
+        )
+      end
+    end
+
+    context "when providing an id in a hash without a shard key" do
+
+      let(:error) do
+        described_class.new(Person, { _id: 1 }, { _id: 1 })
+      end
+
+      it "contains the problem in the message" do
+        expect(error.message).to include(
+          "Document(s) not found for class Person with id(s) 1."
+        )
+      end
+
+      it "contains the summary in the message" do
+        expect(error.message).to include(
+          "When calling Person.find with an id or array of ids"
+        )
+      end
+
+      it "contains the resolution in the message" do
+        expect(error.message).to include(
+          "Search for an id that is in the database or set the"
+        )
+      end
+    end
   end
 
   describe "#params" do


### PR DESCRIPTION
```
message:
  Document not found for class Foo with id 6290f569d1327a17ddfb7ed8 and shard key a: 538.
summary:
  When calling Foo.find with an id and a shard key, each parameter must match a document in the database or this error will be raised. The search was for the id: 6290f569d1327a17ddfb7ed8 with shard_key: a: 538 and it was not found.
resolution:
  Search for an id/shard key that is in the database or set the Mongoid.raise_not_found_error configuration option to false, which will cause a nil to be returned instead of raising this error when searching for a single document.
```