### PR TITLE
MONGOID-5391 - Support Criteria#pluck_each method

### DIFF
--- a/docs/reference/queries.txt
+++ b/docs/reference/queries.txt
@@ -1386,12 +1386,49 @@ Mongoid also has some helpful methods on criteria.
         .. code-block:: ruby
 
           Band.all.pluck(:name)
+            #=> ["Daft Punk", "Aphex Twin", "Ween"]
 
-          Band.all.pluck('cities.name')
+          Band.all.pluck('address.city')
+            #=> ["Paris", "Limerick", "New Hope"]
 
           # Using the earlier definition of Manager,
           # expands out to "managers.name" in the query:
           Band.all.pluck('managers.n')
+            #=> [ ["Berry Gordy", "Tommy Mottola"], [], ["Quincy Jones"] ]
+
+          # Accepts multiple field arguments, in which case
+          # the result will be returned as an Array of Arrays.
+          Band.all.pluck(:name, :likes)
+            #=> [ ["Daft Punk", 342], ["Aphex Twin", 98], ["Ween", 227] ]
+
+   * - ``Criteria#pluck_each``
+
+       *This method returns an Enumerator for the results of ``pluck``.
+       A block may optionally be given, which will be called once for
+       each result.*
+
+       *Similar to the ``each`` method, this method will use the
+       `MongoDB getMore command
+       <https://mongodb.com/docs/manual/reference/command/getMore/>`_
+       to load results in batches. This is useful for working with
+       large query results.*
+
+       *The method arguments and field normalization behavior are
+       otherwise identical to ``pluck``.*
+
+     -
+       .. code-block:: ruby
+
+         Band.all.pluck_each(:name)
+           #=> #<Enumerator: ... >
+
+         Band.all.pluck_each(:name, 'address.city', :founded) do |name, city, founded|
+           puts "#{name} from #{city} started in #{founded}"
+         end
+           # =>
+           # The Rolling Stones from London started in 1962
+           # The Beatles from Liverpool started in 1960
+           # The Monkees from Los Angeles started in 1966
 
    * - ``Criteria#take``
 

--- a/docs/release-notes/mongoid-8.0.txt
+++ b/docs/release-notes/mongoid-8.0.txt
@@ -245,7 +245,7 @@ Mongoid 8.0 behavior:
 
 .. code-block:: ruby
 
-  Band.any_of({name: 'The Rolling Stones'}, {founded: 1990}).
+  Band.any_of({name: 'The Rolling Stones'}, {founded: 1962}).
     any_of({members: 2}, {last_tour: 1995})
   # =>
   # #<Mongoid::Criteria
@@ -255,7 +255,7 @@ Mongoid 8.0 behavior:
   #   class:    Band
   #   embedded: false>
 
-  Band.any_of({name: 'The Rolling Stones'}, {founded: 1990}).any_of({members: 2})
+  Band.any_of({name: 'The Rolling Stones'}, {founded: 1962}).any_of({members: 2})
   # =>
   # #<Mongoid::Criteria
   #   selector: {"$or"=>[{"name"=>"The Rolling Stones"}, {"founded"=>1990}], "members"=>2}
@@ -267,7 +267,7 @@ Mongoid 7 behavior:
 
 .. code-block:: ruby
 
-  Band.any_of({name: 'The Rolling Stones'}, {founded: 1990}).
+  Band.any_of({name: 'The Rolling Stones'}, {founded: 1962}).
     any_of({members: 2}, {last_tour: 1995})
   # =>
   # #<Mongoid::Criteria
@@ -277,13 +277,42 @@ Mongoid 7 behavior:
   #   class:    Band
   #   embedded: false>
 
-  Band.any_of({name: 'The Rolling Stones'}, {founded: 1990}).any_of({members: 2})
+  Band.any_of({name: 'The Rolling Stones'}, {founded: 1962}).any_of({members: 2})
   # =>
   # #<Mongoid::Criteria
   #   selector: {"$or"=>[{"name"=>"The Rolling Stones"}, {"founded"=>1990}], "members"=>2}
   #   options:  {}
   #   class:    Band
   #   embedded: false>
+
+
+``Criteria#pluck_each`` Method Added
+----------------------------------------
+
+The newly introduced ``Criteria#pluck_each`` method returns
+an Enumerator for the results of ``pluck``, or if a block is given,
+calls the block once for each pluck result in a progressively-loaded
+fashion.
+
+Previously, calling ``criteria.pluck(:name).each`` would load the
+entire result set into Ruby's memory before iterating over the results.
+In contrast, ``criteria.pluck_each(:name)`` uses the `MongoDB getMore command
+<https://mongodb.com/docs/manual/reference/command/getMore/>`_
+to load results in batches, similar to how ``criteria.each`` behaves.
+This is useful for working with large query results.
+
+The method arguments and behavior of ``pluck_each`` are otherwise
+identical to ``pluck``.
+
+.. code-block:: ruby
+
+  Band.all.pluck_each(:name, 'address.city', :founded) do |name, city, founded|
+    puts "#{name} from #{city} started in #{founded}"
+  end
+  # =>
+  # The Rolling Stones from London started in 1962
+  # The Beatles from Liverpool started in 1960
+  # The Monkees from Los Angeles started in 1966
 
 
 ``Changeable`` Module Behavior Made Compatible With ``ActiveModel::Dirty``
@@ -326,6 +355,7 @@ Mongoid 7 output:
 
 Notice that in 7 ``attribute_was(:age)`` returns the old attribute value,
 while in 8.0 ``attribute_was(:age)`` returns the new value.
