### PR TITLE
MONGOID-4829: Clarify RAILS_ENV, MONGOID_ENV must be set in ENV

### DIFF
--- a/lib/config/locales/en.yml
+++ b/lib/config/locales/en.yml
@@ -430,13 +430,13 @@ en:
         no_environment:
           message: "Could not load the configuration since no environment
             was defined."
-          summary: "Mongoid could not find an environment value in any of
-            the following locations: Rails.env, Sinatra::Base.environment,
-            ENV[\"RACK_ENV\"], or ENV[\"MONGOID_ENV\"]. Without knowing the
-            environment, Mongoid cannot load its configuration from mongoid.yml."
+          summary: "Mongoid could not determine the environment to use because
+            it was not specified in any of the following locations:
+            Rails.env, Sinatra::Base.environment,
+            ENV[\"RACK_ENV\"], ENV[\"MONGOID_ENV\"]. Without knowing the
+            environment, Mongoid cannot load its configuration."
           resolution: "Please ensure an environment is set in one of the
-            mentioned locations. By design, Mongoid does not default to
-            development environment."
+            listed locations. The environment must be explicitly set."
         no_map_reduce_output:
           message: "No output location was specified for the map/reduce
             operation."

--- a/lib/config/locales/en.yml
+++ b/lib/config/locales/en.yml
@@ -430,14 +430,13 @@ en:
         no_environment:
           message: "Could not load the configuration since no environment
             was defined."
-          summary: "Mongoid attempted to find the appropriate environment
-            but no Rails.env, Sinatra::Base.environment, RACK_ENV, or
-            MONGOID_ENV could be found."
-          resolution: "Make sure some environment is set from the mentioned
-            options. Mongoid cannot load configuration from the yaml without
-            knowing which environment it is in, and we have considered
-            defaulting to development an undesirable side effect of this not
-            being defined."
+          summary: "Mongoid could not find an environment value in any of
+            the following locations: Rails.env, Sinatra::Base.environment,
+            ENV[\"RACK_ENV\"], or ENV[\"MONGOID_ENV\"]. Without knowing the
+            environment, Mongoid cannot load its configuration from mongoid.yml."
+          resolution: "Please ensure an environment value is set in one of
+            the mentioned locations. By design, Mongoid does not default to
+            development environment."
         no_map_reduce_output:
           message: "No output location was specified for the map/reduce
             operation."

--- a/lib/config/locales/en.yml
+++ b/lib/config/locales/en.yml
@@ -434,8 +434,8 @@ en:
             the following locations: Rails.env, Sinatra::Base.environment,
             ENV[\"RACK_ENV\"], or ENV[\"MONGOID_ENV\"]. Without knowing the
             environment, Mongoid cannot load its configuration from mongoid.yml."
-          resolution: "Please ensure an environment value is set in one of
-            the mentioned locations. By design, Mongoid does not default to
+          resolution: "Please ensure an environment is set in one of the
+            mentioned locations. By design, Mongoid does not default to
             development environment."
         no_map_reduce_output:
           message: "No output location was specified for the map/reduce

--- a/spec/mongoid/errors/no_environment_spec.rb
+++ b/spec/mongoid/errors/no_environment_spec.rb
@@ -24,7 +24,7 @@ describe Mongoid::Errors::NoEnvironment do
 
     it "contains the resolution in the message" do
       expect(error.message).to include(
-        "Please ensure an environment value is set in one of the mentioned locations"
+        "Please ensure an environment is set in one of the mentioned locations"
       )
     end
   end

--- a/spec/mongoid/errors/no_environment_spec.rb
+++ b/spec/mongoid/errors/no_environment_spec.rb
@@ -18,13 +18,13 @@ describe Mongoid::Errors::NoEnvironment do
 
     it "contains the summary in the message" do
       expect(error.message).to include(
-        "Mongoid attempted to find the appropriate environment but no Rails.env"
+        "Mongoid could not find an environment setting in any of the following"
       )
     end
 
     it "contains the resolution in the message" do
       expect(error.message).to include(
-        "Make sure some environment is set from the mentioned options"
+        "Please ensure an environment value is set in one of the mentioned locations"
       )
     end
   end

--- a/spec/mongoid/errors/no_environment_spec.rb
+++ b/spec/mongoid/errors/no_environment_spec.rb
@@ -12,19 +12,19 @@ describe Mongoid::Errors::NoEnvironment do
 
     it "contains the problem in the message" do
       expect(error.message).to include(
-        "Could not load the configuration since no environment was defined."
+        "Mongoid could not determine the environment"
       )
     end
 
     it "contains the summary in the message" do
       expect(error.message).to include(
-        "Mongoid could not find an environment value in any of the following"
+        "it was not specified in any of the following locations"
       )
     end
 
     it "contains the resolution in the message" do
       expect(error.message).to include(
-        "Please ensure an environment is set in one of the mentioned locations"
+        "Please ensure an environment is set"
       )
     end
   end

--- a/spec/mongoid/errors/no_environment_spec.rb
+++ b/spec/mongoid/errors/no_environment_spec.rb
@@ -18,7 +18,7 @@ describe Mongoid::Errors::NoEnvironment do
 
     it "contains the summary in the message" do
       expect(error.message).to include(
-        "Mongoid could not find an environment setting in any of the following"
+        "Mongoid could not find an environment value in any of the following"
       )
     end
 


### PR DESCRIPTION
- Clarify RAILS_ENV, MONGOID_ENV must be set in ENV.
- Cleanup error language while we're here (e.g. "resolution" section contained info that belongs in "summary", etc.)