### PR TITLE
MONGOID-4998 deprecate :id_sort and implement limit positional argument on #first/#last

### DIFF
--- a/docs/reference/queries.txt
+++ b/docs/reference/queries.txt
@@ -1303,7 +1303,7 @@ Mongoid also has some helpful methods on criteria.
 
        *Finds a single document given the provided criteria. This automatically adds a sort on _id.
        Opt out of adding the id sort with the {id_sort: :none} option. This option is deprecated.
-       Get a list of documents by passing in a limit argument.*
+       please call ``take`` instead. Get a list of documents by passing in a limit argument.*
 
      -
         .. code-block:: ruby

--- a/docs/reference/queries.txt
+++ b/docs/reference/queries.txt
@@ -1302,7 +1302,8 @@ Mongoid also has some helpful methods on criteria.
    * - ``Criteria#first|last``
 
        *Finds a single document given the provided criteria. This automatically adds a sort on id.
-       Opt out of adding the id sort with the {id_sort: :none} option.*
+       Opt out of adding the id sort with the {id_sort: :none} option. This option is deprecated.
+       Get a list of documents by passing in a limit argument.*
 
      -
         .. code-block:: ruby
@@ -1310,6 +1311,7 @@ Mongoid also has some helpful methods on criteria.
           Band.first
           Band.where(:members.with_size => 3).first
           Band.where(:members.with_size => 3).last
+          Band.first(2)
 
    * - ``Criteria#first_or_create``
 

--- a/docs/reference/queries.txt
+++ b/docs/reference/queries.txt
@@ -1302,7 +1302,7 @@ Mongoid also has some helpful methods on criteria.
    * - ``Criteria#first|last``
 
        *Finds a single document given the provided criteria. This automatically adds a sort on _id.
-       Opt out of adding the id sort with the {id_sort: :none} option. This option is deprecated.
+       Opt out of adding the id sort with the {id_sort: :none} option. This option is deprecated -
        please call ``take`` instead. Get a list of documents by passing in a limit argument.*
 
      -

--- a/docs/reference/queries.txt
+++ b/docs/reference/queries.txt
@@ -1301,7 +1301,7 @@ Mongoid also has some helpful methods on criteria.
 
    * - ``Criteria#first|last``
 
-       *Finds a single document given the provided criteria. This automatically adds a sort on id.
+       *Finds a single document given the provided criteria. This automatically adds a sort on _id.
        Opt out of adding the id sort with the {id_sort: :none} option. This option is deprecated.
        Get a list of documents by passing in a limit argument.*
 

--- a/docs/release-notes/mongoid-7.5.txt
+++ b/docs/release-notes/mongoid-7.5.txt
@@ -193,7 +193,7 @@ Mongoid 8.
 Deprecate ``:id_sort`` Option and Support ``limit`` on ``#first/last``
 ----------------------------------------------------------------------
 
-Mongoid 7.5 deprecates support for the ``:id_sort`` keyword argument for the
+Mongoid 7.5 deprecates the ``:id_sort`` keyword argument for the
 ``Criteria#first`` and ``Criteria#last`` methods. These methods have added
 support for adding a limit as a positional argument:
 

--- a/docs/release-notes/mongoid-7.5.txt
+++ b/docs/release-notes/mongoid-7.5.txt
@@ -194,7 +194,7 @@ Deprecate ``:id_sort`` Option and Support ``limit`` on ``#first/last``
 ----------------------------------------------------------------------
 
 Mongoid 7.5 deprecates the ``:id_sort`` keyword argument for the
-``Criteria#first`` and ``Criteria#last`` methods. These methods have added
+``Criteria#first`` and ``Criteria#last`` methods. Please use ``Criteria#take`` to retrieve documents without sorting by id. ```
 The ``first`` and ``last`` methods now take the number of documents to return as a positional argument, mirroring the functionality of Ruby's ``Enumerable`` method and ActiveRecord's ``first`` and ``last`` methods. Both invocations (with limit as positional arguments and with ``:id_sort`` option) remain supported in Mongoid 7.x, but the ``:id_sort`` invocation will be removed in Mongoid 8.
 
 .. code:: ruby

--- a/docs/release-notes/mongoid-7.5.txt
+++ b/docs/release-notes/mongoid-7.5.txt
@@ -195,7 +195,7 @@ Deprecate ``:id_sort`` Option and Support ``limit`` on ``#first/last``
 
 Mongoid 7.5 deprecates the ``:id_sort`` keyword argument for the
 ``Criteria#first`` and ``Criteria#last`` methods. These methods have added
-support for adding a limit as a positional argument:
+The ``first`` and ``last`` methods now take the number of documents to return as a positional argument, mirroring the functionality of Ruby's ``Enumerable`` method and ActiveRecord's ``first`` and ``last`` methods. Both invocations (with limit as positional arguments and with ``:id_sort`` option) remain supported in Mongoid 7.x, but the ``:id_sort`` invocation will be removed in Mongoid 8.
 
 .. code:: ruby
 

--- a/docs/release-notes/mongoid-7.5.txt
+++ b/docs/release-notes/mongoid-7.5.txt
@@ -188,3 +188,30 @@ calling ``#first`` or ``#last`` with the ``{ id_sort: :none }`` option. This
 option has been deprecated in Mongoid 7.5 and it is recommended to use ``#take``
 instead going forward. Support for the ``:id_sort`` option will be dropped in
 Mongoid 8.
+
+
+Deprecate ``:id_sort`` Option and Support ``limit`` on ``#first/last``
+----------------------------------------------------------------------
+
+Mongoid 7.5 deprecates support for the ``:id_sort`` keyword argument for the
+``Criteria#first`` and ``Criteria#last`` methods. These methods have added
+support for adding a limit as a positional argument:
+
+.. code:: ruby
+
+  Band.first
+  # => #<Band _id: 62c835813282a4470c07d530, >
+  Band.first(2)
+  # => [ #<Band _id: 62c835813282a4470c07d530, >, #<Band _id: 62c835823282a4470c07d531, > ]
+  Band.last
+  # => #<Band _id: 62c835823282a4470c07d531, >
+  Band.last(2)
+  # => [#<Band _id: 62c835813282a4470c07d530, >, #<Band _id: 62c835823282a4470c07d531, >]
+
+When providing a limit, ``#first/last`` will return a list of documents, and
+when not providing a limit (or providing ``nil``), a single document will be
+returned.
+
+Note that the ``#first/last`` methods apply a sort on ``_id``, which can
+cause performance issues. To get a document without sorting first, use the
+``Critera#take`` method.

--- a/docs/release-notes/mongoid-7.5.txt
+++ b/docs/release-notes/mongoid-7.5.txt
@@ -194,8 +194,15 @@ Deprecate ``:id_sort`` Option and Support ``limit`` on ``#first/last``
 ----------------------------------------------------------------------
 
 Mongoid 7.5 deprecates the ``:id_sort`` keyword argument for the
-``Criteria#first`` and ``Criteria#last`` methods. Please use ``Criteria#take`` to retrieve documents without sorting by id. ```
-The ``first`` and ``last`` methods now take the number of documents to return as a positional argument, mirroring the functionality of Ruby's ``Enumerable`` method and ActiveRecord's ``first`` and ``last`` methods. Both invocations (with limit as positional arguments and with ``:id_sort`` option) remain supported in Mongoid 7.x, but the ``:id_sort`` invocation will be removed in Mongoid 8.
+``Criteria#first`` and ``Criteria#last`` methods. Please use ``Criteria#take``
+to retrieve documents without sorting by id.
+
+The ``first`` and ``last`` methods now take the number of documents to return
+as a positional argument, mirroring the functionality of Ruby's ``Enumerable``
+method and ActiveRecord's ``first`` and ``last`` methods. Both invocations
+(with limit as a positional arguments and with the ``:id_sort`` option) remain
+supported in Mongoid 7.x, but the ``:id_sort`` invocation will be removed in
+Mongoid 8.
 
 .. code:: ruby
 

