### PR TITLE
MONGOID-4992 - Fix Rails syntax in docs

### DIFF
--- a/docs/reference/persistence-configuration.txt
+++ b/docs/reference/persistence-configuration.txt
@@ -208,8 +208,8 @@ schema in each remains the same.
 .. code-block:: ruby
 
   class BandsController < ApplicationController
-    before_filter :switch_database
-    after_filter :reset_database
+    before_action :switch_database
+    after_action :reset_database
 
     private
 


### PR DESCRIPTION
Documentation only. This syntax changed in Rails 4.

(I checked all the docs but these are the only usages I found)