### PR TITLE
MONGOID-5415: Code docs: denote type unions with pipe

### DIFF
--- a/lib/mongoid/association.rb
+++ b/lib/mongoid/association.rb
@@ -56,7 +56,7 @@ module Mongoid
     # @example Is the document embedded?
     #   address.embedded?
     #
-    # @return [ true, false ] True if the document has a parent document.
+    # @return [ true | false ] True if the document has a parent document.
     def embedded?
       @embedded ||= (cyclic ? _parent.present? : self.class.embedded?)
     end
@@ -66,7 +66,7 @@ module Mongoid
     # @example Is the document in an embeds many?
     #   address.embedded_many?
     #
-    # @return [ true, false ] True if in an embeds many.
+    # @return [ true | false ] True if in an embeds many.
     def embedded_many?
       _association && _association.is_a?(Association::Embedded::EmbedsMany)
     end
@@ -76,7 +76,7 @@ module Mongoid
     # @example Is the document in an embeds one?
     #   address.embedded_one?
     #
-    # @return [ true, false ] True if in an embeds one.
+    # @return [ true | false ] True if in an embeds one.
     def embedded_one?
       _association && _association.is_a?(Association::Embedded::EmbedsOne)
     end
@@ -100,7 +100,7 @@ module Mongoid
     # @example Is the document in a references many?
     #   post.referenced_many?
     #
-    # @return [ true, false ] True if in a references many.
+    # @return [ true | false ] True if in a references many.
     def referenced_many?
       _association && _association.is_a?(Association::Referenced::HasMany)
     end
@@ -110,7 +110,7 @@ module Mongoid
     # @example Is the document in a references one?
     #   address.referenced_one?
     #
-    # @return [ true, false ] True if in a references one.
+    # @return [ true | false ] True if in a references one.
     def referenced_one?
       _association && _association.is_a?(Association::Referenced::HasOne)
     end

--- a/lib/mongoid/association/accessors.rb
+++ b/lib/mongoid/association/accessors.rb
@@ -225,7 +225,7 @@ module Mongoid
       # @example Is autobuild disabled?
       #   document.without_autobuild?
       #
-      # @return [ true, false ] If autobuild is disabled.
+      # @return [ true | false ] If autobuild is disabled.
       def without_autobuild?
         Threaded.executing?(:without_autobuild)
       end

--- a/lib/mongoid/association/accessors.rb
+++ b/lib/mongoid/association/accessors.rb
@@ -15,7 +15,7 @@ module Mongoid
       # @example Build the association.
       #   person.__build__(:addresses, { :_id => 1 }, association)
       #
-      # @param [ String, Symbol ] name The name of the association.
+      # @param [ String | Symbol ] name The name of the association.
       # @param [ Hash, BSON::ObjectId ] object The id or attributes to use.
       # @param [ Association ] association The association metadata.
       # @param [ Hash ] selected_fields Fields which were retrieved via #only.
@@ -80,7 +80,7 @@ module Mongoid
       # @example Set the proxy on the document.
       #   person.set(:addresses, addresses)
       #
-      # @param [ String, Symbol ] name The name of the association.
+      # @param [ String | Symbol ] name The name of the association.
       # @param [ Proxy ] relation The association to set.
       #
       # @return [ Proxy ] The association.

--- a/lib/mongoid/association/accessors.rb
+++ b/lib/mongoid/association/accessors.rb
@@ -16,7 +16,7 @@ module Mongoid
       #   person.__build__(:addresses, { :_id => 1 }, association)
       #
       # @param [ String | Symbol ] name The name of the association.
-      # @param [ Hash, BSON::ObjectId ] object The id or attributes to use.
+      # @param [ Hash | BSON::ObjectId ] object The id or attributes to use.
       # @param [ Association ] association The association metadata.
       # @param [ Hash ] selected_fields Fields which were retrieved via #only.
       #   If selected_fields is specified, fields not listed in it will not be
@@ -33,7 +33,7 @@ module Mongoid
       # @example Create the association.
       #   person.create_relation(document, association)
       #
-      # @param [ Document, Array<Document> ] object The association target.
+      # @param [ Document | Array<Document> ] object The association target.
       # @param [ Association ] association The association metadata.
       # @param [ Hash ] selected_fields Fields which were retrieved via #only.
       #   If selected_fields is specified, fields not listed in it will not be
@@ -101,7 +101,7 @@ module Mongoid
       # @param [ Symbol ] name The name of the association.
       # @param [ Association ] association The association metadata.
       # @param [ Object ] object The object used to build the association.
-      # @param [ true, false ] reload If the association is to be reloaded.
+      # @param [ true | false ] reload If the association is to be reloaded.
       #
       # @return [ Proxy ] The association.
       def get_relation(name, association, object, reload = false)

--- a/lib/mongoid/association/bindable.rb
+++ b/lib/mongoid/association/bindable.rb
@@ -200,7 +200,7 @@ module Mongoid
       # @example Set the base association.
       #   binding.set_base_association
       #
-      # @return [ true, false ] If the association changed.
+      # @return [ true | false ] If the association changed.
       def set_base_association
         inverse_association = _association.inverse_association(_target)
         if inverse_association != _association && !inverse_association.nil?

--- a/lib/mongoid/association/bindable.rb
+++ b/lib/mongoid/association/bindable.rb
@@ -15,7 +15,7 @@ module Mongoid
       #   Binding.new(base, target, association)
       #
       # @param [ Document ] base The base of the binding.
-      # @param [ Document, Array<Document> ] target The target of the binding.
+      # @param [ Document | Array<Document> ] target The target of the binding.
       # @param [ Association ] association The association metadata.
       def initialize(base, target, association)
         @_base, @_target, @_association = base, target, association

--- a/lib/mongoid/association/embedded/batchable.rb
+++ b/lib/mongoid/association/embedded/batchable.rb
@@ -196,7 +196,7 @@ module Mongoid
         # @example Can inserts be performed?
         #   batchable.insertable?
         #
-        # @return [ true, false ] If inserts can be performed.
+        # @return [ true | false ] If inserts can be performed.
         def insertable?
           persistable? && !_assigning? && inserts_valid
         end
@@ -208,7 +208,7 @@ module Mongoid
         # @example Are the inserts currently valid.
         #   batchable.inserts_valid
         #
-        # @return [ true, false ] If inserts are currently valid.
+        # @return [ true | false ] If inserts are currently valid.
         def inserts_valid
           @inserts_valid
         end
@@ -222,7 +222,7 @@ module Mongoid
         #
         # @param [ true | false ] value The flag.
         #
-        # @return [ true, false ] The flag.
+        # @return [ true | false ] The flag.
         def inserts_valid=(value)
           @inserts_valid = value
         end

--- a/lib/mongoid/association/embedded/batchable.rb
+++ b/lib/mongoid/association/embedded/batchable.rb
@@ -220,7 +220,7 @@ module Mongoid
         # @example Set the flag.
         #   batchable.inserts_valid = true
         #
-        # @param [ true, false ] value The flag.
+        # @param [ true | false ] value The flag.
         #
         # @return [ true, false ] The flag.
         def inserts_valid=(value)
@@ -235,7 +235,7 @@ module Mongoid
         # @example Normalize the docs.
         #   batchable.normalize_docs(docs)
         #
-        # @param [ Array<Hash, Document> ] docs The docs to normalize.
+        # @param [ Array<Hash | Document> ] docs The docs to normalize.
         #
         # @return [ Array<Document> ] The docs.
         def normalize_docs(docs)

--- a/lib/mongoid/association/embedded/cyclic.rb
+++ b/lib/mongoid/association/embedded/cyclic.rb
@@ -88,7 +88,7 @@ module Mongoid
           # @example Determine the child name.
           #   Role.cyclic_child_name
           #
-          # @param [ true, false ] many Is the a many association?
+          # @param [ true | false ] many Is the a many association?
           #
           # @return [ String ] "child_" plus the class name underscored in
           #   singular or plural form.

--- a/lib/mongoid/association/embedded/embedded_in.rb
+++ b/lib/mongoid/association/embedded/embedded_in.rb
@@ -75,7 +75,7 @@ module Mongoid
 
         # Is this association polymorphic?
         #
-        # @return [ true, false ] Whether this association is polymorphic.
+        # @return [ true | false ] Whether this association is polymorphic.
         def polymorphic?
           !!@options[:polymorphic]
         end

--- a/lib/mongoid/association/embedded/embedded_in/proxy.rb
+++ b/lib/mongoid/association/embedded/embedded_in/proxy.rb
@@ -74,7 +74,7 @@ module Mongoid
           # @example Can we persist the association?
           #   relation.persistable?
           #
-          # @return [ true, false ] If the association is persistable.
+          # @return [ true | false ] If the association is persistable.
           def persistable?
             _target.persisted? && !_binding? && !_building?
           end

--- a/lib/mongoid/association/embedded/embedded_in/proxy.rb
+++ b/lib/mongoid/association/embedded/embedded_in/proxy.rb
@@ -32,7 +32,7 @@ module Mongoid
           #
           # @param [ Document ] replacement A document to replace the target.
           #
-          # @return [ Document, nil ] The association or nil.
+          # @return [ Document | nil ] The association or nil.
           def substitute(replacement)
             unbind_one
             unless replacement

--- a/lib/mongoid/association/embedded/embeds_many.rb
+++ b/lib/mongoid/association/embedded/embeds_many.rb
@@ -92,7 +92,7 @@ module Mongoid
 
         # Is this association polymorphic?
         #
-        # @return [ true, false ] Whether this association is polymorphic.
+        # @return [ true | false ] Whether this association is polymorphic.
         def polymorphic?
           @polymorphic ||= !!@options[:as]
         end

--- a/lib/mongoid/association/embedded/embeds_many.rb
+++ b/lib/mongoid/association/embedded/embeds_many.rb
@@ -101,7 +101,7 @@ module Mongoid
         #
         # @note Only relevant if the association is polymorphic.
         #
-        # @return [ String, nil ] The field for storing the associated object's type.
+        # @return [ String | nil ] The field for storing the associated object's type.
         def type
           @type ||= "#{as}_type" if polymorphic?
         end

--- a/lib/mongoid/association/embedded/embeds_many/proxy.rb
+++ b/lib/mongoid/association/embedded/embeds_many/proxy.rb
@@ -135,7 +135,7 @@ module Mongoid
           #
           # @param [ Document ] document The document to be deleted.
           #
-          # @return [ Document, nil ] The deleted document or nil if nothing deleted.
+          # @return [ Document | nil ] The deleted document or nil if nothing deleted.
           def delete(document)
             execute_callbacks_around(:remove, document) do
               doc = _target.delete_one(document)
@@ -176,7 +176,7 @@ module Mongoid
           #     doc.state == "GA"
           #   end
           #
-          # @return [ Many, Enumerator ] The association or an enumerator if no
+          # @return [ Many | Enumerator ] The association or an enumerator if no
           #   block was provided.
           def delete_if
             if block_given?
@@ -210,7 +210,7 @@ module Mongoid
           # @example Are there persisted documents?
           #   person.posts.exists?
           #
-          # @return [ true, false ] True is persisted documents exist, false if not.
+          # @return [ true | false ] True is persisted documents exist, false if not.
           def exists?
             count > 0
           end
@@ -287,7 +287,7 @@ module Mongoid
           # @param [ Integer ] count The number of documents to pop, or 1 if not
           #   provided.
           #
-          # @return [ Document, Array<Document> ] The popped document(s).
+          # @return [ Document | Array<Document> ] The popped document(s).
           def pop(count = nil)
             if count
               if docs = _target[_target.size - count, _target.size]
@@ -312,7 +312,7 @@ module Mongoid
           # @param [ Integer ] count The number of documents to shift, or 1 if not
           #   provided.
           #
-          # @return [ Document, Array<Document> ] The shifted document(s).
+          # @return [ Document | Array<Document> ] The shifted document(s).
           def shift(count = nil)
             if count
               if _target.size > 0 && docs = _target[0, count]
@@ -446,7 +446,7 @@ module Mongoid
           # @example Can we persist the association?
           #   relation.persistable?
           #
-          # @return [ true, false ] If the association is persistable.
+          # @return [ true | false ] If the association is persistable.
           def persistable?
             _base.persisted? && !_binding?
           end

--- a/lib/mongoid/association/embedded/embeds_many/proxy.rb
+++ b/lib/mongoid/association/embedded/embeds_many/proxy.rb
@@ -19,7 +19,7 @@ module Mongoid
           # @example Push a document.
           #   person.addresses.push(address)
           #
-          # @param [ Document, Array<Document> ] args Any number of documents.
+          # @param [ Document | Array<Document> ] args Any number of documents.
           def <<(*args)
             docs = args.flatten
             return concat(docs) if docs.size > 1
@@ -117,7 +117,7 @@ module Mongoid
           # @example Use #persisted? inside block to count persisted documents.
           #   person.addresses.count { |a| a.persisted? && a.country == "FR" }
           #
-          # @param [ Object, Array<Object> ] args Args to delegate to the target.
+          # @param [ Object | Array<Object> ] args Args to delegate to the target.
           #
           # @return [ Integer ] The total number of persisted embedded docs, as
           #   flagged by the #persisted? method.
@@ -490,7 +490,7 @@ module Mongoid
           #   relation.remove_all({ :num => 1 }, true)
           #
           # @param [ Hash ] conditions Conditions to filter by.
-          # @param [ true, false ] method :delete or :destroy.
+          # @param [ true | false ] method :delete or :destroy.
           #
           # @return [ Integer ] The number of documents removed.
           def remove_all(conditions = {}, method = :delete)

--- a/lib/mongoid/association/embedded/embeds_many/proxy.rb
+++ b/lib/mongoid/association/embedded/embeds_many/proxy.rb
@@ -429,7 +429,7 @@ module Mongoid
           #
           # If the method exists on the array, use the default proxy behavior.
           #
-          # @param [ Symbol, String ] name The name of the method.
+          # @param [ Symbol | String ] name The name of the method.
           # @param [ Array ] args The method args
           # @param [ Proc ] block Optional block to pass.
           #

--- a/lib/mongoid/association/embedded/embeds_one.rb
+++ b/lib/mongoid/association/embedded/embeds_one.rb
@@ -66,7 +66,7 @@ module Mongoid
         # @example Get the validation default.
         #   Proxy.validation_default
         #
-        # @return [ true, false ] The validation default.
+        # @return [ true | false ] The validation default.
         def validation_default; true; end
 
         # Does this association type store the foreign key?
@@ -88,7 +88,7 @@ module Mongoid
 
         # Is this association polymorphic?
         #
-        # @return [ true, false ] Whether this association is polymorphic.
+        # @return [ true | false ] Whether this association is polymorphic.
         def polymorphic?
           @polymorphic ||= !!@options[:as]
         end

--- a/lib/mongoid/association/embedded/embeds_one.rb
+++ b/lib/mongoid/association/embedded/embeds_one.rb
@@ -97,7 +97,7 @@ module Mongoid
         #
         # @note Only relevant if the association is polymorphic.
         #
-        # @return [ String, nil ] The field for storing the associated object's type.
+        # @return [ String | nil ] The field for storing the associated object's type.
         def type
           @type ||= "#{as}_type" if polymorphic?
         end

--- a/lib/mongoid/association/embedded/embeds_one/proxy.rb
+++ b/lib/mongoid/association/embedded/embeds_one/proxy.rb
@@ -45,7 +45,7 @@ module Mongoid
           #
           # @param [ Document ] replacement A document to replace the target.
           #
-          # @return [ Document, nil ] The association or nil.
+          # @return [ Document | nil ] The association or nil.
           def substitute(replacement)
             if replacement != self
               if _assigning?

--- a/lib/mongoid/association/embedded/embeds_one/proxy.rb
+++ b/lib/mongoid/association/embedded/embeds_one/proxy.rb
@@ -112,7 +112,7 @@ module Mongoid
           # @example Can we persist the association?
           #   relation.persistable?
           #
-          # @return [ true, false ] If the association is persistable.
+          # @return [ true | false ] If the association is persistable.
           def persistable?
             _base.persisted? && !_binding? && !_building? && !_assigning?
           end

--- a/lib/mongoid/association/many.rb
+++ b/lib/mongoid/association/many.rb
@@ -17,7 +17,7 @@ module Mongoid
       # @example Is the association empty??
       #   person.addresses.blank?
       #
-      # @return [ true, false ] If the association is empty or not.
+      # @return [ true | false ] If the association is empty or not.
       def blank?
         !any?
       end
@@ -133,7 +133,7 @@ module Mongoid
       # @param [ Symbol ] name The method name.
       # @param [ true | false ] include_private Whether to include private methods.
       #
-      # @return [ true, false ] If the proxy responds to the method.
+      # @return [ true | false ] If the proxy responds to the method.
       def respond_to?(name, include_private = false)
         [].respond_to?(name, include_private) ||
           klass.respond_to?(name, include_private) || super

--- a/lib/mongoid/association/many.rb
+++ b/lib/mongoid/association/many.rb
@@ -131,7 +131,7 @@ module Mongoid
       #   relation.respond_to?(:name)
       #
       # @param [ Symbol ] name The method name.
-      # @param [ true, false ] include_private Whether to include private methods.
+      # @param [ true | false ] include_private Whether to include private methods.
       #
       # @return [ true, false ] If the proxy responds to the method.
       def respond_to?(name, include_private = false)

--- a/lib/mongoid/association/many.rb
+++ b/lib/mongoid/association/many.rb
@@ -158,9 +158,9 @@ module Mongoid
       #
       # @param [ Hash ] options The options to pass.
       #
-      # @option options [ Symbol ] :include What associations to include
-      # @option options [ Symbol ] :only Limit the fields to only these.
-      # @option options [ Symbol ] :except Dont include these fields.
+      # @option options [ Symbol | Array<Symbol> ] :include Which association(s) to include.
+      # @option options [ Symbol | Array<Symbol> ] :only Limit the field(s) to only these.
+      # @option options [ Symbol | Array<Symbol> ] :except Do not include these field(s).
       #
       # @return [ Hash ] The documents, ready to be serialized.
       def serializable_hash(options = {})

--- a/lib/mongoid/association/nested/many.rb
+++ b/lib/mongoid/association/nested/many.rb
@@ -165,7 +165,7 @@ module Mongoid
         #   builder.update_nested_relation(parent, id, attrs)
         #
         # @param [ Document ] parent The parent document.
-        # @param [ String, BSON::ObjectId ] id of the related document.
+        # @param [ String | BSON::ObjectId ] id of the related document.
         # @param [ Hash ] attrs The single document attributes to process.
         def update_nested_relation(parent, id, attrs)
           first = existing.first

--- a/lib/mongoid/association/nested/many.rb
+++ b/lib/mongoid/association/nested/many.rb
@@ -65,7 +65,7 @@ module Mongoid
         #
         # @param [ Hash ] attributes The attributes to pull the flag from.
         #
-        # @return [ true, false ] If the association can potentially be deleted.
+        # @return [ true | false ] If the association can potentially be deleted.
         def destroyable?(attributes)
           destroy = attributes.delete(:_destroy)
           Nested::DESTROY_FLAGS.include?(destroy) && allow_destroy?
@@ -79,7 +79,7 @@ module Mongoid
         #
         # @param [ Hash ] attributes The attributes being set.
         #
-        # @return [ true, false ] If the attributes exceed the limit.
+        # @return [ true | false ] If the attributes exceed the limit.
         def over_limit?(attributes)
           limit = options[:limit]
           limit ? attributes.size > limit : false

--- a/lib/mongoid/association/nested/nested_buildable.rb
+++ b/lib/mongoid/association/nested/nested_buildable.rb
@@ -12,7 +12,7 @@ module Mongoid
         # @example Do we allow a destroy?
         #   builder.allow_destroy?
         #
-        # @return [ true, false ] True if the allow destroy option was set.
+        # @return [ true | false ] True if the allow destroy option was set.
         def allow_destroy?
           options[:allow_destroy] || false
         end
@@ -25,7 +25,7 @@ module Mongoid
         # @param [ Document ] document The parent document of the association
         # @param [ Hash ] attrs The attributes to check for rejection.
         #
-        # @return [ true, false ] True and call proc or method if rejectable, false if not.
+        # @return [ true | false ] True and call proc or method if rejectable, false if not.
         def reject?(document, attrs)
           case callback = options[:reject_if]
             when Symbol
@@ -43,7 +43,7 @@ module Mongoid
         # @example Is this update only?
         #   builder.update_only?
         #
-        # @return [ true, false ] True if the update_only option was set.
+        # @return [ true | false ] True if the update_only option was set.
         def update_only?
           options[:update_only] || false
         end

--- a/lib/mongoid/association/nested/nested_buildable.rb
+++ b/lib/mongoid/association/nested/nested_buildable.rb
@@ -56,7 +56,7 @@ module Mongoid
         # @param [ Class ] klass The class we're trying to convert for.
         # @param [ String ] id The id, usually coming from the form.
         #
-        # @return [ BSON::ObjectId, String, Object ] The converted id.
+        # @return [ BSON::ObjectId | String | Object ] The converted id.
         def convert_id(klass, id)
           klass.using_object_ids? ? BSON::ObjectId.mongoize(id) : id
         end

--- a/lib/mongoid/association/nested/one.rb
+++ b/lib/mongoid/association/nested/one.rb
@@ -74,7 +74,7 @@ module Mongoid
         # @example Can the existing object be deleted?
         #   one.delete?
         #
-        # @return [ true, false ] If the association should be deleted.
+        # @return [ true | false ] If the association should be deleted.
         def delete?
           id = association.klass.extract_id_field(attributes)
           destroyable? && !id.nil?
@@ -85,7 +85,7 @@ module Mongoid
         # @example Is the object destroyable?
         #   one.destroyable?({ :_destroy => "1" })
         #
-        # @return [ true, false ] If the association can potentially be
+        # @return [ true | false ] If the association can potentially be
         #   destroyed.
         def destroyable?
           Nested::DESTROY_FLAGS.include?(destroy) && allow_destroy?
