### PR TITLE
MONGOID-4547 adds regexps to all DocumentNotFound error tests.

### DIFF
--- a/spec/mongoid/association/counter_cache_spec.rb
+++ b/spec/mongoid/association/counter_cache_spec.rb
@@ -133,7 +133,7 @@ describe Mongoid::Association::Referenced::CounterCache do
       it "expect to raise an error" do
         expect {
           Person.reset_counters "1", :drugs
-        }.to raise_error(Mongoid::Errors::DocumentNotFound)
+        }.to raise_error(Mongoid::Errors::DocumentNotFound, /Document\(s\) not found for class Person with id\(s\)/)
       end
     end
 

--- a/spec/mongoid/association/depending_spec.rb
+++ b/spec/mongoid/association/depending_spec.rb
@@ -73,7 +73,7 @@ describe Mongoid::Association::Depending do
             r = DependentReportCard.create!(dependent_student: s)
             s.destroy!
 
-            expect { DependentReportCard.find(r.id) }.to raise_error(Mongoid::Errors::DocumentNotFound)
+            expect { DependentReportCard.find(r.id) }.to raise_error(Mongoid::Errors::DocumentNotFound, /Document\(s\) not found for class DependentReportCard with id\(s\)/)
           end
 
           it 'facilitates proper transitive destroying of the object' do
@@ -84,7 +84,7 @@ describe Mongoid::Association::Depending do
             r = DependentReportCard.create!(dependent_student: s)
             s.destroy!
 
-            expect { DependentReportCard.find(r.id) }.to raise_error(Mongoid::Errors::DocumentNotFound)
+            expect { DependentReportCard.find(r.id) }.to raise_error(Mongoid::Errors::DocumentNotFound, /Document\(s\) not found for class DependentReportCard with id\(s\)/)
           end
 
           it 'adds the dependent to subclasses' do
@@ -105,7 +105,7 @@ describe Mongoid::Association::Depending do
             r = DependentReportCard.create!(dependent_student: s)
             s.destroy!
 
-            expect { DependentReportCard.find(r.id) }.to raise_error(Mongoid::Errors::DocumentNotFound)
+            expect { DependentReportCard.find(r.id) }.to raise_error(Mongoid::Errors::DocumentNotFound, /Document\(s\) not found for class DependentReportCard with id\(s\)/)
           end
 
           it "doesn't add the dependent to sibling classes" do
@@ -177,7 +177,7 @@ describe Mongoid::Association::Depending do
 
             expect {
               DependentOwnedOne.find(owned.id)
-            }.to raise_error(Mongoid::Errors::DocumentNotFound)
+            }.to raise_error(Mongoid::Errors::DocumentNotFound, /Document\(s\) not found for class DependentOwnedOne with id\(s\)/)
           end
         end
 
@@ -250,7 +250,7 @@ describe Mongoid::Association::Depending do
             dep = Dep.create!(double_assoc: two)
             two.destroy!
 
-            expect { Dep.find(dep.id) }.to raise_error(Mongoid::Errors::DocumentNotFound)
+            expect { Dep.find(dep.id) }.to raise_error(Mongoid::Errors::DocumentNotFound, /Document\(s\) not found for class Dep with id\(s\)/)
           end
         end
       end
@@ -362,7 +362,7 @@ describe Mongoid::Association::Depending do
           it "deletes the associated documents" do
             expect {
               child.class.find(child.id)
-            }.to raise_error(Mongoid::Errors::DocumentNotFound)
+            }.to raise_error(Mongoid::Errors::DocumentNotFound, /Document\(s\) not found for class #{child.class.to_s} with id\(s\)/)
           end
         end
 
@@ -674,7 +674,7 @@ describe Mongoid::Association::Depending do
           it "persists the deletion" do
             expect {
               home.reload
-            }.to raise_error(Mongoid::Errors::DocumentNotFound)
+            }.to raise_error(Mongoid::Errors::DocumentNotFound, /Document\(s\) not found for class Home with id\(s\)/)
           end
         end
 