+
 
 ``*_previously_was``, ``previously_new_record?``, and ``previously_persisted?`` helpers
 ---------------------------------------------------------------------------------------

--- a/lib/mongoid/contextual/memory.rb
+++ b/lib/mongoid/contextual/memory.rb
@@ -261,6 +261,22 @@ module Mongoid
         end
       end
 
+      # Iterate through plucked field values in memory.
+      #
+      # @example Iterate through the values for null context.
+      #   context.pluck_each(:name) { |name| puts name }
+      #
+      # @param [ String, Symbol ] *fields Field(s) to pluck.
+      # @param [ Proc ] block The block to call once for each plucked
+      #   result.
+      #
+      # @return [ Enumerator, Memory ] An enumerator, or the context
+      #   if a block was given.
+      def pluck_each(*fields, &block)
+        enum = pluck(*fields).each(&block)
+        block_given? ? self : enum
+      end
+
       # Tally the field values in memory.
       #
       # @example Get the counts of values in memory.

--- a/lib/mongoid/contextual/mongo.rb
+++ b/lib/mongoid/contextual/mongo.rb
@@ -5,6 +5,7 @@ require "mongoid/contextual/aggregable/mongo"
 require "mongoid/contextual/command"
 require "mongoid/contextual/geo_near"
 require "mongoid/contextual/map_reduce"
+require "mongoid/contextual/mongo/pluck_enumerator"
 require "mongoid/association/eager_loadable"
 
 module Mongoid
@@ -391,45 +392,44 @@ module Mongoid
         MapReduce.new(collection, criteria, map, reduce)
       end
 
-      # Pluck the single field values from the database. Will return duplicates
-      # if they exist and only works for top level fields.
+      # Pluck the field value(s) from the database. Returns one
+      # result for each document found in the database for
+      # the context. The results are normalized according to their
+      # Mongoid field types. Note that the results may include
+      # duplicates and nil values.
       #
       # @example Pluck a field.
       #   context.pluck(:_id)
       #
-      # @note This method will return the raw db values - it performs no custom
-      #   serialization.
-      #
-      # @param [ String, Symbol, Array ] fields Fields to pluck.
+      # @param [ String, Symbol ] *fields Field(s) to pluck,
+      #   which may include nested fields using dot-notation.
       #
       # @return [ Array<Object, Array> ] The plucked values.
+      #   If the *fields arg contains a single value, each result
+      #   in the array will be a single value. Otherwise, each
+      #   result in the array will be an array of values.
       def pluck(*fields)
-        # Multiple fields can map to the same field name. For example, plucking
-        # a field and its _translations field map to the same field in the database.
-        # because of this, we need to keep track of the fields requested.
-        normalized_field_names = []
-        normalized_select = fields.inject({}) do |hash, f|
-          db_fn = klass.database_field_name(f)
-          normalized_field_names.push(db_fn)
+        pluck_each(*fields).to_a
+      end
 
-          if Mongoid.legacy_pluck_distinct
-            hash[db_fn] = true
-          else
-            hash[klass.cleanse_localized_field_names(f)] = true
-          end
-          hash
-        end
-
-        view.projection(normalized_select).reduce([]) do |plucked, doc|
-          values = normalized_field_names.map do |n|
-            if Mongoid.legacy_pluck_distinct
-              n.include?('.') ? doc[n.partition('.')[0]] : doc[n]
-            else
-              extract_value(doc, n)
-            end
-          end
-          plucked << (values.size == 1 ? values.first : values)
-        end
+      # Iterate through plucked field value(s) from the database
+      # for the context. Yields result values progressively as they are
+      # read from the database. The yielded results are normalized
+      # according to their Mongoid field types.
+      #
+      # @example Iterate through the plucked values from the database.
+      #   context.pluck_each(:name) { |name| puts name }
+      #
+      # @param [ String, Symbol ] *fields Field(s) to pluck,
+      #   which may include nested fields using dot-notation.
+      # @param [ Proc ] block The block to call once for each plucked
+      #   result.
+      #
+      # @return [ Enumerator, Mongo ] The enumerator, or the context
+      #   if a block was given.
+      def pluck_each(*fields, &block)
+        enum = PluckEnumerator.new(klass, view, fields).each(&block)
+        block_given? ? self : enum
       end
 
       # Get a hash of counts for the values of a single field. For example,
@@ -676,78 +676,6 @@ module Mongoid
 
       def acknowledged_write?
         collection.write_concern.nil? || collection.write_concern.acknowledged?
