### PR TITLE
MONGOID-5399: Contextual #map should take a splat of field args

### DIFF
--- a/lib/mongoid/contextual/memory.rb
+++ b/lib/mongoid/contextual/memory.rb
@@ -123,6 +123,30 @@ module Mongoid
       alias :one :first
       alias :find_first :first
 
+      # Invoke the block for each element of Contextual. Create a new array
+      # containing the values returned by the block.
+      #
+      # If the field name(s) are passed instead of the block, the result
+      # will be identical to #pluck.
+      #
+      # @example Map by some field.
+      #   context.map(:field1)
+      #
+      # @example Map with block.
+      #   context.map(&:field1)
+      #
+      # @param [ String | Symbol ] *fields The field name(s).
+      #
+      # @return [ Array ] The result of mapping, or the plucked
+      #   field values if no block was given.
+      def map(*fields, &block)
+        if block_given?
+          super(&block)
+        else
+          pluck(fields)
+        end
+      end
+
       # Create the new in memory context.
       #
       # @example Create the new context.

--- a/lib/mongoid/contextual/mongo.rb
+++ b/lib/mongoid/contextual/mongo.rb
@@ -314,8 +314,8 @@ module Mongoid
       # Invoke the block for each element of Contextual. Create a new array
       # containing the values returned by the block.
       #
-      # If the symbol field name is passed instead of the block, additional
-      # optimizations would be used.
+      # If the field name(s) are passed instead of the block, the result
+      # will be identical to #pluck.
       #
       # @example Map by some field.
       #   context.map(:field1)
@@ -323,14 +323,15 @@ module Mongoid
       # @example Map with block.
       #   context.map(&:field1)
       #
-      # @param [ Symbol ] field The field name.
+      # @param [ String | Symbol ] *fields The field name(s).
       #
-      # @return [ Array ] The result of mapping.
-      def map(field = nil, &block)
+      # @return [ Array ] The result of mapping, or the plucked
+      #   field values if no block was given.
+      def map(*fields, &block)
         if block_given?
           super(&block)
         else
-          criteria.pluck(field)
+          pluck(fields)
         end
       end
 

--- a/lib/mongoid/contextual/none.rb
+++ b/lib/mongoid/contextual/none.rb
@@ -83,6 +83,21 @@ module Mongoid
       # @return [ false ] Always false.
       def exists?; false; end
 
+      # Map fields in null context.
+      #
+      # @example Map by some field.
+      #   context.map(:field1)
+      #
+      # @example Map with block.
+      #   context.map(&:field1)
+      #
+      # @param [ String | Symbol ] *fields The field name(s).
+      #
+      # @return [ Array ] An empty Array.
+      def map(*_fields, &block)
+        []
+      end
+
       # Pluck the field values in null context.
       #
       # @example Get the values for null context.


### PR DESCRIPTION
Fixes the following issues:
- MONGOID-5399: Contextual #map should take a splat of field args
- MONGOID-5148: Add missing #map to Contextual::Memory and None