--- a/lib/mongoid.rb
+++ b/lib/mongoid.rb
@@ -24,6 +24,7 @@ require "mongoid/clients"
 require "mongoid/document"
 require "mongoid/tasks/database"
 require "mongoid/query_cache"
+require "mongoid/warnings"
 
 # If we are using Rails then we will include the Mongoid railtie. This has all
 # the nifty initializers that Mongoid needs.

--- a/lib/mongoid/association/referenced/has_many/enumerable.rb
+++ b/lib/mongoid/association/referenced/has_many/enumerable.rb
@@ -243,14 +243,16 @@ module Mongoid
           #   use the option { id_sort: :none }.
           #   Be aware that #first/#last won't guarantee order in this case.
           #
-          # @param [ Hash ] opts The options for the query returning the first document.
+          # @param [ Integer | Hash ] limit_or_opts The number of documents to
+          #   return, or a hash of options.
           #
-          # @option opts [ :none ] :id_sort Don't apply a sort on _id.
+          # @option limit_or_opts [ :none ] :id_sort This option is deprecated.
+          #   Don't apply a sort on _id if no other sort is defined on the criteria.
           #
           # @return [ Document ] The first document found.
-          def first(opts = {})
+          def first(limit_or_opts = nil)
             _loaded.try(:values).try(:first) ||
-                _added[(ul = _unloaded.try(:first, opts)).try(:_id)] ||
+                _added[(ul = _unloaded.try(:first, limit_or_opts)).try(:_id)] ||
                 ul ||
                 _added.values.try(:first)
           end

--- a/lib/mongoid/association/referenced/has_many/enumerable.rb
+++ b/lib/mongoid/association/referenced/has_many/enumerable.rb
@@ -332,15 +332,17 @@ module Mongoid
           #   use the option { id_sort: :none }.
           #   Be aware that #first/#last won't guarantee order in this case.
           #
-          # @param [ Hash ] opts The options for the query returning the first document.
+          # @param [ Integer | Hash ] limit_or_opts The number of documents to
+          #   return, or a hash of options.
           #
-          # @option opts [ :none ] :id_sort Don't apply a sort on _id.
+          # @option limit_or_opts [ :none ] :id_sort This option is deprecated.
+          #   Don't apply a sort on _id if no other sort is defined on the criteria.
           #
           # @return [ Document ] The last document found.
-          def last(opts = {})
+          def last(limit_or_opts = nil)
             _added.values.try(:last) ||
                 _loaded.try(:values).try(:last) ||
-                _added[(ul = _unloaded.try(:last, opts)).try(:_id)] ||
+                _added[(ul = _unloaded.try(:last, limit_or_opts)).try(:_id)] ||
                 ul
           end
 

--- a/lib/mongoid/contextual/memory.rb
+++ b/lib/mongoid/contextual/memory.rb
@@ -173,8 +173,8 @@ module Mongoid
       #   Don't apply a sort on _id if no other sort is defined on the criteria.
       #
       # @return [ Document ] The last document.
-      def last(limit_or_opts = {})
-        if limit_or_opts.is_a?(Hash)
+      def last(limit_or_opts = nil)
+        if !limit_or_opts || limit_or_opts.is_a?(Hash)
           eager_load([documents.last]).first
         else
           eager_load(documents.last(limit_or_opts))

--- a/lib/mongoid/contextual/memory.rb
+++ b/lib/mongoid/contextual/memory.rb
@@ -121,7 +121,7 @@ module Mongoid
       #
       # @return [ Document ] The first document.
       def first(limit_or_opts = nil)
-        if !limit_or_opts || limit_or_opts.is_a?(Hash)
+        if limit_or_opts.nil? || limit_or_opts.is_a?(Hash)
           eager_load([documents.first]).first
         else
           eager_load(documents.first(limit_or_opts))

--- a/lib/mongoid/contextual/memory.rb
+++ b/lib/mongoid/contextual/memory.rb
@@ -116,9 +116,17 @@ module Mongoid
       # @example Get the first document.
       #   context.first
       #
+      # @param [ Hash ] opts The options for the query returning the first document.
+      #
+      # @options opts [ Integer ] :limit The number of documents to return.
+      #
       # @return [ Document ] The first document.
-      def first(*args)
-        eager_load([documents.first]).first
+      def first(opts = {})
+        if opts[:limit]
+          eager_load(documents.first(opts[:limit]))
+        else
+          eager_load([documents.first]).first
+        end
       end
       alias :one :first
       alias :find_first :first
@@ -159,9 +167,17 @@ module Mongoid
       # @example Get the last document.
       #   context.last
       #
+      # @param [ Hash ] opts The options for the query returning the first document.
+      #
+      # @options opts [ Integer ] :limit The number of documents to return.
+      #
       # @return [ Document ] The last document.
-      def last
-        eager_load([documents.last]).first
+      def last(opts = {})
+        if opts[:limit]
+          eager_load(documents.last(opts[:limit]))
+        else
+          eager_load([documents.last]).first
+        end
       end
 
       # Take the given number of documents from the database.

--- a/lib/mongoid/contextual/memory.rb
+++ b/lib/mongoid/contextual/memory.rb
@@ -166,16 +166,18 @@ module Mongoid
       # @example Get the last document.
       #   context.last
       #
-      # @param [ Hash ] opts The options for the query returning the first document.
+      # @param [ Integer | Hash ] limit_or_opts The number of documents to
+      #   return, or a hash of options.
       #
-      # @options opts [ Integer ] :limit The number of documents to return.
+      # @option limit_or_opts [ :none ] :id_sort This option is deprecated.
+      #   Don't apply a sort on _id if no other sort is defined on the criteria.
       #
       # @return [ Document ] The last document.
-      def last(opts = {})
-        if opts[:limit]
-          eager_load(documents.last(opts[:limit]))
-        else
+      def last(limit_or_opts = {})
+        if limit_or_opts.is_a?(Hash)
           eager_load([documents.last]).first
+        else
+          eager_load(documents.last(limit_or_opts))
         end
       end
 

--- a/lib/mongoid/contextual/memory.rb
+++ b/lib/mongoid/contextual/memory.rb
@@ -116,16 +116,15 @@ module Mongoid
       # @example Get the first document.
       #   context.first
       #
-      # @param [ Hash ] opts The options for the query returning the first document.
-      #
-      # @options opts [ Integer ] :limit The number of documents to return.
+      # @param [ Integer | Hash ] limit_or_opts The number of documents to
+      #   return, or a hash of options.
       #
       # @return [ Document ] The first document.
-      def first(opts = {})
-        if opts[:limit]
-          eager_load(documents.first(opts[:limit]))
-        else
+      def first(limit_or_opts = nil)
+        if limit_or_opts.is_a?(Hash)
           eager_load([documents.first]).first
+        else
+          eager_load(documents.first(limit))
         end
       end
       alias :one :first

