### PR TITLE
MONGOID-5420: "a nil" --> "nil" in various places

### DIFF
--- a/lib/config/locales/en.yml
+++ b/lib/config/locales/en.yml
@@ -65,7 +65,7 @@ en:
             and the following ids were not found: %{missing}."
           resolution: "Search for an id that is in the database or set
             the Mongoid.raise_not_found_error configuration option to false,
-            which will cause a nil to be returned instead of raising this error when
+            which will cause nil to be returned instead of raising this error when
             searching for a single id, or only the matched documents when searching
             for multiples."
         document_with_attributes_not_found:
@@ -75,7 +75,7 @@ en:
             will be raised."
           resolution: "Search for attributes that are in the database or set
             the Mongoid.raise_not_found_error configuration option to false,
-            which will cause a nil to be returned instead of raising this error."
+            which will cause nil to be returned instead of raising this error."
         document_with_shard_key_not_found:
           message: "Document not found for class %{klass} with id %{missing} and
             shard key %{shard_key}."
@@ -85,7 +85,7 @@ en:
             shard_key: %{shard_key} and it was not found."
           resolution: "Search for an id/shard key that is in the database or set
             the Mongoid.raise_not_found_error configuration option to false,
-            which will cause a nil to be returned instead of raising this error."
+            which will cause nil to be returned instead of raising this error."
         empty_config_file:
           message: "Empty configuration file: %{path}."
           summary: "Your mongoid.yml configuration file appears to be empty."

--- a/spec/mongoid/association/embedded/embeds_many/proxy_spec.rb
+++ b/spec/mongoid/association/embedded/embeds_many/proxy_spec.rb
@@ -3534,7 +3534,7 @@ describe Mongoid::Association::Embedded::EmbedsMany::Proxy do
 
     describe "replacing the entire embedded list" do
 
-      context "when an embeds many relationship contains a nil as the first item" do
+      context "when an embeds many relationship contains nil as the first item" do
 
         let(:person) do
           Person.create!
@@ -3555,7 +3555,7 @@ describe Mongoid::Association::Embedded::EmbedsMany::Proxy do
         end
       end
 
-      context "when an embeds many relationship contains a nil in the middle of the list" do
+      context "when an embeds many relationship contains nil in the middle of the list" do
 
         let(:person) do
           Person.create!
@@ -3576,7 +3576,7 @@ describe Mongoid::Association::Embedded::EmbedsMany::Proxy do
         end
       end
 
-      context "when an embeds many relationship contains a nil at the end of the list" do
+      context "when an embeds many relationship contains nil at the end of the list" do
 
         let(:person) do
           Person.create!
@@ -3600,7 +3600,7 @@ describe Mongoid::Association::Embedded::EmbedsMany::Proxy do
 
     describe "appending to the embedded list" do
 
-      context "when appending a nil to the first position in an embedded list" do
+      context "when appending nil to the first position in an embedded list" do
 
         let(:person) do
           Person.create! phone_numbers: []
@@ -3619,7 +3619,7 @@ describe Mongoid::Association::Embedded::EmbedsMany::Proxy do
         end
       end
 
-      context "when appending a nil into the middle of an embedded list" do
+      context "when appending nil into the middle of an embedded list" do
 
         let(:person) do
           Person.create! phone_numbers: []
@@ -3638,7 +3638,7 @@ describe Mongoid::Association::Embedded::EmbedsMany::Proxy do
         end
       end
 
-      context "when appending a nil to the end of an embedded list" do
+      context "when appending nil to the end of an embedded list" do
 
         let(:person) do
           Person.create! phone_numbers: []

--- a/spec/mongoid/criteria_spec.rb
+++ b/spec/mongoid/criteria_spec.rb
@@ -1939,7 +1939,7 @@ describe Mongoid::Criteria do
         end
 
         with_config_values :legacy_pluck_distinct, true, false do
-          it "returns a array with nil values" do
+          it "returns an array with nil values" do
             expect(plucked).to eq([nil, nil, nil])
           end
         end
@@ -1952,7 +1952,7 @@ describe Mongoid::Criteria do
         end
 
         with_config_values :legacy_pluck_distinct, true, false do
-          it "returns a nil arrays" do
+          it "returns an array of arrays with nil values" do
             expect(plucked).to eq([[nil, nil], [nil, nil], [nil, nil]])
           end
         end

--- a/spec/mongoid/findable_spec.rb
+++ b/spec/mongoid/findable_spec.rb
@@ -472,7 +472,7 @@ describe Mongoid::Findable do
         Band.pluck(:follows)
       end
 
-      it "returns a array with nil values" do
+      it "returns an array with nil values" do
         expect(plucked).to eq([nil, nil, nil])
       end
     end


### PR DESCRIPTION
Ruby is nil is like Highlander: "There can only be one."

```ruby
nil.object_id       #=> 8
nil.dup.object_id   #=> 8

foo = []
foo.object_id       #=> 106240
foo.dup.object_id   #=> 117020
```