### PR TITLE
MONGOID-5376: Use exists? or any? instead of count to determine existence of any document

### DIFF
--- a/lib/mongoid/association/embedded/embeds_many/proxy.rb
+++ b/lib/mongoid/association/embedded/embeds_many/proxy.rb
@@ -212,7 +212,7 @@ module Mongoid
           #
           # @return [ true, false ] True is persisted documents exist, false if not.
           def exists?
-            count > 0
+            _target.any? { |doc| doc.persisted? }
           end
 
           # Finds a document in this association through several different

--- a/lib/mongoid/contextual/aggregable/memory.rb
+++ b/lib/mongoid/contextual/aggregable/memory.rb
@@ -29,7 +29,7 @@ module Mongoid
         #
         # @return [ Float ] The average.
         def avg(field)
-          count > 0 ? sum(field).to_f / count.to_f : nil
+          any? ? sum(field).to_f / count.to_f : nil
         end
 
         # Get the max value of the provided field. If provided a block, will
@@ -88,7 +88,7 @@ module Mongoid
           if block_given?
             super()
           else
-            count > 0 ? super(0) { |doc| doc.public_send(field) } : 0
+            any? ? super(0) { |doc| doc.public_send(field) } : 0
           end
         end
 
@@ -106,7 +106,7 @@ module Mongoid
         #
         # @return [ Integer ] The aggregate.
         def aggregate_by(field, method)
-          count > 0 ? send(method) { |doc| doc.public_send(field) }.public_send(field) : nil
+          any? ? send(method) { |doc| doc.public_send(field) }.public_send(field) : nil
         end
       end
     end

--- a/lib/mongoid/contextual/memory.rb
+++ b/lib/mongoid/contextual/memory.rb
@@ -108,7 +108,7 @@ module Mongoid
       #
       # @return [ true, false ] If the count is more than zero.
       def exists?
-        count > 0
+        any?
       end
 
       # Get the first document in the database for the criteria's selector.

--- a/lib/mongoid/validatable/uniqueness.rb
+++ b/lib/mongoid/validatable/uniqueness.rb
@@ -242,7 +242,7 @@ module Mongoid
         relation = document._parent.send(document.association_name)
         criteria = create_criteria(relation, document, attribute, value)
         criteria = criteria.merge(options[:conditions].call) if options[:conditions]
-        add_error(document, attribute, value) if criteria.count > 1
+        add_error(document, attribute, value) if criteria.exists?
       end
 
       # Validate a root document.

--- a/lib/mongoid/validatable/uniqueness.rb
+++ b/lib/mongoid/validatable/uniqueness.rb
@@ -242,7 +242,8 @@ module Mongoid
         relation = document._parent.send(document.association_name)
         criteria = create_criteria(relation, document, attribute, value)
         criteria = criteria.merge(options[:conditions].call) if options[:conditions]
-        add_error(document, attribute, value) if criteria.exists?
+        criteria = criteria.limit(2)
+        add_error(document, attribute, value) if criteria.count > 1
       end
 
       # Validate a root document.


### PR DESCRIPTION
Upon investigation, the issue described in MONGOID-5376 seems only to affect cases which are loaded in Ruby's memory (including embeds many). I couldn't find any example of calling .count on the DB itself; I think we already fixed a few of those cases in the past.