--- a/lib/mongoid/contextual/memory.rb
+++ b/lib/mongoid/contextual/memory.rb
@@ -174,7 +174,7 @@ module Mongoid
       #
       # @return [ Document ] The last document.
       def last(limit_or_opts = nil)
-        if !limit_or_opts || limit_or_opts.is_a?(Hash)
+        if limit_or_opts.nil? || limit_or_opts.is_a?(Hash)
           eager_load([documents.last]).first
         else
           eager_load(documents.last(limit_or_opts))

--- a/lib/mongoid/contextual/memory.rb
+++ b/lib/mongoid/contextual/memory.rb
@@ -121,10 +121,10 @@ module Mongoid
       #
       # @return [ Document ] The first document.
       def first(limit_or_opts = nil)
-        if limit_or_opts.is_a?(Hash)
+        if !limit_or_opts || limit_or_opts.is_a?(Hash)
           eager_load([documents.first]).first
         else
-          eager_load(documents.first(limit))
+          eager_load(documents.first(limit_or_opts))
         end
       end
       alias :one :first

--- a/lib/mongoid/contextual/mongo.rb
+++ b/lib/mongoid/contextual/mongo.rb
@@ -640,7 +640,7 @@ module Mongoid
       # @return the result of the block
       def try_cache(key, &block)
         unless cached?
-          yield if block_given?
+          yield
         else
           unless ret = instance_variable_get("@#{key}")
             instance_variable_set("@#{key}", ret = yield)
@@ -656,7 +656,7 @@ module Mongoid
       #   if none is requested.
       # @param [ Symbol ] meth Method to extract the correct number of elements.
       #
-      # @return [ Object ] the result of the block
+      # @return [ Object ] The result of the block.
       def try_numbered_cache(key, n, meth, &block)
         unless cached?
           yield if block_given?

--- a/lib/mongoid/contextual/none.rb
+++ b/lib/mongoid/contextual/none.rb
@@ -122,8 +122,11 @@ module Mongoid
       # @example Get the first document in null context.
       #   context.first
       #
+      # @param [ Integer | Hash ] limit_or_opts The number of documents to
+      #   return, or a hash of options.
+      #
       # @return [ nil ] Always nil.
-      def first(opts = {}); nil; end
+      def first(limit_or_opts = nil); nil; end
 
       # Always returns nil.
       #

--- a/lib/mongoid/contextual/none.rb
+++ b/lib/mongoid/contextual/none.rb
@@ -119,6 +119,14 @@ module Mongoid
 
       # Always returns nil.
       #
+      # @example Get the first document in null context.
+      #   context.first
+      #
+      # @return [ nil ] Always nil.
+      def first(*args); nil; end
+
+      # Always returns nil.
+      #
       # @example Get the last document in null context.
       #   context.last
       #

--- a/lib/mongoid/contextual/none.rb
+++ b/lib/mongoid/contextual/none.rb
@@ -142,7 +142,7 @@ module Mongoid
       #
       # @return [ nil ] Always nil.
       def last(limit_or_opts = nil)
-        if limit_or_opts && !limit_or_opts.is_a?(Hash)
+        if !limit_or_opts.nil? && !limit_or_opts.is_a?(Hash)
           []
         end
       end

--- a/lib/mongoid/contextual/none.rb
+++ b/lib/mongoid/contextual/none.rb
@@ -127,7 +127,7 @@ module Mongoid
       #
       # @return [ nil ] Always nil.
       def first(limit_or_opts = nil)
-        if limit_or_opts && !limit_or_opts.is_a?(Hash)
+        if !limit_or_opts.nil? && !limit_or_opts.is_a?(Hash)
           []
         end
       end

--- a/lib/mongoid/contextual/none.rb
+++ b/lib/mongoid/contextual/none.rb
@@ -123,7 +123,7 @@ module Mongoid
       #   context.first
       #
       # @return [ nil ] Always nil.
-      def first(*args); nil; end
+      def first(opts = {}); nil; end
 
       # Always returns nil.
       #
@@ -131,7 +131,7 @@ module Mongoid
       #   context.last
       #
       # @return [ nil ] Always nil.
-      def last; nil; end
+      def last(opts = {}); nil; end
 
       # Returns nil or empty array.
       #

--- a/lib/mongoid/contextual/none.rb
+++ b/lib/mongoid/contextual/none.rb
@@ -126,15 +126,26 @@ module Mongoid
       #   return, or a hash of options.
       #
       # @return [ nil ] Always nil.
-      def first(limit_or_opts = nil); nil; end
+      def first(limit_or_opts = nil)
+        if limit_or_opts && !limit_or_opts.is_a?(Hash)
+          []
+        end
+      end
 
       # Always returns nil.
       #
       # @example Get the last document in null context.
       #   context.last
       #
+      # @param [ Integer | Hash ] limit_or_opts The number of documents to
+      #   return, or a hash of options.
+      #
       # @return [ nil ] Always nil.
-      def last(opts = {}); nil; end
+      def last(limit_or_opts = nil)
+        if limit_or_opts && !limit_or_opts.is_a?(Hash)
+          []
+        end
+      end
 
       # Returns nil or empty array.
       #

--- a/lib/mongoid/findable.rb
+++ b/lib/mongoid/findable.rb
@@ -206,8 +206,8 @@ module Mongoid
     #   Person.last
     #
     # @return [ Document ] The last matching document.
-    def last
-      with_default_scope.last
+    def last(opts = {})
+      with_default_scope.last(opts)
     end
   end
 end

--- a/lib/mongoid/findable.rb
+++ b/lib/mongoid/findable.rb
@@ -195,8 +195,8 @@ module Mongoid
     #   Person.first
     #
     # @return [ Document ] The first matching document.
-    def first
-      with_default_scope.first
+    def first(opts = {})
+      with_default_scope.first(opts)
     end
     alias :one :first
 

--- a/lib/mongoid/findable.rb
+++ b/lib/mongoid/findable.rb
@@ -194,9 +194,15 @@ module Mongoid
     # @example Find the first document.
     #   Person.first
     #
+    # @param [ Integer | Hash ] limit_or_opts The number of documents to
+    #   return, or a hash of options.
+    #
+    # @option limit_or_opts [ :none ] :id_sort This option is deprecated.
+    #   Don't apply a sort on _id if no other sort is defined on the criteria.
+    #
     # @return [ Document ] The first matching document.
-    def first(opts = {})
-      with_default_scope.first(opts)
+    def first(limit_or_opts = nil)
+      with_default_scope.first(limit_or_opts)
     end
     alias :one :first
 
@@ -205,9 +211,15 @@ module Mongoid
     # @example Find the last document.
     #   Person.last
     #
+    # @param [ Integer | Hash ] limit_or_opts The number of documents to
+    #   return, or a hash of options.
+    #
+    # @option limit_or_opts [ :none ] :id_sort This option is deprecated.
+    #   Don't apply a sort on _id if no other sort is defined on the criteria.
+    #
     # @return [ Document ] The last matching document.
-    def last(opts = {})
-      with_default_scope.last(opts)
+    def last(limit_or_opts = nil)
+      with_default_scope.last(limit_or_opts)
     end
   end
 end

--- a/lib/mongoid/warnings.rb
+++ b/lib/mongoid/warnings.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Mongoid
+
+  # Encapsulates behavior around logging and caching warnings so they are only
+  # logged once.
+  #
+  # @api private
+  module Warnings
+
+    class << self
+      def add_warning(id, message)
+        singleton_class.class_eval do
+          define_method("warn_#{id}") do
+            unless instance_variable_get("@#{id}")
+              Mongoid.logger.warn(message)
+              instance_variable_set("@#{id}", true)
+            end
+          end
+        end
+      end
+    end
+
+    add_warning :id_sort_deprecated, 'The :id_sort option has been deprecated. Use Mongo#take to get a document without a sort on _id.'
+  end
+end
+

