### PR TITLE
MONGOID-5390: Mongoid::Contextual::Memory#pluck should return nil values

### DIFF
--- a/docs/release-notes/mongoid-8.0.txt
+++ b/docs/release-notes/mongoid-8.0.txt
@@ -305,13 +305,13 @@ Mongoid 7 behavior:
   end
 
 
-`#pluck` on Embedded Criteria Returns Nil Values
+``#pluck`` on Embedded Criteria Returns Nil Values
 ------------------------------------------------
 
-Mongoid 8 fixes a bug where calling `#pluck` on a Mongoid::Criteria
-for embedded documents discards nil values. This behavior was inconsistent
-with the `#pluck` method in ActiveSupport, and also with how
-`#pluck` works when reading documents from the database.
+Mongoid 8 fixes a bug where calling ``#pluck`` on a Mongoid::Criteria
+for embedded documents discarded nil values. This behavior was
+inconsistent with both the ``#pluck`` method in ActiveSupport and
+with how ``#pluck`` works when reading documents from the database.
 
 The following example illustrates the bug:
 

--- a/docs/release-notes/mongoid-8.0.txt
+++ b/docs/release-notes/mongoid-8.0.txt
@@ -305,7 +305,7 @@ Mongoid 7 behavior:
   end
 
 
-``#pluck`` on Embedded Criteria Returns Nil Values
+``#pluck`` on Embedded Criteria Returns ``nil`` Values
 ------------------------------------------------
 
 Mongoid 8 fixes a bug where calling ``#pluck`` on a Mongoid::Criteria

--- a/docs/release-notes/mongoid-8.0.txt
+++ b/docs/release-notes/mongoid-8.0.txt
@@ -305,6 +305,50 @@ Mongoid 7 behavior:
   end
 
 
+`#pluck` on Embedded Criteria to Returns Nil Values
+---------------------------------------------------
+
+Mongoid 8 fixes a bug where calling `#pluck` on a Mongoid::Criteria
+for embedded documents discards nil values. This behavior was inconsistent
+with the `#pluck` method in ActiveSupport, and also with how
+`#pluck` works when reading documents from the database.
+
+The following example illustrates the bug:
+
+.. code-block:: ruby
+
+  class Address
+    include Mongoid::Document
+
+    embedded_in :mall
+
+    field :street, type: String
+  end
+
+  class Mall
+    include Mongoid::Document
+
+    embeds_many :addresses
+  end
+
+  mall = Mall.create!
+  mall.addresses.create!(street: "Elm Street")
+  mall.addresses.create!(street: nil)
+
+  # Pluck from database
+  Mall.all.pluck('addresses.street')
+    #=> Correct: Mongoid 7 and 8 both return [ ['Elm Street', nil] ]
+
+  # Pluck using ActiveSupport Array#pluck
+  mall.addresses.pluck(:street)
+    #=> Correct: Mongoid 7 and 8 both return ['Elm Street', nil]
+
+  # Pluck from embedded document criteria
+  mall.addresses.all.pluck(:street)
+    #=> Bug: Mongoid 7 returns ['Elm Street']
+    #=> Correct: Mongoid 8 returns ['Elm Street', nil]
+
+
 Removed ``:drop_dups`` Option from Indexes
 ------------------------------------------
 

--- a/docs/release-notes/mongoid-8.0.txt
+++ b/docs/release-notes/mongoid-8.0.txt
@@ -305,8 +305,8 @@ Mongoid 7 behavior:
   end
 
 
-`#pluck` on Embedded Criteria to Returns Nil Values
----------------------------------------------------
+`#pluck` on Embedded Criteria Returns Nil Values
+------------------------------------------------
 
 Mongoid 8 fixes a bug where calling `#pluck` on a Mongoid::Criteria
 for embedded documents discards nil values. This behavior was inconsistent

--- a/docs/release-notes/mongoid-8.0.txt
+++ b/docs/release-notes/mongoid-8.0.txt
@@ -313,7 +313,7 @@ for embedded documents discarded nil values. This behavior was
 inconsistent with both the ``#pluck`` method in ActiveSupport and
 with how ``#pluck`` works when reading documents from the database.
 
-The following example illustrates the bug:
+The following example illustrates the behavior change:
 
 .. code-block:: ruby
 
@@ -337,16 +337,16 @@ The following example illustrates the bug:
 
   # Pluck from database
   Mall.all.pluck('addresses.street')
-    #=> Correct: Mongoid 7 and 8 both return [ ['Elm Street', nil] ]
+    #=> Mongoid 7 and 8 both return [ ['Elm Street', nil] ]
 
   # Pluck using ActiveSupport Array#pluck
   mall.addresses.pluck(:street)
-    #=> Correct: Mongoid 7 and 8 both return ['Elm Street', nil]
+    #=> Mongoid 7 and 8 both return ['Elm Street', nil]
 
   # Pluck from embedded document criteria
   mall.addresses.all.pluck(:street)
