### PR TITLE
MONGOID-4547 Implement #take / #take! for AR feature parity

### DIFF
--- a/docs/reference/queries.txt
+++ b/docs/reference/queries.txt
@@ -1390,6 +1390,20 @@ Mongoid also has some helpful methods on criteria.
           # expands out to "managers.name" in the query:
           Band.all.pluck('managers.n')
 
+   * - ``Criteria#take``
+
+       *Get a list of n documents from the database or just one if no parameter
+       is provided..*
+
+       *This method does not apply a sort to the documents, so can return
+       different document(s) than #first and #last.*
+
+     -
+        .. code-block:: ruby
+
+          Band.take
+          Band.take(5)
+
    * - ``Criteria#tally``
 
        *Get a mapping of values to counts for the provided field.*

--- a/docs/reference/queries.txt
+++ b/docs/reference/queries.txt
@@ -1395,7 +1395,7 @@ Mongoid also has some helpful methods on criteria.
        *Get a list of n documents from the database or just one if no parameter
        is provided.*
 
-       *This method does not apply a sort to the documents, so can return
+       *This method does not apply a sort to the documents, so it can return
        different document(s) than #first and #last.*
 
      -
@@ -1408,7 +1408,7 @@ Mongoid also has some helpful methods on criteria.
 
        *Get a document from the database or raise an error if none exist.*
 
-       *This method does not apply a sort to the documents, so can return
+       *This method does not apply a sort to the documents, so it can return
        different document(s) than #first and #last.*
 
      -

--- a/docs/reference/queries.txt
+++ b/docs/reference/queries.txt
@@ -1393,7 +1393,7 @@ Mongoid also has some helpful methods on criteria.
    * - ``Criteria#take``
 
        *Get a list of n documents from the database or just one if no parameter
-       is provided..*
+       is provided.*
 
        *This method does not apply a sort to the documents, so can return
        different document(s) than #first and #last.*
@@ -1403,6 +1403,18 @@ Mongoid also has some helpful methods on criteria.
 
           Band.take
           Band.take(5)
+
+   * - ``Criteria#take!``
+
+       *Get a document from the database or raise an error if none exist.*
+
+       *This method does not apply a sort to the documents, so can return
+       different document(s) than #first and #last.*
+
+     -
+        .. code-block:: ruby
+
+          Band.take!
 
    * - ``Criteria#tally``
 

--- a/docs/release-notes/mongoid-7.5.txt
+++ b/docs/release-notes/mongoid-7.5.txt
@@ -126,3 +126,35 @@ return a ``Hash`` when instantiating a new document:
   band = Band.first
   p band.attributes.class
   # => BSON::Document
+
+
+Implemented ``Criteria#take`` Method
+------------------------------------
+
+Mongoid 7.5 introduces the ``#take`` method which returns an unsorted document
+or list of documents from the database:
+
+.. code:: ruby
+
+  class Band
+    include Mongoid::Document
+  end
+
+  Band.create!
+  Band.create!
+
+  Band.take
+  # => #<Band _id: 62c835813282a4470c07d530, >
+  Band.take(2)
+  # => [ #<Band _id: 62c835813282a4470c07d530, >, #<Band _id: 62c835823282a4470c07d531, > ]
+
+If a parameter is given to ``#take``, a list is returned. If no parameter is
+given, a singular document is returned.
+
+Note that the ``#take`` method does not apply a sort to the view before retrieving
+the documents from the database, and therefore it may return different results
+than the ``#first`` and ``#last`` methods. This method is equivalent to calling
+``#first`` and ``#last`` with the ``{ id_sort: :none }`` option. This option
+has been deprecated in Mongoid 7.5 and it is recommended to use ``#take``
+instead going forward. Support for the ``:id_sort`` option will be dropped in
+Mongoid 8.

--- a/docs/release-notes/mongoid-7.5.txt
+++ b/docs/release-notes/mongoid-7.5.txt
@@ -131,8 +131,8 @@ return a ``Hash`` when instantiating a new document:
 Implemented ``Criteria#take/take!`` Method
 ------------------------------------------
 
