### PR TITLE
MONGOID-4811 Output controller runtime stats in milliseconds

### DIFF
--- a/lib/mongoid/railties/controller_runtime.rb
+++ b/lib/mongoid/railties/controller_runtime.rb
@@ -62,7 +62,7 @@ module Mongoid
         def started _; end
 
         def _completed e
-          Collector.runtime += e.duration
+          Collector.runtime += e.duration * 1000
         end
         alias :succeeded :_completed
         alias :failed :_completed

--- a/spec/rails/controller_extension/controller_runtime_spec.rb
+++ b/spec/rails/controller_extension/controller_runtime_spec.rb
@@ -30,11 +30,11 @@ describe "Mongoid::Railties::ControllerRuntime" do
 
       clear_metric!
       instance.succeeded event_payload
-      expect(collector.runtime).to eq(42)
+      expect(collector.runtime).to eq(42000)
 
       clear_metric!
       instance.failed event_payload
-      expect(collector.runtime).to eq(42)
+      expect(collector.runtime).to eq(42000)
     end
 
     it "resets the metric and returns the value" do


### PR DESCRIPTION
For retrieving all posts from the database:
```
> e.duration
# => 0.0004160000244155526 (this is in seconds)
```
Before this change:
```
Completed 200 OK in 73ms (Views: 45.8ms | MongoDB: 0.0ms | Allocations: 54152)
```
After this change:
```
Completed 200 OK in 73ms (Views: 45.8ms | MongoDB: 0.4ms | Allocations: 54152)
```