-    #=> Bug: Mongoid 7 returns ['Elm Street']
-    #=> Correct: Mongoid 8 returns ['Elm Street', nil]
+    #=> Mongoid 7 returns ['Elm Street']
+    #=> Mongoid 8 returns ['Elm Street', nil]
 
 
 Removed ``:drop_dups`` Option from Indexes

--- a/docs/release-notes/mongoid-8.0.txt
+++ b/docs/release-notes/mongoid-8.0.txt
@@ -313,7 +313,7 @@ for embedded documents discarded nil values. This behavior was
 inconsistent with both the ``#pluck`` method in ActiveSupport and
 with how ``#pluck`` works when reading documents from the database.
 
-Mongoid 8 behavior:
+Mongoid 8.0 behavior:
 
 .. code-block:: ruby
 
@@ -339,7 +339,7 @@ Mongoid 8 behavior:
   mall.addresses.all.pluck(:street)
     #=> ['Elm Street', nil]
 
-Given the same setup, Mongoid 7 has the following behavior:
+Mongoid 7 behavior, given the same setup:
 
 .. code-block:: ruby
 
@@ -358,10 +358,6 @@ For clarity, the following behavior is unchanged from Mongoid 7 to Mongoid 8.0:
   # Pluck using ActiveSupport Array#pluck
   mall.addresses.pluck(:street)
     #=> ['Elm Street', nil]
-
-  # Pluck from embedded document criteria
-  mall.addresses.all.pluck(:street)
-    #=> ['Elm Street']
 
 
 Removed ``:drop_dups`` Option from Indexes

--- a/docs/release-notes/mongoid-8.0.txt
+++ b/docs/release-notes/mongoid-8.0.txt
@@ -313,7 +313,7 @@ for embedded documents discarded nil values. This behavior was
 inconsistent with both the ``#pluck`` method in ActiveSupport and
 with how ``#pluck`` works when reading documents from the database.
 
-The following example illustrates the behavior change:
+Mongoid 8 behavior:
 
 .. code-block:: ruby
 
@@ -335,18 +335,33 @@ The following example illustrates the behavior change:
   mall.addresses.create!(street: "Elm Street")
   mall.addresses.create!(street: nil)
 
-  # Pluck from database
-  Mall.all.pluck('addresses.street')
-    #=> Mongoid 7 and 8 both return [ ['Elm Street', nil] ]
+  # Pluck from embedded document criteria
+  mall.addresses.all.pluck(:street)
+    #=> ['Elm Street', nil]
 
-  # Pluck using ActiveSupport Array#pluck
-  mall.addresses.pluck(:street)
-    #=> Mongoid 7 and 8 both return ['Elm Street', nil]
+Given the same setup, Mongoid 7 has the following behavior:
+
+.. code-block:: ruby
 
   # Pluck from embedded document criteria
   mall.addresses.all.pluck(:street)
-    #=> Mongoid 7 returns ['Elm Street']
-    #=> Mongoid 8 returns ['Elm Street', nil]
+    #=> ['Elm Street']
+
+For clarity, the following behavior is unchanged from Mongoid 7 to Mongoid 8.0:
+
+.. code-block:: ruby
+
+  # Pluck from database
+  Mall.all.pluck('addresses.street')
+    #=> [ ['Elm Street', nil] ]
+
+  # Pluck using ActiveSupport Array#pluck
+  mall.addresses.pluck(:street)
+    #=> ['Elm Street', nil]
+
+  # Pluck from embedded document criteria
+  mall.addresses.all.pluck(:street)
+    #=> ['Elm Street']
 
 
 Removed ``:drop_dups`` Option from Indexes

--- a/lib/mongoid/contextual/memory.rb
+++ b/lib/mongoid/contextual/memory.rb
@@ -193,7 +193,7 @@ module Mongoid
       # @example Get the values in memory.
       #   context.pluck(:name)
       #
-      # @param [ String, Symbol, Array ] fields Field or fields to pluck.
+      # @param [ Array<String | Symbol> ] *fields Field(s) to pluck.
       #
       # @return [ Array ] The array of plucked values.
       def pluck(*fields)

--- a/lib/mongoid/contextual/memory.rb
+++ b/lib/mongoid/contextual/memory.rb
@@ -193,7 +193,7 @@ module Mongoid
       # @example Get the values in memory.
       #   context.pluck(:name)
       #
-      # @param [ Array<String | Symbol> ] *fields Field(s) to pluck.
+      # @param [ Array<String, Symbol> ] *fields Field(s) to pluck.
       #
       # @return [ Array ] The array of plucked values.
       def pluck(*fields)

--- a/lib/mongoid/contextual/memory.rb
+++ b/lib/mongoid/contextual/memory.rb
@@ -193,7 +193,7 @@ module Mongoid
       # @example Get the values in memory.
       #   context.pluck(:name)
       #
-      # @param [ Array<String, Symbol> ] *fields Field(s) to pluck.
+      # @param [ String | Symbol ] *fields Field(s) to pluck.
       #
       # @return [ Array ] The array of plucked values.
       def pluck(*fields)

