### PR TITLE
MONGOID-4520 Set inverse keys on HABTM relationship when subsequently persisting document

### DIFF
--- a/spec/mongoid/association/syncable_spec.rb
+++ b/spec/mongoid/association/syncable_spec.rb
@@ -497,7 +497,7 @@ describe "Syncable Association" do
     end
   end
 
-  context "when setting one on unpersisted HABTM association" do
+  context "when setting one document on unpersisted HABTM association" do
     let!(:dog) { Dog.create! }
     let!(:breed) { Breed.new }
 

--- a/spec/mongoid/association/syncable_spec.rb
+++ b/spec/mongoid/association/syncable_spec.rb
@@ -503,7 +503,7 @@ describe "Syncable Association" do
 
     before do
       breed.dogs = Dog.all
-      breed.save
+      breed.save!
     end
 
     it "sets the foreign key on the other side" do

--- a/spec/mongoid/association/syncable_spec.rb
+++ b/spec/mongoid/association/syncable_spec.rb
@@ -496,4 +496,18 @@ describe "Syncable Association" do
       expect(dog.reload.breed_ids).to eq([ breed.id ])
     end
   end
+
+  context "when setting one on unpersisted HABTM association" do
+    let!(:dog) { Dog.create! }
+    let!(:breed) { Breed.new }
+
+    before do
+      breed.dogs = Dog.all
+      breed.save
+    end
+
+    it "sets the foreign key on the other side" do
+      expect(dog.reload.breed_ids).to eq([breed._id])
+    end
+  end
 end


### PR DESCRIPTION
MONGOID-4520 

The idea here is that we don't always want to clear the value for the foreign key in the `changed_attributes` hash. There is a situation, when setting the foreign key of a HABTM association on an unpersisted model, when you want the `changed_attributes` hash to contain a value for the foreign key, since:

1) it entered the << method with a value for the foreign key already
2) it is used later in the Syncable module to update the inverse foreign keys

Note that this doesn't really change MONGOID-4843, and all of the tests there still pass after these changes. The core of that ticket was clearing the changes caused by the `reset_unloaded` method and shouldn't necessarily have been getting rid of all presence of the foreign key value in the `changed_attributes` hash. 

Also note that this bug was not caused by MONGOID-4843, it existed before that fix.