-Mongoid 7.5 introduces the ``#take`` method which returns an unsorted document
-or list of documents from the database:
+Mongoid 7.5 introduces the ``#take`` method which returns a document
+or a set of documents from the database without ordering by ``_id``:
 
 .. code:: ruby
 
@@ -148,12 +148,11 @@ or list of documents from the database:
   Band.take(2)
   # => [ #<Band _id: 62c835813282a4470c07d530, >, #<Band _id: 62c835823282a4470c07d531, > ]
 
-If a parameter is given to ``#take``, a list is returned. If no parameter is
+If a parameter is given to ``#take``, an array of documents is returned. If no parameter is
 given, a singular document is returned.
 
-The ``#take!`` method does not take parameters but otherwise functions the same
-as calling ``#take``. The ``#take!`` method returns a single document, and
-raises an error if none are found.
+The ``#take!`` method functions the same as calling ``#take`` without arguments,
+but raises an error instead of returning nil if no documents are found.
 
 .. code:: ruby
 
@@ -161,9 +160,9 @@ raises an error if none are found.
   # => #<Band _id: 62c835813282a4470c07d530, >
 
 Note that the ``#take/take!`` methods do not apply a sort to the view before
-retrieving the documents from the database, and therefore it may return different
-results than the ``#first`` and ``#last`` methods. This method is equivalent to
-calling ``#first`` and ``#last`` with the ``{ id_sort: :none }`` option. This
+retrieving the documents from the database, and therefore they may return different
+results than the ``#first`` and ``#last`` methods. ``#take`` is equivalent to
+calling ``#first`` or ``#last`` with the ``{ id_sort: :none }`` option. This
 option has been deprecated in Mongoid 7.5 and it is recommended to use ``#take``
 instead going forward. Support for the ``:id_sort`` option will be dropped in
 Mongoid 8.

--- a/docs/release-notes/mongoid-7.5.txt
+++ b/docs/release-notes/mongoid-7.5.txt
@@ -128,8 +128,8 @@ return a ``Hash`` when instantiating a new document:
   # => BSON::Document
 
 
-Implemented ``Criteria#take`` Method
-------------------------------------
+Implemented ``Criteria#take/take!`` Method
+------------------------------------------
 
 Mongoid 7.5 introduces the ``#take`` method which returns an unsorted document
 or list of documents from the database:
@@ -151,10 +151,19 @@ or list of documents from the database:
 If a parameter is given to ``#take``, a list is returned. If no parameter is
 given, a singular document is returned.
 
-Note that the ``#take`` method does not apply a sort to the view before retrieving
-the documents from the database, and therefore it may return different results
-than the ``#first`` and ``#last`` methods. This method is equivalent to calling
-``#first`` and ``#last`` with the ``{ id_sort: :none }`` option. This option
-has been deprecated in Mongoid 7.5 and it is recommended to use ``#take``
+The ``#take!`` method does not take parameters but otherwise functions the same
+as calling ``#take``. The ``#take!`` method returns a single document, and
+raises an error if none are found.
+
+.. code:: ruby
+
+  Band.take!
+  # => #<Band _id: 62c835813282a4470c07d530, >
+
+Note that the ``#take/take!`` methods do not apply a sort to the view before
+retrieving the documents from the database, and therefore it may return different
+results than the ``#first`` and ``#last`` methods. This method is equivalent to
+calling ``#first`` and ``#last`` with the ``{ id_sort: :none }`` option. This
+option has been deprecated in Mongoid 7.5 and it is recommended to use ``#take``
 instead going forward. Support for the ``:id_sort`` option will be dropped in
 Mongoid 8.

--- a/docs/release-notes/mongoid-7.5.txt
+++ b/docs/release-notes/mongoid-7.5.txt
@@ -152,7 +152,8 @@ If a parameter is given to ``#take``, an array of documents is returned. If no p
 given, a singular document is returned.
 
 The ``#take!`` method functions the same as calling ``#take`` without arguments,