--- a/lib/mongoid/contextual/memory.rb
+++ b/lib/mongoid/contextual/memory.rb
@@ -188,15 +188,16 @@ module Mongoid
         self
       end
 
+      # Pluck the field values in memory.
+      #
+      # @example Get the values in memory.
+      #   context.pluck(:name)
+      #
+      # @param [ String, Symbol, Array ] fields Field or fields to pluck.
+      #
+      # @return [ Array ] The array of plucked values.
       def pluck(*fields)
-        fields = Array.wrap(fields)
-        documents.map do |doc|
-          if fields.size == 1
-            doc[fields.first]
-          else
-            fields.map { |n| doc[n] }.compact
-          end
-        end.compact
+        documents.pluck(*Array.wrap(fields))
       end
 
       # Skips the provided number of documents.

--- a/lib/mongoid/contextual/memory.rb
+++ b/lib/mongoid/contextual/memory.rb
@@ -197,7 +197,7 @@ module Mongoid
       #
       # @return [ Array ] The array of plucked values.
       def pluck(*fields)
-        documents.pluck(*Array.wrap(fields))
+        documents.pluck(*fields)
       end
 
       # Skips the provided number of documents.

--- a/spec/mongoid/contextual/memory_spec.rb
+++ b/spec/mongoid/contextual/memory_spec.rb
@@ -927,9 +927,13 @@ describe Mongoid::Contextual::Memory do
       Address.new(street: "friedel")
     end
 
+    let(:empty_doc) do
+      Address.new(street: nil)
+    end
+
     let(:criteria) do
       Address.all.tap do |crit|
-        crit.documents = [ hobrecht, friedel ]
+        crit.documents = [ hobrecht, friedel, empty_doc ]
       end
     end
 
@@ -944,7 +948,7 @@ describe Mongoid::Contextual::Memory do
       end
 
       it "returns the values" do
-        expect(plucked).to eq([ "hobrecht", "friedel" ])
+        expect(plucked).to eq([ "hobrecht", "friedel", nil ])
       end
     end
 
@@ -957,7 +961,7 @@ describe Mongoid::Contextual::Memory do
         end
 
         it "returns a empty array" do
-          expect(plucked).to eq([])
+          expect(plucked).to eq([nil, nil, nil])
         end
       end
 
@@ -968,7 +972,7 @@ describe Mongoid::Contextual::Memory do
         end
 
         it "returns a empty array" do
-          expect(plucked).to eq([[], []])
+          expect(plucked).to eq([[nil, nil], [nil, nil], [nil, nil]])
         end
       end
     end

--- a/spec/mongoid/contextual/memory_spec.rb
+++ b/spec/mongoid/contextual/memory_spec.rb
@@ -927,13 +927,9 @@ describe Mongoid::Contextual::Memory do
       Address.new(street: "friedel")
     end
 
-    let(:empty_doc) do
-      Address.new(street: nil)
-    end
-
     let(:criteria) do
       Address.all.tap do |crit|
-        crit.documents = [ hobrecht, friedel, empty_doc ]
+        crit.documents = [ hobrecht, friedel ]
       end
     end
 
@@ -942,6 +938,27 @@ describe Mongoid::Contextual::Memory do
     end
 
     context "when plucking" do
+
+      let!(:plucked) do
+        context.pluck(:street)
+      end
+
+      it "returns the values" do
+        expect(plucked).to eq([ "hobrecht", "friedel" ])
+      end
+    end
+
+    context "when plucking a mix of empty and non-empty values" do
+
+      let(:empty_doc) do
+        Address.new(street: nil)
+      end
+
+      let(:criteria) do
+        Address.all.tap do |crit|
+          crit.documents = [ hobrecht, friedel, empty_doc ]
+        end
+      end
 
       let!(:plucked) do
         context.pluck(:street)
@@ -961,7 +978,7 @@ describe Mongoid::Contextual::Memory do
         end
 
         it "returns a empty array" do
-          expect(plucked).to eq([nil, nil, nil])
+          expect(plucked).to eq([nil, nil])
         end
       end
 
@@ -972,7 +989,7 @@ describe Mongoid::Contextual::Memory do
         end
 
         it "returns a empty array" do
-          expect(plucked).to eq([[nil, nil], [nil, nil], [nil, nil]])
+          expect(plucked).to eq([[nil, nil], [nil, nil]])
         end
       end
     end


### PR DESCRIPTION
Fixes MONGOID-5390

Conveniently, we can now use ActiveSupport's `Array#pluck` here, which was introduced in Rails 5.0.

The #pluck method was also missing a doc comment, so I added it.

In addition, the original method called `Array.wrap(fields)`. However, this had no useful effect. If the method was called with a first-arg Array like `pluck([:a, :b])`, then `Array.wrap(fields) #=> [[:a, :b]]`, which is non-sensical. So I've removed this call.

Lastly, I don't think we need to have a feature flag here. Refer to MONGOID-5390 JIRA ticket for details.