@@ -733,13 +733,13 @@ describe Mongoid::Association::Depending do
             it "persists the first deletion" do
               expect {
                 post_one.reload
-              }.to raise_error(Mongoid::Errors::DocumentNotFound)
+              }.to raise_error(Mongoid::Errors::DocumentNotFound, /Document\(s\) not found for class Post with id\(s\)/)
             end
 
             it "persists the second deletion" do
               expect {
                 post_two.reload
-              }.to raise_error(Mongoid::Errors::DocumentNotFound)
+              }.to raise_error(Mongoid::Errors::DocumentNotFound, /Document\(s\) not found for class Post with id\(s\)/)
             end
           end
         end

--- a/spec/mongoid/association/embedded/embeds_many/proxy_spec.rb
+++ b/spec/mongoid/association/embedded/embeds_many/proxy_spec.rb
@@ -2360,7 +2360,7 @@ describe Mongoid::Association::Embedded::EmbedsMany::Proxy do
           it "raises an error" do
             expect {
               person.addresses.find(BSON::ObjectId.new)
-            }.to raise_error(Mongoid::Errors::DocumentNotFound)
+            }.to raise_error(Mongoid::Errors::DocumentNotFound, /Document\(s\) not found for class Address with id\(s\)/)
           end
         end
 
@@ -2409,7 +2409,7 @@ describe Mongoid::Association::Embedded::EmbedsMany::Proxy do
           it "raises an error" do
             expect {
               person.addresses.find([ BSON::ObjectId.new ])
-            }.to raise_error(Mongoid::Errors::DocumentNotFound)
+            }.to raise_error(Mongoid::Errors::DocumentNotFound, /Document\(s\) not found for class Address with id\(s\)/)
           end
         end
 

--- a/spec/mongoid/association/referenced/has_and_belongs_to_many/proxy_spec.rb
+++ b/spec/mongoid/association/referenced/has_and_belongs_to_many/proxy_spec.rb
@@ -2516,7 +2516,7 @@ describe Mongoid::Association::Referenced::HasAndBelongsToMany::Proxy do
           it "raises an error" do
             expect {
               preference
-            }.to raise_error(Mongoid::Errors::DocumentNotFound)
+            }.to raise_error(Mongoid::Errors::DocumentNotFound, /Document\(s\) not found for class Preference with id\(s\)/)
           end
         end
 
@@ -2531,7 +2531,7 @@ describe Mongoid::Association::Referenced::HasAndBelongsToMany::Proxy do
             it "raises an error" do
               expect {
                 person.preferences.find(BSON::ObjectId.new)
-              }.to raise_error(Mongoid::Errors::DocumentNotFound)
+              }.to raise_error(Mongoid::Errors::DocumentNotFound, /Document\(s\) not found for class Preference with id\(s\)/)
             end
           end
 
@@ -2580,7 +2580,7 @@ describe Mongoid::Association::Referenced::HasAndBelongsToMany::Proxy do
           it "raises an error" do
             expect {
               preferences
-            }.to raise_error(Mongoid::Errors::DocumentNotFound)
+            }.to raise_error(Mongoid::Errors::DocumentNotFound, /Document\(s\) not found for class Preference with id\(s\)/)
           end
         end
 
@@ -2595,7 +2595,7 @@ describe Mongoid::Association::Referenced::HasAndBelongsToMany::Proxy do
             it "raises an error" do
               expect {
                 person.preferences.find([ BSON::ObjectId.new ])
-              }.to raise_error(Mongoid::Errors::DocumentNotFound)
+              }.to raise_error(Mongoid::Errors::DocumentNotFound, /Document\(s\) not found for class Preference with id\(s\)/)
             end
           end
 

--- a/spec/mongoid/association/referenced/has_many/proxy_spec.rb
+++ b/spec/mongoid/association/referenced/has_many/proxy_spec.rb
@@ -2540,7 +2540,7 @@ describe Mongoid::Association::Referenced::HasMany::Proxy do
           it "raises an error" do
             expect {
               person.posts.find(post.id)
-            }.to raise_error(Mongoid::Errors::DocumentNotFound)
+            }.to raise_error(Mongoid::Errors::DocumentNotFound, /Document\(s\) not found for class Post with id\(s\)/)
           end
         end
 
@@ -2555,7 +2555,7 @@ describe Mongoid::Association::Referenced::HasMany::Proxy do
             it "raises an error" do
               expect {
                 person.posts.find(BSON::ObjectId.new)
-              }.to raise_error(Mongoid::Errors::DocumentNotFound)
+              }.to raise_error(Mongoid::Errors::DocumentNotFound, /Document\(s\) not found for class Post with id\(s\)/)
             end
           end
 