-      end
-
-      # Fetch the element from the given hash and demongoize it using the
-      # given field. If the obj is an array, map over it and call this method
-      # on all of its elements.
-      #
-      # @param [ Hash | Array<Hash> ] obj The hash or array of hashes to fetch from.
-      # @param [ String ] meth The key to fetch from the hash.
-      # @param [ Field ] field The field to use for demongoization.
-      #
-      # @return [ Object ] The demongoized value.
-      #
-      # @api private
-      def fetch_and_demongoize(obj, meth, field)
-        if obj.is_a?(Array)
-          obj.map { |doc| fetch_and_demongoize(doc, meth, field) }
-        else
-          res = obj.try(:fetch, meth, nil)
-          field ? field.demongoize(res) : res.class.demongoize(res)
-        end
-      end
-
-      # Extracts the value for the given field name from the given attribute
-      # hash.
-      #
-      # @param [ Hash ] attrs The attributes hash.
-      # @param [ String ] field_name The name of the field to extract.
-      #
-      # @param [ Object ] The value for the given field name
-      def extract_value(attrs, field_name)
-        i = 1
-        num_meths = field_name.count('.') + 1
-        curr = attrs.dup
-
-        klass.traverse_association_tree(field_name) do |meth, obj, is_field|
-          field = obj if is_field
-          is_translation = false
-          # If no association or field was found, check if the meth is an
-          # _translations field.
-          if obj.nil? & tr = meth.match(/(.*)_translations\z/)&.captures&.first
-            is_translation = true
-            meth = tr
-          end
-
-          # 1. If curr is an array fetch from all elements in the array.
-          # 2. If the field is localized, and is not an _translations field
-          #    (_translations fields don't show up in the fields hash).
-          #    - If this is the end of the methods, return the translation for
-          #      the current locale.
-          #    - Otherwise, return the whole translations hash so the next method
-          #      can select the language it wants.
-          # 3. If the meth is an _translations field, do not demongoize the
-          #    value so the full hash is returned.
-          # 4. Otherwise, fetch and demongoize the value for the key meth.
-          curr = if curr.is_a? Array
-            res = fetch_and_demongoize(curr, meth, field)
-            res.empty? ? nil : res
-          elsif !is_translation && field&.localized?
-            if i < num_meths
-              curr.try(:fetch, meth, nil)
-            else
-              fetch_and_demongoize(curr, meth, field)
-            end
-          elsif is_translation
-            curr.try(:fetch, meth, nil)
-          else
-            fetch_and_demongoize(curr, meth, field)
-          end
-
-          i += 1
-        end
-        curr
       end
 
       # Recursively demongoize the given value. This method recursively traverses

--- a/lib/mongoid/contextual/mongo/pluck_enumerator.rb
+++ b/lib/mongoid/contextual/mongo/pluck_enumerator.rb
@@ -1,0 +1,157 @@
+# frozen_string_literal: true
+
+module Mongoid
+  module Contextual
+    class Mongo
+
+      # Utility class to add enumerable behavior for Criteria#pluck_each.
+      #
+      # @api private
+      class PluckEnumerator
+        include Enumerable
+
+        # Create the new PluckEnumerator.
+        #
+        # @api private
+        #
+        # @example Initialize a PluckEnumerator.
+        #   PluckEnumerator.new(klass, view, fields)
+        #
+        # @param [ Class ] klass The base of the binding.
+        # @param [ Mongo::Collection::View ] view The Mongo view context.
+        # @param [ String, Symbol ] *fields Field(s) to pluck,
+        #   which may include nested fields using dot-notation.
+        def initialize(klass, view, fields)
+          @klass = klass
+          @view = view
+          @fields = fields
+        end
+
+        # Iterate through plucked field value(s) from the database
+        # for the view context. Yields result values progressively as
+        # they are read from the database. The yielded results are
+        # normalized according to their Mongoid field types.
+        #
+        # @api private
+        #
+        # @example Iterate through the plucked values from the database.
+        #   context.pluck_each(:name) { |name| puts name }
+        #
+        # @param [ Proc ] block The block to call once for each plucked
+        #   result.
+        #
+        # @return [ Enumerator, PluckEnumerator ] The enumerator, or
+        #   self if a block was given.
+        def each(&block)
+          return to_enum unless block_given?
+
+          @view.projection(normalized_field_names.index_with(true)).each do |doc|
+            yield_result(doc, &block)
+          end
+
+          self
+        end
+
+        private
+
+        def database_field_names
+          @database_field_names ||= @fields.map {|f| @klass.database_field_name(f) }
+        end
+
+        def normalized_field_names
+          @normalized_field_names ||= if Mongoid.legacy_pluck_distinct
+            database_field_names
+          else
+            @fields.map {|f| @klass.cleanse_localized_field_names(f) }
+          end
+        end
+
+        def yield_result(doc)
+          values = database_field_names.map do |n|
+            if Mongoid.legacy_pluck_distinct
+              n.include?('.') ? doc[n.partition('.')[0]] : doc[n]
+            else
+              extract_value(doc, n)
+            end
+          end
+          yield(values.size == 1 ? values.first : values)
+        end
+
+        # Fetch the element from the given hash and demongoize it using the
+        # given field. If the obj is an array, map over it and call this method
+        # on all of its elements.
+        #
+        # @param [ Hash | Array<Hash> ] obj The hash or array of hashes to fetch from.
+        # @param [ String ] meth The key to fetch from the hash.
+        # @param [ Field ] field The field to use for demongoization.
+        #
+        # @return [ Object ] The demongoized value.
+        #
+        # @api private
+        def fetch_and_demongoize(obj, meth, field)
+          if obj.is_a?(Array)
+            obj.map { |doc| fetch_and_demongoize(doc, meth, field) }
+          else
+            res = obj.try(:fetch, meth, nil)
+            field ? field.demongoize(res) : res.class.demongoize(res)
+          end
+        end
+
+        # Extracts the value for the given field name from the given attribute
+        # hash.
+        #
+        # @param [ Hash ] attrs The attributes hash.
+        # @param [ String ] field_name The name of the field to extract.
+        #
+        # @return [ Object ] The value for the given field name
+        #
+        # @api private
+        def extract_value(attrs, field_name)
+          i = 1
+          num_meths = field_name.count('.') + 1
+          curr = attrs.dup
+
+          @klass.traverse_association_tree(field_name) do |meth, obj, is_field|
+            field = obj if is_field
+            is_translation = false
+            # If no association or field was found, check if the meth is an
+            # _translations field.
+            if obj.nil? & tr = meth.match(/(.*)_translations\z/)&.captures&.first
+              is_translation = true
+              meth = tr
+            end
+
+            # 1. If curr is an array fetch from all elements in the array.
+            # 2. If the field is localized, and is not an _translations field
+            #    (_translations fields don't show up in the fields hash).
+            #    - If this is the end of the methods, return the translation for
+            #      the current locale.
+            #    - Otherwise, return the whole translations hash so the next method
+            #      can select the language it wants.
+            # 3. If the meth is an _translations field, do not demongoize the
+            #    value so the full hash is returned.
+            # 4. Otherwise, fetch and demongoize the value for the key meth.
+            curr = if curr.is_a? Array
+              res = fetch_and_demongoize(curr, meth, field)
+              res.empty? ? nil : res
+            elsif !is_translation && field&.localized?
+              if i < num_meths
+                curr.try(:fetch, meth, nil)
+              else
+                fetch_and_demongoize(curr, meth, field)
+              end
+            elsif is_translation
+              curr.try(:fetch, meth, nil)
+            else
+              fetch_and_demongoize(curr, meth, field)
+            end
+
+            i += 1
+          end
+
+          curr
+        end
+      end
+    end
+  end
+end