--- a/lib/mongoid/warnings.rb
+++ b/lib/mongoid/warnings.rb
@@ -21,7 +21,7 @@ module Mongoid
       end
     end
 
-    add_warning :id_sort_deprecated, 'The :id_sort option has been deprecated. Use Mongo#take to get a document without a sort on _id.'
+    warning :id_sort_deprecated, 'The :id_sort option has been deprecated. Use Mongo#take to get a document without a sort on _id.'
   end
 end
 

--- a/lib/mongoid/warnings.rb
+++ b/lib/mongoid/warnings.rb
@@ -9,7 +9,7 @@ module Mongoid
   module Warnings
 
     class << self
-      def add_warning(id, message)
+      def warning(id, message)
         singleton_class.class_eval do
           define_method("warn_#{id}") do
             unless instance_variable_get("@#{id}")

--- a/spec/mongoid/association/referenced/has_many/enumerable_spec.rb
+++ b/spec/mongoid/association/referenced/has_many/enumerable_spec.rb
@@ -1784,7 +1784,7 @@ describe Mongoid::Association::Referenced::HasMany::Enumerable do
       end
 
       it 'does not use the sort on id' do
-        expect(enumerable.last(id_sort: :none)).to eq(first_post)
+        expect(enumerable.last(id_sort: :none)).to eq(second_post)
       end
     end
 

--- a/spec/mongoid/association/referenced/has_many/enumerable_spec.rb
+++ b/spec/mongoid/association/referenced/has_many/enumerable_spec.rb
@@ -1264,6 +1264,33 @@ describe Mongoid::Association::Referenced::HasMany::Enumerable do
       end
     end
 
+    context 'when including a limit' do
+
+      let(:person) do
+        Person.create!
+      end
+
+      let(:criteria) do
+        Post.where(person_id: person.id)
+      end
+
+      let(:enumerable) do
+        described_class.new(criteria)
+      end
+
+      let!(:first_post) do
+        person.posts.create!(title: "One")
+      end
+
+      let!(:second_post) do
+        person.posts.create!(title: "Two")
+      end
+
+      it 'returns the matching document' do
+        expect(enumerable.first(1)).to eq([first_post])
+      end
+    end
+
     context 'when the id_sort option is not provided' do
 
       let(:person) do

--- a/spec/mongoid/association/referenced/has_many/enumerable_spec.rb
+++ b/spec/mongoid/association/referenced/has_many/enumerable_spec.rb
@@ -1734,6 +1734,33 @@ describe Mongoid::Association::Referenced::HasMany::Enumerable do
       end
     end
 
+    context 'when including a limit' do
+
+      let(:person) do
+        Person.create!
+      end
+
+      let(:criteria) do
+        Post.where(person_id: person.id)
+      end
+
+      let(:enumerable) do
+        described_class.new(criteria)
+      end
+
+      let!(:first_post) do
+        person.posts.create!(title: "One")
+      end
+
+      let!(:second_post) do
+        person.posts.create!(title: "Two")
+      end
+
+      it 'returns the matching document' do
+        expect(enumerable.last(1)).to eq([second_post])
+      end
+    end
+
     context 'when the id_sort option is none' do
 
       let(:person) do

--- a/spec/mongoid/association/referenced/has_many/enumerable_spec.rb
+++ b/spec/mongoid/association/referenced/has_many/enumerable_spec.rb
@@ -1784,7 +1784,7 @@ describe Mongoid::Association::Referenced::HasMany::Enumerable do
       end
 
       it 'does not use the sort on id' do
-        expect(enumerable.last(id_sort: :none)).to eq(second_post)
+        expect(enumerable.last(id_sort: :none)).to eq(first_post)
       end
     end
 

--- a/spec/mongoid/contextual/memory_spec.rb
+++ b/spec/mongoid/contextual/memory_spec.rb
@@ -624,6 +624,14 @@ describe Mongoid::Contextual::Memory do
         expect(context.send(method)).to eq(hobrecht)
       end
 
+      it "returns a list when passing a limit" do
+        expect(context.send(method, limit: 2)).to eq([ hobrecht, friedel ])
+      end
+
+      it "returns a list when passing 1" do
+        expect(context.send(method, limit: 1)).to eq([ hobrecht ])
+      end
+
       context 'when there is a collation on the criteria' do
 
         let(:criteria) do
@@ -866,6 +874,14 @@ describe Mongoid::Contextual::Memory do
 
     it "returns the last matching document" do
       expect(context.last).to eq(friedel)
+    end
+
+    it "returns a list when a limit is passed" do
+      expect(context.last(limit: 2)).to eq([ hobrecht, friedel ])
+    end
+
+    it "returns a list when the limit is 1" do
+      expect(context.last(limit: 1)).to eq([ friedel ])
     end
 
     context 'when there is a collation on the criteria' do

--- a/spec/mongoid/contextual/memory_spec.rb
+++ b/spec/mongoid/contextual/memory_spec.rb
@@ -881,11 +881,11 @@ describe Mongoid::Contextual::Memory do
     end
 
     it "returns a list when a limit is passed" do
-      expect(context.last(limit: 2)).to eq([ hobrecht, friedel ])
+      expect(context.last(2)).to eq([ hobrecht, friedel ])
     end
 
     it "returns a list when the limit is 1" do
-      expect(context.last(limit: 1)).to eq([ friedel ])
+      expect(context.last(1)).to eq([ friedel ])
     end
 
     it "returns the matching document when passing deprecated options" do

--- a/spec/mongoid/contextual/memory_spec.rb
+++ b/spec/mongoid/contextual/memory_spec.rb
@@ -888,6 +888,10 @@ describe Mongoid::Contextual::Memory do
       expect(context.last(limit: 1)).to eq([ friedel ])
     end
 
+    it "returns the matching document when passing deprecated options" do
+      expect(context.last(id_sort: :none)).to eq(friedel)
+    end
+
     context 'when there is a collation on the criteria' do
 
       let(:criteria) do

--- a/spec/mongoid/contextual/memory_spec.rb
+++ b/spec/mongoid/contextual/memory_spec.rb
@@ -625,11 +625,15 @@ describe Mongoid::Contextual::Memory do
       end
 
       it "returns a list when passing a limit" do
-        expect(context.send(method, limit: 2)).to eq([ hobrecht, friedel ])
+        expect(context.send(method, 2)).to eq([ hobrecht, friedel ])
       end
 
       it "returns a list when passing 1" do
-        expect(context.send(method, limit: 1)).to eq([ hobrecht ])
+        expect(context.send(method, 1)).to eq([ hobrecht ])
+      end
+
+      it "returns the matching document when passing deprecated options" do
+        expect(context.send(method, id_sort: :none)).to eq(hobrecht)
       end
 
       context 'when there is a collation on the criteria' do

--- a/spec/mongoid/contextual/mongo_spec.rb
+++ b/spec/mongoid/contextual/mongo_spec.rb
@@ -159,7 +159,7 @@ describe Mongoid::Contextual::Mongo do
       end
 
       let(:count) do
-        context.count(2)
+        context.count(limit: 2)
       end
 
       it "returns the number of documents that match" do
@@ -2315,32 +2315,32 @@ describe Mongoid::Contextual::Mongo do
           end
         end
       end