-but raises an error instead of returning nil if no documents are found.
+but raises an DocumentNotFound error instead of returning nil if no documents
+are found.
 
 .. code:: ruby
 

--- a/lib/config/locales/en.yml
+++ b/lib/config/locales/en.yml
@@ -427,6 +427,11 @@ en:
             \_\_\_\_\_\_default:\n
             \_\_\_\_\_\_\_\_hosts:\n
             \_\_\_\_\_\_\_\_\_\_- localhost:27017\n\n"
+        no_documents_found:
+          message: "Could not find a document of class %{klass}."
+          summary: "Mongoid attempted to find a document from the class %{klass}
+            but none exist."
+          resolution: "Create a document of class %{klass}."
         no_environment:
           message: "Could not load the configuration since no environment
             was defined."

--- a/lib/config/locales/en.yml
+++ b/lib/config/locales/en.yml
@@ -431,7 +431,9 @@ en:
           message: "Could not find a document of class %{klass}."
           summary: "Mongoid attempted to find a document of the class %{klass}
             but none exist."
-          resolution: "Create a document of class %{klass}."
+          resolution: "Create a document of class %{klass} or use a finder
+            method that returns nil when no documents are found instead of
+            raising an exception."
         no_environment:
           message: "Could not load the configuration since no environment
             was defined."

--- a/lib/mongoid/contextual/memory.rb
+++ b/lib/mongoid/contextual/memory.rb
@@ -170,6 +170,7 @@ module Mongoid
       #   context.take
       #
       # @param [ Integer ] value The number of documents to take.
+      #
       # @return [ Document ] The document.
       def take(value = nil)
         if value
@@ -185,6 +186,9 @@ module Mongoid
       #   context.take
       #
       # @return [ Document ] The document.
+      #
+      # @raises [ Mongoid::Errors::DocumentNotFound ] raises when there are no
+      #   documents to take.
       def take!
         if documents.empty?
           raise Errors::DocumentNotFound.new(klass, nil, nil)

--- a/lib/mongoid/contextual/memory.rb
+++ b/lib/mongoid/contextual/memory.rb
@@ -169,12 +169,12 @@ module Mongoid
       # @example Take a document.
       #   context.take
       #
-      # @param [ Integer ] value The number of documents to take.
+      # @param [ Integer | nil ] limit The number of documents to take or nil.
       #
       # @return [ Document ] The document.
-      def take(value = nil)
-        if value
-          eager_load(documents.take(value))
+      def take(limit = nil)
+        if limit
+          eager_load(documents.take(limit))
         else
           eager_load([documents.first]).first
         end

--- a/lib/mongoid/contextual/memory.rb
+++ b/lib/mongoid/contextual/memory.rb
@@ -164,6 +164,35 @@ module Mongoid
         eager_load([documents.last]).first
       end
 
+      # Take the given number of documents from the database.
+      #
+      # @example Take a document.
+      #   context.take
+      #
+      # @param [ Integer ] value The number of documents to take.
+      # @return [ Document ] The document.
+      def take(value = nil)
+        if value
+          eager_load(documents.take(value))
+        else
+          eager_load([documents.first]).first
+        end
+      end
+
+      # Take the given number of documents from the database.
+      #
+      # @example Take a document.
+      #   context.take
+      #
+      # @return [ Document ] The document.
+      def take!
+        if documents.empty?
+          raise Errors::DocumentNotFound.new(klass, nil, nil)
+        else
+          eager_load([documents.first]).first
+        end
+      end
+
       # Get the length of matching documents in the context.
       #
       # @example Get the length of matching documents.

--- a/lib/mongoid/contextual/mongo.rb
+++ b/lib/mongoid/contextual/mongo.rb
@@ -425,6 +425,9 @@ module Mongoid
       #   context.take!
       #
       # @return [ Document ] The document.
+      #
+      # @raises [ Mongoid::Errors::DocumentNotFound ] raises when there are no
+      #   documents to take.
       def take!
         # Do to_a first so that the Mongo#first method is not used and the
         # result is not sorted.