--- a/lib/mongoid/contextual/none.rb
+++ b/lib/mongoid/contextual/none.rb
@@ -88,11 +88,27 @@ module Mongoid
       # @example Get the values for null context.
       #   context.pluck(:name)
       #
-      # @param [ String | Symbol ] *_fields Field or fields to pluck.
+      # @param [ String | Symbol ] *_fields Field(s) to pluck.
       #
       # @return [ Array ] An empty Array.
       def pluck(*_fields)
         []
+      end
+
+      # Iterate through plucked field values in null context.
+      #
+      # @example Iterate through the values for null context.
+      #   context.pluck_each(:name) { |name| puts name }
+      #
+      # @param [ String, Symbol ] *_fields Field(s) to pluck.
+      # @param [ Proc ] block The block which will not be called
+      #   due to null context.
+      #
+      # @return [ Enumerator, None ] An enumerator, or the context
+      #   if a block was given.
+      def pluck_each(*_fields, &block)
+        enum = pluck(*_fields).each(&block)
+        block_given? ? self : enum
       end
 
       # Tally the field values in null context.

--- a/lib/mongoid/findable.rb
+++ b/lib/mongoid/findable.rb
@@ -39,6 +39,7 @@ module Mongoid
       :min,
       :none,
       :pluck,
+      :pluck_each,
       :read,
       :sum,
       :take,

--- a/spec/mongoid/contextual/memory_spec.rb
+++ b/spec/mongoid/contextual/memory_spec.rb
@@ -1243,11 +1243,11 @@ describe Mongoid::Contextual::Memory do
       config_override :legacy_pluck_distinct, true
 
       let(:hobrecht) do
-        Address.new(street: "hobrecht")
+        Address.new(street: "hobrecht", number: 213)
       end
 
       let(:friedel) do
-        Address.new(street: "friedel")
+        Address.new(street: "friedel", number: 11)
       end
 
       let(:criteria) do
@@ -1264,6 +1264,17 @@ describe Mongoid::Contextual::Memory do
 
         it "returns the values" do
           expect(plucked).to eq([ "hobrecht", "friedel" ])
+        end
+      end
+
+      context "when plucking multiple fields" do
+
+        let!(:plucked) do
+          context.pluck(:street, :number)
+        end
+
+        it "returns the values as an array" do
+          expect(plucked).to eq([ ["hobrecht", 213], ["friedel", 11] ])
         end
       end
 
@@ -1296,7 +1307,7 @@ describe Mongoid::Contextual::Memory do
             context.pluck(:foo)
           end
 
-          it "returns a empty array" do
+          it "returns an empty array" do
             expect(plucked).to eq([nil, nil])
           end
         end
@@ -1307,7 +1318,7 @@ describe Mongoid::Contextual::Memory do
             context.pluck(:foo, :bar)
           end
 
-          it "returns a empty array" do
+          it "returns an empty array" do
             expect(plucked).to eq([[nil, nil], [nil, nil]])
           end
         end
@@ -1720,7 +1731,7 @@ describe Mongoid::Contextual::Memory do
         end
       end
 
-      context "when tallying deeply nested arrays/embedded associations" do
+      context "when plucking deeply nested arrays/embedded associations" do
 
         let(:criteria) do
           Person.all.tap do |crit|
@@ -1741,6 +1752,126 @@ describe Mongoid::Contextual::Memory do
             [ [ 1, 2 ] ], [ [ 1, 2 ] ], [ [ 1, 3 ] ]
           ])
         end