-    end
 
-    context "when calling #first then #last" do
+      context "when calling #first then #last" do
 
-      let(:context) do
-        described_class.new(criteria)
-      end
+        let(:context) do
+          described_class.new(criteria)
+        end
 
-      let(:criteria) do
-        Band.all.cache
-      end
+        let(:criteria) do
+          Band.all.cache
+        end
 
-      before do
-        context.first(before_limit)
-      end
+        before do
+          context.first(before_limit)
+        end
 
-      let(:docs) do
-        context.last(limit)
-      end
+        let(:docs) do
+          context.last(limit)
+        end
 
-      context "when getting one from the beginning and one from the end" do
-        let(:before_limit) { 2 }
-        let(:limit) { 1 }
+        context "when getting one from the beginning and one from the end" do
+          let(:before_limit) { 2 }
+          let(:limit) { 1 }
 
-        it "gets the correct document" do
-          expect(docs).to eq([rolling_stones])
+          it "gets the correct document" do
+            expect(docs).to eq([rolling_stones])
+          end
         end
       end
     end

--- a/spec/mongoid/contextual/mongo_spec.rb
+++ b/spec/mongoid/contextual/mongo_spec.rb
@@ -2006,9 +2006,9 @@ describe Mongoid::Contextual::Mongo do
 
           context 'when calling #last' do
 
-            it 'applies a sort on _id' do
+            it 'doesn\'t apply a sort on _id' do
               expect(context.send(method, opts)).to eq(depeche_mode)
-              expect(context.last(opts)).to eq(rolling_stones)
+              expect(context.last(opts)).to eq(depeche_mode)
             end
           end
         end
@@ -2036,19 +2036,19 @@ describe Mongoid::Contextual::Mongo do
           end
         end
 
-        context 'with option { sort: :none }' do
+        context 'with option { id_sort: :none }' do
 
           let(:opts) do
             { id_sort: :none }
           end
 
-          it 'does not use the option' do
+          it 'uses the preexisting sort' do
             expect(context.send(method, opts)).to eq(rolling_stones)
           end
 
           context 'when calling #last' do
 
-            it 'does not use the option' do
+            it 'uses the preexisting sort' do
               expect(context.send(method, opts)).to eq(rolling_stones)
               expect(context.last(opts)).to eq(depeche_mode)
             end
@@ -2285,7 +2285,7 @@ describe Mongoid::Contextual::Mongo do
                 let(:limit) { 3 }
 
                 it "returns the correct documents and touches the database" do
-                  expect(context).to receive(:view).twice.and_call_original
+                  expect(context).to receive(:view).exactly(3).times.and_call_original
                   expect(docs).to eq([ depeche_mode, new_order, rolling_stones ])
                 end
               end
@@ -2307,7 +2307,7 @@ describe Mongoid::Contextual::Mongo do
                 let(:limit) { 3 }
 
                 it "returns the correct documents and touches the database" do
-                  expect(context).to receive(:view).twice.and_call_original
+                  expect(context).to receive(:view).exactly(3).times.and_call_original
                   expect(docs).to eq([ depeche_mode, new_order, rolling_stones ])
                 end
               end
@@ -2440,13 +2440,13 @@ describe Mongoid::Contextual::Mongo do
           { id_sort: :none }
         end
 
-        it 'applies the sort on _id' do
-          expect(context.last(opts)).to eq(rolling_stones)
+        it 'doesn\'t apply the sort on _id' do
+          expect(context.last(opts)).to eq(depeche_mode)
         end
 
         context 'when calling #first' do
 
-          it 'applies a sort on _id' do
+          it 'doesn\'t apply the sort on _id' do
             pending "MONGOID-5416"
             expect(context.last(opts)).to eq(rolling_stones)
             expect(context.first(opts)).to eq(depeche_mode)
@@ -2478,19 +2478,19 @@ describe Mongoid::Contextual::Mongo do
         end
       end
 
-      context 'with option { sort: :none }' do
+      context 'with option { id_sort: :none }' do
 
         let(:opts) do
           { id_sort: :none }
         end
 
-        it 'does not use the option' do
+        it 'uses the preexisting sort' do
           expect(context.last(opts)).to eq(depeche_mode)
         end
 
         context 'when calling #first' do
 
-          it 'does not use the option' do
+          it 'uses the preexisting sort' do
             expect(context.last(opts)).to eq(depeche_mode)
             expect(context.first(opts)).to eq(rolling_stones)
           end
@@ -2781,7 +2781,7 @@ describe Mongoid::Contextual::Mongo do
         let(:limit) { 1 }
 
         it "hits the database" do
-          expect(context).to receive(:view).twice.and_call_original
+          expect(context).to receive(:view).exactly(3).times.and_call_original
           docs
         end
 

--- a/spec/mongoid/contextual/mongo_spec.rb
+++ b/spec/mongoid/contextual/mongo_spec.rb
@@ -159,7 +159,7 @@ describe Mongoid::Contextual::Mongo do
       end
 
       let(:count) do
-        context.count(limit: 2)
+        context.count(2)
       end
 
       it "returns the number of documents that match" do
@@ -2131,7 +2131,7 @@ describe Mongoid::Contextual::Mongo do
             end
 
             let(:docs) do
-              context.send(method, limit: 1)
+              context.send(method, 1)
             end
 
             it "returns an array of documents" do
@@ -2145,7 +2145,7 @@ describe Mongoid::Contextual::Mongo do
             end
 
             let(:docs) do
-              context.send(method, limit: 2)
+              context.send(method, 2)
             end
 
             it "returns the number of documents in order" do
@@ -2161,7 +2161,7 @@ describe Mongoid::Contextual::Mongo do
             end
 
             it "returns the first matching document" do
-              expect(context.send(method, limit: 1)).to eq([ depeche_mode ])
+              expect(context.send(method, 1)).to eq([ depeche_mode ])
             end
           end
         end
@@ -2187,7 +2187,7 @@ describe Mongoid::Contextual::Mongo do
               context "when requesting all of the documents" do
 
                 let(:docs) do
-                  context.send(method, limit: 3)
+                  context.send(method, 3)
                 end
 
                 it "returns all of the documents without touching the database" do
@@ -2199,7 +2199,7 @@ describe Mongoid::Contextual::Mongo do
               context "when requesting fewer than all of the documents" do
 
                 let(:docs) do
-                  context.send(method, limit: 2)
+                  context.send(method, 2)
                 end
 
                 it "returns all of the documents without touching the database" do
@@ -2218,7 +2218,7 @@ describe Mongoid::Contextual::Mongo do
               context "when requesting one document" do
 
                 let(:docs) do
-                  context.send(method, limit: 1)
+                  context.send(method, 1)
                 end
 
                 it "returns one document without touching the database" do
@@ -2240,11 +2240,11 @@ describe Mongoid::Contextual::Mongo do
             end
 
             before do
-              context.first(limit: before_limit)
+              context.first(before_limit)
             end
 
             let(:docs) do
-              context.send(method, limit: limit)
+              context.send(method, limit)
             end
 
             context "when getting all of the documents before" do
@@ -2316,6 +2316,34 @@ describe Mongoid::Contextual::Mongo do
         end
       end
     end