--- a/lib/mongoid/contextual/mongo.rb
+++ b/lib/mongoid/contextual/mongo.rb
@@ -400,6 +400,37 @@ module Mongoid
         @view = view.limit(value) and self
       end
 
+      # Takes the given number of documents from the database.
+      #
+      # @example Take 10 documents
+      #   context.take(10)
+      #
+      # @param [ Integer ] value The number of documents to return.
+      #
+      # @return [ Document | Array<Document> ] The list of documents, or one
+      #   document if no value was given.
+      def take(value = nil)
+        if value
+          limit(value).to_a
+        else
+          first
+        end
+      end
+
+      # Take one document from the database and raise an error if there are none.
+      #
+      # @example Take a document
+      #   context.take!
+      #
+      # @return [ Document ] The document.
+      def take!
+        if fst = first
+          fst
+        else
+          raise Errors::DocumentNotFound.new(klass, nil, nil)
+        end
+      end
+
       # Initiate a map/reduce operation from the context.
       #
       # @example Initiate a map/reduce.

--- a/lib/mongoid/contextual/mongo.rb
+++ b/lib/mongoid/contextual/mongo.rb
@@ -400,7 +400,7 @@ module Mongoid
         @view = view.limit(value) and self
       end
 
-      # Takes the given number of documents from the database.
+      # Take the given number of documents from the database.
       #
       # @example Take 10 documents
       #   context.take(10)

--- a/lib/mongoid/contextual/mongo.rb
+++ b/lib/mongoid/contextual/mongo.rb
@@ -405,13 +405,13 @@ module Mongoid
       # @example Take 10 documents
       #   context.take(10)
       #
-      # @param [ Integer ] value The number of documents to return.
+      # @param [ Integer | nil ] limit The number of documents to return or nil.
       #
       # @return [ Document | Array<Document> ] The list of documents, or one
       #   document if no value was given.
-      def take(value = nil)
-        if value
-          limit(value).to_a
+      def take(limit = nil)
+        if limit
+          limit(limit).to_a
         else
           # Do to_a first so that the Mongo#first method is not used and the
           # result is not sorted.

--- a/lib/mongoid/contextual/mongo.rb
+++ b/lib/mongoid/contextual/mongo.rb
@@ -410,7 +410,13 @@ module Mongoid
       # @return [ Document | Array<Document> ] The list of documents, or one
       #   document if no value was given.
       def take(value = nil)
-        value ? limit(value).to_a : first
+        if value
+          limit(value).to_a
+        else
+          # Do to_a first so that the Mongo#first method is not used and the
+          # result is not sorted.
+          limit(1).to_a.first
+        end
       end
 
       # Take one document from the database and raise an error if there are none.
@@ -420,7 +426,9 @@ module Mongoid
       #
       # @return [ Document ] The document.
       def take!
-        if fst = first
+        # Do to_a first so that the Mongo#first method is not used and the
+        # result is not sorted.
+        if fst = limit(1).to_a.first
           fst
         else
           raise Errors::DocumentNotFound.new(klass, nil, nil)

--- a/lib/mongoid/contextual/mongo.rb
+++ b/lib/mongoid/contextual/mongo.rb
@@ -410,11 +410,7 @@ module Mongoid
       # @return [ Document | Array<Document> ] The list of documents, or one
       #   document if no value was given.
       def take(value = nil)
-        if value
-          limit(value).to_a
-        else
-          first
-        end
+        value ? limit(value).to_a : first
       end
 
       # Take one document from the database and raise an error if there are none.

--- a/lib/mongoid/contextual/none.rb
+++ b/lib/mongoid/contextual/none.rb
@@ -125,15 +125,17 @@ module Mongoid
       # @return [ nil ] Always nil.
       def last; nil; end
 
-      # Always returns nil.
+      # Returns nil or empty array.
       #
       # @example Take a document in null context.
       #   context.take
       #
       # @param [ Integer ] value The number of documents to take.
       #
-      # @return [ nil ] Always nil.
-      def take(value = nil); nil; end
+      # @return [ [] | nil ] Empty array or nil.
+      def take(value = nil)
+        value ? [] : nil
+      end
 
       # Always raises an error.
       #