@@ -2604,7 +2604,7 @@ describe Mongoid::Association::Referenced::HasMany::Proxy do
             it "raises an error" do
               expect {
                 person.posts.find([ BSON::ObjectId.new ])
-              }.to raise_error(Mongoid::Errors::DocumentNotFound)
+              }.to raise_error(Mongoid::Errors::DocumentNotFound, /Document\(s\) not found for class Post with id\(s\)/)
             end
           end
 
@@ -2668,7 +2668,7 @@ describe Mongoid::Association::Referenced::HasMany::Proxy do
             it "raises an error" do
               expect {
                 movie.ratings.find(BSON::ObjectId.new)
-              }.to raise_error(Mongoid::Errors::DocumentNotFound)
+              }.to raise_error(Mongoid::Errors::DocumentNotFound, /Document\(s\) not found for class Rating with id\(s\)/)
             end
           end
 
@@ -2725,7 +2725,7 @@ describe Mongoid::Association::Referenced::HasMany::Proxy do
             it "raises an error" do
               expect {
                 movie.ratings.find([ BSON::ObjectId.new ])
-              }.to raise_error(Mongoid::Errors::DocumentNotFound)
+              }.to raise_error(Mongoid::Errors::DocumentNotFound, /Document\(s\) not found for class Rating with id\(s\)/)
             end
           end
 

--- a/spec/mongoid/association/referenced/has_one/proxy_spec.rb
+++ b/spec/mongoid/association/referenced/has_one/proxy_spec.rb
@@ -133,7 +133,7 @@ describe Mongoid::Association::Referenced::HasOne::Proxy do
             it "detaches the previous relation" do
               expect {
                 game.reload
-              }.to raise_error(Mongoid::Errors::DocumentNotFound)
+              }.to raise_error(Mongoid::Errors::DocumentNotFound, /Document\(s\) not found for class Game with id\(s\)/)
             end
           end
         end

--- a/spec/mongoid/attributes/nested_spec.rb
+++ b/spec/mongoid/attributes/nested_spec.rb
@@ -1356,7 +1356,7 @@ describe Mongoid::Attributes::Nested do
                 expect {
                   person.addresses_attributes =
                     { "foo" => { "id" => "test", "street" => "Test" } }
-                }.to raise_error(Mongoid::Errors::DocumentNotFound)
+                }.to raise_error(Mongoid::Errors::DocumentNotFound, /Document\(s\) not found for class Address with id\(s\)/)
               end
             end
           end
@@ -3015,7 +3015,7 @@ describe Mongoid::Attributes::Nested do
                       { "0" =>
                         { "id" => BSON::ObjectId.new.to_s, "title" => "Rogue" }
                       }
-                  }.to raise_error(Mongoid::Errors::DocumentNotFound)
+                  }.to raise_error(Mongoid::Errors::DocumentNotFound, /Document\(s\) not found for class Post with id\(s\)/)
                 end
               end
             end
@@ -3049,7 +3049,7 @@ describe Mongoid::Attributes::Nested do
                 expect {
                   person.posts_attributes =
                     { "foo" => { "id" => "test", "title" => "Test" } }
-                }.to raise_error(Mongoid::Errors::DocumentNotFound)
+                }.to raise_error(Mongoid::Errors::DocumentNotFound, /Document\(s\) not found for class Post with id\(s\)/)
               end
             end
           end
@@ -3766,7 +3766,7 @@ describe Mongoid::Attributes::Nested do
                 expect {
                   person.preferences_attributes =
                     { "foo" => { "id" => "test", "name" => "Test" } }
-                }.to raise_error(Mongoid::Errors::DocumentNotFound)
+                }.to raise_error(Mongoid::Errors::DocumentNotFound, /Document\(s\) not found for class Preference with id\(s\)/)
               end
             end
           end

--- a/spec/mongoid/clients_spec.rb
+++ b/spec/mongoid/clients_spec.rb
@@ -802,7 +802,7 @@ describe Mongoid::Clients do
         it "does not persist to the default database" do
           expect {
             Band.find(band.id)
-          }.to raise_error(Mongoid::Errors::DocumentNotFound)
+          }.to raise_error(Mongoid::Errors::DocumentNotFound, /Document\(s\) not found for class Band with id\(s\)/)
         end
 
         let(:from_db) do
