### PR TITLE
MONGOID-5374 HABTM fails length validation on create when association is not accessed from child

### DIFF
--- a/lib/mongoid/validatable/localizable.rb
+++ b/lib/mongoid/validatable/localizable.rb
@@ -20,6 +20,8 @@ module Mongoid
           value.values.each do |_value|
             super(document, attribute, _value)
           end
+        elsif assoc = document.relations[attribute]
+          super(document, assoc.foreign_key, document.send(assoc.foreign_key))
         else
           super
         end

--- a/spec/mongoid/association/referenced/has_and_belongs_to_many/proxy_spec.rb
+++ b/spec/mongoid/association/referenced/has_and_belongs_to_many/proxy_spec.rb
@@ -3833,4 +3833,15 @@ describe Mongoid::Association::Referenced::HasAndBelongsToMany::Proxy do
       expect(contract.signature_ids).to eq([signature.id])
     end
   end
+
+  context "when there is a minimum length validator" do
+
+    let(:user) { HabtmmUser.create! }
+    let(:post) { user.posts.create! }
+    it "doesn't raise when creating enough documents" do
+      expect do
+        post
+      end.to_not raise_error
+    end
+  end
 end

--- a/spec/mongoid/association/referenced/has_and_belongs_to_many_models.rb
+++ b/spec/mongoid/association/referenced/has_and_belongs_to_many_models.rb
@@ -90,3 +90,13 @@ class HabtmmStudent
   end
 end
 
+class HabtmmUser
+  include Mongoid::Document
+  has_and_belongs_to_many :posts, class_name: "HabtmmPost"
+end
+
+class HabtmmPost
+  include Mongoid::Document
+  has_and_belongs_to_many :users, class_name: "HabtmmUser"
+  validates :users, length: { minimum: 1, maximum: 2 }
+end


### PR DESCRIPTION
Very preliminary PR here. A few things:

1. As per my comment on MONGOID-5374 this PR implements fix #2, which, as discussed there, is not an optimal solution.
2. This solution should be reworked to move the changes somewhere else instead of the Localizable module. This PR is sort of "proof-of-concept" and needs a few changes in order to be ready to merge if this is the direction we would like to go.