--- a/lib/mongoid/contextual/none.rb
+++ b/lib/mongoid/contextual/none.rb
@@ -125,6 +125,26 @@ module Mongoid
       # @return [ nil ] Always nil.
       def last; nil; end
 
+      # Always returns nil.
+      #
+      # @example Take a document in null context.
+      #   context.take
+      #
+      # @param [ Integer ] value The number of documents to take.
+      #
+      # @return [ nil ] Always nil.
+      def take(value = nil); nil; end
+
+      # Always raises an error.
+      #
+      # @example Take a document in null context.
+      #   context.take!
+      #
+      # @raises [ Mongoid::Errors::DocumentNotFound ] always raises.
+      def take!
+        raise Errors::DocumentNotFound.new(klass, nil, nil)
+      end
+
       # Always returns zero.
       #
       # @example Get the length of null context.

--- a/lib/mongoid/contextual/none.rb
+++ b/lib/mongoid/contextual/none.rb
@@ -130,11 +130,11 @@ module Mongoid
       # @example Take a document in null context.
       #   context.take
       #
-      # @param [ Integer ] value The number of documents to take.
+      # @param [ Integer | nil ] limit The number of documents to take or nil.
       #
       # @return [ [] | nil ] Empty array or nil.
-      def take(value = nil)
-        value ? [] : nil
+      def take(limit = nil)
+        limit ? [] : nil
       end
 
       # Always raises an error.

--- a/lib/mongoid/errors/document_not_found.rb
+++ b/lib/mongoid/errors/document_not_found.rb
@@ -24,7 +24,7 @@ module Mongoid
       #   there is a shard key this will be a hash.
       def initialize(klass, params, unmatched = nil)
         if !unmatched && !params.is_a?(Hash)
-          unmatched = Array(params)
+          unmatched = Array(params) if params
         end
 
         @klass, @params = klass, params
@@ -98,7 +98,9 @@ module Mongoid
       #
       # @return [ String ] The problem.
       def message_key(params, unmatched)
-        if Hash === params
+        if !params && !unmatched
+          "no_documents_found"
+        elsif Hash === params
           "document_with_attributes_not_found"
         elsif Hash === unmatched && unmatched.size >= 2
           "document_with_shard_key_not_found"

--- a/lib/mongoid/findable.rb
+++ b/lib/mongoid/findable.rb
@@ -41,10 +41,12 @@ module Mongoid
       :pluck,
       :read,
       :sum,
+      :take,
+      :take!,
+      :tally,
       :text_search,
       :update,
       :update_all,
-      :tally,
 
     # Returns a count of records in the database.
     # If you want to specify conditions use where.

--- a/spec/mongoid/contextual/mongo_spec.rb
+++ b/spec/mongoid/contextual/mongo_spec.rb
@@ -2268,6 +2268,80 @@ describe Mongoid::Contextual::Mongo do
     end
   end
 
+  describe "#take" do
+
+    let!(:depeche_mode) do
+      Band.create!(name: "Depeche Mode")
+    end
+
+    let!(:new_order) do
+      Band.create!(name: "New Order")
+    end
+
+    let!(:rolling_stones) do
+      Band.create!(name: "The Rolling Stones")
+    end
+
+    let(:criteria) do
+      Band.all
+    end
+
+    let(:context) do
+      described_class.new(criteria)
+    end
+
+    it "takes the correct number results" do
+      expect(context.take(2)).to eq([ depeche_mode, new_order ])
+    end
+
+    it "returns an array when passing 1" do
+      expect(context.take(1)).to eq([ depeche_mode ])
+    end
+
+    it "does not return an array when not passing an argument" do
+      expect(context.take).to eq(depeche_mode)
+    end
+
+    it "returns all the documents taking more than whats in the db" do
+      expect(context.take(5)).to eq([ depeche_mode, new_order, rolling_stones ])
+    end
+  end
+
+  describe "#take!" do
+
+    let!(:depeche_mode) do
+      Band.create!(name: "Depeche Mode")
+    end
+
+    let!(:new_order) do
+      Band.create!(name: "New Order")
+    end
+
+    let!(:rolling_stones) do
+      Band.create!(name: "The Rolling Stones")
+    end
+
+    let(:criteria) do
+      Band.all
+    end
+
+    let(:context) do
+      described_class.new(criteria)
+    end
+
+    it "takes the first document" do
+      expect(context.take!).to eq(depeche_mode)
+    end
+
+    context "when there are no documents" do
+      it "raises an error" do
+        expect do
+          Person.take!
+        end.to raise_error(/Could not find a document of class Person./)
+      end
+    end
+  end
+
   describe "#map" do
 
     before do

