### PR TITLE
MONGOID-5369 - Improvements to the Aggregation Pipeline doc page

### DIFF
--- a/docs/reference/aggregation.txt
+++ b/docs/reference/aggregation.txt
@@ -12,8 +12,6 @@ Aggregation Pipeline
    :depth: 2
    :class: singlecol
 
-Aggregation Pipeline Overview
-=============================
 
 Mongoid exposes `MongoDB's aggregation pipeline
 <https://www.mongodb.com/docs/manual/core/aggregation-pipeline/>`_,
@@ -22,10 +20,13 @@ The aggregation pipeline is a superset of the deprecated
 :ref:`map/reduce framework <map-reduce>` functionality.
 
 
+Basic Usage
+===========
+
 .. _aggregation-pipeline-example-multiple-collections:
 
-Example: Querying Across Multiple Collections
-`````````````````````````````````````````````
+Querying Across Multiple Collections
+````````````````````````````````````
 
 The aggregation pipeline may be used for queries involving multiple
 referenced associations at the same time:
@@ -88,8 +89,8 @@ having to send the list of document ids to Mongoid in the second query
 
 .. _aggregation-pipeline-builder-dsl:
 
-Aggregation Pipeline Builder DSL
-================================
+Builder DSL
+===========
 
 Mongoid provides limited support for constructing the aggregation pipeline
 itself using a high-level DSL. The following aggregation pipeline operators

--- a/docs/reference/aggregation.txt
+++ b/docs/reference/aggregation.txt
@@ -12,11 +12,23 @@ Aggregation Pipeline
    :depth: 2
    :class: singlecol
 
+Aggregation Pipeline Overview
+=============================
 
-Mongoid exposes MongoDB's `aggregation pipeline
-<https://mongodb.com/docs/manual/core/aggregation-pipeline/>`_ for queries
-involving multiple referenced associations at the same time. Given the
-following model definitions with referenced associations:
+Mongoid exposes `MongoDB's aggregation pipeline
+<https://www.mongodb.com/docs/manual/core/aggregation-pipeline/>`_,
+which is used to construct flows of operations that process and return results.
+The aggregation pipeline is a superset of the deprecated
+:ref:`map/reduce framework <map-reduce>` functionality.
+
+.. _aggregation-pipeline-example-multiple-collections:
+
+
+Example: Querying Across Multiple Collections
+`````````````````````````````````````````````
+
+The aggregation pipeline may be used for queries involving multiple
+referenced associations at the same time:
 
 .. code-block:: ruby
 
@@ -45,28 +57,28 @@ could do the following:
 .. code-block:: ruby
 
   band_ids = Band.collection.aggregate([
-    {'$lookup' => {
+    { '$lookup' => {
       from: 'tours',
       localField: '_id',
       foreignField: 'band_id',
       as: 'tours',
-    }},
-    {'$lookup' => {
+    } },
+    { '$lookup' => {
       from: 'awards',
       localField: '_id',
       foreignField: 'band_id',
       as: 'awards',
-    }},
-    {'$match' => {
+    } },
+    { '$match' => {
       'tours.year' => {'$gte' => 2000},
       'awards._id' => {'$exists' => true},
-    }},
+    } },
     {'$project' => {_id: 1}},
   ])
   bands = Band.find(band_ids)
 
-Note that the aggregation pipeline, since it is implemented by the Ruby driver
-for MongoDB and not Mongoid, returns raw ``BSON::Document`` objects rather than
+Since the aggregation pipeline is implemented by the MongoDB Ruby Driver
+and not Mongoid, it returns raw ``BSON::Document`` objects rather than
 ``Mongoid::Document`` model instances. The above example projects only
 the ``_id`` field which is then used to load full models. An alternative is
 to not perform such a projection and work with raw fields, which would eliminate
@@ -76,8 +88,8 @@ having to send the list of document ids to Mongoid in the second query
 
 .. _aggregation-pipeline-builder-dsl:
 
-Builder DSL
------------
+Aggregation Pipeline Builder DSL
+================================
 
 Mongoid provides limited support for constructing the aggregation pipeline
 itself using a high-level DSL. The following aggregation pipeline operators
@@ -113,7 +125,7 @@ For example, given the following models:
     field :name, type: String
   end
 
-We could find out which states a participant visited:
+We can find out which states a participant visited:
 
 .. code-block:: ruby
 

--- a/docs/reference/aggregation.txt
+++ b/docs/reference/aggregation.txt
@@ -78,8 +78,8 @@ could do the following:
   ])
   bands = Band.find(band_ids)
 
-Since the aggregation pipeline is implemented by the MongoDB Ruby Driver
-and not Mongoid, it returns raw ``BSON::Document`` objects rather than
+Note that the aggregation pipeline, since it is implemented by the Ruby driver
+for MongoDB and not Mongoid, returns raw ``BSON::Document`` objects rather than
 ``Mongoid::Document`` model instances. The above example projects only
 the ``_id`` field which is then used to load full models. An alternative is
 to not perform such a projection and work with raw fields, which would eliminate

--- a/docs/reference/aggregation.txt
+++ b/docs/reference/aggregation.txt
@@ -21,8 +21,8 @@ which is used to construct flows of operations that process and return results.
 The aggregation pipeline is a superset of the deprecated
 :ref:`map/reduce framework <map-reduce>` functionality.
 
-.. _aggregation-pipeline-example-multiple-collections:
 
+.. _aggregation-pipeline-example-multiple-collections:
 
 Example: Querying Across Multiple Collections
 `````````````````````````````````````````````

--- a/docs/working-with-data.txt
+++ b/docs/working-with-data.txt
@@ -12,6 +12,7 @@ Working With Data
   reference/crud
   reference/queries
   reference/text-search
+  reference/aggregation
   reference/map-reduce
   reference/persistence-configuration
   reference/nested-attributes


### PR DESCRIPTION
This is a redux of my changes from https://github.com/mongodb/mongoid/pull/5308. It basically adds an intro section to the Aggregation Pipeline docs page, since its a standalone, along with a few small fixes.

I haven't changed any links and manually tested that all the links I could find work.