@@ -840,7 +840,7 @@ describe Mongoid::Clients do
         it "does not persist to the default database" do
           expect {
             Band.find(band.id)
-          }.to raise_error(Mongoid::Errors::DocumentNotFound)
+          }.to raise_error(Mongoid::Errors::DocumentNotFound, /Document\(s\) not found for class Band with id\(s\)/)
         end
 
         let(:from_db) do

--- a/spec/mongoid/contextual/mongo_spec.rb
+++ b/spec/mongoid/contextual/mongo_spec.rb
@@ -1853,7 +1853,7 @@ describe Mongoid::Contextual::Mongo do
       it "deletes the document from the database" do
         expect {
           depeche.reload
-        }.to raise_error(Mongoid::Errors::DocumentNotFound)
+        }.to raise_error(Mongoid::Errors::DocumentNotFound, /Document\(s\) not found for class Band with id\(s\)/)
       end
 
       context 'when a collation is specified on the criteria' do
@@ -1878,7 +1878,7 @@ describe Mongoid::Contextual::Mongo do
         it "deletes the document from the database" do
           expect {
             depeche.reload
-          }.to raise_error(Mongoid::Errors::DocumentNotFound)
+          }.to raise_error(Mongoid::Errors::DocumentNotFound, /Document\(s\) not found for class Band with id\(s\)/)
         end
       end
     end

--- a/spec/mongoid/criteria/findable_spec.rb
+++ b/spec/mongoid/criteria/findable_spec.rb
@@ -50,7 +50,7 @@ describe Mongoid::Criteria::Findable do
         it 'respects conditions' do
           expect do
             found
-          end.to raise_error(Mongoid::Errors::DocumentNotFound)
+          end.to raise_error(Mongoid::Errors::DocumentNotFound, /Document\(s\) not found for class Band with id\(s\)/)
         end
       end
 
@@ -70,7 +70,7 @@ describe Mongoid::Criteria::Findable do
         it 'respects both conditions' do
           expect do
             found
-          end.to raise_error(Mongoid::Errors::DocumentNotFound)
+          end.to raise_error(Mongoid::Errors::DocumentNotFound, /Document\(s\) not found for class Band with id\(s\)/)
         end
       end
     end
@@ -117,7 +117,7 @@ describe Mongoid::Criteria::Findable do
             it "raises an error" do
               expect {
                 found
-              }.to raise_error(Mongoid::Errors::DocumentNotFound)
+              }.to raise_error(Mongoid::Errors::DocumentNotFound, /Document\(s\) not found for class Band with id\(s\)/)
             end
           end
 
@@ -179,7 +179,7 @@ describe Mongoid::Criteria::Findable do
             it "raises an error" do
               expect {
                 found
-              }.to raise_error(Mongoid::Errors::DocumentNotFound)
+              }.to raise_error(Mongoid::Errors::DocumentNotFound, /Document\(s\) not found for class Band with id\(s\)/)
             end
           end
 
@@ -241,7 +241,7 @@ describe Mongoid::Criteria::Findable do
             it "raises an error" do
               expect {
                 found
-              }.to raise_error(Mongoid::Errors::DocumentNotFound)
+              }.to raise_error(Mongoid::Errors::DocumentNotFound, /Document\(s\) not found for class Band with id\(s\)/)
             end
           end
 
@@ -284,7 +284,7 @@ describe Mongoid::Criteria::Findable do
             it "raises an error" do
               expect {
                 found
-              }.to raise_error(Mongoid::Errors::DocumentNotFound)
+              }.to raise_error(Mongoid::Errors::DocumentNotFound, /Document\(s\) not found for class Band with id\(s\)/)
             end
           end
 
@@ -346,7 +346,7 @@ describe Mongoid::Criteria::Findable do
             it "raises an error" do
               expect {
                 found
-              }.to raise_error(Mongoid::Errors::DocumentNotFound)
+              }.to raise_error(Mongoid::Errors::DocumentNotFound, /Document\(s\) not found for class Band with id\(s\)/)
             end
           end
 
@@ -408,7 +408,7 @@ describe Mongoid::Criteria::Findable do
             it "raises an error" do
               expect {
                 found
-              }.to raise_error(Mongoid::Errors::DocumentNotFound)
+              }.to raise_error(Mongoid::Errors::DocumentNotFound, /Document\(s\) not found for class Band with id\(s\)/)
             end
           end
 