+      end
+    end
+  end
+
+  describe "#pluck_each" do
+
+    let(:hobrecht) do
+      Address.new(street: "hobrecht", number: 213)
+    end
+
+    let(:friedel) do
+      Address.new(street: "friedel", number: 11)
+    end
+
+    let(:criteria) do
+      Address.all.tap do |crit|
+        crit.documents = [ hobrecht, friedel ]
+      end
+    end
+
+    let(:context) do
+      described_class.new(criteria)
+    end
+
+    context "when block given" do
+
+      let!(:plucked_values) { [] }
+
+      let!(:plucked) do
+        context.pluck_each(:street) { |value| plucked_values << value }
+      end
+
+      it "returns the context" do
+        expect(plucked).to eq context
+      end
+
+      it "yields values to the block" do
+        expect(plucked_values).to eq([ "hobrecht", "friedel" ])
+      end
+    end
+
+    context "when block not given" do
+
+      let!(:plucked) do
+        context.pluck_each(:street)
+      end
+
+      it "returns an Enumerator" do
+        expect(plucked).to be_an Enumerator
+      end
+
+      it "can yield the values" do
+        expect(plucked.map { |value| value }).to eq([ "hobrecht", "friedel" ])
+      end
+    end
+
+    context "when plucking multiple fields" do
+
+      let!(:plucked_values) { [] }
+
+      let!(:plucked) do
+        context.pluck_each(:street, :number) { |value| plucked_values << value }
+      end
+
+      it "returns the context" do
+        expect(plucked).to eq context
+      end
+
+      it "yields values to the block" do
+        expect(plucked_values).to eq([ ["hobrecht", 213], ["friedel", 11] ])
+      end
+    end
+
+    context "when plucking a field that doesnt exist" do
+
+      let!(:plucked_values) { [] }
+
+      let!(:plucked) do
+        context.pluck_each(*pluck_args) { |value| plucked_values << value }
+      end
+
+      context "when plucking one field" do
+
+        let(:pluck_args) { [:foo] }
+
+        it "returns the context" do
+          expect(plucked).to eq context
+        end
+
+        it "yields the plucked values" do
+          expect(plucked_values).to eq([nil, nil])
+        end
+      end
+
+      context "when plucking multiple fields" do
+
+        let(:pluck_args) { [:foo, :bar] }
+
+        it "returns the context" do
+          expect(plucked).to eq context
+        end
+
+        it "yields the plucked values" do
+          expect(plucked_values).to eq([[nil, nil], [nil, nil]])
+        end
+      end
+    end
+
+    context 'when there is a collation on the criteria' do
+
+      let(:criteria) do
+        Address.all.tap do |crit|
+          crit.documents = [ hobrecht, friedel ]
+        end.collation(locale: 'en_US', strength: 2)
+      end
+
+      it "raises an exception" do
+        expect {
+          context.pluck(:foo, :bar)
+        }.to raise_exception(Mongoid::Errors::InMemoryCollationNotSupported)
       end
     end
   end

--- a/spec/mongoid/contextual/none_spec.rb
+++ b/spec/mongoid/contextual/none_spec.rb
@@ -54,8 +54,52 @@ describe Mongoid::Contextual::None do
   end
 
   describe "#pluck" do
-    it "returns an empty array" do
-      expect(context.pluck(:id)).to eq([])
+
+    context "when plucking one field" do
+      it "returns an empty array" do
+        expect(context.pluck(:id)).to eq([])
+      end
+    end
+
+    context "when plucking multiple fields" do
+      it "returns an empty array" do
+        expect(context.pluck(:id, :foo)).to eq([])
+      end
+    end
+  end
+
+  describe "#pluck_each" do
+
+    context "when block given" do
+
+      let!(:plucked_values) { [] }
+
+      let!(:plucked) do
+        context.pluck_each(:street) { |value| plucked_values << value }
+      end
+
+      it "returns the context" do
+        expect(plucked).to eq context
+      end
+
+      it "yields no values to the block" do
+        expect(plucked_values).to eq([])
+      end
+    end
+
+    context "when block not given" do
+
+      let!(:plucked) do
+        context.pluck_each(:street)
+      end
+
+      it "returns an Enumerator" do
+        expect(plucked).to be_an Enumerator
+      end
+
+      it "does not yield any values" do
+        expect(plucked.map { |value| value }).to eq([])
+      end
     end
   end
 

--- a/spec/mongoid/criteria_spec.rb
+++ b/spec/mongoid/criteria_spec.rb
@@ -2294,6 +2294,611 @@ describe Mongoid::Criteria do
     end
   end
 