@@ -96,7 +96,7 @@ module Mongoid
         # @example Is the document to be replaced?
         #   one.replace?
         #
-        # @return [ true, false ] If the document should be replaced.
+        # @return [ true | false ] If the document should be replaced.
         def replace?
           !existing && !destroyable? && !attributes.blank?
         end
@@ -106,7 +106,7 @@ module Mongoid
         # @example Should the document be updated?
         #   one.update?
         #
-        # @return [ true, false ] If the object should have its attributes updated.
+        # @return [ true | false ] If the object should have its attributes updated.
         def update?
           existing && !destroyable? && acceptable_id?
         end

--- a/lib/mongoid/association/nested/one.rb
+++ b/lib/mongoid/association/nested/one.rb
@@ -62,7 +62,7 @@ module Mongoid
         # @example Is the id acceptable?
         #   one.acceptable_id?
         #
-        # @return [ true, false ] If the id part of the logic will allow an update.
+        # @return [ true | false ] If the id part of the logic will allow an update.
         def acceptable_id?
           id = association.klass.extract_id_field(attributes)
           id = convert_id(existing.class, id)

--- a/lib/mongoid/association/one.rb
+++ b/lib/mongoid/association/one.rb
@@ -12,7 +12,7 @@ module Mongoid
       # @example Clear the relation.
       #   relation.clear
       #
-      # @return [ true, false ] If the delete succeeded.
+      # @return [ true | false ] If the delete succeeded.
       def clear
         _target.delete
       end
@@ -34,7 +34,7 @@ module Mongoid
       #
       # @param [ Symbol ] name The method name.
       #
-      # @return [ true, false ] If the proxy responds to the method.
+      # @return [ true | false ] If the proxy responds to the method.
       def respond_to?(name, include_private = false)
         _target.respond_to?(name, include_private) || super
       end

--- a/lib/mongoid/association/options.rb
+++ b/lib/mongoid/association/options.rb
@@ -7,7 +7,7 @@ module Mongoid
 
       # Returns the name of the parent to a polymorphic child.
       #
-      # @return [ String, Symbol ] The name.
+      # @return [ String | Symbol ] The name.
       def as
         @options[:as]
       end
@@ -57,7 +57,7 @@ module Mongoid
       # Mongoid assumes that the field used to hold the primary key of the association is id.
       # You can override this and explicitly specify the primary key with the :primary_key option.
       #
-      # @return [ Symbol, String ] The primary key.
+      # @return [ Symbol | String ] The primary key.
       def primary_key
         @primary_key ||= @options[:primary_key] ? @options[:primary_key].to_s : Relatable::PRIMARY_KEY_DEFAULT
       end

--- a/lib/mongoid/association/options.rb
+++ b/lib/mongoid/association/options.rb
@@ -28,21 +28,21 @@ module Mongoid
 
       # Whether to index the primary or foreign key field.
       #
-      # @return [ true, false ]
+      # @return [ true | false ]
       def indexed?
         @indexed ||= !!@options[:index]
       end
 
       # Whether the association is autobuilding.
       #
-      # @return [ true, false ]
+      # @return [ true | false ]
       def autobuilding?
         !!@options[:autobuild]
       end
 
       # Is the association cyclic.
       #
-      # @return [ true, false ] Whether the association is cyclic.
+      # @return [ true | false ] Whether the association is cyclic.
       def cyclic?
         !!@options[:cyclic]
       end
@@ -65,7 +65,7 @@ module Mongoid
       # Options to save any loaded members and destroy members that are marked for destruction
       # when the parent object is saved.
       #
-      # @return [ true, false ] The autosave option.
+      # @return [ true | false ] The autosave option.
       def autosave
         !!@options[:autosave]
       end
@@ -73,19 +73,19 @@ module Mongoid
 
       # Whether the association is counter-cached.
       #
-      # @return [ true, false ]
+      # @return [ true | false ]
       def counter_cached?
         !!@options[:counter_cache]
       end
 
       # Whether this association is polymorphic.
       #
-      # @return [ true, false ] Whether the association is polymorphic.
+      # @return [ true | false ] Whether the association is polymorphic.
       def polymorphic?; false; end
 
       # Whether the association has callbacks cascaded down from the parent.
       #
-      # @return [ true, false ] Whether callbacks are cascaded.
+      # @return [ true | false ] Whether callbacks are cascaded.
       def cascading_callbacks?
         !!@options[:cascade_callbacks]
       end

--- a/lib/mongoid/association/proxy.rb
+++ b/lib/mongoid/association/proxy.rb
@@ -117,7 +117,7 @@ module Mongoid
       # Default behavior of method missing should be to delegate all calls
       # to the target of the proxy. This can be overridden in special cases.
       #
-      # @param [ String, Symbol ] name The name of the method.
+      # @param [ String | Symbol ] name The name of the method.
       # @param [ Array ] args The arguments passed to the method.
       #
       ruby2_keywords def method_missing(name, *args, &block)

--- a/lib/mongoid/association/proxy.rb
+++ b/lib/mongoid/association/proxy.rb
@@ -48,7 +48,7 @@ module Mongoid
       #   proxy.init(person, name, association)
       #
       # @param [ Document ] base The base document on the proxy.
-      # @param [ Document, Array<Document> ] target The target of the proxy.
+      # @param [ Document | Array<Document> ] target The target of the proxy.
       # @param [ Association ] association The association metadata.
       def init(base, target, association)
         @_base, @_target, @_association = base, target, association

--- a/lib/mongoid/association/referenced/auto_save.rb
+++ b/lib/mongoid/association/referenced/auto_save.rb
@@ -12,7 +12,7 @@ module Mongoid
         # @example Is the document autosaved?
         #   document.autosaved?
         #
-        # @return [ true, false ] Has the document already been autosaved?
+        # @return [ true | false ] Has the document already been autosaved?
         def autosaved?
           Threaded.autosaved?(self)
         end

--- a/lib/mongoid/association/referenced/belongs_to.rb
+++ b/lib/mongoid/association/referenced/belongs_to.rb
@@ -97,7 +97,7 @@ module Mongoid
 
         # Is this association polymorphic?
         #
-        # @return [ true, false ] Whether this association is polymorphic.
+        # @return [ true | false ] Whether this association is polymorphic.
         def polymorphic?
           @polymorphic ||= !!@options[:polymorphic]
         end

--- a/lib/mongoid/association/referenced/belongs_to/proxy.rb
+++ b/lib/mongoid/association/referenced/belongs_to/proxy.rb
@@ -18,7 +18,7 @@ module Mongoid
           #   Association::BelongsTo::Proxy.new(game, person, association)
           #
           # @param [ Document ] base The document this association hangs off of.
-          # @param [ Document, Array<Document> ] target The target (parent) of the
+          # @param [ Document | Array<Document> ] target The target (parent) of the
           #   association.
           # @param [ Association ] association The association object.
           def initialize(base, target, association)
@@ -46,7 +46,7 @@ module Mongoid
           # @example Substitute the association.
           #   name.substitute(new_name)
           #
-          # @param [ Document, Array<Document> ] replacement The replacement.
+          # @param [ Document | Array<Document> ] replacement The replacement.
           #
           # @return [ self, nil ] The association or nil.
           def substitute(replacement)
@@ -77,7 +77,7 @@ module Mongoid
           # @example Normalize the substitute.
           #   proxy.normalize(id)
           #
-          # @param [ Document, Object ] replacement The replacement object.
+          # @param [ Document | Object ] replacement The replacement object.
           #
           # @return [ Document ] The document.
           def normalize(replacement)

--- a/lib/mongoid/association/referenced/belongs_to/proxy.rb
+++ b/lib/mongoid/association/referenced/belongs_to/proxy.rb
@@ -48,7 +48,7 @@ module Mongoid
           #
           # @param [ Document | Array<Document> ] replacement The replacement.
           #
-          # @return [ self, nil ] The association or nil.
+          # @return [ self | nil ] The association or nil.
           def substitute(replacement)
             unbind_one
             if replacement

--- a/lib/mongoid/association/referenced/belongs_to/proxy.rb
+++ b/lib/mongoid/association/referenced/belongs_to/proxy.rb
@@ -90,7 +90,7 @@ module Mongoid
           # @example Can we persist the association?
           #   relation.persistable?
           #
-          # @return [ true, false ] If the association is persistable.
+          # @return [ true | false ] If the association is persistable.
           def persistable?
             _target.persisted? && !_binding? && !_building?
           end

--- a/lib/mongoid/association/referenced/counter_cache.rb
+++ b/lib/mongoid/association/referenced/counter_cache.rb
@@ -13,7 +13,7 @@ module Mongoid
         # @example Reset the given counter cache
         #   post.reset_counters(:comments)
         #
-        # @param [ Symbol, Array ] counters One or more counter caches to reset
+        # @param [ Symbol | Array ] counters One or more counter caches to reset
         def reset_counters(*counters)
           self.class.with(persistence_context) do |_class|
             _class.reset_counters(self, *counters)
@@ -30,7 +30,7 @@ module Mongoid
           #   Post.reset_counters('50e0edd97c71c17ea9000001', :comments)
           #
           # @param [ String ] id The id of the object that will be reset.
-          # @param [ Symbol, Array ] counters One or more counter caches to reset
+          # @param [ Symbol | Array ] counters One or more counter caches to reset
           def reset_counters(id, *counters)
             document = id.is_a?(Document) ? id : find(id)
             counters.each do |name|

--- a/lib/mongoid/association/referenced/eager.rb
+++ b/lib/mongoid/association/referenced/eager.rb
@@ -85,7 +85,7 @@ module Mongoid
           #   loader.set_on_parent("foo", docs)
           #
           # @param [ ObjectId ] id parent`s id
-          # @param [ Document, Array ] element to push into the parent
+          # @param [ Document | Array ] element to push into the parent
           def set_on_parent(id, element)
             grouped_docs[id].each do |d|
               set_relation(d, element)
@@ -140,7 +140,7 @@ module Mongoid
           #   loader.set_relation(doc, docs)
           #
           # @param [ Document ] doc The object to set the association on
-          # @param [ Document, Array ] element to set into the parent
+          # @param [ Document | Array ] element to set into the parent
           def set_relation(doc, element)
             doc.set_relation(@association.name, element) unless doc.blank?
           end

--- a/lib/mongoid/association/referenced/has_and_belongs_to_many.rb
+++ b/lib/mongoid/association/referenced/has_and_belongs_to_many.rb
@@ -78,7 +78,7 @@ module Mongoid
 
         # Are ids only saved on this side of the association?
         #
-        # @return [ true, false ] Whether this association has a forced nil inverse.
+        # @return [ true | false ] Whether this association has a forced nil inverse.
         def forced_nil_inverse?
           @forced_nil_inverse ||= @options.key?(:inverse_of) && !@options[:inverse_of]
         end
@@ -131,7 +131,7 @@ module Mongoid
         #
         # @param [ Document ] doc The document to be bound.
         #
-        # @return [ true, false ] Whether the document can be bound.
+        # @return [ true | false ] Whether the document can be bound.
         def bindable?(doc)
           forced_nil_inverse? || (!!inverse && doc.fields.keys.include?(foreign_key))
         end

--- a/lib/mongoid/association/referenced/has_and_belongs_to_many/proxy.rb
+++ b/lib/mongoid/association/referenced/has_and_belongs_to_many/proxy.rb
@@ -282,7 +282,7 @@ module Mongoid
           #
           # @param [ Document ] doc The document.
           #
-          # @return [ true, false ] If the document can be persisted.
+          # @return [ true | false ] If the document can be persisted.
           def child_persistable?(doc)
             (persistable? || _creating?) &&
                 !(doc.persisted? && _association.forced_nil_inverse?)

--- a/lib/mongoid/association/referenced/has_and_belongs_to_many/proxy.rb
+++ b/lib/mongoid/association/referenced/has_and_belongs_to_many/proxy.rb
@@ -21,7 +21,7 @@ module Mongoid
           # @example Concat with other documents.
           #   person.posts.concat([ post_one, post_two ])
           #
-          # @param [ Document, Array<Document> ] args Any number of documents.
+          # @param [ Document | Array<Document> ] args Any number of documents.
           #
           # @return [ Array<Document> ] The loaded docs.
           def <<(*args)

--- a/lib/mongoid/association/referenced/has_many.rb
+++ b/lib/mongoid/association/referenced/has_many.rb
@@ -140,7 +140,7 @@ module Mongoid
 
         # Is this association polymorphic?
         #
-        # @return [ true, false ] Whether this association is polymorphic.
+        # @return [ true | false ] Whether this association is polymorphic.
         def polymorphic?
           @polymorphic ||= !!as
         end
@@ -150,7 +150,7 @@ module Mongoid
         #
         # @param [ Document ] doc The document to be bound.
         #
-        # @return [ true, false ] Whether the document can be bound.
+        # @return [ true | false ] Whether the document can be bound.
         def bindable?(doc)
           forced_nil_inverse? || (!!inverse && doc.fields.keys.include?(foreign_key))
         end

--- a/lib/mongoid/association/referenced/has_many.rb
+++ b/lib/mongoid/association/referenced/has_many.rb
@@ -118,7 +118,7 @@ module Mongoid
         #
         # @note Only relevant for polymorphic associations.
         #
-        # @return [ String, nil ] The type field.
+        # @return [ String | nil ] The type field.
         def type
           @type ||= "#{as}_type" if polymorphic?
         end

--- a/lib/mongoid/association/referenced/has_many/enumerable.rb
+++ b/lib/mongoid/association/referenced/has_many/enumerable.rb
@@ -263,7 +263,7 @@ module Mongoid
           # @example Initialize the enumerable with an array.
           #   Enumerable.new([ post ])
           #
-          # @param [ Criteria, Array<Document> ] target The wrapped object.
+          # @param [ Criteria | Array<Document> ] target The wrapped object.
           def initialize(target, base = nil, association = nil)
             @_base = base
             @_association = association
@@ -410,7 +410,7 @@ module Mongoid
           #   enumerable.respond_to?(:sum)
           #
           # @param [ String | Symbol ] name The name of the method.
-          # @param [ true, false ] include_private Whether to include private
+          # @param [ true | false ] include_private Whether to include private
           #   methods.
           #
           # @return [ true, false ] Whether the enumerable responds.

--- a/lib/mongoid/association/referenced/has_many/enumerable.rb
+++ b/lib/mongoid/association/referenced/has_many/enumerable.rb
@@ -28,7 +28,7 @@ module Mongoid
           #
           # @param [ Enumerable ] other The other enumerable.
           #
-          # @return [ true, false ] If the objects are equal.
+          # @return [ true | false ] If the objects are equal.
           def ==(other)
             return false unless other.respond_to?(:entries)
             entries == other.entries
@@ -42,7 +42,7 @@ module Mongoid
           #
           # @param [ Object ] other The object to check.
           #
-          # @return [ true, false ] If the objects are equal in a case.
+          # @return [ true | false ] If the objects are equal in a case.
           def ===(other)
             return false unless other.respond_to?(:entries)
             if Mongoid.legacy_triple_equals
@@ -192,7 +192,7 @@ module Mongoid
           # @example Is the enumerable empty?
           #   enumerable.empty?
           #
-          # @return [ true, false ] If the enumerable is empty.
+          # @return [ true | false ] If the enumerable is empty.
           def empty?
             if _loaded?
               in_memory.empty?
@@ -224,7 +224,7 @@ module Mongoid
           # @param [ Object ] condition The condition that documents
           #   must satisfy. See Enumerable documentation for details.
           #
-          # @return [ true, false ] If the association has any documents.
+          # @return [ true | false ] If the association has any documents.
           def any?(*args)
             return super if args.any? || block_given?
 
@@ -285,7 +285,7 @@ module Mongoid
           #
           # @param [ Document ] doc The document to check.
           #
-          # @return [ true, false ] If the document is in the target.
+          # @return [ true | false ] If the document is in the target.
           def include?(doc)
             return super unless _unloaded
             _unloaded.where(_id: doc._id).exists? || _added.has_key?(doc._id)
@@ -356,7 +356,7 @@ module Mongoid
           # @example Is the enumerable _loaded?
           #   enumerable._loaded?
           #
-          # @return [ true, false ] If the enumerable has been _loaded.
+          # @return [ true | false ] If the enumerable has been _loaded.
           def _loaded?
             !!@executed
           end
@@ -413,7 +413,7 @@ module Mongoid
           # @param [ true | false ] include_private Whether to include private
           #   methods.
           #
-          # @return [ true, false ] Whether the enumerable responds.
+          # @return [ true | false ] Whether the enumerable responds.
           def respond_to?(name, include_private = false)
             [].respond_to?(name, include_private) || super
           end

--- a/lib/mongoid/association/referenced/has_many/enumerable.rb
+++ b/lib/mongoid/association/referenced/has_many/enumerable.rb
@@ -409,7 +409,7 @@ module Mongoid
           # @example Does the enumerable respond to the method?
           #   enumerable.respond_to?(:sum)
           #
-          # @param [ String, Symbol ] name The name of the method.
+          # @param [ String | Symbol ] name The name of the method.
           # @param [ true, false ] include_private Whether to include private
           #   methods.
           #

--- a/lib/mongoid/association/referenced/has_many/proxy.rb
+++ b/lib/mongoid/association/referenced/has_many/proxy.rb
@@ -414,7 +414,7 @@ module Mongoid
           # @param [ Array ] args The method args
           # @param [ Proc ] block Optional block to pass.
           #
-          # @return [ Criteria, Object ] A Criteria or return value from the target.
+          # @return [ Criteria | Object ] A Criteria or return value from the target.
           ruby2_keywords def method_missing(name, *args, &block)
             if _target.respond_to?(name)
               _target.send(name, *args, &block)

--- a/lib/mongoid/association/referenced/has_many/proxy.rb
+++ b/lib/mongoid/association/referenced/has_many/proxy.rb
@@ -410,7 +410,7 @@ module Mongoid
           #
           # If the method exists on the array, use the default proxy behavior.
           #
-          # @param [ Symbol, String ] name The name of the method.
+          # @param [ Symbol | String ] name The name of the method.
           # @param [ Array ] args The method args
           # @param [ Proc ] block Optional block to pass.
           #

--- a/lib/mongoid/association/referenced/has_many/proxy.rb
+++ b/lib/mongoid/association/referenced/has_many/proxy.rb
@@ -25,7 +25,7 @@ module Mongoid
           # @example Concat with other documents.
           #   person.posts.concat([ post_one, post_two ])
           #
-          # @param [ Document, Array<Document> ] args Any number of documents.
+          # @param [ Document | Array<Document> ] args Any number of documents.
           #
           # @return [ Array<Document> ] The loaded docs.
           def <<(*args)
@@ -196,7 +196,7 @@ module Mongoid
           # @note This will keep matching documents in memory for iteration
           #   later.
           #
-          # @param [ BSON::ObjectId, Array<BSON::ObjectId> ] args The ids.
+          # @param [ BSON::ObjectId | Array<BSON::ObjectId> ] args The ids.
           # @param [ Proc ] block Optional block to pass.
           #
           # @return [ Document | Array<Document> | nil ] A document or matching documents.
@@ -328,7 +328,7 @@ module Mongoid
           #   relation.with_add_callbacks(document, false)
           #
           # @param [ Document ] document The document to append to the target.
-          # @param [ true, false ] already_related Whether the document is already related
+          # @param [ true | false ] already_related Whether the document is already related
           #   to the target.
           def with_add_callbacks(document, already_related)
             execute_callback :before_add, document unless already_related

--- a/lib/mongoid/association/referenced/has_many/proxy.rb
+++ b/lib/mongoid/association/referenced/has_many/proxy.rb
@@ -168,7 +168,7 @@ module Mongoid
           # @example Are there persisted documents?
           #   person.posts.exists?
           #
-          # @return [ true, false ] True is persisted documents exist, false if not.
+          # @return [ true | false ] True is persisted documents exist, false if not.
           def exists?
             criteria.exists?
           end
@@ -343,7 +343,7 @@ module Mongoid
           #
           # @param [ Document ] document The document to possibly append to the target.
           #
-          # @return [ true, false ] Whether the document is already related to the base and the
+          # @return [ true | false ] Whether the document is already related to the base and the
           #   association is persisted.
           def already_related?(document)
             document.persisted? &&
@@ -391,7 +391,7 @@ module Mongoid
           #
           # @param [ Document ] document The document to cascade on.
           #
-          # @return [ true, false ] If the association is destructive.
+          # @return [ true | false ] If the association is destructive.
           def cascade!(document)
             if persistable?
               case _association.dependent
@@ -450,7 +450,7 @@ module Mongoid
           # @example Can we persist the association?
           #   relation.persistable?
           #
-          # @return [ true, false ] If the association is persistable.
+          # @return [ true | false ] If the association is persistable.
           def persistable?
             !_binding? && (_creating? || _base.persisted? && !_building?)
           end

--- a/lib/mongoid/association/referenced/has_one.rb
+++ b/lib/mongoid/association/referenced/has_one.rb
@@ -101,7 +101,7 @@ module Mongoid
         #
         # @note Only relevant for polymorphic associations.
         #
-        # @return [ String, nil ] The type field.
+        # @return [ String | nil ] The type field.
         def type
           @type ||= "#{as}_type" if polymorphic?
         end

--- a/lib/mongoid/association/referenced/has_one.rb
+++ b/lib/mongoid/association/referenced/has_one.rb
@@ -92,7 +92,7 @@ module Mongoid
 
         # Is this association polymorphic?
         #
-        # @return [ true, false ] Whether this association is polymorphic.
+        # @return [ true | false ] Whether this association is polymorphic.
         def polymorphic?
           @polymorphic ||= !!as
         end
@@ -111,7 +111,7 @@ module Mongoid
         #
         # @param [ Document ] doc The document to be bound.
         #
