### PR TITLE
MONGOID-5107: Remove reference to mongoid.github.io

### DIFF
--- a/docs/index.txt
+++ b/docs/index.txt
@@ -20,6 +20,3 @@ for MongoDB in Ruby.
   release-notes
   additional-resources
   ecosystem
-
-
-For documentation on Mongoid 3 and 4, see `<http://mongoid.github.io>`_.


### PR DESCRIPTION
The https://mongoid.github.io/ looks broken CSS-wise and think these versions are deep, deep EOL, so should just remove.

(If you want to keep this, please close MONGOID-5107)