+  describe "#pluck_each" do
+
+    let!(:depeche) do
+      Band.create!(name: "Depeche Mode", likes: 3)
+    end
+
+    let!(:tool) do
+      Band.create!(name: "Tool", likes: 3)
+    end
+
+    let!(:photek) do
+      Band.create!(name: "Photek", likes: 1)
+    end
+
+    let(:maniacs) do
+      Band.create!(name: "10,000 Maniacs", likes: 1, sales: "1E2")
+    end
+
+    context "when block given" do
+
+      let!(:plucked_values) { [] }
+
+      let!(:plucked) do
+        Band.pluck_each(:name) { |value| plucked_values << value }
+      end
+
+      it "returns the context" do
+        expect(plucked).to be_a Mongoid::Contextual::Mongo
+      end
+
+      it "yields values to the block" do
+        expect(plucked_values).to eq([ "Depeche Mode", "Tool", "Photek" ])
+      end
+    end
+
+    context "when block not given" do
+
+      let!(:plucked) do
+        Band.pluck_each(:name)
+      end
+
+      it "returns an Enumerator" do
+        expect(plucked).to be_an Enumerator
+      end
+
+      it "can yield the values" do
+        expect(plucked.map { |value| value }).to eq([ "Depeche Mode", "Tool", "Photek" ])
+      end
+    end
+
+    context "when the field is aliased" do
+
+      let!(:expensive) do
+        Product.create!(price: 100000)
+      end
+
+      let!(:cheap) do
+        Product.create!(price: 1)
+      end
+
+      context "when using alias_attribute" do
+
+        let!(:plucked) { [] }
+        let!(:pluck_each) { Product.pluck_each(:price) { |v| plucked << v } }
+
+        with_config_values :legacy_pluck_distinct, true, false do
+          it "uses the aliases" do
+            expect(plucked).to eq([ 100000, 1 ])
+          end
+        end
+      end
+    end
+
+    context "when the criteria matches" do
+
+      context "when there are no duplicate values" do
+
+        let(:criteria) do
+          Band.where(:name.exists => true)
+        end
+
+        let!(:plucked) { [] }
+        let!(:pluck_each) { criteria.pluck_each(:name) { |v| plucked << v } }
+
+        with_config_values :legacy_pluck_distinct, true, false do
+          it "returns the values" do
+            expect(plucked).to contain_exactly("Depeche Mode", "Tool", "Photek")
+          end
+        end
+
+        context "when subsequently executing the criteria without a pluck" do
+
+          with_config_values :legacy_pluck_distinct, true, false do
+            it "does not limit the fields" do
+              expect(criteria.first.likes).to eq(3)
+            end
+          end
+        end
+
+        context 'when the field is a subdocument' do
+
+          let(:criteria) do
+            Band.where(name: 'FKA Twigs')
+          end
+
+          context 'when a top-level field and a subdocument field are plucked' do
+            before do
+              Band.create!(name: 'FKA Twigs')
+              Band.create!(name: 'FKA Twigs', records: [ Record.new(name: 'LP1') ])
+            end
+
+            context "when legacy_pluck_distinct is set" do
+              config_override :legacy_pluck_distinct, true
+              let(:expected) do
+                [
+                  ["FKA Twigs", nil],
+                  ['FKA Twigs', [{ "name" => "LP1" }]]
+                ]
+              end
+
+              it 'returns the list of top-level field and subdocument values' do
+                plucked = []
+                criteria.pluck_each(:name, 'records.name') { |v| plucked << v }
+                expect(plucked).to eq(expected)
+              end
+            end
+
+            context "when legacy_pluck_distinct is not set" do
+              config_override :legacy_pluck_distinct, false
+              let(:expected) do
+                [
+                  ["FKA Twigs", nil],
+                  ['FKA Twigs', ["LP1"]]
+                ]
+              end
+
+              it 'returns the list of top-level field and subdocument values' do
+                plucked = []
+                criteria.pluck_each(:name, 'records.name') { |v| plucked << v }
+                expect(plucked).to eq(expected)
+              end
+            end
+          end
+
+          context 'when only a subdocument field is plucked' do
+
+            before do
+              Band.create!(name: 'FKA Twigs')
+              Band.create!(name: 'FKA Twigs', records: [ Record.new(name: 'LP1') ])
+            end
+
+            context "when legacy_pluck_distinct is set" do
+              config_override :legacy_pluck_distinct, true
+              let(:expected) do
+                [
+                  nil,
+                  [{ "name" => "LP1" }]
+                ]
+              end
+
+              it 'returns the list of subdocument values' do
+                plucked = []
+                criteria.pluck_each('records.name') { |v| plucked << v }
+                expect(plucked).to eq(expected)
+              end
+            end
+
+            context "when legacy_pluck_distinct is not set" do
+              config_override :legacy_pluck_distinct, false
+              let(:expected) do
+                [
+                  nil,
+                  ["LP1"]
+                ]
+              end
+
+              it 'returns the list of subdocument values' do
+                plucked = []
+                criteria.pluck_each('records.name') { |v| plucked << v }
+                expect(plucked).to eq(expected)
+              end
+            end
+          end
+        end
+      end
+
+      context "when plucking multi-fields" do
+
+        let!(:plucked) { [] }
+        let!(:pluck_each) { Band.where(:name.exists => true).pluck_each(:name, :likes) { |v| plucked << v } }
+
+        with_config_values :legacy_pluck_distinct, true, false do
+          it "returns the values" do
+            expect(plucked).to contain_exactly(["Depeche Mode", 3], ["Tool", 3], ["Photek", 1])
+          end
+        end
+      end
+
+      context "when there are duplicate values" do
+
+        let!(:plucked) { [] }
+        let!(:pluck_each) { Band.where(:name.exists => true).pluck_each(:likes) { |v| plucked << v } }
+
+        with_config_values :legacy_pluck_distinct, true, false do
+          it "returns the duplicates" do
+            expect(plucked).to contain_exactly(3, 3, 1)
+          end
+        end
+      end
+    end
+
+    context "when the criteria does not match" do
+
+      let!(:plucked) { [] }
+      let!(:pluck_each) { Band.where(name: "New Order").pluck_each(:_id) { |v| plucked << v } }
+
+      with_config_values :legacy_pluck_distinct, true, false do
+        it "returns an empty array" do
+          expect(plucked).to be_empty
+        end
+      end
+    end
+
+    context "when plucking an aliased field" do
+
+      let!(:plucked) { [] }
+      let!(:pluck_each) { Band.all.pluck_each(:id) { |v| plucked << v } }
+
+      with_config_values :legacy_pluck_distinct, true, false do
+        it "returns the field values" do
+          expect(plucked).to eq([ depeche.id, tool.id, photek.id ])
+        end
+      end
+    end
+
+    context "when plucking existent and non-existent fields" do
+
+      let!(:plucked) { [] }
+      let!(:pluck_each) { Band.all.pluck_each(:id, :fooz) { |v| plucked << v } }
+
+      with_config_values :legacy_pluck_distinct, true, false do
+        it "returns nil for the field that doesnt exist" do
+          expect(plucked).to eq([[depeche.id, nil], [tool.id, nil], [photek.id, nil] ])
+        end
+      end
+    end
+
+    context "when plucking a field that doesnt exist" do
+
+      context "when pluck one field" do
+
+        let!(:plucked) { [] }
+        let!(:pluck_each) { Band.all.pluck_each(:foo) { |v| plucked << v } }
+
+        with_config_values :legacy_pluck_distinct, true, false do
+          it "returns a array with nil values" do
+            expect(plucked).to eq([nil, nil, nil])
+          end
+        end
+      end
+
+      context "when pluck multiple fields" do
+
+        let!(:plucked) { [] }
+        let!(:pluck_each) { Band.all.pluck_each(:foo, :bar) { |v| plucked << v } }
+
+        with_config_values :legacy_pluck_distinct, true, false do
+          it "returns a nil arrays" do
+            expect(plucked).to eq([[nil, nil], [nil, nil], [nil, nil]])
+          end
+        end
+      end
+    end
+
+    context 'when plucking a localized field' do
+
+      before do
+        I18n.locale = :en
+        d = Dictionary.create!(description: 'english-text')
+        I18n.locale = :de
+        d.description = 'deutsch-text'
+        d.save!
+      end
+
+      after do
+        I18n.locale = :en
+      end
+
+      context 'when plucking the entire field' do
+
+        let!(:plucked) { [] }
+        let!(:plucked_translations) { [] }
+        let!(:plucked_translations_both) { [] }
+
+        let!(:pluck_each) do
+          Dictionary.all.pluck_each(:description) { |v| plucked << v }
+        end
+
+        let!(:pluck_each_translations) do
+          Dictionary.all.pluck_each(:description_translations) { |v| plucked_translations << v }
+        end
+
+        let!(:pluck_each_translations_both) do
+          Dictionary.all.pluck_each(:description_translations, :description) { |v| plucked_translations_both << v }
+        end
+
+        context "when legacy_pluck_distinct is set" do
+          config_override :legacy_pluck_distinct, true
+
+          it 'returns the non-demongoized translations' do
+            expect(plucked.first).to eq({"de"=>"deutsch-text", "en"=>"english-text"})
+          end
+
+          it 'returns nil' do
+            expect(plucked_translations.first).to eq(nil)
+          end
+
+          it 'returns nil for _translations' do
+            expect(plucked_translations_both.first).to eq([nil, {"de"=>"deutsch-text", "en"=>"english-text"}])
+          end
+        end
+
+        context "when legacy_pluck_distinct is not set" do
+          config_override :legacy_pluck_distinct, false
+
+          it 'returns the demongoized translations' do
+            expect(plucked.first).to eq('deutsch-text')
+          end
+
+          it 'returns the full translations hash to _translations' do
+            expect(plucked_translations.first).to eq({"de"=>"deutsch-text", "en"=>"english-text"})
+          end
+
+          it 'returns both' do
+            expect(plucked_translations_both.first).to eq([{"de"=>"deutsch-text", "en"=>"english-text"}, "deutsch-text"])
+          end
+        end
+      end
+
+      context 'when plucking a specific locale' do
+
+        let(:plucked) do
+          Dictionary.all.pluck_each(:'description.de')
+        end
+
+        context "when legacy_pluck_distinct is set" do
+          config_override :legacy_pluck_distinct, true
+
+          it 'returns the specific translations' do
+            expect(plucked.first).to eq({'de' => 'deutsch-text'})
+          end
+        end
+
+        context "when legacy_pluck_distinct is not set" do
+          config_override :legacy_pluck_distinct, false
+
+          it 'returns the specific translations' do
+            expect(plucked.first).to eq('deutsch-text')
+          end
+        end
+      end
+
+      context 'when plucking a specific locale from _translations field' do
+
+        let(:plucked) do
+          Dictionary.all.pluck_each(:'description_translations.de')
+        end
+
+        context "when legacy_pluck_distinct is set" do
+          config_override :legacy_pluck_distinct, true
+
+          it 'returns the specific translations' do
+            expect(plucked.first).to eq(nil)
+          end
+        end
+
+        context "when legacy_pluck_distinct is not set" do
+          config_override :legacy_pluck_distinct, false
+
+          it 'returns the specific translations' do
+            expect(plucked.first).to eq('deutsch-text')
+          end
+        end
+      end
+
+      context 'when fallbacks are enabled with a locale list' do
+        require_fallbacks
+
+        around(:all) do |example|
+          prev_fallbacks = I18n.fallbacks.dup
+          I18n.fallbacks[:he] = [ :en ]
+          example.run
+          I18n.fallbacks = prev_fallbacks
+        end
+
+        let(:plucked) do
+          Dictionary.all.pluck_each(:description).first
+        end
+
+        context "when legacy_pluck_distinct is set" do
+          config_override :legacy_pluck_distinct, true
+
+          it "does not correctly use the fallback" do
+            plucked.should == {"de"=>"deutsch-text", "en"=>"english-text"}
+          end
+        end
+
+        context "when legacy_pluck_distinct is not set" do
+          config_override :legacy_pluck_distinct, false
+
+          it "correctly uses the fallback" do
+            I18n.locale = :en
+            d = Dictionary.create!(description: 'english-text')
+            I18n.locale = :he
+            plucked.should == "english-text"
+          end
+        end
+      end
+
+      context "when the localized field is embedded" do
+        before do
+          p = Passport.new
+          I18n.locale = :en
+          p.name = "Neil"
+          I18n.locale = :he
+          p.name = "Nissim"
+
+          Person.create!(passport: p, employer_id: 12345)
+        end
+
+        let(:plucked) do
+          Person.where(employer_id: 12345).pluck_each("pass.name").first
+        end
+
+        let(:plucked_translations) do
+          Person.where(employer_id: 12345).pluck_each("pass.name_translations").first
+        end
+
+        let(:plucked_translations_field) do
+          Person.where(employer_id: 12345).pluck_each("pass.name_translations.en").first
+        end
+
+        context "when legacy_pluck_distinct is set" do
+          config_override :legacy_pluck_distinct, true
+
+          it "returns the full hash embedded" do
+            expect(plucked).to eq({ "name" => { "en" => "Neil", "he" => "Nissim" } })
+          end
+
+          it "returns the empty hash" do
+            expect(plucked_translations).to eq({})
+          end
+
+          it "returns the empty hash" do
+            expect(plucked_translations_field).to eq({})
+          end
+        end
+
+        context "when legacy_pluck_distinct is not set" do
+          config_override :legacy_pluck_distinct, false
+
+          it "returns the translation for the current locale" do
+            expect(plucked).to eq("Nissim")
+          end
+
+          it "returns the full _translation hash" do
+            expect(plucked_translations).to eq({ "en" => "Neil", "he" => "Nissim" })
+          end
+
+          it "returns the translation for the requested locale" do
+            expect(plucked_translations_field).to eq("Neil")
+          end
+        end
+      end
+    end
+
+    context 'when plucking a field to be demongoized' do
+
+      let(:plucked) do
+        Band.where(name: maniacs.name).pluck_each(:sales)
+      end
+
+      context "when legacy_pluck_distinct is set" do
+        config_override :legacy_pluck_distinct, true
+
+        context 'when value is stored as string' do
+          config_override :map_big_decimal_to_decimal128, false
+
+          it "does not demongoize the field" do
+            expect(plucked.first).to be_a(String)
+            expect(plucked.first).to eq("1E2")
+          end
+        end
+
+        context 'when value is stored as decimal128' do
+          config_override :map_big_decimal_to_decimal128, true
+          max_bson_version '4.99.99'
+
+          it "does not demongoize the field" do
+            expect(plucked.first).to be_a(BSON::Decimal128)
+            expect(plucked.first).to eq(BSON::Decimal128.new("1E2"))
+          end
+        end
+      end
+
+      context "when legacy_pluck_distinct is not set" do
+        config_override :legacy_pluck_distinct, false
+
+        context 'when value is stored as string' do
+          config_override :map_big_decimal_to_decimal128, false
+
+          it "demongoizes the field" do
+            expect(plucked.first).to be_a(BigDecimal)
+            expect(plucked.first).to eq(BigDecimal("1E2"))
+          end
+        end
+
+        context 'when value is stored as decimal128' do
+          config_override :map_big_decimal_to_decimal128, true
+
+          it "demongoizes the field" do
+            expect(plucked.first).to be_a(BigDecimal)
+            expect(plucked.first).to eq(BigDecimal("1E2"))
+          end
+        end
+      end
+    end
+
+    context "when plucking an embedded field" do
+      let(:label) { Label.new(sales: "1E2") }
+      let!(:band) { Band.create!(label: label) }
+
+      let!(:plucked) { [] }
+      let!(:pluck_each) { Band.where(_id: band.id).pluck_each("label.sales") { |v| plucked << v } }
+
+      context "when legacy_pluck_distinct is set" do
+        config_override :legacy_pluck_distinct, true
+        config_override :map_big_decimal_to_decimal128, true
+        max_bson_version '4.99.99'
+
+        it "returns a hash with a non-demongoized field" do
+          expect(plucked.first).to eq({ 'sales' => BSON::Decimal128.new('1E+2') })
+        end
+      end
+
+      context "when legacy_pluck_distinct is not set" do
+        config_override :legacy_pluck_distinct, false
+
+        it "demongoizes the field" do
+          expect(plucked.first).to eq(BigDecimal("1E2"))
+        end
+      end
+    end
+
+    context "when plucking an embeds_many field" do
+      let(:label) { Label.new(sales: "1E2") }
+      let!(:band) { Band.create!(labels: [label]) }
+
+      let!(:plucked) { [] }
+      let!(:pluck_each) { Band.where(_id: band.id).pluck_each("labels.sales") { |v| plucked << v } }
+
+      context "when legacy_pluck_distinct is set" do
+        config_override :legacy_pluck_distinct, true
+        config_override :map_big_decimal_to_decimal128, true
+        max_bson_version '4.99.99'
+
+        it "returns a hash with a non-demongoized field" do
+          expect(plucked.first).to eq([{ 'sales' => BSON::Decimal128.new('1E+2') }])
+        end
+      end
+
+      context "when legacy_pluck_distinct is not set" do
+        config_override :legacy_pluck_distinct, false
+
+        it "demongoizes the field" do
+          expect(plucked.first).to eq([BigDecimal("1E2")])
+        end
+      end
+    end
+
+    context "when plucking a nonexistent embedded field" do
+      let(:label) { Label.new(sales: "1E2") }
+      let!(:band) { Band.create!(label: label) }
+
+      let!(:plucked) { [] }
+      let!(:pluck_each) { Band.where(_id: band.id).pluck_each("label.qwerty") { |v| plucked << v } }
+
+      context "when legacy_pluck_distinct is set" do
+        config_override :legacy_pluck_distinct, true
+
+        it "returns an empty hash" do
+          expect(plucked.first).to eq({})
+        end
+      end
+
+      context "when legacy_pluck_distinct is not set" do
+        config_override :legacy_pluck_distinct, false
+
+        it "returns nil" do
+          expect(plucked.first).to eq(nil)
+        end
+      end
+    end
+  end
+
   describe "#respond_to?" do
 
     let(:criteria) do


### PR DESCRIPTION
Resolves MONGOID-5391

This PR extracts out some code into `Mongoid::Contextual::Mongo::PluckEnumerator`. This class is used for both #pluck and #pluck_each (#pluck is simply `pluck_each(fields).to_a`.) There has been no change to the logic of #pluck; all existing #pluck cases pass without modification.