+
+    context "when calling #first then #last" do
+
+      let(:context) do
+        described_class.new(criteria)
+      end
+
+      let(:criteria) do
+        Band.all.cache
+      end
+
+      before do
+        context.first(before_limit)
+      end
+
+      let(:docs) do
+        context.last(limit)
+      end
+
+      context "when getting one from the beginning and one from the end" do
+        let(:before_limit) { 2 }
+        let(:limit) { 1 }
+
+        it "gets the correct document" do
+          expect(docs).to eq([rolling_stones])
+        end
+      end
+    end
   end
 
   describe "#last" do
@@ -2374,6 +2402,14 @@ describe Mongoid::Contextual::Mongo do
           expect(context.last).to eq(depeche_mode)
         end
       end
+
+      context "when subsequently calling #first" do
+
+        it "returns the correct document" do
+          expect(context.last).to eq(depeche_mode)
+          expect(context.first).to eq(rolling_stones)
+        end
+      end
     end
 
     context 'when the criteria has no sort' do
@@ -2390,6 +2426,15 @@ describe Mongoid::Contextual::Mongo do
         expect(context.last).to eq(rolling_stones)
       end
 
+      context 'when calling #first' do
+
+        it 'returns the first document, sorted by _id' do
+          pending "MONGOID-5416"
+          expect(context.last).to eq(rolling_stones)
+          expect(context.first).to eq(depeche_mode)
+        end
+      end
+
       context 'with option { id_sort: :none }' do
         let(:opts) do
           { id_sort: :none }
@@ -2397,6 +2442,15 @@ describe Mongoid::Contextual::Mongo do
 
         it 'applies the sort on _id' do
           expect(context.last(opts)).to eq(rolling_stones)
+        end
+
+        context 'when calling #first' do
+
+          it 'applies a sort on _id' do
+            pending "MONGOID-5416"
+            expect(context.last(opts)).to eq(rolling_stones)
+            expect(context.first(opts)).to eq(depeche_mode)
+          end
         end
       end
     end
@@ -2416,6 +2470,14 @@ describe Mongoid::Contextual::Mongo do
         expect(context.last).to eq(depeche_mode)
       end
 
+      context 'when calling #first' do
+
+        it 'applies the criteria sort' do
+          expect(context.last).to eq(depeche_mode)
+          expect(context.first).to eq(rolling_stones)
+        end
+      end
+
       context 'with option { sort: :none }' do
 
         let(:opts) do
@@ -2424,6 +2486,14 @@ describe Mongoid::Contextual::Mongo do
 
         it 'does not use the option' do
           expect(context.last(opts)).to eq(depeche_mode)
+        end
+
+        context 'when calling #first' do
+
+          it 'does not use the option' do
+            expect(context.last(opts)).to eq(depeche_mode)
+            expect(context.first(opts)).to eq(rolling_stones)
+          end
         end
       end
     end
@@ -2442,6 +2512,14 @@ describe Mongoid::Contextual::Mongo do
 
         it "follows the main sort" do
           expect(context.last).to eq(depeche_mode)
+        end
+      end
+
+      context "when subsequently calling #first" do
+
+        it "returns the correct document" do
+          expect(context.last).to eq(depeche_mode)
+          expect(context.first).to eq(rolling_stones)
         end
       end
     end
@@ -2495,7 +2573,7 @@ describe Mongoid::Contextual::Mongo do
           end
 
           let(:docs) do
-            context.last(limit: 1)
+            context.last(1)
           end
 
           it "returns an array of documents" do
@@ -2509,7 +2587,7 @@ describe Mongoid::Contextual::Mongo do
           end
 
           let(:docs) do
-            context.last(limit: 2)
+            context.last(2)
           end
 
           it "returns the number of documents in order" do
@@ -2525,7 +2603,7 @@ describe Mongoid::Contextual::Mongo do
           end
 
           it "returns the first matching document" do
-            expect(context.last(limit: 1)).to eq([ depeche_mode ])
+            expect(context.last(1)).to eq([ depeche_mode ])
           end
         end
       end
@@ -2551,7 +2629,7 @@ describe Mongoid::Contextual::Mongo do
             context "when requesting all of the documents" do
 
               let(:docs) do
-                context.last(limit: 3)
+                context.last(3)
               end
 
               it "returns all of the documents without touching the database" do
@@ -2563,7 +2641,7 @@ describe Mongoid::Contextual::Mongo do
             context "when requesting fewer than all of the documents" do
 
               let(:docs) do
-                context.last(limit: 2)
+                context.last(2)
               end
 
               it "returns all of the documents without touching the database" do
@@ -2582,7 +2660,7 @@ describe Mongoid::Contextual::Mongo do
             context "when requesting one document" do
 
               let(:docs) do
-                context.last(limit: 1)
+                context.last(1)
               end
 
               it "returns one document without touching the database" do
@@ -2604,11 +2682,11 @@ describe Mongoid::Contextual::Mongo do
           end
 
           before do
-            context.last(limit: before_limit)
+            context.last(before_limit)
           end
 
           let(:docs) do
-            context.last(limit: limit)
+            context.last(limit)
           end
 
           context "when getting all of the documents before" do
@@ -2680,7 +2758,7 @@ describe Mongoid::Contextual::Mongo do
       end
     end
 
-    context "when calling #first then #last" do
+    context "when calling #last then #first" do
 
       let(:context) do
         described_class.new(criteria)
@@ -2691,19 +2769,25 @@ describe Mongoid::Contextual::Mongo do
       end
 
       before do
-        context.first(limit: before_limit)
+        context.last(before_limit)
       end
 
       let(:docs) do
-        context.last(limit: limit)
+        context.first(limit)
       end
 
       context "when getting one from the beginning and one from the end" do
         let(:before_limit) { 2 }
         let(:limit) { 1 }
 
+        it "hits the database" do
+          expect(context).to receive(:view).twice.and_call_original
+          docs
+        end
+
         it "gets the correct document" do
-          expect(docs).to eq([rolling_stones])
+          pending "MONGOID-5416"
+          expect(docs).to eq([ depeche_mode ])
         end
       end
     end

--- a/spec/mongoid/contextual/mongo_spec.rb
+++ b/spec/mongoid/contextual/mongo_spec.rb
@@ -1959,14 +1959,14 @@ describe Mongoid::Contextual::Mongo do
         context "when there is sort on the context" do
 
           it "follows the main sort" do
-            expect(context.send(method)).to eq(new_order)
+            expect(context.send(method)).to eq(rolling_stones)
           end
         end
 
         context "when subsequently calling #last" do
 
           it "returns the correct document" do
-            expect(context.send(method)).to eq(new_order)
+            expect(context.send(method)).to eq(rolling_stones)
             expect(context.last).to eq(depeche_mode)
           end
         end
@@ -1991,7 +1991,7 @@ describe Mongoid::Contextual::Mongo do
 
           it 'returns the last document, sorted by _id' do
             expect(context.send(method)).to eq(depeche_mode)
-            expect(context.last).to eq(new_order)
+            expect(context.last).to eq(rolling_stones)
           end
         end
 
@@ -2000,15 +2000,15 @@ describe Mongoid::Contextual::Mongo do
             { id_sort: :none }
           end
 
-          it 'does not applies the sort on _id' do
+          it 'applies the sort on _id' do
             expect(context.send(method, opts)).to eq(depeche_mode)
           end
 
           context 'when calling #last' do
 
-            it 'does not applies a sort on _id' do
+            it 'applies a sort on _id' do
               expect(context.send(method, opts)).to eq(depeche_mode)
-              expect(context.last(opts)).to eq(depeche_mode)
+              expect(context.last(opts)).to eq(rolling_stones)
             end
           end
         end