--- a/spec/mongoid/contextual/mongo_spec.rb
+++ b/spec/mongoid/contextual/mongo_spec.rb
@@ -2337,7 +2337,7 @@ describe Mongoid::Contextual::Mongo do
       it "raises an error" do
         expect do
           Person.take!
-        end.to raise_error(/Could not find a document of class Person./)
+        end.to raise_error(Mongoid::Errors::DocumentNotFound, /Could not find a document of class Person./)
       end
     end
   end

--- a/spec/mongoid/contextual/none_spec.rb
+++ b/spec/mongoid/contextual/none_spec.rb
@@ -77,6 +77,24 @@ describe Mongoid::Contextual::None do
     end
   end
 
+  describe "#take" do
+    it "returns nil" do
+      expect(context.take).to be_nil
+    end
+
+    it "returns nil with params" do
+      expect(context.take(1)).to be_nil
+    end
+  end
+
+  describe "#take!" do
+    it "raises an error" do
+      expect do
+        context.take!
+      end.to raise_error(Mongoid::Errors::DocumentNotFound, /Could not find a document of class Band./)
+    end
+  end
+
   describe "#length" do
     it "returns zero" do
       expect(context.length).to eq(0)

--- a/spec/mongoid/contextual/none_spec.rb
+++ b/spec/mongoid/contextual/none_spec.rb
@@ -83,7 +83,7 @@ describe Mongoid::Contextual::None do
     end
 
     it "returns nil with params" do
-      expect(context.take(1)).to be_nil
+      expect(context.take(1)).to eq([])
     end
   end
 

--- a/spec/mongoid/errors/document_not_found_spec.rb
+++ b/spec/mongoid/errors/document_not_found_spec.rb
@@ -132,6 +132,30 @@ describe Mongoid::Errors::DocumentNotFound do
         )
       end
     end
+
+    context "when not providing params or unmatched" do
+      let(:error) do
+        described_class.new(Person, nil, nil)
+      end
+
+      it "contains the problem in the message" do
+        expect(error.message).to include(
+          "Could not find a document of class Person."
+        )
+      end
+
+      it "contains the summary in the message" do
+        expect(error.message).to include(
+          "Mongoid attempted to find a document from the class Person but none exist."
+        )
+      end
+
+      it "contains the resolution in the message" do
+        expect(error.message).to include(
+          "Create a document of class Person."
+        )
+      end
+    end
   end
 
   describe "#params" do

--- a/spec/mongoid/errors/document_not_found_spec.rb
+++ b/spec/mongoid/errors/document_not_found_spec.rb
@@ -146,13 +146,13 @@ describe Mongoid::Errors::DocumentNotFound do
 
       it "contains the summary in the message" do
         expect(error.message).to include(
-          "Mongoid attempted to find a document from the class Person but none exist."
+          "Mongoid attempted to find a document of the class Person but none exist."
         )
       end
 
       it "contains the resolution in the message" do
         expect(error.message).to include(
-          "Create a document of class Person."
+          "Create a document of class Person or use a finder method that returns nil when no documents are found instead of raising an exception."
         )
       end
     end


### PR DESCRIPTION
A decision I made here is that `take` should return documents instead of a criteria. This draws a distinction between `take` and `limit`, as well as I think it would be a little strange if we returned a criteria on just `Person.take` (i.e. without params) since only one document is returned.

TODO:

- memory
- none
- release note
- crud documentation