@@ -468,7 +468,7 @@ describe Mongoid::Criteria::Findable do
             it "raises an error" do
               expect {
                 found
-              }.to raise_error(Mongoid::Errors::DocumentNotFound)
+              }.to raise_error(Mongoid::Errors::DocumentNotFound, /Document\(s\) not found for class Band with id\(s\)/)
             end
           end
 
@@ -521,7 +521,7 @@ describe Mongoid::Criteria::Findable do
             it "raises an error" do
               expect {
                 found
-              }.to raise_error(Mongoid::Errors::DocumentNotFound)
+              }.to raise_error(Mongoid::Errors::DocumentNotFound, /Document\(s\) not found for class Band with id\(s\)/)
             end
           end
 
@@ -574,7 +574,7 @@ describe Mongoid::Criteria::Findable do
             it "raises an error" do
               expect {
                 found
-              }.to raise_error(Mongoid::Errors::DocumentNotFound)
+              }.to raise_error(Mongoid::Errors::DocumentNotFound, /Document\(s\) not found for class Band with id\(s\)/)
             end
           end
 
@@ -634,7 +634,7 @@ describe Mongoid::Criteria::Findable do
             it "raises an error" do
               expect {
                 found
-              }.to raise_error(Mongoid::Errors::DocumentNotFound)
+              }.to raise_error(Mongoid::Errors::DocumentNotFound, /Document\(s\) not found for class Band with id\(s\)/)
             end
           end
 
@@ -687,7 +687,7 @@ describe Mongoid::Criteria::Findable do
             it "raises an error" do
               expect {
                 found
-              }.to raise_error(Mongoid::Errors::DocumentNotFound)
+              }.to raise_error(Mongoid::Errors::DocumentNotFound, /Document\(s\) not found for class Band with id\(s\)/)
             end
           end
 
@@ -740,7 +740,7 @@ describe Mongoid::Criteria::Findable do
             it "raises an error" do
               expect {
                 found
-              }.to raise_error(Mongoid::Errors::DocumentNotFound)
+              }.to raise_error(Mongoid::Errors::DocumentNotFound, /Document\(s\) not found for class Band with id\(s\)/)
             end
           end
 
@@ -800,7 +800,7 @@ describe Mongoid::Criteria::Findable do
             it "raises an error" do
               expect {
                 found
-              }.to raise_error(Mongoid::Errors::DocumentNotFound)
+              }.to raise_error(Mongoid::Errors::DocumentNotFound, /Document\(s\) not found for class Band with id\(s\)/)
             end
           end
 
@@ -853,7 +853,7 @@ describe Mongoid::Criteria::Findable do
             it "raises an error" do
               expect {
                 found
-              }.to raise_error(Mongoid::Errors::DocumentNotFound)
+              }.to raise_error(Mongoid::Errors::DocumentNotFound, /Document\(s\) not found for class Band with id\(s\)/)
             end
           end
 
@@ -906,7 +906,7 @@ describe Mongoid::Criteria::Findable do
             it "raises an error" do
               expect {
                 found
-              }.to raise_error(Mongoid::Errors::DocumentNotFound)
+              }.to raise_error(Mongoid::Errors::DocumentNotFound, /Document\(s\) not found for class Band with id\(s\)/)
             end
           end
 
@@ -959,7 +959,7 @@ describe Mongoid::Criteria::Findable do
             it "raises an error" do
               expect {
                 found
-              }.to raise_error(Mongoid::Errors::DocumentNotFound)
+              }.to raise_error(Mongoid::Errors::DocumentNotFound, /Document\(s\) not found for class Band with id\(s\)/)
             end
           end
 

--- a/spec/mongoid/criteria_spec.rb
+++ b/spec/mongoid/criteria_spec.rb
@@ -1000,7 +1000,7 @@ describe Mongoid::Criteria do
         it "deletes the document from the database" do
           expect {
             depeche.reload
-          }.to raise_error(Mongoid::Errors::DocumentNotFound)
+          }.to raise_error(Mongoid::Errors::DocumentNotFound, /Document\(s\) not found for class Band with id\(s\)/)
         end
       end
     end