@@ -2024,15 +2024,14 @@ describe Mongoid::Contextual::Mongo do
           described_class.new(criteria)
         end
 
-
         it 'applies the criteria sort' do
-          expect(context.send(method)).to eq(new_order)
+          expect(context.send(method)).to eq(rolling_stones)
         end
 
         context 'when calling #last' do
 
           it 'applies the criteria sort' do
-            expect(context.send(method)).to eq(new_order)
+            expect(context.send(method)).to eq(rolling_stones)
             expect(context.last).to eq(depeche_mode)
           end
         end
@@ -2043,14 +2042,14 @@ describe Mongoid::Contextual::Mongo do
             { id_sort: :none }
           end
 
-          it 'applies the criteria sort' do
-            expect(context.send(method, opts)).to eq(new_order)
+          it 'does not use the option' do
+            expect(context.send(method, opts)).to eq(rolling_stones)
           end
 
           context 'when calling #last' do
 
-            it 'applies the criteria sort' do
-              expect(context.send(method, opts)).to eq(new_order)
+            it 'does not use the option' do
+              expect(context.send(method, opts)).to eq(rolling_stones)
               expect(context.last(opts)).to eq(depeche_mode)
             end
           end
@@ -2070,14 +2069,14 @@ describe Mongoid::Contextual::Mongo do
         context "when there is sort on the context" do
 
           it "follows the main sort" do
-            expect(context.send(method)).to eq(new_order)
+            expect(context.send(method)).to eq(rolling_stones)
           end
         end
 
         context "when subsequently calling #last" do
 
           it "returns the correct document" do
-            expect(context.send(method)).to eq(new_order)
+            expect(context.send(method)).to eq(rolling_stones)
             expect(context.last).to eq(depeche_mode)
           end
         end
@@ -2314,6 +2313,397 @@ describe Mongoid::Contextual::Mongo do
               end
             end
           end
+        end
+      end
+    end
+  end
+
+  describe "#last" do
+    let!(:depeche_mode) do
+      Band.create!(name: "Depeche Mode")
+    end
+
+    let!(:new_order) do
+      Band.create!(name: "New Order")
+    end
+
+    let!(:rolling_stones) do
+      Band.create!(name: "The Rolling Stones")
+    end
+
+    context "when the context is not cached" do
+
+      let(:criteria) do
+        Band.where(name: "Depeche Mode")
+      end
+
+      let(:context) do
+        described_class.new(criteria)
+      end
+
+      it "returns the last matching document" do
+        expect(context.last).to eq(depeche_mode)
+      end
+
+      context 'when the criteria has a collation' do
+        min_server_version '3.4'
+
+        let(:criteria) do
+          Band.where(name: "DEPECHE MODE").collation(locale: 'en_US', strength: 2)
+        end
+
+        it "returns the last matching document" do
+          expect(context.last).to eq(depeche_mode)
+        end
+      end
+    end
+
+    context "when using .desc" do
+
+      let(:criteria) do
+        Band.desc(:name)
+      end
+
+      let(:context) do
+        described_class.new(criteria)
+      end
+
+      context "when there is sort on the context" do
+
+        it "follows the main sort" do
+          expect(context.last).to eq(depeche_mode)
+        end
+      end
+    end
+
+    context 'when the criteria has no sort' do
+
+      let(:criteria) do
+        Band.all
+      end
+
+      let(:context) do
+        described_class.new(criteria)
+      end
+
+      it 'applies a sort on _id' do
+        expect(context.last).to eq(rolling_stones)
+      end
+
+      context 'with option { id_sort: :none }' do
+        let(:opts) do
+          { id_sort: :none }
+        end
+
+        it 'applies the sort on _id' do
+          expect(context.last(opts)).to eq(rolling_stones)
+        end
+      end
+    end
+
+    context 'when the criteria has a sort' do
+
+      let(:criteria) do
+        Band.desc(:name)
+      end
+
+      let(:context) do
+        described_class.new(criteria)
+      end
+
+
+      it 'applies the criteria sort' do
+        expect(context.last).to eq(depeche_mode)
+      end
+
+      context 'with option { sort: :none }' do
+
+        let(:opts) do
+          { id_sort: :none }
+        end
+
+        it 'does not use the option' do
+          expect(context.last(opts)).to eq(depeche_mode)
+        end
+      end
+    end
+
+    context "when using .sort" do
+
+      let(:criteria) do
+        Band.all.sort(:name => -1).criteria
+      end
+
+      let(:context) do
+        described_class.new(criteria)
+      end
+
+      context "when there is sort on the context" do
+
+        it "follows the main sort" do
+          expect(context.last).to eq(depeche_mode)
+        end
+      end
+    end
+
+    context "when the context is cached" do
+
+      let(:criteria) do
+        Band.where(name: "Depeche Mode").cache
+      end
+
+      let(:context) do
+        described_class.new(criteria)
+      end
+
+      context "when the cache is loaded" do
+
+        before do
+          context.to_a
+        end
+
+        it "returns the last document without touching the database" do
+          expect(context).to receive(:view).never
+          expect(context.last).to eq(depeche_mode)
+        end
+      end
+
+      context "when last method was called before" do
+
+        before do
+          context.last
+        end
+
+        it "returns the last document without touching the database" do
+          expect(context).to receive(:view).never
+          expect(context.last).to eq(depeche_mode)
+        end
+      end
+    end
+
+    context "when including a limit" do
+
+      context "when the context is not cached" do
+
+        let(:context) do
+          described_class.new(criteria)
+        end
+
+        context "when the limit is 1" do
+          let(:criteria) do
+            Band.criteria
+          end
+
+          let(:docs) do
+            context.last(limit: 1)
+          end
+
+          it "returns an array of documents" do
+            expect(docs).to eq([ rolling_stones ])
+          end
+        end
+
+        context "when the limit is >1" do
+          let(:criteria) do
+            Band.criteria
+          end
+
+          let(:docs) do
+            context.last(limit: 2)
+          end
+
+          it "returns the number of documents in order" do
+            expect(docs).to eq([ new_order, rolling_stones ])
+          end
+        end
+
+        context 'when the criteria has a collation' do
+          min_server_version '3.4'
+
+          let(:criteria) do
+            Band.where(name: "DEPECHE MODE").collation(locale: 'en_US', strength: 2)
+          end
+
+          it "returns the first matching document" do
+            expect(context.last(limit: 1)).to eq([ depeche_mode ])
+          end
+        end
+      end
+
+      context "when the context is cached" do
+
+        let(:context) do
+          described_class.new(criteria)
+        end
+
+        context "when the whole context is loaded" do
+
+          before do
+            context.to_a
+          end
+
+          context "when all of the documents are cached" do
+
+            let(:criteria) do
+              Band.all.cache
+            end
+
+            context "when requesting all of the documents" do
+
+              let(:docs) do
+                context.last(limit: 3)
+              end
+
+              it "returns all of the documents without touching the database" do
+                expect(context).to receive(:view).never
+                expect(docs).to eq([ depeche_mode, new_order, rolling_stones ])
+              end
+            end
+
+            context "when requesting fewer than all of the documents" do
+
+              let(:docs) do
+                context.last(limit: 2)
+              end
+
+              it "returns all of the documents without touching the database" do
+                expect(context).to receive(:view).never
+                expect(docs).to eq([ new_order, rolling_stones ])
+              end
+            end
+          end
+
+          context "when only one document is cached" do
+
+            let(:criteria) do
+              Band.where(name: "Depeche Mode").cache
+            end
+
+            context "when requesting one document" do
+
+              let(:docs) do
+                context.last(limit: 1)
+              end
+
+              it "returns one document without touching the database" do
+                expect(context).to receive(:view).never
+                expect(docs).to eq([ depeche_mode ])
+              end
+            end
+          end
+        end
+
+        context "when the last method was called before" do
+
+          let(:context) do
+            described_class.new(criteria)
+          end
+
+          let(:criteria) do
+            Band.all.cache
+          end
+
+          before do
+            context.last(limit: before_limit)
+          end
+
+          let(:docs) do
+            context.last(limit: limit)
+          end
+
+          context "when getting all of the documents before" do
+            let(:before_limit) { 3 }
+
+            context "when getting all of the documents" do
+              let(:limit) { 3 }
+
+              it "returns all documents without touching the database" do
+                expect(context).to receive(:view).never
+                expect(docs).to eq([ depeche_mode, new_order, rolling_stones ])
+              end
+            end
+
+            context "when getting fewer documents" do
+              let(:limit) { 2 }
+
+              it "returns the correct documents without touching the database" do
+                expect(context).to receive(:view).never
+                expect(docs).to eq([ new_order, rolling_stones ])
+              end
+            end
+          end
+
+          context "when getting fewer documents before" do
+            let(:before_limit) { 2 }
+
+            context "when getting the same number of documents" do
+              let(:limit) { 2 }
+
+              it "returns the correct documents without touching the database" do
+                expect(context).to receive(:view).never
+                expect(docs).to eq([ new_order, rolling_stones ])
+              end
+            end
+
+            context "when getting more documents" do
+              let(:limit) { 3 }
+
+              it "returns the correct documents and touches the database" do
+                expect(context).to receive(:view).twice.and_call_original
+                expect(docs).to eq([ depeche_mode, new_order, rolling_stones ])
+              end
+            end
+          end
+
+          context "when getting one document before" do
+            let(:before_limit) { 1 }
+
+            context "when getting one document" do
+              let(:limit) { 1 }
+
+              it "returns the correct documents without touching the database" do
+                expect(context).to receive(:view).never
+                expect(docs).to eq([ rolling_stones ])
+              end
+            end
+
+            context "when getting more than one document" do
+              let(:limit) { 3 }
+
+              it "returns the correct documents and touches the database" do
+                expect(context).to receive(:view).twice.and_call_original
+                expect(docs).to eq([ depeche_mode, new_order, rolling_stones ])
+              end
+            end
+          end
+        end
+      end
+    end
+
+    context "when calling #first then #last" do
+
+      let(:context) do
+        described_class.new(criteria)
+      end
+
+      let(:criteria) do
+        Band.all.cache
+      end
+
+      before do
+        context.first(limit: before_limit)
+      end
+
+      let(:docs) do
+        context.last(limit: limit)
+      end
+
+      context "when getting one from the beginning and one from the end" do
+        let(:before_limit) { 2 }
+        let(:limit) { 1 }
+
+        it "gets the correct document" do
+          expect(docs).to eq([rolling_stones])
         end
       end
     end