-        # @return [ true, false ] Whether the document can be bound.
+        # @return [ true | false ] Whether the document can be bound.
         def bindable?(doc)
           forced_nil_inverse? || (!!inverse && doc.fields.keys.include?(foreign_key))
         end

--- a/lib/mongoid/association/referenced/has_one/nested_builder.rb
+++ b/lib/mongoid/association/referenced/has_one/nested_builder.rb
@@ -60,7 +60,7 @@ module Mongoid
           # @example Is the id acceptable?
           #   one.acceptable_id?
           #
-          # @return [ true, false ] If the id part of the logic will allow an update.
+          # @return [ true | false ] If the id part of the logic will allow an update.
           def acceptable_id?
             id = convert_id(existing.class, attributes[:_id])
             existing._id == id || id.nil? || (existing._id != id && update_only?)
@@ -71,7 +71,7 @@ module Mongoid
           # @example Can the existing object be deleted?
           #   one.delete?
           #
-          # @return [ true, false ] If the association should be deleted.
+          # @return [ true | false ] If the association should be deleted.
           def delete?
             destroyable? && !attributes[:_id].nil?
           end
@@ -81,7 +81,7 @@ module Mongoid
           # @example Is the object destroyable?
           #   one.destroyable?({ :_destroy => "1" })
           #
-          # @return [ true, false ] If the association can potentially be
+          # @return [ true | false ] If the association can potentially be
           #   destroyed.
           def destroyable?
             [ 1, "1", true, "true" ].include?(destroy) && allow_destroy?
@@ -92,7 +92,7 @@ module Mongoid
           # @example Is the document to be replaced?
           #   one.replace?
           #
-          # @return [ true, false ] If the document should be replaced.
+          # @return [ true | false ] If the document should be replaced.
           def replace?
             !existing && !destroyable? && !attributes.blank?
           end
@@ -102,7 +102,7 @@ module Mongoid
           # @example Should the document be updated?
           #   one.update?
           #
-          # @return [ true, false ] If the object should have its attributes updated.
+          # @return [ true | false ] If the object should have its attributes updated.
           def update?
             existing && !destroyable? && acceptable_id?
           end

--- a/lib/mongoid/association/referenced/has_one/proxy.rb
+++ b/lib/mongoid/association/referenced/has_one/proxy.rb
@@ -79,7 +79,7 @@ module Mongoid
           # @example Can we persist the association?
           #   relation.persistable?
           #
-          # @return [ true, false ] If the association is persistable.
+          # @return [ true | false ] If the association is persistable.
           def persistable?
             _base.persisted? && !_binding? && !_building?
           end

--- a/lib/mongoid/association/referenced/syncable.rb
+++ b/lib/mongoid/association/referenced/syncable.rb
@@ -16,7 +16,7 @@ module Mongoid
         #
         # @param [ Association ] association The association metadata.
         #
-        # @return [ true, false ] If we can sync.
+        # @return [ true | false ] If we can sync.
         def _syncable?(association)
           !_synced?(association.foreign_key) && send(association.foreign_key_check)
         end
@@ -38,7 +38,7 @@ module Mongoid
         #
         # @param [ String ] foreign_key The foreign key.
         #
-        # @return [ true, false ] If we can sync.
+        # @return [ true | false ] If we can sync.
         def _synced?(foreign_key)
           !!_synced[foreign_key]
         end

--- a/lib/mongoid/association/reflections.rb
+++ b/lib/mongoid/association/reflections.rb
@@ -13,7 +13,7 @@ module Mongoid
       # @example Find association metadata by name.
       #   person.reflect_on_association(:addresses)
       #
-      # @param [ String, Symbol ] name The name of the association to find.
+      # @param [ String | Symbol ] name The name of the association to find.
       #
       # @return [ Association ] The matching association metadata.
       def reflect_on_association(name)
@@ -39,7 +39,7 @@ module Mongoid
         # @example Find association metadata by name.
         #   Person.reflect_on_association(:addresses)
         #
-        # @param [ String, Symbol ] name The name of the association to find.
+        # @param [ String | Symbol ] name The name of the association to find.
         #
         # @return [ Association ] The matching association metadata.
         def reflect_on_association(name)

--- a/lib/mongoid/association/relatable.rb
+++ b/lib/mongoid/association/relatable.rb
@@ -189,7 +189,7 @@ module Mongoid
       # The foreign key field if this association stores a foreign key.
       # Otherwise, the primary key.
       #
-      # @return [ Symbol, String ] The primary key.
+      # @return [ Symbol | String ] The primary key.
       def key
         stores_foreign_key? ? foreign_key : primary_key
       end

--- a/lib/mongoid/association/relatable.rb
+++ b/lib/mongoid/association/relatable.rb
@@ -69,7 +69,7 @@ module Mongoid
       #
       # @param [ Symbol ] callback_type The type of callback type.
       #
-      # @return [ Array<Proc, Symbol> ] A list of the callbacks, either method
+      # @return [ Array<Proc | Symbol> ] A list of the callbacks, either method
       #   names or Procs.
       def get_callbacks(callback_type)
         Array(options[callback_type])

--- a/lib/mongoid/association/relatable.rb
+++ b/lib/mongoid/association/relatable.rb
@@ -248,7 +248,7 @@ module Mongoid
       # Create an association proxy object using the owner and target.
       #
       # @param [ Document ] owner The document this association hangs off of.
-      # @param [ Document, Array<Document> ] target The target (parent) of the
+      # @param [ Document | Array<Document> ] target The target (parent) of the
       #   association.
       #
       # @return [ Proxy ]

--- a/lib/mongoid/association/relatable.rb
+++ b/lib/mongoid/association/relatable.rb
@@ -88,7 +88,7 @@ module Mongoid
       #
       # @param [ Document ] doc The document to be bound.
       #
-      # @return [ true, false ] Whether the document can be bound.
+      # @return [ true | false ] Whether the document can be bound.
       def bindable?(doc); false; end
 
       # Get the inverse names.
@@ -258,7 +258,7 @@ module Mongoid
 
       # Whether the dependent method is destructive.
       #
-      # @return [ true, false ] If the dependent method is destructive.
+      # @return [ true | false ] If the dependent method is destructive.
       def destructive?
         @destructive ||= !!(dependent && (dependent == :delete_all || dependent == :destroy))
       end
@@ -289,7 +289,7 @@ module Mongoid
 
       # Whether the associated object(s) should be validated.
       #
-      # @return [ true, false ] If the associated object(s)
+      # @return [ true | false ] If the associated object(s)
       #   should be validated.
       def validate?
         @validate ||= if @options[:validate].nil?

--- a/lib/mongoid/atomic/modifiers.rb
+++ b/lib/mongoid/atomic/modifiers.rb
@@ -153,7 +153,7 @@ module Mongoid
       #
       # @param [ String ] field The field.
       #
-      # @return [ true, false ] If this field is a conflict.
+      # @return [ true | false ] If this field is a conflict.
       def set_conflict?(field)
         name = field.split(".", 2)[0]
         pull_fields.has_key?(name) || push_fields.has_key?(name)
@@ -166,7 +166,7 @@ module Mongoid
       #
       # @param [ String ] field The field.
       #
-      # @return [ true, false ] If this field is a conflict.
+      # @return [ true | false ] If this field is a conflict.
       def push_conflict?(field)
         name = field.split(".", 2)[0]
         set_fields.has_key?(name) || pull_fields.has_key?(name) ||

--- a/lib/mongoid/attributes.rb
+++ b/lib/mongoid/attributes.rb
@@ -25,7 +25,7 @@ module Mongoid
     # @example Is the attribute present?
     #   person.attribute_present?("title")
     #
-    # @param [ String, Symbol ] name The name of the attribute.
+    # @param [ String | Symbol ] name The name of the attribute.
     #
     # @return [ true, false ] True if present, false if not.
     def attribute_present?(name)
@@ -50,7 +50,7 @@ module Mongoid
     # @example Does the document have the attribute?
     #   model.has_attribute?(:name)
     #
-    # @param [ String, Symbol ] name The name of the attribute.
+    # @param [ String | Symbol ] name The name of the attribute.
     #
     # @return [ true, false ] If the key is present in the attributes.
     def has_attribute?(name)
@@ -63,7 +63,7 @@ module Mongoid
     # @example Does the document have the attribute before it was assigned?
     #   model.has_attribute_before_type_cast?(:name)
     #
-    # @param [ String, Symbol ] name The name of the attribute.
+    # @param [ String | Symbol ] name The name of the attribute.
     #
     # @return [ true, false ] If the key is present in the
     #   attributes_before_type_cast.
@@ -80,7 +80,7 @@ module Mongoid
     # @example Read an attribute (alternate syntax.)
     #   person[:title]
     #
-    # @param [ String, Symbol ] name The name of the attribute to get.
+    # @param [ String | Symbol ] name The name of the attribute to get.
     #
     # @return [ Object ] The value of the attribute.
     def read_attribute(name)
@@ -113,7 +113,7 @@ module Mongoid
     # @example Read an attribute before type cast.
     #   person.read_attribute_before_type_cast(:price)
     #
-    # @param [ String, Symbol ] name The name of the attribute to get.
+    # @param [ String | Symbol ] name The name of the attribute to get.
     #
     # @return [ Object ] The value of the attribute before type cast, if
     #   available. Otherwise, the value of the attribute.
@@ -132,7 +132,7 @@ module Mongoid
     # @example Remove the attribute.
     #   person.remove_attribute(:title)
     #
-    # @param [ String, Symbol ] name The name of the attribute to remove.
+    # @param [ String | Symbol ] name The name of the attribute to remove.
     #
     # @raise [ Errors::ReadonlyAttribute ] If the field cannot be removed due
     #   to being flagged as reaodnly.
@@ -157,7 +157,7 @@ module Mongoid
     # @example Write the attribute (alternate syntax.)
     #   person[:title] = "Mr."
     #
-    # @param [ String, Symbol ] name The name of the attribute to update.
+    # @param [ String | Symbol ] name The name of the attribute to update.
     # @param [ Object ] value The value to set for the attribute.
     def write_attribute(name, value)
       validate_writable_field_name!(name.to_s)
@@ -272,7 +272,7 @@ module Mongoid
     # @example Get the value typecasted.
     #   person.typed_value_for(:title, :sir)
     #
-    # @param [ String, Symbol ] key The field name.
+    # @param [ String | Symbol ] key The field name.
     # @param [ Object ] value The uncast value.
     #
     # @return [ Object ] The cast value.
@@ -363,7 +363,7 @@ module Mongoid
     # in the database, not (necessarily) the Ruby method name used to read/write
     # the said field.
     #
-    # @param [ String, Symbol ] field_name The name of the field.
+    # @param [ String | Symbol ] field_name The name of the field.
     # @param [ Object ] value The value to be validated.
     def validate_attribute_value(field_name, value)
       return if value.nil?

--- a/lib/mongoid/attributes.rb
+++ b/lib/mongoid/attributes.rb
@@ -27,7 +27,7 @@ module Mongoid
     #
     # @param [ String | Symbol ] name The name of the attribute.
     #
-    # @return [ true, false ] True if present, false if not.
+    # @return [ true | false ] True if present, false if not.
     def attribute_present?(name)
       attribute = read_raw_attribute(name)
       !attribute.blank? || attribute == false
@@ -52,7 +52,7 @@ module Mongoid
     #
     # @param [ String | Symbol ] name The name of the attribute.
     #
-    # @return [ true, false ] If the key is present in the attributes.
+    # @return [ true | false ] If the key is present in the attributes.
     def has_attribute?(name)
       attributes.key?(name.to_s)
     end
@@ -65,7 +65,7 @@ module Mongoid
     #
     # @param [ String | Symbol ] name The name of the attribute.
     #
-    # @return [ true, false ] If the key is present in the
+    # @return [ true | false ] If the key is present in the
     #   attributes_before_type_cast.
     def has_attribute_before_type_cast?(name)
       attributes_before_type_cast.key?(name.to_s)
@@ -238,7 +238,7 @@ module Mongoid
     #
     # @param [ String ] name The name of the attribute.
     #
-    # @return [ true, false ] If the attribute is missing.
+    # @return [ true | false ] If the attribute is missing.
     def attribute_missing?(name)
       !Projector.new(__selected_fields).attribute_or_path_allowed?(name)
     end
@@ -262,7 +262,7 @@ module Mongoid
     # @example Is the string in dot syntax.
     #   model.hash_dot_syntax?
     #
-    # @return [ true, false ] If the string contains a "."
+    # @return [ true | false ] If the string contains a "."
     def hash_dot_syntax?(string)
       string.include?(".")
     end

--- a/lib/mongoid/attributes/dynamic.rb
+++ b/lib/mongoid/attributes/dynamic.rb
@@ -13,7 +13,7 @@ module Mongoid
       #   person.respond_to?(:title)
       #
       # @param [ Array ] name The name of the method.
-      # @param [ true, false ] include_private
+      # @param [ true | false ] include_private
       #
       # @return [ true, false ] True if it does, false if not.
       def respond_to?(name, include_private = false)

--- a/lib/mongoid/attributes/dynamic.rb
+++ b/lib/mongoid/attributes/dynamic.rb
@@ -15,7 +15,7 @@ module Mongoid
       # @param [ Array ] name The name of the method.
       # @param [ true | false ] include_private
       #