--- a/spec/mongoid/findable_spec.rb
+++ b/spec/mongoid/findable_spec.rb
@@ -85,7 +85,7 @@ describe Mongoid::Findable do
           it "raises an error" do
             expect {
               person.messages.find_by(body: 'bar')
-            }.to raise_error(Mongoid::Errors::DocumentNotFound)
+            }.to raise_error(Mongoid::Errors::DocumentNotFound, /Document not found for class Message with attributes/)
           end
         end
 
@@ -144,7 +144,7 @@ describe Mongoid::Findable do
         it "raises an error" do
           expect {
             Person.find_by(ssn: "333-22-1111")
-          }.to raise_error(Mongoid::Errors::DocumentNotFound)
+          }.to raise_error(Mongoid::Errors::DocumentNotFound, /Document not found for class Person with attributes/)
         end
       end
 
@@ -213,7 +213,7 @@ describe Mongoid::Findable do
       it "raises an error" do
         expect {
           Person.find_by!(ssn: "333-22-1111")
-        }.to raise_error(Mongoid::Errors::DocumentNotFound)
+        }.to raise_error(Mongoid::Errors::DocumentNotFound, /Document not found for class Person with attributes/)
       end
     end
   end

--- a/spec/mongoid/persistable/deletable_spec.rb
+++ b/spec/mongoid/persistable/deletable_spec.rb
@@ -33,7 +33,7 @@ describe Mongoid::Persistable::Deletable do
       it 'deletes the matching document from the database' do
         lambda do
           person.reload
-        end.should raise_error(Mongoid::Errors::DocumentNotFound)
+        end.should raise_error(Mongoid::Errors::DocumentNotFound, /Document\(s\) not found for class Person with id\(s\)/)
       end
     end
 
@@ -46,7 +46,7 @@ describe Mongoid::Persistable::Deletable do
       it "deletes the document from the collection" do
         expect {
           Person.find(person.id)
-        }.to raise_error(Mongoid::Errors::DocumentNotFound)
+        }.to raise_error(Mongoid::Errors::DocumentNotFound, /Document\(s\) not found for class Person with id\(s\)/)
       end
 
       it "returns true" do

--- a/spec/mongoid/persistable/destroyable_spec.rb
+++ b/spec/mongoid/persistable/destroyable_spec.rb
@@ -33,7 +33,7 @@ describe Mongoid::Persistable::Destroyable do
       it 'deletes the matching document from the database' do
         lambda do
           person.reload
-        end.should raise_error(Mongoid::Errors::DocumentNotFound)
+        end.should raise_error(Mongoid::Errors::DocumentNotFound, /Document\(s\) not found for class Person with id\(s\)/)
       end
     end
 
@@ -46,7 +46,7 @@ describe Mongoid::Persistable::Destroyable do
       it "destroys the document from the collection" do
         expect {
           Person.find(person.id)
-        }.to raise_error(Mongoid::Errors::DocumentNotFound)
+        }.to raise_error(Mongoid::Errors::DocumentNotFound, /Document\(s\) not found for class Person with id\(s\)/)
       end
 
       it "returns true" do

--- a/spec/mongoid/reloadable_spec.rb
+++ b/spec/mongoid/reloadable_spec.rb
@@ -114,7 +114,7 @@ describe Mongoid::Reloadable do
         it "raises an error" do
           expect {
             Person.new.reload
-          }.to raise_error(Mongoid::Errors::DocumentNotFound)
+          }.to raise_error(Mongoid::Errors::DocumentNotFound, /Document\(s\) not found for class Person with id\(s\)/)
         end
       end
 

--- a/spec/mongoid/validatable/presence_spec.rb
+++ b/spec/mongoid/validatable/presence_spec.rb
@@ -287,7 +287,7 @@ describe Mongoid::Validatable::PresenceValidator do
             it "does not save the association target" do
               child.persisted?.should be false
 
-              expect { child.reload }.to raise_error(Mongoid::Errors::DocumentNotFound)
+              expect { child.reload }.to raise_error(Mongoid::Errors::DocumentNotFound, /Document\(s\) not found for class HomAccreditation with id\(s\)/)
             end
           end
         end


### PR DESCRIPTION
MONGOID-4547 adds another test description to the DocumentNotFound error. To ensure that the correct messages are still being used for the correct 
situations, I have added regexps to all tests that use the DocumentNotFound error.

I have decided to put this in a separate PR for readability of the other PR.