--- a/spec/mongoid/contextual/none_spec.rb
+++ b/spec/mongoid/contextual/none_spec.rb
@@ -75,6 +75,14 @@ describe Mongoid::Contextual::None do
         context.first(id_sort: :none)
       end.to_not raise_error
     end
+
+    it "returns nil when passing a hash" do
+      expect(context.first(id_sort: :none)).to be_nil
+    end
+
+    it "returns [] when passing a limit" do
+      expect(context.first(1)).to eq([])
+    end
   end
 
   describe "#last" do
@@ -86,6 +94,14 @@ describe Mongoid::Contextual::None do
       expect do
         context.last(id_sort: :none)
       end.to_not raise_error
+    end
+
+    it "returns nil when passing a hash" do
+      expect(context.last(id_sort: :none)).to be_nil
+    end
+
+    it "returns [] when passing a limit" do
+      expect(context.last(1)).to eq([])
     end
   end
 

--- a/spec/mongoid/contextual/none_spec.rb
+++ b/spec/mongoid/contextual/none_spec.rb
@@ -69,11 +69,23 @@ describe Mongoid::Contextual::None do
     it "returns nil" do
       expect(context.first).to be_nil
     end
+
+    it "doen't raise when passing options" do
+      expect do
+        context.first(id_sort: :none)
+      end.to_not raise_error
+    end
   end
 
   describe "#last" do
     it "returns nil" do
       expect(context.last).to be_nil
+    end
+
+    it "doen't raise when passing options" do
+      expect do
+        context.last(id_sort: :none)
+      end.to_not raise_error
     end
   end
 

--- a/spec/mongoid/findable_spec.rb
+++ b/spec/mongoid/findable_spec.rb
@@ -236,8 +236,8 @@ describe Mongoid::Findable do
         end.to_not raise_error
       end
 
-      it "passes the options through" do
-        Person.first(limit: 1).length.should == 1
+      it "passes the limit through" do
+        Person.first(1).length.should == 1
       end
     end
   end
@@ -257,8 +257,8 @@ describe Mongoid::Findable do
       end.to_not raise_error
     end
 
-    it "passes the options through" do
-      Person.last(limit: 1).length.should == 1
+    it "passes the limit through" do
+      Person.last(1).length.should == 1
     end
   end
 

--- a/spec/mongoid/findable_spec.rb
+++ b/spec/mongoid/findable_spec.rb
@@ -242,6 +242,26 @@ describe Mongoid::Findable do
     end
   end
 
+  describe "#last" do
+    let!(:person) do
+      Person.create!
+    end
+
+    it "returns the first matching document" do
+      expect(Person.last).to eq(person)
+    end
+
+    it "doen't raise when passing options" do
+      expect do
+        Person.last(id_sort: :none)
+      end.to_not raise_error
+    end
+
+    it "passes the options through" do
+      Person.last(limit: 1).length.should == 1
+    end
+  end
+
   describe ".first_or_create" do
 
     context "when the document is found" do

--- a/spec/mongoid/findable_spec.rb
+++ b/spec/mongoid/findable_spec.rb
@@ -229,6 +229,16 @@ describe Mongoid::Findable do
       it "returns the first matching document" do
         expect(Person.send(method)).to eq(person)
       end
+
+      it "doen't raise when passing options" do
+        expect do
+          Person.first(id_sort: :none)
+        end.to_not raise_error
+      end
+
+      it "passes the options through" do
+        Person.first(limit: 1).length.should == 1
+      end
     end
   end
 


### PR DESCRIPTION
PLEASE READ THIS before reviewing this PR. There's a lot going on here, and a lot still left to do.

First, this change is actually a few different changes wrapped in one (besides all of the #take stuff under it):
1) remove support for the `id_sort` option
2) add support for the `limit` option 
3) add support for passing options in all of our first/last methods, so that users don't get errors when they pass in options to different first/lasts. Note that our syntax differs from Ruby's. We use keyword args (well actually, a hash) whereas Ruby uses an optional arg to pass the limit. This is annoying, but I fear it would be too complicated to completely do away with the hash in favor of just a limit integer. 

Things still left to do:
- Release notes about changes to first/last
- Deprecate the id_none option in 7.5 and add a release note

Note that this PR should not be merged before that of MONGOID-4547, since this deprecation/removal of the id_none option only works once we have take. take provides the functionality that the id_none option did in first/last.

Future directives: 
- first! method
- last! method
- other take-like methods: `second`, `third` etc.