-      # @return [ true, false ] True if it does, false if not.
+      # @return [ true | false ] True if it does, false if not.
       def respond_to?(name, include_private = false)
         super || (
           attributes &&

--- a/lib/mongoid/attributes/dynamic.rb
+++ b/lib/mongoid/attributes/dynamic.rb
@@ -114,7 +114,7 @@ module Mongoid
       # @example Call through method_missing.
       #   document.method_missing(:test)
       #
-      # @param [ String, Symbol ] name The name of the method.
+      # @param [ String | Symbol ] name The name of the method.
       # @param [ Array ] args The arguments to the method.
       #
       # @return [ Object ] The result of the method call.

--- a/lib/mongoid/attributes/nested.rb
+++ b/lib/mongoid/attributes/nested.rb
@@ -33,7 +33,7 @@ module Mongoid
         #     accepts_nested_attributes_for :addresses, :game, :posts
         #   end
         #
-        # @param [ Array<Symbol>, Hash ] args A list of association names, followed
+        # @param [ Array<Symbol> | Hash ] args A list of association names, followed
         #   by a hash of options.
         #
         # @option *args [ true, false ] :allow_destroy Can deletion occur?

--- a/lib/mongoid/attributes/nested.rb
+++ b/lib/mongoid/attributes/nested.rb
@@ -36,12 +36,12 @@ module Mongoid
         # @param [ Array<Symbol> | Hash ] args A list of association names, followed
         #   by a hash of options.
         #
-        # @option *args [ true, false ] :allow_destroy Can deletion occur?
+        # @option *args [ true | false ] :allow_destroy Can deletion occur?
         # @option *args [ Proc, Symbol ] :reject_if Block or symbol pointing
         #   to a class method to reject documents with.
         # @option *args [ Integer ] :limit The max number to create.
-        # @option *args [ true, false ] :update_only Only update existing docs.
-        # @options *args [ true, false ] :autosave Whether autosave should be enabled on the
+        # @option *args [ true | false ] :update_only Only update existing docs.
+        # @option *args [ true | false ] :autosave Whether autosave should be enabled on the
         #   association. Note that since the default is true, setting autosave to nil will still
         #   enable it.
         def accepts_nested_attributes_for(*args)

--- a/lib/mongoid/attributes/nested.rb
+++ b/lib/mongoid/attributes/nested.rb
@@ -37,7 +37,7 @@ module Mongoid
         #   by a hash of options.
         #
         # @option *args [ true | false ] :allow_destroy Can deletion occur?
-        # @option *args [ Proc, Symbol ] :reject_if Block or symbol pointing
+        # @option *args [ Proc | Symbol ] :reject_if Block or symbol pointing
         #   to a class method to reject documents with.
         # @option *args [ Integer ] :limit The max number to create.
         # @option *args [ true | false ] :update_only Only update existing docs.

--- a/lib/mongoid/attributes/processing.rb
+++ b/lib/mongoid/attributes/processing.rb
@@ -40,7 +40,7 @@ module Mongoid
       # @param [ Symbol ] key The name of the attribute.
       # @param [ Object ] value The value of the attribute.
       #
-      # @return [ true, false ] True if pending, false if not.
+      # @return [ true | false ] True if pending, false if not.
       def pending_attribute?(key, value)
         name = key.to_s
 

--- a/lib/mongoid/attributes/projector.rb
+++ b/lib/mongoid/attributes/projector.rb
@@ -41,7 +41,7 @@ module Mongoid
       #
       # @param [ String ] name The name of the attribute or a dot notation path.
       #
-      # @return [ true, false ] Whether the attribute is allowed by projection.
+      # @return [ true | false ] Whether the attribute is allowed by projection.
       #
       # @api private
       def attribute_or_path_allowed?(name)

--- a/lib/mongoid/attributes/readonly.rb
+++ b/lib/mongoid/attributes/readonly.rb
@@ -17,7 +17,7 @@ module Mongoid
       # @example Can we write the attribute?
       #   model.attribute_writable?(:title)
       #
-      # @param [ String, Symbol ] name The name of the field.
+      # @param [ String | Symbol ] name The name of the field.
       #
       # @return [ true, false ] If the document is new, or if the field is not
       #   readonly.

--- a/lib/mongoid/attributes/readonly.rb
+++ b/lib/mongoid/attributes/readonly.rb
@@ -19,7 +19,7 @@ module Mongoid
       #
       # @param [ String | Symbol ] name The name of the field.
       #
-      # @return [ true, false ] If the document is new, or if the field is not
+      # @return [ true | false ] If the document is new, or if the field is not
       #   readonly.
       def attribute_writable?(name)
         new_record? || (!readonly_attributes.include?(name) && _loaded?(name))

--- a/lib/mongoid/changeable.rb
+++ b/lib/mongoid/changeable.rb
@@ -21,7 +21,7 @@ module Mongoid
     # @example Has the document changed?
     #   model.changed?
     #
-    # @return [ true, false ] If the document is changed.
+    # @return [ true | false ] If the document is changed.
     def changed?
       changes.values.any? { |val| val } || children_changed?
     end
@@ -30,7 +30,7 @@ module Mongoid
     #
     # @note This intentionally only considers children and not descendants.
     #
-    # @return [ true, false ] If any children have changed.
+    # @return [ true | false ] If any children have changed.
     def children_changed?
       _children.any?(&:changed?)
     end
@@ -162,7 +162,7 @@ module Mongoid
     #
     # @param [ String ] attr The name of the attribute.
     #
-    # @return [ true, false ] Whether the attribute has changed.
+    # @return [ true | false ] Whether the attribute has changed.
     def attribute_changed?(attr)
       attr = database_field_name(attr)
       return false unless changed_attributes.key?(attr)
@@ -176,7 +176,7 @@ module Mongoid
     #
     # @param [ String ] attr The name of the attribute.
     #
-    # @return [ true, false ] If the attribute differs.
+    # @return [ true | false ] If the attribute differs.
     def attribute_changed_from_default?(attr)
       field = fields[attr]
       return false unless field

--- a/lib/mongoid/changeable.rb
+++ b/lib/mongoid/changeable.rb
@@ -102,7 +102,7 @@ module Mongoid
     # @example Remove a flagged change.
     #   model.remove_change(:field)
     #
-    # @param [ Symbol, String ] name The name of the field.
+    # @param [ Symbol | String ] name The name of the field.
     def remove_change(name)
       changed_attributes.delete(name.to_s)
     end

--- a/lib/mongoid/clients/options.rb
+++ b/lib/mongoid/clients/options.rb
@@ -12,7 +12,7 @@ module Mongoid
       #     m.save
       #   end
       #
-      # @param [ Hash, Mongoid::PersistenceContext ] options_or_context
+      # @param [ Hash | Mongoid::PersistenceContext ] options_or_context
       #   The storage options or a persistence context.
       #
       # @option options [ String | Symbol ] :collection The collection name.

--- a/lib/mongoid/clients/validators/storage.rb
+++ b/lib/mongoid/clients/validators/storage.rb
@@ -17,7 +17,7 @@ module Mongoid
         #   Storage.validate(:collection_name)
         #
         # @param [ Class ] klass The model class.
-        # @param [ Hash, String, Symbol ] options The provided options.
+        # @param [ Hash | String | Symbol ] options The provided options.
         def validate(klass, options)
           valid_keys?(options) or raise Errors::InvalidStorageOptions.new(klass, options)
           valid_parent?(klass) or raise Errors::InvalidStorageParent.new(klass)

--- a/lib/mongoid/clients/validators/storage.rb
+++ b/lib/mongoid/clients/validators/storage.rb
@@ -31,7 +31,7 @@ module Mongoid
         #
         # @param [ Class ] klass
         #
-        # @return [ true, false ] If the class is valid
+        # @return [ true | false ] If the class is valid.
         def valid_parent?(klass)
           !klass.superclass.include?(Mongoid::Document)
         end
@@ -45,7 +45,7 @@ module Mongoid
         #
         # @param [ Hash ] options The options hash.
         #
-        # @return [ true, false ] If all keys are valid.
+        # @return [ true | false ] If all keys are valid.
         def valid_keys?(options)
           return false unless options.is_a?(::Hash)
           options.keys.all? do |key|

--- a/lib/mongoid/config.rb
+++ b/lib/mongoid/config.rb
@@ -172,7 +172,7 @@ module Mongoid
     #   Mongoid.load!("/path/to/mongoid.yml")
     #
     # @param [ String ] path The path to the file.
-    # @param [ String, Symbol ] environment The environment to load.
+    # @param [ String | Symbol ] environment The environment to load.
     def load!(path, environment = nil)
       settings = Environment.load_yaml(path, environment)
       if settings.present?
@@ -224,9 +224,9 @@ module Mongoid
     # @example Override the database globally.
     #   config.override_database(:optional)
     #
-    # @param [ String, Symbol ] name The name of the database.
+    # @param [ String | Symbol ] name The name of the database.
     #
-    # @return [ String, Symbol ] The global override.
+    # @return [ String | Symbol ] The global override.
     def override_database(name)
       Threaded.database_override = name
     end
@@ -236,9 +236,9 @@ module Mongoid
     # @example Override the client globally.
     #   config.override_client(:optional)
     #
-    # @param [ String, Symbol ] name The name of the client.
+    # @param [ String | Symbol ] name The name of the client.
     #
-    # @return [ String, Symbol ] The global override.
+    # @return [ String | Symbol ] The global override.
     def override_client(name)
       Threaded.client_override = name ? name.to_s : nil
     end

--- a/lib/mongoid/config.rb
+++ b/lib/mongoid/config.rb
@@ -131,7 +131,7 @@ module Mongoid
     # @example Is Mongoid configured?
     #   config.configured?
     #
-    # @return [ true, false ] If Mongoid is configured.
+    # @return [ true | false ] If Mongoid is configured.
     def configured?
       clients.key?(:default)
     end
@@ -309,7 +309,7 @@ module Mongoid
     # @example Is the application using passenger?
     #   config.running_with_passenger?
     #
-    # @return [ true, false ] If the app is deployed on Passenger.
+    # @return [ true | false ] If the app is deployed on Passenger.
     def running_with_passenger?
       @running_with_passenger ||= defined?(PhusionPassenger)
     end

--- a/lib/mongoid/config/validators/client.rb
+++ b/lib/mongoid/config/validators/client.rb
@@ -86,7 +86,7 @@ module Mongoid
         #
         # @param [ Hash ] config The configuration options.
         #
-        # @return [ true, false ] If no database or uri is defined.
+        # @return [ true | false ] If no database or uri is defined.
         def no_database_or_uri?(config)
           !config.has_key?(:database) && !config.has_key?(:uri)
         end
@@ -101,7 +101,7 @@ module Mongoid
         #
         # @param [ Hash ] config The configuration options.
         #
-        # @return [ true, false ] If no hosts or uri is defined.
+        # @return [ true | false ] If no hosts or uri is defined.
         def no_hosts_or_uri?(config)
           !config.has_key?(:hosts) && !config.has_key?(:uri)
         end
@@ -116,7 +116,7 @@ module Mongoid
         #
         # @param [ Hash ] config The configuration options.
         #
-        # @return [ true, false ] If both standard and uri are defined.
+        # @return [ true | false ] If both standard and uri are defined.
         def both_uri_and_standard?(config)
           config.has_key?(:uri) && config.keys.any? do |key|
             STANDARD.include?(key.to_sym)

--- a/lib/mongoid/config/validators/client.rb
+++ b/lib/mongoid/config/validators/client.rb
@@ -37,7 +37,7 @@ module Mongoid
         # @example Validate the client has database.
         #   validator.validate_client_database(:default, {})
         #
-        # @param [ String, Symbol ] name The config key.
+        # @param [ String | Symbol ] name The config key.
         # @param [ Hash ] config The configuration.
         def validate_client_database(name, config)
           if no_database_or_uri?(config)
@@ -52,7 +52,7 @@ module Mongoid
         # @example Validate the client has hosts.
         #   validator.validate_client_hosts(:default, {})
         #
-        # @param [ String, Symbol ] name The config key.
+        # @param [ String | Symbol ] name The config key.
         # @param [ Hash ] config The configuration.
         def validate_client_hosts(name, config)
           if no_hosts_or_uri?(config)
@@ -68,7 +68,7 @@ module Mongoid
         # @example Validate the uri and options.
         #   validator.validate_client_uri(:default, {})
         #
-        # @param [ String, Symbol ] name The config key.
+        # @param [ String | Symbol ] name The config key.
         # @param [ Hash ] config The configuration.
         def validate_client_uri(name, config)
           if both_uri_and_standard?(config)

--- a/lib/mongoid/contextual.rb
+++ b/lib/mongoid/contextual.rb
@@ -30,7 +30,7 @@ module Mongoid
     # @example Get the context.
     #   criteria.context
     #
-    # @return [ Memory, Mongo ] The context.
+    # @return [ Memory | Mongo ] The context.
     def context
       @context ||= create_context
     end
@@ -45,7 +45,7 @@ module Mongoid
     # @example Create the context.
     #   contextual.create_context
     #
-    # @return [ Mongo, Memory ] The context.
+    # @return [ Mongo | Memory ] The context.
     def create_context
       return None.new(self) if empty_and_chainable?
       embedded ? Memory.new(self) : Mongo.new(self)

--- a/lib/mongoid/contextual/aggregable/memory.rb
+++ b/lib/mongoid/contextual/aggregable/memory.rb
@@ -9,7 +9,7 @@ module Mongoid
         # Get all the aggregate values for the provided field.
         # Provided for interface consistency with Aggregable::Mongo.
         #
-        # @param [ String, Symbol ] field The field name.
+        # @param [ String | Symbol ] field The field name.
         #
         # @return [ Hash ] A Hash containing the aggregate values.
         #   If no documents are present, then returned Hash will have

--- a/lib/mongoid/contextual/aggregable/memory.rb
+++ b/lib/mongoid/contextual/aggregable/memory.rb
@@ -46,7 +46,7 @@ module Mongoid
         #
         # @param [ Symbol ] field The field to max.
         #
-        # @return [ Float, Document ] The max value or document with the max
+        # @return [ Float | Document ] The max value or document with the max
         #   value.
         def max(field = nil)
           block_given? ? super() : aggregate_by(field, :max_by)
@@ -66,7 +66,7 @@ module Mongoid
         #
         # @param [ Symbol ] field The field to min.
         #
-        # @return [ Float, Document ] The min value or document with the min
+        # @return [ Float | Document ] The min value or document with the min
         #   value.
         def min(field = nil)
           block_given? ? super() : aggregate_by(field, :min_by)

--- a/lib/mongoid/contextual/aggregable/mongo.rb
+++ b/lib/mongoid/contextual/aggregable/mongo.rb
@@ -20,7 +20,7 @@ module Mongoid
         #   #   "avg" => 750.0
         #   # }
         #
-        # @param [ String, Symbol ] field The field name.
+        # @param [ String | Symbol ] field The field name.
         #
         # @return [ Hash ] A Hash containing the aggregate values.
         #   If no documents are found, then returned Hash will have
@@ -115,7 +115,7 @@ module Mongoid
         # @example Get the pipeline.
         #   aggregable.pipeline(:likes)
         #
-        # @param [ String, Symbol ] field The name of the field.
+        # @param [ String | Symbol ] field The name of the field.
         #
         # @return [ Array ] The array of pipeline operators.
         def pipeline(field)

--- a/lib/mongoid/contextual/aggregable/mongo.rb
+++ b/lib/mongoid/contextual/aggregable/mongo.rb
@@ -64,7 +64,7 @@ module Mongoid
         #
         # @param [ Symbol ] field The field to max.
         #
-        # @return [ Float, Document ] The max value or document with the max
+        # @return [ Float | Document ] The max value or document with the max
         #   value.
         def max(field = nil)
           block_given? ? super() : aggregates(field)["max"]
@@ -84,7 +84,7 @@ module Mongoid
         #
         # @param [ Symbol ] field The field to min.
         #
-        # @return [ Float, Document ] The min value or document with the min
+        # @return [ Float | Document ] The min value or document with the min
         #   value.
         def min(field = nil)
           block_given? ? super() : aggregates(field)["min"]

--- a/lib/mongoid/contextual/aggregable/none.rb
+++ b/lib/mongoid/contextual/aggregable/none.rb
@@ -11,7 +11,7 @@ module Mongoid
         # Get all the aggregate values for the provided field in null context.
         # Provided for interface consistency with Aggregable::Mongo.
         #
-        # @param [ String, Symbol ] _field The field name.
+        # @param [ String | Symbol ] _field The field name.
         #
         # @return [ Hash ] A Hash with count, sum of 0 and max, min, avg of nil.
         def aggregates(_field)

--- a/lib/mongoid/contextual/geo_near.rb
+++ b/lib/mongoid/contextual/geo_near.rb
@@ -46,7 +46,7 @@ module Mongoid
       # @example Provide the distance multiplier.
       #   geo_near.distance_multiplier(13113.1)
       #
-      # @param [ Integer, Float ] value The distance multiplier.
+      # @param [ Integer | Float ] value The distance multiplier.
       #
       # @return [ GeoNear ] The GeoNear wrapper.
       def distance_multiplier(value)
@@ -98,7 +98,7 @@ module Mongoid
       # @example Get the max distance.
       #   geo_near.max_distance
       #
-      # @param [ Integer, Float ] value The maximum distance.
+      # @param [ Integer | Float ] value The maximum distance.
       #
       # @return [ GeoNear, Float ] The GeoNear command or the value.
       def max_distance(value = nil)
@@ -115,7 +115,7 @@ module Mongoid
       # @example Set the min distance.
       #   geo_near.min_distance(0.5)
       #
-      # @param [ Integer, Float ] value The minimum distance.
+      # @param [ Integer | Float ] value The minimum distance.
       #
       # @return [ GeoNear ] The GeoNear command.
       def min_distance(value)
@@ -139,7 +139,7 @@ module Mongoid
       # @example Set the unique flag.
       #   geo_near.unique(false)
       #
-      # @param [ true, false ] value Whether to return unique documents.
+      # @param [ true | false ] value Whether to return unique documents.
       #
       # @return [ GeoNear ] The command.
       def unique(value = true)

--- a/lib/mongoid/contextual/geo_near.rb
+++ b/lib/mongoid/contextual/geo_near.rb
@@ -16,7 +16,7 @@ module Mongoid
       # @example Get the average distance.
       #   geo_near.average_distance
       #
-      # @return [ Float, nil ] The average distance.
+      # @return [ Float | nil ] The average distance.
       def average_distance
         average = stats["avgDistance"]
         (average.nil? || average.nan?) ? nil : average
@@ -100,7 +100,7 @@ module Mongoid
       #
       # @param [ Integer | Float ] value The maximum distance.
       #
-      # @return [ GeoNear, Float ] The GeoNear command or the value.
+      # @return [ GeoNear | Float ] The GeoNear command or the value.
       def max_distance(value = nil)
         if value
           command[:maxDistance] = value
@@ -211,7 +211,7 @@ module Mongoid
       # @example Get the documents.
       #   geo_near.documents
       #
-      # @return [ Array, Cursor ] The documents.
+      # @return [ Array | Cursor ] The documents.
       def documents
         results["results"].map do |attributes|
           doc = Factory.from_db(criteria.klass, attributes["obj"], criteria)

--- a/lib/mongoid/contextual/memory.rb
+++ b/lib/mongoid/contextual/memory.rb
@@ -74,7 +74,7 @@ module Mongoid
       # @example Get the distinct values.
       #   context.distinct(:name)
       #
-      # @param [ String, Symbol ] field The name of the field.
+      # @param [ String | Symbol ] field The name of the field.
       #
       # @return [ Array<Object> ] The distinct values for the field.
       def distinct(field)

--- a/lib/mongoid/contextual/memory.rb
+++ b/lib/mongoid/contextual/memory.rb
@@ -25,7 +25,7 @@ module Mongoid
       #
       # @param [ Array ] other The other array.
       #
-      # @return [ true, false ] If the objects are equal.
+      # @return [ true | false ] If the objects are equal.
       def ==(other)
         return false unless other.respond_to?(:entries)
         entries == other.entries
@@ -106,7 +106,7 @@ module Mongoid
       # @example Do any documents exist for the context.
       #   context.exists?
       #
-      # @return [ true, false ] If the count is more than zero.
+      # @return [ true | false ] If the count is more than zero.
       def exists?
         count > 0
       end

--- a/lib/mongoid/contextual/memory.rb
+++ b/lib/mongoid/contextual/memory.rb
@@ -274,7 +274,7 @@ module Mongoid
       #
       # @param [ Hash ] attributes The new attributes for the document.
       #
-      # @return [ nil, false ] False if no attributes were provided.
+      # @return [ nil | false ] False if no attributes were provided.
       def update(attributes = nil)
         update_documents(attributes, [ first ])
       end
@@ -286,7 +286,7 @@ module Mongoid
       #
       # @param [ Hash ] attributes The new attributes for each document.
       #
-      # @return [ nil, false ] False if no attributes were provided.
+      # @return [ nil | false ] False if no attributes were provided.
       def update_all(attributes = nil)
         update_documents(attributes, entries)
       end

--- a/lib/mongoid/contextual/mongo.rb
+++ b/lib/mongoid/contextual/mongo.rb
@@ -198,7 +198,7 @@ module Mongoid
       # @param [ Hash ] update The updates.
       # @param [ Hash ] options The command options.
       #
-      # @option options [ :before, :after ] :return_document Return the updated document
+      # @option options [ :before | :after ] :return_document Return the updated document
       #   from before or after update.
       # @option options [ true | false ] :upsert Create the document if it doesn't exist.
       #
@@ -218,7 +218,7 @@ module Mongoid
       # @param [ Hash ] replacement The replacement.
       # @param [ Hash ] options The command options.
       #
-      # @option options [ :before, :after ] :return_document Return the updated document
+      # @option options [ :before | :after ] :return_document Return the updated document
       #   from before or after update.
       # @option options [ true | false ] :upsert Create the document if it doesn't exist.
       #
@@ -884,7 +884,7 @@ module Mongoid
       #
       # @param [ String ] field_name The name of the field to demongoize.
       # @param [ Object ] value The value to demongoize.
-      # @param [ Boolean ] is_translation The field we are retrieving is an
+      # @param [ true | false ] is_translation The field we are retrieving is an
       #   _translations field.
       #
       # @return [ Object ] The demongoized value.
@@ -898,7 +898,7 @@ module Mongoid
       #
       # @param [ Field ] field The field to use to demongoize.
       # @param [ Object ] value The value to demongoize.
-      # @param [ Boolean ] is_translation The field we are retrieving is an
+      # @param [ true | false ] is_translation The field we are retrieving is an
       #   _translations field.
       #
       # @return [ Object ] The demongoized value.

--- a/lib/mongoid/contextual/mongo.rb
+++ b/lib/mongoid/contextual/mongo.rb
@@ -119,7 +119,7 @@ module Mongoid
       # @example Get the distinct values.
       #   context.distinct(:name)
       #
-      # @param [ String, Symbol ] field The name of the field.
+      # @param [ String | Symbol ] field The name of the field.
       #
       # @return [ Array<Object> ] The distinct values for the field.
       def distinct(field)
@@ -460,7 +460,7 @@ module Mongoid
       # @note This method will return the raw db values - it performs no custom
       #   serialization.
       #
-      # @param [ String, Symbol, Array ] fields Fields to pluck.
+      # @param [ String | Symbol, Array ] fields Fields to pluck.
       #
       # @return [ Array<Object, Array> ] The plucked values.
       def pluck(*fields)
@@ -629,7 +629,7 @@ module Mongoid
 
       # yield the block given or return the cached value
       #
-      # @param [ String, Symbol ] key The instance variable name
+      # @param [ String | Symbol ] key The instance variable name
       #
       # @return the result of the block
       def try_cache(key, &block)

--- a/lib/mongoid/contextual/mongo.rb
+++ b/lib/mongoid/contextual/mongo.rb
@@ -42,7 +42,7 @@ module Mongoid
       # @example Is the context cached?
       #   context.cached?
       #
-      # @return [ true, false ] If the context is cached.
+      # @return [ true | false ] If the context is cached.
       def cached?
         !!@cache
       end
@@ -169,7 +169,7 @@ module Mongoid
       #   b-tree indexes, unless a count is already cached then that is
       #   used to determine the value.
       #
-      # @return [ true, false ] If the count is more than zero.
+      # @return [ true | false ] If the count is more than zero.
       def exists?
         return !documents.empty? if cached? && cache_loaded?
         return @count > 0 if instance_variable_defined?(:@count)
@@ -200,7 +200,7 @@ module Mongoid
       #
       # @option options [ :before, :after ] :return_document Return the updated document
       #   from before or after update.
-      # @option options [ true, false ] :upsert Create the document if it doesn't exist.
+      # @option options [ true | false ] :upsert Create the document if it doesn't exist.
       #
       # @return [ Document ] The result of the command.
       def find_one_and_update(update, options = {})
@@ -220,7 +220,7 @@ module Mongoid
       #
       # @option options [ :before, :after ] :return_document Return the updated document
       #   from before or after update.
-      # @option options [ true, false ] :upsert Create the document if it doesn't exist.
+      # @option options [ true | false ] :upsert Create the document if it doesn't exist.
       #
       # @return [ Document ] The result of the command.
       def find_one_and_replace(replacement, options = {})
@@ -653,7 +653,7 @@ module Mongoid
       # @param [ Hash ] attributes The updates.
       # @param [ Symbol ] method The method to use.
       #
-      # @return [ true, false ] If the update succeeded.
+      # @return [ true | false ] If the update succeeded.
       def update_documents(attributes, method = :update_one, opts = {})
         return false unless attributes
         attributes = Hash[attributes.map { |k, v| [klass.database_field_name(k.to_s), v] }]
@@ -724,7 +724,7 @@ module Mongoid
       # @example Is the context cacheable?
       #   context.cacheable?
       #
-      # @return [ true, false ] If caching, and the cache isn't loaded.
+      # @return [ true | false ] If caching, and the cache isn't loaded.
       def cacheable?
         cached? && !cache_loaded?
       end
@@ -737,7 +737,7 @@ module Mongoid
       # @example Is the cache loaded?
       #   context.cache_loaded?
       #
-      # @return [ true, false ] If the cache is loaded.
+      # @return [ true | false ] If the cache is loaded.
       def cache_loaded?
         !!@cache_loaded
       end

--- a/lib/mongoid/contextual/mongo.rb
+++ b/lib/mongoid/contextual/mongo.rb
@@ -460,7 +460,7 @@ module Mongoid
       # @note This method will return the raw db values - it performs no custom
       #   serialization.
       #
-      # @param [ String | Symbol, Array ] fields Fields to pluck.
+      # @param [ String | Symbol | Array ] fields Fields to pluck.
       #
       # @return [ Array<Object, Array> ] The plucked values.
       def pluck(*fields)

--- a/lib/mongoid/contextual/none.rb
+++ b/lib/mongoid/contextual/none.rb
@@ -40,7 +40,7 @@ module Mongoid
       #
       # @param [ Array ] other The other array.
       #
-      # @return [ true, false ] If the objects are equal.
+      # @return [ true | false ] If the objects are equal.
       def ==(other)
         other.is_a?(None)
       end

--- a/lib/mongoid/contextual/none.rb
+++ b/lib/mongoid/contextual/none.rb
@@ -88,7 +88,7 @@ module Mongoid
       # @example Get the values for null context.
       #   context.pluck(:name)
       #
-      # @param [ String | Symbol, Array ] args Field or fields to pluck.
+      # @param [ String | Symbol | Array ] args Field or fields to pluck.
       #
       # @return [ Array ] An empty Array.
       def pluck(*args)

--- a/lib/mongoid/contextual/none.rb
+++ b/lib/mongoid/contextual/none.rb
@@ -50,7 +50,7 @@ module Mongoid
       # @example Get the distinct values in null context.
       #   context.distinct(:name)
       #
-      # @param [ String, Symbol ] _field The name of the field.
+      # @param [ String | Symbol ] _field The name of the field.
       #
       # @return [ Array ] An empty Array.
       def distinct(_field)
@@ -88,7 +88,7 @@ module Mongoid
       # @example Get the values for null context.
       #   context.pluck(:name)
       #
-      # @param [ String, Symbol, Array ] args Field or fields to pluck.
+      # @param [ String | Symbol, Array ] args Field or fields to pluck.
       #
       # @return [ Array ] An empty Array.
       def pluck(*args)
@@ -100,7 +100,7 @@ module Mongoid
       # @example Get the values for null context.
       #   context.tally(:name)
       #
-      # @param [ String, Symbol ] arg Field to tally.
+      # @param [ String | Symbol ] arg Field to tally.
       #
       # @return [ Hash ] An empty Hash.
       def tally(arg)

--- a/lib/mongoid/contextual/queryable.rb
+++ b/lib/mongoid/contextual/queryable.rb
@@ -14,7 +14,7 @@ module Mongoid
       # @example Is the context empty?
       #   context.blank?
       #
-      # @return [ true, false ] If the context is empty.
+      # @return [ true | false ] If the context is empty.
       def blank?
         !exists?
       end

--- a/lib/mongoid/criteria.rb
+++ b/lib/mongoid/criteria.rb
@@ -52,7 +52,7 @@ module Mongoid
     #
     # @param [ Object ] other The other +Enumerable+ or +Criteria+ to compare to.
     #
-    # @return [ true, false ] If the objects are equal.
+    # @return [ true | false ] If the objects are equal.
     def ==(other)
       return super if other.respond_to?(:selector)
       entries == other
@@ -132,7 +132,7 @@ module Mongoid
     # @example Is the criteria cached?
     #   criteria.cached?
     #
-    # @return [ true, false ] If the criteria is flagged as cached.
+    # @return [ true | false ] If the criteria is flagged as cached.
     def cached?
       options[:cache] == true
     end
@@ -163,7 +163,7 @@ module Mongoid
     # @example Is the criteria for embedded documents?
     #   criteria.embedded?
     #
-    # @return [ true, false ] If the criteria is embedded.
+    # @return [ true | false ] If the criteria is embedded.
     def embedded?
       !!@embedded
     end
@@ -293,7 +293,7 @@ module Mongoid
     # @example Is the criteria a none criteria?
     #   criteria.empty_and_chainable?
     #
-    # @return [ true, false ] If the criteria is a none.
+    # @return [ true | false ] If the criteria is a none.
     def empty_and_chainable?
       !!@none
     end
@@ -353,7 +353,7 @@ module Mongoid
     # @param [ Symbol ] name The name of the class method on the +Document+.
     # @param [ true | false ] include_private Whether to include privates.
     #
-    # @return [ true, false ] If the criteria responds to the method.
+    # @return [ true | false ] If the criteria responds to the method.
     def respond_to?(name, include_private = false)
       super || klass.respond_to?(name) || CHECK.respond_to?(name, include_private)
     end
@@ -536,7 +536,7 @@ module Mongoid
     # @example Add the type selection.
     #   criteria.merge_type_selection
     #
-    # @return [ true, false ] If type selection was added.
+    # @return [ true | false ] If type selection was added.
     def merge_type_selection
       selector.merge!(type_selection) if type_selectable?
     end
@@ -548,7 +548,7 @@ module Mongoid
     # @example If the criteria type selectable?
     #   criteria.type_selectable?
     #
-    # @return [ true, false ] If type selection should be added.
+    # @return [ true | false ] If type selection should be added.
     def type_selectable?
       klass.hereditary? &&
         !selector.keys.include?(self.discriminator_key) &&

--- a/lib/mongoid/criteria.rb
+++ b/lib/mongoid/criteria.rb
@@ -351,7 +351,7 @@ module Mongoid
     #   crtiteria.respond_to?(:each)
     #
     # @param [ Symbol ] name The name of the class method on the +Document+.
-    # @param [ true, false ] include_private Whether to include privates.
+    # @param [ true | false ] include_private Whether to include privates.
     #
     # @return [ true, false ] If the criteria responds to the method.
     def respond_to?(name, include_private = false)
@@ -404,7 +404,7 @@ module Mongoid
     # @example Add a javascript selection.
     #   criteria.where("this.name == 'syd'")
     #
-    # @param [ String, Hash ] expression The javascript or standard selection.
+    # @param [ String | Hash ] expression The javascript or standard selection.
     #
     # @raise [ UnsupportedJavascript ] If provided a string and the criteria
     #   is embedded.

--- a/lib/mongoid/criteria/findable.rb
+++ b/lib/mongoid/criteria/findable.rb
@@ -10,7 +10,7 @@ module Mongoid
       #   criteria.execute_or_raise(id)
       #
       # @param [ Object ] ids The arguments passed.
-      # @param [ true, false ] multi Whether there arguments were a list.
+      # @param [ true | false ] multi Whether there arguments were a list.
       #
       # @raise [ Errors::DocumentNotFound ] If nothing returned.
       #

--- a/lib/mongoid/criteria/findable.rb
+++ b/lib/mongoid/criteria/findable.rb
@@ -14,7 +14,7 @@ module Mongoid
       #
       # @raise [ Errors::DocumentNotFound ] If nothing returned.
       #
-      # @return [ Document, Array<Document> ] The document(s).
+      # @return [ Document | Array<Document> ] The document(s).
       def execute_or_raise(ids, multi)
         result = multiple_from_db(ids)
         check_for_missing_documents!(result, ids)
@@ -31,7 +31,7 @@ module Mongoid
       #
       # @param [ Array<BSON::ObjectId> ] args The ids to search for.
       #
-      # @return [ Array<Document>, Document ] The matching document(s).
+      # @return [ Array<Document> | Document ] The matching document(s).
       def find(*args)
         ids = args.__find_args__
         raise_invalid if ids.any?(&:nil?)

--- a/lib/mongoid/criteria/includable.rb
+++ b/lib/mongoid/criteria/includable.rb
@@ -21,7 +21,7 @@ module Mongoid
       # @example Eager load the provided associations.
       #   Person.includes(:posts, :game)
       #
-      # @param [ Array<Symbol>, Array<Hash> ] relations The names of the associations to eager
+      # @param [ Array<Symbol> | Array<Hash> ] relations The names of the associations to eager
       #   load.
       #
       # @return [ Criteria ] The cloned criteria.
@@ -66,7 +66,7 @@ module Mongoid
 
       # Iterate through the list of relations and create the inclusions list.
       #
-      # @param [ Class, String, Symbol ] _parent_class The class from which the
+      # @param [ Class | String | Symbol ] _parent_class The class from which the
       #   association originates.
       # @param [ String ] parent The name of the association above this one in
       #   the inclusion tree, if it is a nested inclusion.

--- a/lib/mongoid/criteria/permission.rb
+++ b/lib/mongoid/criteria/permission.rb
@@ -54,7 +54,7 @@ module Mongoid
       # @api private
       #
       # @param [ Object ] criteria
-      # @return [ Boolean ] if should permit
+      # @return [ true | false ] if should permit
       def should_permit?(criteria)
         if criteria.respond_to?(:permitted?)
           return criteria.permitted?

--- a/lib/mongoid/criteria/queryable.rb
+++ b/lib/mongoid/criteria/queryable.rb
@@ -46,7 +46,7 @@ module Mongoid
       #
       # @param [ Object ] other The object to compare against.
       #
-      # @return [ true, false ] If the objects are equal.
+      # @return [ true | false ] If the objects are equal.
       def ==(other)
         return false unless other.is_a?(Queryable)
         selector == other.selector && options == other.options

--- a/lib/mongoid/criteria/queryable/aggregable.rb
+++ b/lib/mongoid/criteria/queryable/aggregable.rb
@@ -20,7 +20,7 @@ module Mongoid
         # @example Is the aggregable aggregating?
         #   aggregable.aggregating?
         #
-        # @return [ true, false ] If the aggregable is aggregating.
+        # @return [ true | false ] If the aggregable is aggregating.
         def aggregating?
           !!@aggregating
         end

--- a/lib/mongoid/criteria/queryable/aggregable.rb
+++ b/lib/mongoid/criteria/queryable/aggregable.rb
@@ -69,7 +69,7 @@ module Mongoid
         # @example Add an unwind to the pipeline.
         #   aggregable.unwind(:field)
         #
-        # @param [ String, Symbol ] field The name of the field to unwind.
+        # @param [ String | Symbol ] field The name of the field to unwind.
         #
         # @return [ Aggregable ] The aggregable.
         def unwind(field)

--- a/lib/mongoid/criteria/queryable/expandable.rb
+++ b/lib/mongoid/criteria/queryable/expandable.rb
@@ -35,7 +35,7 @@ module Mongoid
         # @param [ String | Symbol | Key ] field The field to expand.
         # @param [ Object ] value The field's value.
         #
-        # @return [ Array<String, Object> ] The expanded field and value.
+        # @return [ Array<String | Object> ] The expanded field and value.
         def expand_one_condition(field, value)
           kv = field.__expr_part__(value.__expand_complex__, negating?)
           [kv.keys.first.to_s, kv.values.first]

--- a/lib/mongoid/criteria/queryable/extensions/boolean.rb
+++ b/lib/mongoid/criteria/queryable/extensions/boolean.rb
@@ -17,7 +17,7 @@ module Mongoid
             #
             # @param [ Object ] object The object to evolve.
             #
-            # @return [ true, false ] The boolean value.
+            # @return [ true | false ] The boolean value.
             def evolve(object)
               __evolve__(object) do |obj|
                 obj.to_s =~ (/\A(true|t|yes|y|on|1|1.0)\z/i) ? true : false

--- a/lib/mongoid/criteria/queryable/extensions/regexp.rb
+++ b/lib/mongoid/criteria/queryable/extensions/regexp.rb
@@ -23,7 +23,7 @@ module Mongoid
             # @example Evolve the object to a regex.
             #   Regexp.evolve("\A[123]")
             #
-            # @param [ Regexp, String ] object The object to evolve.
+            # @param [ Regexp | String ] object The object to evolve.
             #
             # @return [ Regexp ] The evolved regex.
             def evolve(object)
@@ -50,7 +50,7 @@ module Mongoid
               # @example Evolve the object to a regex.
               #   BSON::Regexp::Raw.evolve("\\A[123]")
               #
-              # @param [ BSON::Regexp::Raw, String ] object The object to evolve.
+              # @param [ BSON::Regexp::Raw | String ] object The object to evolve.
               #
               # @return [ BSON::Regexp::Raw ] The evolved raw regex.
               def evolve(object)

--- a/lib/mongoid/criteria/queryable/extensions/set.rb
+++ b/lib/mongoid/criteria/queryable/extensions/set.rb
@@ -16,7 +16,7 @@ module Mongoid
             # @example Evolve the set.
             #   Set.evolve(set)
             #
-            # @param [ Set, Object ] object The object to evolve.
+            # @param [ Set | Object ] object The object to evolve.
             #
             # @return [ Array ] The evolved set.
             def evolve(object)

--- a/lib/mongoid/criteria/queryable/extensions/string.rb
+++ b/lib/mongoid/criteria/queryable/extensions/string.rb
@@ -60,7 +60,7 @@ module Mongoid
           #   "field".__expr_part__(value)
           #
           # @param [ Object ] value The value of the criteria.
-          # @param [ true, false ] negating If the selection should be negated.
+          # @param [ true | false ] negating If the selection should be negated.
           #
           # @return [ Hash ] The selection.
           def __expr_part__(value, negating = false)
@@ -86,7 +86,7 @@ module Mongoid
             #
             # @param [ String | Symbol ] key The field key.
             # @param [ Object ] value The value of the criteria.
-            # @param [ true, false ] negating If the selection should be negated.
+            # @param [ true | false ] negating If the selection should be negated.
             #
             # @return [ Hash ] The selection.
             def __expr_part__(key, value, negating = false)

--- a/lib/mongoid/criteria/queryable/extensions/string.rb
+++ b/lib/mongoid/criteria/queryable/extensions/string.rb
@@ -84,7 +84,7 @@ module Mongoid
             # @example Get the value as an expression.
             #   String.__expr_part__("field", value)
             #
-            # @param [ String, Symbol ] key The field key.
+            # @param [ String | Symbol ] key The field key.
             # @param [ Object ] value The value of the criteria.
             # @param [ true, false ] negating If the selection should be negated.
             #

--- a/lib/mongoid/criteria/queryable/extensions/symbol.rb
+++ b/lib/mongoid/criteria/queryable/extensions/symbol.rb
@@ -14,7 +14,7 @@ module Mongoid
           #   :field.__expr_part__(value)
           #
           # @param [ Object ] value The value of the criteria.
-          # @param [ true, false ] negating If the selection should be negated.
+          # @param [ true | false ] negating If the selection should be negated.
           #
           # @return [ Hash ] The selection.
           def __expr_part__(value, negating = false)

--- a/lib/mongoid/criteria/queryable/key.rb
+++ b/lib/mongoid/criteria/queryable/key.rb
@@ -104,7 +104,7 @@ module Mongoid
         # @example Instantiate a key for sorting.
         #   Key.new(:field, :__override__, 1)
         #
-        # @param [ String, Symbol ] name The field name.
+        # @param [ String | Symbol ] name The field name.
         # @param [ Symbol ] strategy The name of the merge strategy.
         # @param [ String | Integer ] operator The MongoDB operator,
         #   or sort direction (1 or -1).

--- a/lib/mongoid/criteria/queryable/key.rb
+++ b/lib/mongoid/criteria/queryable/key.rb
@@ -124,7 +124,7 @@ module Mongoid
         #   key.__expr_part__(50)
         #
         # @param [ Object ] object The value to be included.
-        # @param [ true, false ] negating If the selection should be negated.
+        # @param [ true | false ] negating If the selection should be negated.
         #
         # @return [ Hash ] The raw MongoDB selector.
         def __expr_part__(object, negating = false)

--- a/lib/mongoid/criteria/queryable/key.rb
+++ b/lib/mongoid/criteria/queryable/key.rb
@@ -82,7 +82,7 @@ module Mongoid
         #
         # @param [ Object ] other The object to compare to.
         #
-        # @return [ true, false ] If the objects are equal.
+        # @return [ true | false ] If the objects are equal.
         def ==(other)
           return false unless other.is_a?(Key)
           name == other.name && operator == other.operator && expanded == other.expanded

--- a/lib/mongoid/criteria/queryable/optional.rb
+++ b/lib/mongoid/criteria/queryable/optional.rb
@@ -163,7 +163,7 @@ module Mongoid
         # @example Add sorting options via a string.
         #   optional.order_by("name ASC, dob DESC")
         #
-        # @param [ Array, Hash, String ] spec The sorting specification.
+        # @param [ Array | Hash | String ] spec The sorting specification.
         #
         # @return [ Optional ] The cloned optional.
         def order_by(*spec)
@@ -184,7 +184,7 @@ module Mongoid
         # @example Replace the ordering.
         #   optional.reorder(name: :asc)
         #
-        # @param [ Array, Hash, String ] spec The sorting specification.
+        # @param [ Array | Hash | String ] spec The sorting specification.
         #
         # @return [ Optional ] The cloned optional.
         def reorder(*spec)

--- a/lib/mongoid/criteria/queryable/options.rb
+++ b/lib/mongoid/criteria/queryable/options.rb
@@ -54,7 +54,7 @@ module Mongoid
         # @example Store a value in the options.
         #   options.store(:key, "testing")
         #
-        # @param [ String, Symbol ] key The name of the attribute.
+        # @param [ String | Symbol ] key The name of the attribute.
         # @param [ Object ] value The value to add.
         #
         # @return [ Object ] The stored object.

--- a/lib/mongoid/criteria/queryable/pipeline.rb
+++ b/lib/mongoid/criteria/queryable/pipeline.rb
@@ -67,7 +67,7 @@ module Mongoid
         #   pipeline.unwind(:field)
         #   pipeline.unwind(document)
         #
-        # @param [ String, Symbol, Hash ] field_or_doc A field name or a
+        # @param [ String | Symbol, Hash ] field_or_doc A field name or a
         #   document.
         #
         # @return [ Pipeline ] The pipeline.

--- a/lib/mongoid/criteria/queryable/pipeline.rb
+++ b/lib/mongoid/criteria/queryable/pipeline.rb
@@ -67,7 +67,7 @@ module Mongoid
         #   pipeline.unwind(:field)
         #   pipeline.unwind(document)
         #
-        # @param [ String | Symbol, Hash ] field_or_doc A field name or a
+        # @param [ String | Symbol | Hash ] field_or_doc A field name or a
         #   document.
         #
         # @return [ Pipeline ] The pipeline.

--- a/lib/mongoid/criteria/queryable/selectable.rb
+++ b/lib/mongoid/criteria/queryable/selectable.rb
@@ -529,7 +529,7 @@ module Mongoid
         # @example Is the selectable negating?
         #   selectable.negating?
         #
-        # @return [ true, false ] If the selectable is negating.
+        # @return [ true | false ] If the selectable is negating.
         def negating?
           !!negating
         end

--- a/lib/mongoid/criteria/queryable/selectable.rb
+++ b/lib/mongoid/criteria/queryable/selectable.rb
@@ -605,7 +605,7 @@ module Mongoid
         # @example Same as previous example, also deprecated.
         #   selectable.or([{field: 1}], [{field: 2}])
         #
-        # @param [ Hash | Criteria | Array<Hash | Criteria>, ... ] criteria
+        # @param [ Hash | Criteria | Array<Hash | Criteria>] *criteria
         #   Multiple key/value pair matches or Criteria objects, or arrays
         #   thereof. Passing arrays is deprecated.
         #
@@ -635,7 +635,7 @@ module Mongoid
         # @example Same as previous example, also deprecated.
         #   selectable.any_of([{field: 1}], [{field: 2}])
         #
-        # @param [ Hash | Criteria | Array<Hash | Criteria>, ... ] criteria
+        # @param [ Hash | Criteria | Array<Hash | Criteria>] *criteria
         #   Multiple key/value pair matches or Criteria objects, or arrays
         #   thereof. Passing arrays is deprecated.
         #
@@ -774,7 +774,7 @@ module Mongoid
         # @example Add a javascript selection.
         #   selectable.where("this.name == 'syd'")
         #
-        # @param [ String, Hash ] criterion The javascript or standard selection.
+        # @param [ String | Hash ] criterion The javascript or standard selection.
         #
         # @return [ Selectable ] The cloned selectable.
         def where(*criteria)

--- a/lib/mongoid/criteria/queryable/selectable.rb
+++ b/lib/mongoid/criteria/queryable/selectable.rb
@@ -736,7 +736,7 @@ module Mongoid
         #   conditions in a query. Mongoid will build such a query but the
         #   server will return an error when trying to execute it.
         #
-        # @param [ String, Symbol ] terms A string of terms that MongoDB parses
+        # @param [ String | Symbol ] terms A string of terms that MongoDB parses
         #   and uses to query the text index.
         # @param [ Hash ] opts Text search options. See MongoDB documentation
         #   for options.

--- a/lib/mongoid/criteria/queryable/selector.rb
+++ b/lib/mongoid/criteria/queryable/selector.rb
@@ -81,7 +81,7 @@ module Mongoid
         # @param [ Object ] serializer The optional serializer for the field.
         # @param [ Object ] value The value to serialize.
         #
-        # @return [ Array<String, String> ] The store name and store value.
+        # @return [ Array<String | String> ] The store name and store value.
         def store_creds(name, serializer, value)
           store_name = localized_key(name, serializer)
           if Range === value
@@ -232,7 +232,7 @@ module Mongoid
         # @param [ Object ] serializer The optional serializer for the field.
         # @param [ Range ] value The Range to serialize.
         #
-        # @return [ Array<String, Hash> ] The store name and serialized Range.
+        # @return [ Array<String | Hash> ] The store name and serialized Range.
         def evolve_range(key, serializer, value)
           v = value.__evolve_range__(serializer: serializer)
           assocs = []
@@ -277,7 +277,7 @@ module Mongoid
         #
         # @param [ String ] key The key to check.
         #
-        # @return [ true, false ] If the key is for a multi-select.
+        # @return [ true | false ] If the key is for a multi-select.
         def multi_selection?(key)
           %w($and $or $nor).include?(key)
         end

--- a/lib/mongoid/criteria/queryable/selector.rb
+++ b/lib/mongoid/criteria/queryable/selector.rb
@@ -13,7 +13,7 @@ module Mongoid
         # @example Merge in another selector.
         #   selector.merge!(name: "test")
         #
-        # @param [ Hash, Selector ] other The object to merge in.
+        # @param [ Hash | Selector ] other The object to merge in.
         #
         # @return [ Selector ] The selector.
         def merge!(other)

--- a/lib/mongoid/criteria/queryable/selector.rb
+++ b/lib/mongoid/criteria/queryable/selector.rb
@@ -43,7 +43,7 @@ module Mongoid
         # @example Store a value in the selector.
         #   selector.store(:key, "testing")
         #
-        # @param [ String, Symbol ] key The name of the attribute.
+        # @param [ String | Symbol ] key The name of the attribute.
         # @param [ Object ] value The value to add.
         #
         # @return [ Object ] The stored object.

--- a/lib/mongoid/criteria/queryable/smash.rb
+++ b/lib/mongoid/criteria/queryable/smash.rb
@@ -95,7 +95,7 @@ module Mongoid
         # @example Get the name and serializer.
         #   smash.storage_pair("id")
         #
-        # @param [ Symbol, String ] key The key provided to the selection.
+        # @param [ Symbol | String ] key The key provided to the selection.
         #
         # @return [ Array<String, Object> ] The name of the db field and
         #   serializer.

--- a/lib/mongoid/criteria/queryable/smash.rb
+++ b/lib/mongoid/criteria/queryable/smash.rb
@@ -97,7 +97,7 @@ module Mongoid
         #
         # @param [ Symbol | String ] key The key provided to the selection.
         #
-        # @return [ Array<String, Object> ] The name of the db field and
+        # @return [ Array<String | Object> ] The name of the db field and
         #   serializer.
         def storage_pair(key)
           field = key.to_s

--- a/lib/mongoid/criteria/scopable.rb
+++ b/lib/mongoid/criteria/scopable.rb
@@ -83,7 +83,7 @@ module Mongoid
       # @example Is the default scope applied?
       #   criteria.scoped?
       #
-      # @return [ true, false ] If the default scope is applied.
+      # @return [ true | false ] If the default scope is applied.
       def scoped?
         !!(defined?(@scoped) ? @scoped : nil)
       end
@@ -108,7 +108,7 @@ module Mongoid
       # @example Is the criteria unscoped?
       #   criteria.unscoped?
       #
-      # @return [ true, false ] If the criteria is force unscoped.
+      # @return [ true | false ] If the criteria is force unscoped.
       def unscoped?
         !!(defined?(@unscoped) ? @unscoped : nil)
       end

--- a/lib/mongoid/deprecable.rb
+++ b/lib/mongoid/deprecable.rb
@@ -24,7 +24,7 @@ module Mongoid
     #   #=> Mongoid.logger.warn("meow is deprecated and will be removed from Mongoid 8.0 (eat :catnip instead)")
     #
     # @param [ Module ] target_module The parent which contains the method.
-    # @param [ Symbol | Hash<Symbol, [Symbol|String]> ] method_descriptors
+    # @param [ Symbol | Hash<Symbol, [ Symbol | String ]> ] method_descriptors
     #   The methods to deprecate, with optional replacement instructions.
     def deprecate(target_module, *method_descriptors)
       Mongoid::Deprecation.deprecate_methods(target_module, *method_descriptors)

--- a/lib/mongoid/document.rb
+++ b/lib/mongoid/document.rb
@@ -150,7 +150,7 @@ module Mongoid
     #
     # @param [ Hash ] options The options.
     #
-    # @option options [ true, false ] :compact (Deprecated) Whether to include fields
+    # @option options [ true | false ] :compact (Deprecated) Whether to include fields
     #   with nil values in the json document.
     #
     # @return [ Hash ] The document as json.

--- a/lib/mongoid/document.rb
+++ b/lib/mongoid/document.rb
@@ -56,7 +56,7 @@ module Mongoid
     # @example Check if frozen
     #   document.frozen?
     #
-    # @return [ true, false ] True if frozen, else false.
+    # @return [ true | false ] True if frozen, else false.
     def frozen?
       attributes.frozen?
     end

--- a/lib/mongoid/equality.rb
+++ b/lib/mongoid/equality.rb
@@ -28,7 +28,7 @@ module Mongoid
     #
     # @param [ Document | Object ] other The other object to compare with.
     #
-    # @return [ true, false ] True if the ids are equal, false if not.
+    # @return [ true | false ] True if the ids are equal, false if not.
     def ==(other)
       self.class == other.class &&
           attributes["_id"] == other.attributes["_id"]
@@ -41,7 +41,7 @@ module Mongoid
     #
     # @param [ Document | Object ] other The other object to compare with.
     #
-    # @return [ true, false ] True if the classes are equal, false if not.
+    # @return [ true | false ] True if the classes are equal, false if not.
     def ===(other)
       if Mongoid.legacy_triple_equals
         super
@@ -57,7 +57,7 @@ module Mongoid
     #
     # @param [ Document | Object ] other The object to check against.
     #
-    # @return [ true, false ] True if equal, false if not.
+    # @return [ true | false ] True if equal, false if not.
     def eql?(other)
       self == (other)
     end
@@ -70,7 +70,7 @@ module Mongoid
       #
       # @param [ Document | Object ] other The other object to compare with.
       #
-      # @return [ true, false ] True if the classes are equal, false if not.
+      # @return [ true | false ] True if the classes are equal, false if not.
       def ===(other)
         if Mongoid.legacy_triple_equals
           other.is_a?(self)

--- a/lib/mongoid/equality.rb
+++ b/lib/mongoid/equality.rb
@@ -26,7 +26,7 @@ module Mongoid
     # @example Compare for equality.
     #   document == other
     #
-    # @param [ Document, Object ] other The other object to compare with.
+    # @param [ Document | Object ] other The other object to compare with.
     #
     # @return [ true, false ] True if the ids are equal, false if not.
     def ==(other)
@@ -39,7 +39,7 @@ module Mongoid
     # @example Compare the classes.
     #   document === other
     #
-    # @param [ Document, Object ] other The other object to compare with.
+    # @param [ Document | Object ] other The other object to compare with.
     #
     # @return [ true, false ] True if the classes are equal, false if not.
     def ===(other)
@@ -55,7 +55,7 @@ module Mongoid
     # @example Perform equality checking.
     #   document.eql?(other)
     #
-    # @param [ Document, Object ] other The object to check against.
+    # @param [ Document | Object ] other The object to check against.
     #
     # @return [ true, false ] True if equal, false if not.
     def eql?(other)
@@ -68,7 +68,7 @@ module Mongoid
       # @example Compare the classes.
       #   document === other
       #
-      # @param [ Document, Object ] other The other object to compare with.
+      # @param [ Document | Object ] other The other object to compare with.
       #
       # @return [ true, false ] True if the classes are equal, false if not.
       def ===(other)

--- a/lib/mongoid/errors/document_not_found.rb
+++ b/lib/mongoid/errors/document_not_found.rb
@@ -19,8 +19,8 @@ module Mongoid
       #   DocumentNotFound.new(Person, :ssn => "1234", :name => "Helen")
       #
       # @param [ Class ] klass The model class.
-      # @param [ Hash, Array, Object ] params The attributes or ids.
-      # @param [ Array, Hash ] unmatched The unmatched ids, if appropriate. If
+      # @param [ Hash | Array | Object ] params The attributes or ids.
+      # @param [ Array | Hash ] unmatched The unmatched ids, if appropriate. If
       #   there is a shard key this will be a hash.
       def initialize(klass, params, unmatched = nil)
         if !unmatched && !params.is_a?(Hash)
@@ -50,7 +50,7 @@ module Mongoid
       # @example Get the missing string.
       #   error.missing(1)
       #
-      # @param [ Object, Array ] unmatched The ids that did not match.
+      # @param [ Object | Array ] unmatched The ids that did not match.
       #
       # @return [ String ] The missing string.
       def missing(unmatched)
@@ -68,7 +68,7 @@ module Mongoid
       # @example Get the searched string.
       #   error.searched(1)
       #
-      # @param [ Object, Array ] params The ids that were searched for.
+      # @param [ Object | Array ] params The ids that were searched for.
       #
       # @return [ String ] The searched string.
       def searched(params)
@@ -84,7 +84,7 @@ module Mongoid
       # @example Get the total.
       #   error.total([ 1, 2, 3 ])
       #
-      # @param [ Object, Array ] params What was searched for.
+      # @param [ Object | Array ] params What was searched for.
       #
       # @return [ Integer ] The total number.
       def total(params)

--- a/lib/mongoid/errors/invalid_config_option.rb
+++ b/lib/mongoid/errors/invalid_config_option.rb
@@ -12,7 +12,7 @@ module Mongoid
       # @example Create the new error.
       #   InvalidConfigOption.new(:name, [ :option ])
       #
-      # @param [ Symbol, String ] name The attempted config option name.
+      # @param [ Symbol | String ] name The attempted config option name.
       def initialize(name)
         super(
           compose_message(

--- a/lib/mongoid/errors/invalid_dependent_strategy.rb
+++ b/lib/mongoid/errors/invalid_dependent_strategy.rb
@@ -13,7 +13,7 @@ module Mongoid
       #
       # @param [ Mongoid::Association ] association The association for which this
       #   dependency is defined.
-      # @param [ Symbol, String ] invalid_strategy The attempted invalid strategy.
+      # @param [ Symbol | String ] invalid_strategy The attempted invalid strategy.
       # @param [ Array<Symbol> ] valid_strategies The valid strategies.
       def initialize(association, invalid_strategy, valid_strategies)
         super(

--- a/lib/mongoid/errors/invalid_field.rb
+++ b/lib/mongoid/errors/invalid_field.rb
@@ -42,7 +42,7 @@ module Mongoid
       # @param [ Class ] klass The document class.
       # @param [ Symbol ] name The method name.
       #
-      # @return [ Class, Module ] The originating class or module.
+      # @return [ Class | Module ] The originating class or module.
       def origin(klass, name)
         klass.instance_method(name).owner
       end
@@ -55,7 +55,7 @@ module Mongoid
       # @param [ Class ] klass The document class.
       # @param [ Symbol ] name The method name.
       #
-      # @return [ Array<String, Integer> ] The location of the method.
+      # @return [ Array<String | Integer> ] The location of the method.
       def location(klass, name)
         @location ||=
           (klass.instance_method(name).source_location || [ "Unknown", 0 ])

--- a/lib/mongoid/errors/invalid_relation.rb
+++ b/lib/mongoid/errors/invalid_relation.rb
@@ -38,7 +38,7 @@ module Mongoid
       # @param [ Class ] klass The document class.
       # @param [ Symbol ] name The method name.
       #
-      # @return [ Class, Module ] The originating class or module.
+      # @return [ Class | Module ] The originating class or module.
       def origin(klass, name)
         klass.instance_method(name).owner
       end
@@ -51,7 +51,7 @@ module Mongoid
       # @param [ Class ] klass The document class.
       # @param [ Symbol ] name The method name.
       #
-      # @return [ Array<String, Integer> ] The location of the method.
+      # @return [ Array<String | Integer> ] The location of the method.
       def location(klass, name)
         @location ||=
             (klass.instance_method(name).source_location || [ "Unknown", 0 ])

--- a/lib/mongoid/errors/invalid_relation_option.rb
+++ b/lib/mongoid/errors/invalid_relation_option.rb
@@ -12,7 +12,7 @@ module Mongoid
       #   InvalidRelationOption.new(Person, invalid_option: 'make_me_a_sandwich')
       #
       # @param [ Class ] klass The model class.
-      # @param [ String, Symbol ] name The association name.
+      # @param [ String | Symbol ] name The association name.
       # @param [ Symbol ] option The invalid option.
       # @param [ Array<Symbol> ] valid_options The valid option.
       def initialize(klass, name, option, valid_options)

--- a/lib/mongoid/errors/invalid_session_use.rb
+++ b/lib/mongoid/errors/invalid_session_use.rb
@@ -12,7 +12,7 @@ module Mongoid
       # @example Create the error.
       #   InvalidSessionUse.new(:invalid_session_use)
       #
-      # @param [ :invalid_session_use, :invalid_session_nesting ] error_type The type of session misuse.
+      # @param [ :invalid_session_use | :invalid_session_nesting ] error_type The type of session misuse.
       def initialize(error_type)
         super(compose_message(error_type.to_s))
       end

--- a/lib/mongoid/errors/invalid_storage_options.rb
+++ b/lib/mongoid/errors/invalid_storage_options.rb
@@ -12,7 +12,7 @@ module Mongoid
       #   InvalidStorageOptions.new(Person, invalid_option: 'name')
       #
       # @param [ Class ] klass The model class.
-      # @param [ Hash, String, Symbol ] options The provided options.
+      # @param [ Hash | String | Symbol ] options The provided options.
       def initialize(klass, options)
         super(
           compose_message(

--- a/lib/mongoid/errors/mongoid_error.rb
+++ b/lib/mongoid/errors/mongoid_error.rb
@@ -53,7 +53,7 @@ module Mongoid
       # @example Create the problem.
       #   error.problem("error", {})
       #
-      # @param [ String, Symbol ] key The error key.
+      # @param [ String | Symbol ] key The error key.
       # @param [ Hash ] attributes The attributes to interpolate.
       #
       # @return [ String ] The problem.
@@ -66,7 +66,7 @@ module Mongoid
       # @example Create the summary.
       #   error.summary("error", {})
       #
-      # @param [ String, Symbol ] key The error key.
+      # @param [ String | Symbol ] key The error key.
       # @param [ Hash ] attributes The attributes to interpolate.
       #
       # @return [ String ] The summary.
@@ -79,7 +79,7 @@ module Mongoid
       # @example Create the resolution.
       #   error.resolution("error", {})
       #
-      # @param [ String, Symbol ] key The error key.
+      # @param [ String | Symbol ] key The error key.
       # @param [ Hash ] attributes The attributes to interpolate.
       #
       # @return [ String ] The resolution.

--- a/lib/mongoid/errors/nested_attributes_metadata_not_found.rb
+++ b/lib/mongoid/errors/nested_attributes_metadata_not_found.rb
@@ -13,7 +13,7 @@ module Mongoid
       #   NestedAttributesMetadataNotFound.new(klass, name)
       #
       # @param [ Class ] klass The class of the document.
-      # @param [ Symbol, String ] name The name of the association
+      # @param [ Symbol | String ] name The name of the association
       def initialize(klass, name)
         super(
           compose_message(

--- a/lib/mongoid/errors/no_client_database.rb
+++ b/lib/mongoid/errors/no_client_database.rb
@@ -11,7 +11,7 @@ module Mongoid
       # @example Create the new error.
       #   NoClientDatabase.new(:default, {}})
       #
-      # @param [ Symbol, String ] name The db config key.
+      # @param [ Symbol | String ] name The db config key.
       # @param [ Hash ] config The hash configuration options.
       def initialize(name, config)
         super(

--- a/lib/mongoid/errors/no_client_hosts.rb
+++ b/lib/mongoid/errors/no_client_hosts.rb
@@ -11,7 +11,7 @@ module Mongoid
       # @example Create the new error.
       #   NoClientHosts.new(:default, {}})
       #
-      # @param [ Symbol, String ] name The db config key.
+      # @param [ Symbol | String ] name The db config key.
       # @param [ Hash ] config The hash configuration options.
       def initialize(name, config)
         super(

--- a/lib/mongoid/errors/readonly_attribute.rb
+++ b/lib/mongoid/errors/readonly_attribute.rb
@@ -12,7 +12,7 @@ module Mongoid
       # @example Create the new error.
       #   ReadonlyAttribute.new(:title, "mr")
       #
-      # @param [ Symbol, String ] name The name of the attribute.
+      # @param [ Symbol | String ] name The name of the attribute.
       # @param [ Object ] value The attempted set value.
       def initialize(name, value)
         super(

--- a/lib/mongoid/errors/unknown_attribute.rb
+++ b/lib/mongoid/errors/unknown_attribute.rb
@@ -13,7 +13,7 @@ module Mongoid
       #   UnknownAttribute.new(Person, "gender")
       #
       # @param [ Class ] klass The model class.
-      # @param [ String, Symbol ] name The name of the attribute.
+      # @param [ String | Symbol ] name The name of the attribute.
       def initialize(klass, name)
         super(
           compose_message("unknown_attribute", { klass: klass.name, name: name })

--- a/lib/mongoid/extensions/array.rb
+++ b/lib/mongoid/extensions/array.rb
@@ -76,7 +76,7 @@ module Mongoid
       # @example Is this multi args?
       #   [ 1, 2, 3 ].multi_arged?
       #
-      # @return [ true, false ] If the array is multi args.
+      # @return [ true | false ] If the array is multi args.
       def multi_arged?
         !first.is_a?(Hash) && first.resizable? || size > 1
       end

--- a/lib/mongoid/extensions/big_decimal.rb
+++ b/lib/mongoid/extensions/big_decimal.rb
@@ -48,7 +48,7 @@ module Mongoid
         #
         # @param [ Object ] object The object to demongoize.
         #
-        # @return [ BigDecimal, nil ] A BigDecimal derived from the object or nil.
+        # @return [ BigDecimal | nil ] A BigDecimal derived from the object or nil.
         def demongoize(object)
           unless object.nil?
             if object.is_a?(BSON::Decimal128)

--- a/lib/mongoid/extensions/false_class.rb
+++ b/lib/mongoid/extensions/false_class.rb
@@ -21,7 +21,7 @@ module Mongoid
       #
       # @param [ Class ] other The class to check.
       #
-      # @return [ true, false ] If the other is a boolean.
+      # @return [ true | false ] If the other is a boolean.
       def is_a?(other)
         if other == Mongoid::Boolean || other.class == Mongoid::Boolean
           return true

--- a/lib/mongoid/extensions/hash.rb
+++ b/lib/mongoid/extensions/hash.rb
@@ -190,7 +190,7 @@ module Mongoid
       #
       # @param [ String ] operator The operator.
       # @param [ Class ] klass The model class.
-      # @param [ String, Symbol ] key The field key.
+      # @param [ String | Symbol ] key The field key.
       # @param [ Object ] value The value to mongoize.
       #
       # @return [ Object ] The mongoized value.

--- a/lib/mongoid/extensions/module.rb
+++ b/lib/mongoid/extensions/module.rb
@@ -12,7 +12,7 @@ module Mongoid
       #     self
       #   end
       #
-      # @param [ String, Symbol ] name The name of the method.
+      # @param [ String | Symbol ] name The name of the method.
       # @param [ Proc ] block The method body.
       #
       # @return [ Method ] The new method.

--- a/lib/mongoid/extensions/object.rb
+++ b/lib/mongoid/extensions/object.rb
@@ -90,7 +90,7 @@ module Mongoid
       # @example Do or do not.
       #   object.do_or_do_not(:use, "The Force")
       #
-      # @param [ String, Symbol ] name The method name.
+      # @param [ String | Symbol ] name The method name.
       # @param [ Array ] args The arguments.
       #
       # @return [ Object, nil ] The result of the method call or nil if the
@@ -189,7 +189,7 @@ module Mongoid
       # @example You must perform this execution.
       #   object.you_must(:use, "The Force")
       #
-      # @param [ String, Symbol ] name The method name.
+      # @param [ String | Symbol ] name The method name.
       # @param [ Array ] args The arguments.
       #
       # @return [ Object, nil ] The result of the method call or nil if the

--- a/lib/mongoid/extensions/object.rb
+++ b/lib/mongoid/extensions/object.rb
@@ -93,7 +93,7 @@ module Mongoid
       # @param [ String | Symbol ] name The method name.
       # @param [ Array ] args The arguments.
       #
-      # @return [ Object, nil ] The result of the method call or nil if the
+      # @return [ Object | nil ] The result of the method call or nil if the
       #   method does not exist.
       def do_or_do_not(name, *args)
         send(name, *args) if name && respond_to?(name)
@@ -106,7 +106,7 @@ module Mongoid
       #
       # @param [ String ] name The name of the variable.
       #
-      # @return [ Object, false ] The value or false.
+      # @return [ Object | false ] The value or false.
       def ivar(name)
         var_name = "@_#{name}"
         if instance_variable_defined?(var_name)
@@ -154,7 +154,7 @@ module Mongoid
       #
       # @param [ String ] name The name of the variable.
       #
-      # @return [ true, false ] If the variable was defined.
+      # @return [ true | false ] If the variable was defined.
       def remove_ivar(name)
         if instance_variable_defined?("@_#{name}")
           return remove_instance_variable("@_#{name}")
@@ -192,7 +192,7 @@ module Mongoid
       # @param [ String | Symbol ] name The method name.
       # @param [ Array ] args The arguments.
       #
-      # @return [ Object, nil ] The result of the method call or nil if the
+      # @return [ Object | nil ] The result of the method call or nil if the
       #   method does not exist. Nil if the object is frozen.
       def you_must(name, *args)
         frozen? ? nil : do_or_do_not(name, *args)

--- a/lib/mongoid/extensions/regexp.rb
+++ b/lib/mongoid/extensions/regexp.rb
@@ -12,7 +12,7 @@ module Mongoid
         # @example Mongoize the object.
         #   Regexp.mongoize(/\A[abc]/)
         #
-        # @param [ Regexp, String ] object The object to mongoize.
+        # @param [ Regexp | String ] object The object to mongoize.
         #
         # @return [ Regexp ] The object mongoized.
         def mongoize(object)

--- a/lib/mongoid/extensions/string.rb
+++ b/lib/mongoid/extensions/string.rb
@@ -65,7 +65,7 @@ module Mongoid
       # @example Is the string an id value?
       #   "_id".mongoid_id?
       #
-      # @return [ true, false ] If the string is id or _id.
+      # @return [ true | false ] If the string is id or _id.
       def mongoid_id?
         self =~ /\A(|_)id\z/
       end
@@ -76,7 +76,7 @@ module Mongoid
       # @example Is the string a number.
       #   "1234.23".numeric?
       #
-      # @return [ true, false ] If the string is a number.
+      # @return [ true | false ] If the string is a number.
       def numeric?
         !!Float(self)
       rescue ArgumentError
@@ -98,7 +98,7 @@ module Mongoid
       # @example Is the string a setter method?
       #   "model=".writer?
       #
-      # @return [ true, false ] If the string contains "=".
+      # @return [ true | false ] If the string contains "=".
       def writer?
         include?("=")
       end
@@ -108,7 +108,7 @@ module Mongoid
       # @example Is the string a valid Ruby identifier for use as a method name
       #   "model=".valid_method_name?
       #
-      # @return [ true, false ] If the string contains a valid Ruby identifier.
+      # @return [ true | false ] If the string contains a valid Ruby identifier.
       def valid_method_name?
         /[@$"-]/ !~ self
       end
@@ -118,7 +118,7 @@ module Mongoid
       # @example Is the string a setter method?
       #   "price_before_type_cast".before_type_cast?
       #
-      # @return [ true, false ] If the string ends with "_before_type_cast"
+      # @return [ true | false ] If the string ends with "_before_type_cast"
       def before_type_cast?
         ends_with?("_before_type_cast")
       end
@@ -128,7 +128,7 @@ module Mongoid
       # @example Is the object unconvertable?
       #   object.unconvertable_to_bson?
       #
-      # @return [ true, false ] If the object is unconvertable.
+      # @return [ true | false ] If the object is unconvertable.
       def unconvertable_to_bson?
         @unconvertable_to_bson ||= false
       end

--- a/lib/mongoid/extensions/string.rb
+++ b/lib/mongoid/extensions/string.rb
@@ -12,7 +12,7 @@ module Mongoid
       # @example Evolve the string.
       #   "test".__evolve_object_id__
       #
-      # @return [ String, BSON::ObjectId ] The evolved string.
+      # @return [ String | BSON::ObjectId ] The evolved string.
       def __evolve_object_id__
         convert_to_object_id
       end
@@ -22,7 +22,7 @@ module Mongoid
       # @example Evolve the string.
       #   "test".__mongoize_object_id__
       #
-      # @return [ String, BSON::ObjectId, nil ] The mongoized string.
+      # @return [ String | BSON::ObjectId | nil ] The mongoized string.
       def __mongoize_object_id__
         convert_to_object_id unless blank?
       end
@@ -142,7 +142,7 @@ module Mongoid
       # @example Convert to the object id.
       #   string.convert_to_object_id
       #
-      # @return [ String, BSON::ObjectId ] The string or the id.
+      # @return [ String | BSON::ObjectId ] The string or the id.
       def convert_to_object_id
         BSON::ObjectId.legal?(self) ? BSON::ObjectId.from_string(self) : self
       end

--- a/lib/mongoid/extensions/symbol.rb
+++ b/lib/mongoid/extensions/symbol.rb
@@ -9,7 +9,7 @@ module Mongoid
       # @example Is the string an id value?
       #   :_id.mongoid_id?
       #
-      # @return [ true, false ] If the symbol is :id or :_id.
+      # @return [ true | false ] If the symbol is :id or :_id.
       def mongoid_id?
         to_s.mongoid_id?
       end

--- a/lib/mongoid/extensions/true_class.rb
+++ b/lib/mongoid/extensions/true_class.rb
@@ -21,7 +21,7 @@ module Mongoid
       #
       # @param [ Class ] other The class to check.
       #
-      # @return [ true, false ] If the other is a boolean.
+      # @return [ true | false ] If the other is a boolean.
       def is_a?(other)
         if other == Mongoid::Boolean || other.class == Mongoid::Boolean
           return true

--- a/lib/mongoid/fields.rb
+++ b/lib/mongoid/fields.rb
@@ -214,7 +214,7 @@ module Mongoid
     # @example Get the database field name.
     #   model.database_field_name(:authorization)
     #
-    # @param [ String, Symbol ] name The name to get.
+    # @param [ String | Symbol ] name The name to get.
     #
     # @return [ String ] The name of the field as it's stored in the db.
     def database_field_name(name)
@@ -396,7 +396,7 @@ module Mongoid
       # If the belongs_to association is the last part of the name, we will
       # pass back the _id field.
       #
-      # @param [ String, Symbol ] name The name to get.
+      # @param [ String | Symbol ] name The name to get.
       # @param [ Hash ] relations The associations.
       # @param [ Hash ] alaiased_fields The aliased fields.
       # @param [ Hash ] alaiased_associations The aliased associations.
@@ -455,7 +455,7 @@ module Mongoid
       # Get the name of the provided field as it is stored in the database.
       # Used in determining if the field is aliased or not.
       #
-      # @param [ String, Symbol ] name The name to get.
+      # @param [ String | Symbol ] name The name to get.
       #
       # @return [ String ] The name of the field as it's stored in the db.
       def database_field_name(name)

--- a/lib/mongoid/fields.rb
+++ b/lib/mongoid/fields.rb
@@ -229,7 +229,7 @@ module Mongoid
     # @param [ Field ] field The field.
     # @param [ Object ] value The current value.
     #
-    # @return [ true, false ] If we set the field lazily.
+    # @return [ true | false ] If we set the field lazily.
     def lazy_settable?(field, value)
       !frozen? && value.nil? && field.lazy?
     end
@@ -241,7 +241,7 @@ module Mongoid
     # @example Is the document using object ids?
     #   model.using_object_ids?
     #
-    # @return [ true, false ] Using object ids.
+    # @return [ true | false ] Using object ids.
     def using_object_ids?
       self.class.using_object_ids?
     end
@@ -252,7 +252,7 @@ module Mongoid
     #
     # @param [ String ] name The field name.
     #
-    # @return [ true, false ] If this field is dotted or dollared.
+    # @return [ true | false ] If this field is dotted or dollared.
     def dot_dollar_field?(name)
       n = aliased_fields[name] || name
       fields.key?(n) && (n.include?('.') || n.start_with?('$'))
@@ -507,7 +507,7 @@ module Mongoid
       # @example Does this class use object ids?
       #   person.using_object_ids?
       #
-      # @return [ true, false ] If the class uses BSON::ObjectIds for the id.
+      # @return [ true | false ] If the class uses BSON::ObjectIds for the id.
       def using_object_ids?
         fields["_id"].object_id_field?
       end

--- a/lib/mongoid/fields/foreign_key.rb
+++ b/lib/mongoid/fields/foreign_key.rb
@@ -43,7 +43,7 @@ module Mongoid
       # @example Is the field a foreign key?
       #   field.foreign_key?
       #
-      # @return [ true, false ] If the field is a foreign key.
+      # @return [ true | false ] If the field is a foreign key.
       def foreign_key?
         true
       end
@@ -75,7 +75,7 @@ module Mongoid
       # @example Is the field lazy?
       #   field.lazy?
       #
-      # @return [ true, false ] If the field is lazy.
+      # @return [ true | false ] If the field is lazy.
       def lazy?
         type.resizable?
       end
@@ -101,7 +101,7 @@ module Mongoid
       # @example Is the field a BSON::ObjectId?
       #   field.object_id_field?
       #
-      # @return [ true, false ] If the field is a BSON::ObjectId.
+      # @return [ true | false ] If the field is a BSON::ObjectId.
       def object_id_field?
         @object_id_field ||=
             association.polymorphic? ? true : association.klass.using_object_ids?
@@ -112,7 +112,7 @@ module Mongoid
       # @example Is the field resizable?
       #   field.resizable?
       #
-      # @return [ true, false ] If the field is resizable.
+      # @return [ true | false ] If the field is resizable.
       def resizable?
         type.resizable?
       end

--- a/lib/mongoid/fields/localized.rb
+++ b/lib/mongoid/fields/localized.rb
@@ -24,7 +24,7 @@ module Mongoid
       # @example Is the field localized?
       #   field.localized?
       #
-      # @return [ true, false ] If the field is localized.
+      # @return [ true | false ] If the field is localized.
       def localized?
         true
       end
@@ -50,7 +50,7 @@ module Mongoid
       # @example Should fallbacks be used.
       #   field.fallbacks?
       #
-      # @return [ true, false ] If fallbacks should be used.
+      # @return [ true | false ] If fallbacks should be used.
       def fallbacks?
         return true if options[:fallbacks].nil?
         !!options[:fallbacks]

--- a/lib/mongoid/fields/standard.rb
+++ b/lib/mongoid/fields/standard.rb
@@ -48,7 +48,7 @@ module Mongoid
       # @example Is the field a foreign key?
       #   field.foreign_key?
       #
-      # @return [ true, false ] If the field is a foreign key.
+      # @return [ true | false ] If the field is a foreign key.
       def foreign_key?
         false
       end
@@ -82,7 +82,7 @@ module Mongoid
       # @example Is the field lazy?
       #   field.lazy?
       #
-      # @return [ true, false ] If the field is lazy.
+      # @return [ true | false ] If the field is lazy.
       def lazy?
         false
       end
@@ -92,7 +92,7 @@ module Mongoid
       # @example Is the field localized?
       #   field.localized?
       #
-      # @return [ true, false ] If the field is localized.
+      # @return [ true | false ] If the field is localized.
       def localized?
         false
       end
@@ -112,7 +112,7 @@ module Mongoid
       # @example Is the field a BSON::ObjectId?
       #   field.object_id_field?
       #
-      # @return [ true, false ] If the field is a BSON::ObjectId.
+      # @return [ true | false ] If the field is a BSON::ObjectId.
       def object_id_field?
         @object_id_field ||= (type == BSON::ObjectId)
       end
@@ -122,7 +122,7 @@ module Mongoid
       # @example Does the field pre-process the default?
       #   field.pre_processed?
       #
-      # @return [ true, false ] If the field's default is pre-processed.
+      # @return [ true | false ] If the field's default is pre-processed.
       def pre_processed?
         @pre_processed ||=
           (options[:pre_processed] || (default_val && !default_val.is_a?(::Proc)))
@@ -177,7 +177,7 @@ module Mongoid
       #
       # @param [ Hash ] fields The field limitations.
       #
-      # @return [ true, false ] If the field was included.
+      # @return [ true | false ] If the field was included.
       def included?(fields)
         (fields.values.first == 1 && fields[name.to_s] == 1) ||
           (fields.values.first == 0 && !fields.has_key?(name.to_s))

--- a/lib/mongoid/fields/standard.rb
+++ b/lib/mongoid/fields/standard.rb
@@ -161,7 +161,7 @@ module Mongoid
       #
       # @note Ruby's instance_exec was just too slow.
       #
-      # @param [ Class, Module ] object The class or module the field is
+      # @param [ Class | Module ] object The class or module the field is
       #   defined on.
       def define_default_method(object)
         object.__send__(:define_method, default_name, default_val)

--- a/lib/mongoid/findable.rb
+++ b/lib/mongoid/findable.rb
@@ -75,7 +75,7 @@ module Mongoid
     # @example Are there no saved documents for this model?
     #   Person.empty?
     #
-    # @return [ true, false ] If the collection is empty.
+    # @return [ true | false ] If the collection is empty.
     def empty?
       count == 0
     end
@@ -86,7 +86,7 @@ module Mongoid
     # @example Do any documents exist for the conditions?
     #   Person.exists?
     #
-    # @return [ true, false ] If any documents exist for the conditions.
+    # @return [ true | false ] If any documents exist for the conditions.
     def exists?
       with_default_scope.exists?
     end
@@ -160,7 +160,7 @@ module Mongoid
     # @raise [ Errors::DocumentNotFound ] If no document found
     # and Mongoid.raise_not_found_error is true.
     #
-    # @return [ Document, nil ] A matching document.
+    # @return [ Document | nil ] A matching document.
     def find_by(attrs = {})
       result = where(attrs).find_first
       if result.nil? && Mongoid.raise_not_found_error

--- a/lib/mongoid/indexable/specification.rb
+++ b/lib/mongoid/indexable/specification.rb
@@ -27,7 +27,7 @@ module Mongoid
       #
       # @param [ Specification ] other The spec to compare against.
       #
-      # @return [ true, false ] If the specs are equal.
+      # @return [ true | false ] If the specs are equal.
       def ==(other)
         fields == other.fields && key == other.key
       end

--- a/lib/mongoid/interceptable.rb
+++ b/lib/mongoid/interceptable.rb
@@ -53,7 +53,7 @@ module Mongoid
     #
     # @param [ Symbol ] kind The type of callback.
     #
-    # @return [ true, false ] If the callback can be executed.
+    # @return [ true | false ] If the callback can be executed.
     def callback_executable?(kind)
       respond_to?("_#{kind}_callbacks")
     end
@@ -66,7 +66,7 @@ module Mongoid
     #
     # @param [ Symbol ] kind The callback kind.
     #
-    # @return [ true, false ] If the document is in a callback state.
+    # @return [ true | false ] If the document is in a callback state.
     def in_callback_state?(kind)
       [ :create, :destroy ].include?(kind) || new_record? || flagged_for_destroy? || changed?
     end
@@ -195,7 +195,7 @@ module Mongoid
     # @example Was a before callback halted?
     #   document.before_callback_halted?
     #
-    # @return [ true, false ] If a before callback was halted.
+    # @return [ true | false ] If a before callback was halted.
     def before_callback_halted?
       !!@before_callback_halted
     end
@@ -235,7 +235,7 @@ module Mongoid
     # @param [ Symbol ] kind The type of callback.
     # @param [ Document ] child The child document.
     #
-    # @return [ true, false ] If the child should fire the callback.
+    # @return [ true | false ] If the child should fire the callback.
     def cascadable_child?(kind, child, association)
       return false if kind == :initialize || kind == :find || kind == :touch
       return false if kind == :validate && association.validate?

--- a/lib/mongoid/matchable.rb
+++ b/lib/mongoid/matchable.rb
@@ -15,7 +15,7 @@ module Mongoid
     #
     # @param [ Hash ] selector The MongoDB selector.
     #
-    # @return [ true, false ] True if matches, false if not.
+    # @return [ true | false ] True if matches, false if not.
     def _matches?(selector)
       Matcher::Expression.matches?(self, selector)
     end

--- a/lib/mongoid/matcher.rb
+++ b/lib/mongoid/matcher.rb
@@ -24,17 +24,14 @@ module Mongoid
     #   an array of values of the `bar` field in each of the hashes in the
     #   `foo` array.
     #
-    # The return value is a two-element array. The first element is the value
-    # retrieved, or an array of values. The second element is a boolean flag
-    # indicating whether an array was expanded at any point during the key
-    # traversal (because the respective document field was an array).
-    #
     # @param [ Document | Hash ] document The document to extract from.
     # @param [ String ] key The key path to extract.
     #
-    # @return [ Array<true | false, Object | Array, true | false> ]
-    #   Whether the value existed in the document, the extracted value
-    #   and the array expansion flag.
+    # @return [ Array<Object | Array, true | false> ]
+    #   A two-element array. The first element is the value retrieved, or an
+    #   array of values. The second element is a boolean flag indicating
+    #   whether an array was expanded at any point during the key traversal
+    #   (because the respective document field was an array).
     module_function def extract_attribute(document, key)
       if document.respond_to?(:as_attributes, true)
         # If a document has hash fields, as_attributes would keep those fields

--- a/lib/mongoid/persistable.rb
+++ b/lib/mongoid/persistable.rb
@@ -79,7 +79,7 @@ module Mongoid
     #     document.set name: "Tool"
     #   end
     #
-    # @param [ true, false ] join_context Join the context (i.e. merge
+    # @param [ true | false ] join_context Join the context (i.e. merge
     #   declared atomic operations) of the atomically block wrapping this one
     #   for the same document, if one exists.
     #

--- a/lib/mongoid/persistable.rb
+++ b/lib/mongoid/persistable.rb
@@ -83,7 +83,7 @@ module Mongoid
     #   declared atomic operations) of the atomically block wrapping this one
     #   for the same document, if one exists.
     #
-    # @return [ true, false ] If the operation succeeded.
+    # @return [ true | false ] If the operation succeeded.
     def atomically(join_context: nil)
       join_context = Mongoid.join_contexts if join_context.nil?
       call_depth = @atomic_depth ||= 0
@@ -146,7 +146,7 @@ module Mongoid
     # @example Are we executing atomically?
     #   document.executing_atomically?
     #
-    # @return [ true, false ] If we are current executing atomically.
+    # @return [ true | false ] If we are current executing atomically.
     def executing_atomically?
       !@atomic_updates_to_execute_stack.nil?
     end

--- a/lib/mongoid/persistable/creatable.rb
+++ b/lib/mongoid/persistable/creatable.rb
@@ -135,7 +135,7 @@ module Mongoid
         # @param [ Hash | Array ] attributes The attributes to create with, or an
         #   Array of multiple attributes for multiple documents.
         #
-        # @return [ Document, Array<Document> ] The newly created document(s).
+        # @return [ Document | Array<Document> ] The newly created document(s).
         def create(attributes = nil, &block)
           _creating do
             if attributes.is_a?(::Array)
@@ -162,7 +162,7 @@ module Mongoid
         # @param [ Hash | Array ] attributes The attributes to create with, or an
         #   Array of multiple attributes for multiple documents.
         #
-        # @return [ Document, Array<Document> ] The newly created document(s).
+        # @return [ Document | Array<Document> ] The newly created document(s).
         def create!(attributes = nil, &block)
           _creating do
             if attributes.is_a?(::Array)

--- a/lib/mongoid/persistable/creatable.rb
+++ b/lib/mongoid/persistable/creatable.rb
@@ -132,7 +132,7 @@ module Mongoid
         # @example Create multiple new documents.
         #   Person.create({ title: "Mr" }, { title: "Mrs" })
         #
-        # @param [ Hash, Array ] attributes The attributes to create with, or an
+        # @param [ Hash | Array ] attributes The attributes to create with, or an
         #   Array of multiple attributes for multiple documents.
         #
         # @return [ Document, Array<Document> ] The newly created document(s).
@@ -159,7 +159,7 @@ module Mongoid
         # @example Create multiple new documents.
         #   Person.create!({ title: "Mr" }, { title: "Mrs" })
         #
-        # @param [ Hash, Array ] attributes The attributes to create with, or an
+        # @param [ Hash | Array ] attributes The attributes to create with, or an
         #   Array of multiple attributes for multiple documents.
         #
         # @return [ Document, Array<Document> ] The newly created document(s).

--- a/lib/mongoid/persistable/deletable.rb
+++ b/lib/mongoid/persistable/deletable.rb
@@ -86,7 +86,7 @@ module Mongoid
       #
       # @param [ Hash ] options The delete options.
       #
-      # @return [ true, false ] If the parent should be notified.
+      # @return [ true | false ] If the parent should be notified.
       def notifying_parent?(options = {})
         !options.delete(:suppress)
       end

--- a/lib/mongoid/persistable/destroyable.rb
+++ b/lib/mongoid/persistable/destroyable.rb
@@ -14,7 +14,7 @@ module Mongoid
       #
       # @param [ Hash ] options Options to pass to destroy.
       #
-      # @return [ true, false ] True if successful, false if not.
+      # @return [ true | false ] True if successful, false if not.
       def destroy(options = nil)
         raise Errors::ReadonlyDocument.new(self.class) if readonly?
         self.flagged_for_destroy = true

--- a/lib/mongoid/persistable/savable.rb
+++ b/lib/mongoid/persistable/savable.rb
@@ -14,7 +14,7 @@ module Mongoid
       #
       # @param [ Hash ] options Options to pass to the save.
       #
-      # @return [ true, false ] True is success, false if not.
+      # @return [ true | false ] True is success, false if not.
       def save(options = {})
         if new_record?
           !insert(options).new_record?
@@ -34,7 +34,7 @@ module Mongoid
       # @raise [ Errors::Validations ] If validation failed.
       # @raise [ Errors::Callback ] If a callback returns false.
       #
-      # @return [ true, false ] True if validation passed.
+      # @return [ true | false ] True if validation passed.
       def save!(options = {})
         unless save(options)
           fail_due_to_validation! unless errors.empty?

--- a/lib/mongoid/persistable/unsettable.rb
+++ b/lib/mongoid/persistable/unsettable.rb
@@ -13,7 +13,7 @@ module Mongoid
       # @example Unset the values.
       #   document.unset(:first_name, :last_name, :middle)
       #
-      # @param [ Array<String, Symbol> ] fields The names of the fields to
+      # @param [ Array<String | Symbol> ] fields The names of the fields to
       #   unset.
       #
       # @return [ Document ] The document.

--- a/lib/mongoid/persistable/updatable.rb
+++ b/lib/mongoid/persistable/updatable.rb
@@ -13,7 +13,7 @@ module Mongoid
       # @example Update the attribute.
       #   person.update_attribute(:title, "Sir")
       #
-      # @param [ Symbol, String ] name The name of the attribute.
+      # @param [ Symbol | String ] name The name of the attribute.
       # @param [ Object ] value The new value of the attribute.a
       #
       # @raise [ Errors::ReadonlyAttribute ] If the field cannot be changed due

--- a/lib/mongoid/persistable/updatable.rb
+++ b/lib/mongoid/persistable/updatable.rb
@@ -19,7 +19,7 @@ module Mongoid
       # @raise [ Errors::ReadonlyAttribute ] If the field cannot be changed due
       #   to being flagged as read-only.
       #
-      # @return [ true, false ] True if save was successful, false if not.
+      # @return [ true | false ] True if save was successful, false if not.
       def update_attribute(name, value)
         as_writable_attribute!(name, value) do |access|
           normalized = name.to_s
@@ -35,7 +35,7 @@ module Mongoid
       #
       # @param [ Hash ] attributes The attributes to update.
       #
-      # @return [ true, false ] True if validation passed, false if not.
+      # @return [ true | false ] True if validation passed, false if not.
       def update(attributes = {})
         assign_attributes(attributes)
         save
@@ -53,7 +53,7 @@ module Mongoid
       # @raise [ Errors::Validations ] If validation failed.
       # @raise [ Errors::Callbacks ] If a callback returns false.
       #
-      # @return [ true, false ] True if validation passed.
+      # @return [ true | false ] True if validation passed.
       def update!(attributes = {})
         result = update_attributes(attributes)
         unless result
@@ -91,7 +91,7 @@ module Mongoid
       #
       # @param [ Hash ] options The options.
       #
-      # @return [ true, false ] The result of the update.
+      # @return [ true | false ] The result of the update.
       def prepare_update(options = {})
         return false if performing_validations?(options) &&
           invalid?(options[:context] || :update)
@@ -119,9 +119,9 @@ module Mongoid
       #
       # @param [ Hash ] options Options to pass to update.
       #
-      # @option options [ true, false ] :validate Whether or not to validate.
+      # @option options [ true | false ] :validate Whether or not to validate.
       #
-      # @return [ true, false ] True if succeeded, false if not.
+      # @return [ true | false ] True if succeeded, false if not.
       def update_document(options = {})
         prepare_update(options) do
           updates, conflicts = init_atomic_updates

--- a/lib/mongoid/persistable/upsertable.rb
+++ b/lib/mongoid/persistable/upsertable.rb
@@ -36,7 +36,7 @@ module Mongoid
       #
       # @param [ Hash ] options The options hash.
       #
-      # @return [ true, false ] If the operation succeeded.
+      # @return [ true | false ] If the operation succeeded.
       def prepare_upsert(options = {})
         return false if performing_validations?(options) && invalid?(:upsert)
         result = run_callbacks(:upsert) do

--- a/lib/mongoid/persistence_context.rb
+++ b/lib/mongoid/persistence_context.rb
@@ -118,7 +118,7 @@ module Mongoid
     #
     # @param [ Object ] other The object to be compared with this one.
     #
-    # @return [ true, false ] Whether the two persistence contexts are equal.
+    # @return [ true | false ] Whether the two persistence contexts are equal.
     def ==(other)
       return false unless other.is_a?(PersistenceContext)
       options == other.options

--- a/lib/mongoid/persistence_context.rb
+++ b/lib/mongoid/persistence_context.rb
@@ -184,7 +184,7 @@ module Mongoid
       #  PersistenceContext.set(model)
       #
       # @param [ Object ] object The class or model instance.
-      # @param [ Hash, Mongoid::PersistenceContext ] options_or_context The persistence
+      # @param [ Hash | Mongoid::PersistenceContext ] options_or_context The persistence
       #   options or a persistence context object.
       #
       # @return [ Mongoid::PersistenceContext ] The persistence context for the object.
@@ -221,7 +221,7 @@ module Mongoid
       # @example Clear the persistence context for a class or model instance.
       #  PersistenceContext.clear(model)
       #
-      # @param [ Class, Object ] object The class or model instance.
+      # @param [ Class | Object ] object The class or model instance.
       # @param [ Mongo::Cluster ] cluster The original cluster before this context was used.
       # @param [ Mongoid::PersistenceContext ] original_context The original persistence
       #   context that was set before this context was used.

--- a/lib/mongoid/query_cache.rb
+++ b/lib/mongoid/query_cache.rb
@@ -46,7 +46,7 @@ module Mongoid
       # @example Set if the cache is enabled.
       #   QueryCache.enabled = true
       #
-      # @param [ true, false ] value The enabled value.
+      # @param [ true | false ] value The enabled value.
       def enabled=(value)
         if defined?(Mongo::QueryCache)
           Mongo::QueryCache.enabled = value

--- a/lib/mongoid/query_cache.rb
+++ b/lib/mongoid/query_cache.rb
@@ -60,7 +60,7 @@ module Mongoid
       # @example Is the query cache enabled?
       #   QueryCache.enabled?
       #
-      # @return [ true, false ] If the cache is enabled.
+      # @return [ true | false ] If the cache is enabled.
       def enabled?
         if defined?(Mongo::QueryCache)
           Mongo::QueryCache.enabled?

--- a/lib/mongoid/scopable.rb
+++ b/lib/mongoid/scopable.rb
@@ -23,7 +23,7 @@ module Mongoid
     # @example Apply the default scoping.
     #   document.apply_default_scoping
     #
-    # @return [ true, false ] If default scoping was applied.
+    # @return [ true | false ] If default scoping was applied.
     def apply_default_scoping
       if default_scoping
         default_scoping.call.selector.each do |field, value|
@@ -90,7 +90,7 @@ module Mongoid
       # @example Can the default scope be applied?
       #   Band.default_scopable?
       #
-      # @return [ true, false ] If the default scope can be applied.
+      # @return [ true | false ] If the default scope can be applied.
       def default_scopable?
         default_scoping? && !Threaded.without_default_scope?(self)
       end
@@ -170,7 +170,7 @@ module Mongoid
       #
       # @note This will force the default scope to be removed.
       #
-      # @return [ Criteria, Object ] The unscoped criteria or result of the
+      # @return [ Criteria | Object ] The unscoped criteria or result of the
       #   block.
       def unscoped
         if block_given?

--- a/lib/mongoid/scopable.rb
+++ b/lib/mongoid/scopable.rb
@@ -74,7 +74,7 @@ module Mongoid
       #     default_scope ->{ where(active: true) }
       #   end
       #
-      # @param [ Proc, Criteria ] value The default scope.
+      # @param [ Proc | Criteria ] value The default scope.
       #
       # @raise [ Errors::InvalidScope ] If the scope is not a proc or criteria.
       #
@@ -309,7 +309,7 @@ module Mongoid
       # @example Process the default scope.
       #   Model.process_default_scope(value)
       #
-      # @param [ Criteria, Proc ] value The default scope value.
+      # @param [ Criteria | Proc ] value The default scope value.
       def process_default_scope(value)
         if existing = default_scoping
           ->{ existing.call.merge(value.to_proc.call) }

--- a/lib/mongoid/scopable.rb
+++ b/lib/mongoid/scopable.rb
@@ -240,7 +240,7 @@ module Mongoid
       # @example Warn or raise error if name exists.
       #   Model.valid_scope_name?("test")
       #
-      # @param [ String, Symbol ] name The name of the scope.
+      # @param [ String | Symbol ] name The name of the scope.
       #
       # @raise [ Errors::ScopeOverwrite ] If the name exists and configured to
       #   raise the error.

--- a/lib/mongoid/serializable.rb
+++ b/lib/mongoid/serializable.rb
@@ -137,7 +137,7 @@ module Mongoid
     # @example Get the association names.
     #   document.relation_names(:include => [ :addresses ])
     #
-    # @param [ Hash, Symbol, Array<Symbol> ] inclusions The inclusions.
+    # @param [ Hash | Symbol | Array<Symbol> ] inclusions The inclusions.
     #
     # @return [ Array<Symbol> ] The names of the included associations.
     def relation_names(inclusions)
@@ -150,7 +150,7 @@ module Mongoid
     # @example Get the association options.
     #   document.relation_names(:include => [ :addresses ])
     #
-    # @param [ Hash, Symbol, Array<Symbol> ] inclusions The inclusions.
+    # @param [ Hash | Symbol | Array<Symbol> ] inclusions The inclusions.
     # @param [ Hash ] options The options.
     # @param [ Symbol ] name The name of the association.
     #

--- a/lib/mongoid/stateful.rb
+++ b/lib/mongoid/stateful.rb
@@ -23,7 +23,7 @@ module Mongoid
     # @example Is the document new?
     #   person.new_record?
     #
-    # @return [ true, false ] True if new, false if not.
+    # @return [ true | false ] True if new, false if not.
     def new_record?
       @new_record ||= false
     end
@@ -32,7 +32,7 @@ module Mongoid
     # save, the object didn't exist in the database and new_record? would have
     # returned true.
     #
-    # @return [ true, false ] True if was just created, false if not.
+    # @return [ true | false ] True if was just created, false if not.
     def previously_new_record?
       @previously_new_record ||= false
     end
@@ -43,7 +43,7 @@ module Mongoid
     # @example Is the document persisted?
     #   person.persisted?
     #
-    # @return [ true, false ] True if persisted, false if not.
+    # @return [ true | false ] True if persisted, false if not.
     def persisted?
       !new_record? && !destroyed?
     end
@@ -51,7 +51,7 @@ module Mongoid
     # Checks if the document was previously saved to the database
     # but now it has been deleted.
     #
-    # @return [ true, false ] True if was persisted but now destroyed,
+    # @return [ true | false ] True if was persisted but now destroyed,
     #   otherwise false.
     def previously_persisted?
       !new_record? && destroyed?
@@ -63,7 +63,7 @@ module Mongoid
     # @example Is the document flagged?
     #   document.flagged_for_destroy?
     #
-    # @return [ true, false ] If the document is flagged.
+    # @return [ true | false ] If the document is flagged.
     def flagged_for_destroy?
       @flagged_for_destroy ||= false
     end
@@ -77,7 +77,7 @@ module Mongoid
     # @example Is the document destroyed?
     #   person.destroyed?
     #
-    # @return [ true, false ] True if destroyed, false if not.
+    # @return [ true | false ] True if destroyed, false if not.
     def destroyed?
       @destroyed ||= false
     end
@@ -87,7 +87,7 @@ module Mongoid
     # @example Is this pushable?
     #   person.pushable?
     #
-    # @return [ true, false ] Is the document new and embedded?
+    # @return [ true | false ] Is the document new and embedded?
     def pushable?
       new_record? &&
         embedded_many? &&
@@ -100,7 +100,7 @@ module Mongoid
     # @example Is the document readonly?
     #   document.readonly?
     #
-    # @return [ true, false ] If the document is readonly.
+    # @return [ true | false ] If the document is readonly.
     def readonly?
       __selected_fields != nil
     end
@@ -110,7 +110,7 @@ module Mongoid
     # @example Is this settable?
     #   person.settable?
     #
-    # @return [ true, false ] Is this document a new embeds one?
+    # @return [ true | false ] Is this document a new embeds one?
     def settable?
       new_record? && embedded_one? && _parent.persisted?
     end
@@ -120,7 +120,7 @@ module Mongoid
     # @example Is the document updateable?
     #   person.updateable?
     #
-    # @return [ true, false ] If the document is changed and persisted.
+    # @return [ true | false ] If the document is changed and persisted.
     def updateable?
       persisted? && changed?
     end

--- a/lib/mongoid/threaded.rb
+++ b/lib/mongoid/threaded.rb
@@ -255,7 +255,7 @@ module Mongoid
     #
     # @param [ Document ] document The document to check.
     #
-    # @return [ true, false ] If the document is autosaved.
+    # @return [ true | false ] If the document is autosaved.
     def autosaved?(document)
       autosaves_for(document.class).include?(document._id)
     end
@@ -267,7 +267,7 @@ module Mongoid
     #
     # @param [ Document ] document The document to check.
     #
-    # @return [ true, false ] If the document is validated.
+    # @return [ true | false ] If the document is validated.
     def validated?(document)
       validations_for(document.class).include?(document._id)
     end
@@ -330,7 +330,7 @@ module Mongoid
     # @example Get the session for this thread.
     #   Threaded.get_session
     #
-    # @return [ Mongo::Session, nil ] The session cached on this thread or nil.
+    # @return [ Mongo::Session | nil ] The session cached on this thread or nil.
     def get_session
       Thread.current[:session]
     end

--- a/lib/mongoid/threaded.rb
+++ b/lib/mongoid/threaded.rb
@@ -45,7 +45,7 @@ module Mongoid
     # @example Get the global database override.
     #   Threaded.database_override
     #
-    # @return [ String, Symbol ] The override.
+    # @return [ String | Symbol ] The override.
     def database_override
       Thread.current[DATABASE_OVERRIDE_KEY]
     end
@@ -55,9 +55,9 @@ module Mongoid
     # @example Set the global database override.
     #   Threaded.database_override = :testing
     #
-    # @param [ String, Symbol ] name The global override name.
+    # @param [ String | Symbol ] name The global override name.
     #
-    # @return [ String, Symbol ] The override.
+    # @return [ String | Symbol ] The override.
     def database_override=(name)
       Thread.current[DATABASE_OVERRIDE_KEY] = name
     end
@@ -167,7 +167,7 @@ module Mongoid
     # @example Get the global client override.
     #   Threaded.client_override
     #
-    # @return [ String, Symbol ] The override.
+    # @return [ String | Symbol ] The override.
     def client_override
       Thread.current[CLIENT_OVERRIDE_KEY]
     end
@@ -177,9 +177,9 @@ module Mongoid
     # @example Set the global client override.
     #   Threaded.client_override = :testing
     #
-    # @param [ String, Symbol ] name The global override name.
+    # @param [ String | Symbol ] name The global override name.
     #
-    # @return [ String, Symbol ] The override.
+    # @return [ String | Symbol ] The override.
     def client_override=(name)
       Thread.current[CLIENT_OVERRIDE_KEY] = name
     end

--- a/lib/mongoid/threaded/lifecycle.rb
+++ b/lib/mongoid/threaded/lifecycle.rb
@@ -37,7 +37,7 @@ module Mongoid
       # @example Is the current thread in assigning mode?
       #   proxy._assigning?
       #
-      # @return [ true, false ] If the thread is assigning.
+      # @return [ true | false ] If the thread is assigning.
       def _assigning?
         Threaded.executing?(ASSIGN)
       end
@@ -62,7 +62,7 @@ module Mongoid
       # @example Is the current thread in binding mode?
       #   proxy.binding?
       #
-      # @return [ true, false ] If the thread is binding.
+      # @return [ true | false ] If the thread is binding.
       def _binding?
         Threaded.executing?(BIND)
       end
@@ -87,7 +87,7 @@ module Mongoid
       # @example Is the current thread in building mode?
       #   proxy._building?
       #
-      # @return [ true, false ] If the thread is building.
+      # @return [ true | false ] If the thread is building.
       def _building?
         Threaded.executing?(BUILD)
       end
@@ -97,7 +97,7 @@ module Mongoid
       # @example Is the current thread in creating mode?
       #   proxy.creating?
       #
-      # @return [ true, false ] If the thread is creating.
+      # @return [ true | false ] If the thread is creating.
       def _creating?
         Threaded.executing?(CREATE)
       end
@@ -122,7 +122,7 @@ module Mongoid
       # @example Is the current thread in loading mode?
       #   proxy._loading?
       #
-      # @return [ true, false ] If the thread is loading.
+      # @return [ true | false ] If the thread is loading.
       def _loading?
         Threaded.executing?(LOAD)
       end

--- a/lib/mongoid/timestamps/updated.rb
+++ b/lib/mongoid/timestamps/updated.rb
@@ -35,7 +35,7 @@ module Mongoid
       # @example Can the timestamp be set?
       #   document.able_to_set_updated_at?
       #
-      # @return [ true, false ] If the timestamp can be set.
+      # @return [ true | false ] If the timestamp can be set.
       def able_to_set_updated_at?
         !frozen? && !timeless? && (new_record? || changed?)
       end

--- a/lib/mongoid/traversable.rb
+++ b/lib/mongoid/traversable.rb
@@ -203,7 +203,7 @@ module Mongoid
     # @example Check if the document is a subclass
     #   Square.new.hereditary?
     #
-    # @return [ true, false ] True if hereditary, false if not.
+    # @return [ true | false ] True if hereditary, false if not.
     def hereditary?
       self.class.hereditary?
     end
@@ -283,7 +283,7 @@ module Mongoid
     # @example Is the document the root?
     #   document._root?
     #
-    # @return [ true, false ] If the document is the root.
+    # @return [ true | false ] If the document is the root.
     def _root?
       _parent ? false : true
     end
@@ -295,7 +295,7 @@ module Mongoid
       # @example Check if the document is a subclass.
       #   Square.hereditary?
       #
-      # @return [ true, false ] True if hereditary, false if not.
+      # @return [ true | false ] True if hereditary, false if not.
       def hereditary?
         !!(Mongoid::Document > superclass)
       end

--- a/lib/mongoid/validatable.rb
+++ b/lib/mongoid/validatable.rb
@@ -44,7 +44,7 @@ module Mongoid
     #
     # @param [ Hash ] options The options to check.
     #
-    # @return [ true, false ] If we are validating.
+    # @return [ true | false ] If we are validating.
     def performing_validations?(options = {})
       options[:validate].nil? ? true : options[:validate]
     end
@@ -83,7 +83,7 @@ module Mongoid
     #
     # @param [ Symbol ] context The optional validation context.
     #
-    # @return [ true, false ] True if valid, false if not.
+    # @return [ true | false ] True if valid, false if not.
     def valid?(context = nil)
       super context ? context : (new_record? ? :create : :update)
     end
@@ -93,7 +93,7 @@ module Mongoid
     # @example Is the document validated?
     #   document.validated?
     #
-    # @return [ true, false ] Has the document already been validated?
+    # @return [ true | false ] Has the document already been validated?
     def validated?
       Threaded.validated?(self)
     end
@@ -103,7 +103,7 @@ module Mongoid
     # @example Are we validating with a query?
     #   document.validating_with_query?
     #
-    # @return [ true, false ] If we are validating with a query.
+    # @return [ true | false ] If we are validating with a query.
     def validating_with_query?
       self.class.validating_with_query?
     end
@@ -151,7 +151,7 @@ module Mongoid
       # @example Are we validating with a query?
       #   Model.validating_with_query?
       #
-      # @return [ true, false ] If we are validating with a query.
+      # @return [ true | false ] If we are validating with a query.
       def validating_with_query?
         Threaded.executing?("#{name}-validate-with-query")
       end

--- a/lib/mongoid/validatable.rb
+++ b/lib/mongoid/validatable.rb
@@ -129,7 +129,7 @@ module Mongoid
       # @example Validate with a specific validator.
       #   validates_with MyValidator, on: :create
       #
-      # @param [ Class<Array>, Hash ] args The validator classes and options.
+      # @param [ Class<Array> | Hash ] args The validator classes and options.
       #
       # @note See ActiveModel::Validations::With for full options. This is
       #   overridden to add autosave functionality when presence validation is

--- a/lib/mongoid/validatable/localizable.rb
+++ b/lib/mongoid/validatable/localizable.rb
@@ -12,7 +12,7 @@ module Mongoid
       #   validator.validate_each(model, :name, "value")
       #
       # @param [ Document ] document The document.
-      # @param [ Symbol, String ] attribute The attribute to validate.
+      # @param [ Symbol | String ] attribute The attribute to validate.
       # @param [ Object ] value The attribute value.
       def validate_each(document, attribute, value)
         field = document.fields[document.database_field_name(attribute)]

--- a/lib/mongoid/validatable/presence.rb
+++ b/lib/mongoid/validatable/presence.rb
@@ -56,7 +56,7 @@ module Mongoid
       # @param [ Symbol ] attr The attribute.
       # @param [ Object ] value The value.
       #
-      # @return [ true, false ] If the doc is missing.
+      # @return [ true | false ] If the doc is missing.
       def relation_or_fk_missing?(doc, attr, value)
         return true if value.blank? && doc.send(attr).blank?
         association = doc.relations[attr.to_s]
@@ -72,7 +72,7 @@ module Mongoid
       #
       # @param [ Object ] value The value.
       #
-      # @return [ true, false ] If the value is not present.
+      # @return [ true | false ] If the value is not present.
       def not_present?(value)
         value.blank? && value != false
       end

--- a/lib/mongoid/validatable/uniqueness.rb
+++ b/lib/mongoid/validatable/uniqueness.rb
@@ -74,7 +74,7 @@ module Mongoid
       # @example Is the validation case sensitive?
       #   validator.case_sensitive?
       #
-      # @return [ true, false ] If the validation is case sensitive.
+      # @return [ true | false ] If the validation is case sensitive.
       def case_sensitive?
         !(options[:case_sensitive] == false)
       end
@@ -182,7 +182,7 @@ module Mongoid
       #
       # @param [ Document ] document The embedded document.
       #
-      # @return [ true, false ] If the validation should be skipped.
+      # @return [ true | false ] If the validation should be skipped.
       def skip_validation?(document)
         !document._parent || document.embedded_one?
       end
@@ -196,7 +196,7 @@ module Mongoid
       #
       # @param [ Document ] document The embedded document.
       #
-      # @return [ true, false ] If the scope reference has changed.
+      # @return [ true | false ] If the scope reference has changed.
       def scope_value_changed?(document)
         Array.wrap(options[:scope]).any? do |item|
           document.send("attribute_changed?", item.to_s)
@@ -277,7 +277,7 @@ module Mongoid
       # @param [ Document ] document The document getting validated.
       # @param [ Symbol ] attribute The attribute to validate.
       #
-      # @return [ true, false ] If we need to validate.
+      # @return [ true | false ] If we need to validate.
       def validation_required?(document, attribute)
         document.new_record? ||
           document.send("attribute_changed?", attribute.to_s) ||
@@ -294,7 +294,7 @@ module Mongoid
       # @param [ Document ] document The document getting validated.
       # @param [ Symbol ] attribute The attribute to validate.
       #
-      # @return [ true, false ] If the attribute is localized.
+      # @return [ true | false ] If the attribute is localized.
       def localized?(document, attribute)
         document.fields[document.database_field_name(attribute)].try(:localized?)
       end

--- a/lib/mongoid/validatable/uniqueness.rb
+++ b/lib/mongoid/validatable/uniqueness.rb
@@ -149,7 +149,7 @@ module Mongoid
       #
       # @param [ Object ] value The value to filter.
       #
-      # @return [ Object, Regexp ] The value, filtered or not.
+      # @return [ Object | Regexp ] The value, filtered or not.
       def filter(value)
         !case_sensitive? && value ? /\A#{Regexp.escape(value.to_s)}\z/i : value
       end

--- a/lib/mongoid/validatable/uniqueness.rb
+++ b/lib/mongoid/validatable/uniqueness.rb
@@ -86,7 +86,7 @@ module Mongoid
       # @example Create the criteria.
       #   validator.create_criteria(User, user, :name, "syd")
       #
-      # @param [ Class, Proxy ] base The base to execute the criteria from.
+      # @param [ Class | Proxy ] base The base to execute the criteria from.
       # @param [ Document ] document The document to validate.
       # @param [ Symbol ] attribute The name of the attribute.
       # @param [ Object ] value The value of the object.

--- a/spec/mongoid/criteria/scopable_spec.rb
+++ b/spec/mongoid/criteria/scopable_spec.rb
@@ -413,7 +413,7 @@ describe Mongoid::Criteria::Scopable do
     end
 
     it "returns the scoping options" do
-      expect(criteria.scoping_options).to eq([ true, false ])
+      expect(criteria.scoping_options).to eq([ true | false ])
     end
   end
 


### PR DESCRIPTION
This PR covers only the union comma --> pipe to pipe change. Because this PR is large, splats will be done in a follow-up.

In addition, I've written up the following draft of conventions to use. Comments welcome (please provide a suggested alternate way)

---

#### Draft: Ruby Code Doc Conventions

Use pipe character to denote a union of allowed types:

```ruby
  # @param [ Symbol | String ] name Either a Symbol or a String.
```

Hash: Use comma to denote key and value types:

```ruby
  # @param [ Hash<Symbol, Integer> ] hash A Hash whose keys are Symbols, and whose values are Integers.
```

Array: Use pipe to denote a union of allowed types:

```ruby
  # @param [ Array<Symbol | String> ] array An Array whose members must be either Symbols or Strings
```

Array: Use comma to denote the types of each position in a tuple:

```ruby
  # @return [ Array<Symbol, Integer, [ true | false ]> ] A 3-member Array whose first element is a Symbol,
  #   second element is an Integer, and third element is a boolean value.
```

For clarity, use brackets to denote nested unions when commas are also used:

```ruby
  # @param [ Hash<Symbol, [ true | false ]> ] hash A Hash whose keys are Symbols, and whose values are boolean values.
```

Specific values may be denoted in the type using Ruby syntax.

```ruby
  # @param [ :before | :after ] timing One of the Symbol values :before or :after.
```

Use "true", "false", and "nil" rather than "TrueClass", "FalseClass", and "NilClass". Do not use "Boolean" as a type as it does not exist in Ruby.

```ruby
  # GOOD:
  # @param [ true | false | nil ] bool A boolean or nil value.

  # BAD:
  # @param [ TrueClass | FalseClass | NilClass ] bool A boolean or nil value.
  # @param [ Boolean ] bool A boolean value.
```

Return value "self" is allowed.

```ruby
  # @return [ self ] Returns the object self.
```

Splats: Use * in the parameter name to denote a splat:

```ruby
  # @param [ String ] *items The list of items name(s) as Strings.
  # ...
  def buy_groceries(*items)
```

Splats: Use comma to denote positionality in a splat:

```ruby
  # @param [ Symbol, Hash ] *args A list of names, followed by a hash of options.
  # ...
  def say_hello(*args)
```

Named keyword arguments: following YARD convention, use `@param` as normal for named keyword arguments.

```ruby
  # @param [String] query The search string
  # @param [Boolean] exact_match Whether to do an exact match
  # @param [Integer] results_per_page Number of results
  def search(query, exact_match: false, results_per_page: 10)
```

Double-splats: Use ** in the parameter name to denote a double-splat. Note that type does not need declared on the double-splat element (it is implicly <Symbol, Object>). Define the types with @option macro below:

```ruby
  # @param **kwargs The optional keyword argument(s).
  #
  # @option **kwargs [ String | Array<String> ] :items The items(s) as Strings to include.
  # @option **kwargs [ Integer ] :limit An Integer denoting the limit.
  # ...
  def buy_groceries(**kwargs)
```

Long comments: Use double-space indent when wrapping lines.

```ruby
  # @return [ Symbol ] This sentence is so long that is must be double-space
  #   idented on the second, third, etc. lines.
```