### PR TITLE
MONGOID-5270: Follow-ups to tally PR

### DIFF
--- a/lib/mongoid/contextual/memory.rb
+++ b/lib/mongoid/contextual/memory.rb
@@ -74,7 +74,7 @@ module Mongoid
       # @example Get the distinct values.
       #   context.distinct(:name)
       #
-      # @param [ String, Symbol ] field The name of the field.
+      # @param [ String | Symbol ] field The name of the field.
       #
       # @return [ Array<Object> ] The distinct values for the field.
       def distinct(field)
@@ -205,7 +205,7 @@ module Mongoid
       # @example Get the counts of values in memory.
       #   context.tally(:name)
       #
-      # @param [ String, Symbol ] field Field to tally.
+      # @param [ String | Symbol ] field Field to tally.
       #
       # @return [ Hash ] The hash of counts.
       def tally(field)

--- a/lib/mongoid/contextual/memory.rb
+++ b/lib/mongoid/contextual/memory.rb
@@ -182,7 +182,7 @@ module Mongoid
       #
       # @param [ Integer ] value The number of documents to return.
       #
-      # @return [ Mongo ] The context.
+      # @return [ Memory ] The context.
       def limit(value)
         self.limiting = value
         self
@@ -200,6 +200,14 @@ module Mongoid
         documents.pluck(*fields)
       end
 
+      # Tally the field values in memory.
+      #
+      # @example Get the counts of values in memory.
+      #   context.tally(:name)
+      #
+      # @param [ String, Symbol ] field Field to tally.
+      #
+      # @return [ Hash ] The hash of counts.
       def tally(field)
         return documents.each_with_object({}) do |d, acc|
           v = retrieve_value_at_path(d, field)
@@ -215,7 +223,7 @@ module Mongoid
       #
       # @param [ Integer ] value The number of documents to skip.
       #
-      # @return [ Mongo ] The context.
+      # @return [ Memory ] The context.
       def skip(value)
         self.skipping = value
         self
@@ -229,7 +237,7 @@ module Mongoid
       # @param [ Hash ] values The sorting values as field/direction(1/-1)
       #   pairs.
       #
-      # @return [ Mongo ] The context.
+      # @return [ Memory ] The context.
       def sort(values)
         in_place_sort(values) and self
       end

--- a/lib/mongoid/contextual/mongo.rb
+++ b/lib/mongoid/contextual/mongo.rb
@@ -377,7 +377,8 @@ module Mongoid
         end
       end
 
-      # Get's the number of documents matching the query selector.
+      # Returns the number of documents in the database matching
+      # the query selector.
       #
       # @example Get the length.
       #   context.length
@@ -794,7 +795,6 @@ module Mongoid
       def extract_value(attrs, field_name)
         i = 1
         num_meths = field_name.count('.') + 1
-        k = klass
         curr = attrs.dup
 
         klass.traverse_association_tree(field_name) do |meth, obj, is_field|
@@ -832,10 +832,6 @@ module Mongoid
             fetch_and_demongoize(curr, meth, field)
           end
 
-          # If it's a relation, update the current klass with the relation klass.
-          if !is_field && !obj.nil?
-            k = obj.klass
-          end
           i += 1
         end
         curr
@@ -872,7 +868,7 @@ module Mongoid
           # again, we already have the translation. If it's an _translations
           # field, don't demongoize, we want the full hash not just a
           # specific translation.
-          # If it is a hash, and it's not a transaltions field, we need to
+          # If it is a hash, and it's not a translations field, we need to
           # demongoize to get the correct translation.
           if field.localized? && (!value.is_a?(Hash) || is_translation)
             value.class.demongoize(value)

--- a/lib/mongoid/contextual/none.rb
+++ b/lib/mongoid/contextual/none.rb
@@ -50,7 +50,7 @@ module Mongoid
       # @example Get the distinct values in null context.
       #   context.distinct(:name)
       #
-      # @param [ String, Symbol ] _field The name of the field.
+      # @param [ String | Symbol ] _field The name of the field.
       #
       # @return [ Array ] An empty Array.
       def distinct(_field)
@@ -88,10 +88,10 @@ module Mongoid
       # @example Get the values for null context.
       #   context.pluck(:name)
       #
-      # @param [ String, Symbol, Array ] args Field or fields to pluck.
+      # @param [ String | Symbol ] *_fields Field or fields to pluck.
       #
       # @return [ Array ] An empty Array.
-      def pluck(*args)
+      def pluck(*_fields)
         []
       end
 
@@ -100,7 +100,7 @@ module Mongoid
       # @example Get the values for null context.
       #   context.tally(:name)
       #
-      # @param [ String, Symbol ] _field Field to tally.
+      # @param [ String | Symbol ] _field Field to tally.
       #
       # @return [ Hash ] An empty Hash.
       def tally(_field)

--- a/lib/mongoid/contextual/none.rb
+++ b/lib/mongoid/contextual/none.rb
@@ -100,10 +100,10 @@ module Mongoid
       # @example Get the values for null context.
       #   context.tally(:name)
       #
-      # @param [ String, Symbol ] arg Field to tally.
+      # @param [ String, Symbol ] _field Field to tally.
       #
       # @return [ Hash ] An empty Hash.
-      def tally(arg)
+      def tally(_field)
         {}
       end
 


### PR DESCRIPTION
This contains a few things I missed in code review of #5344
1. Remove unused variable `k` in `Contextual::Mongo#extract_value`
2. Add missing code comment for `Contextual::Memory#tally`
3. Minor code comment fixes
