### PR TITLE
MONGOID-4867 Deprecate geoHaystack and geoSearch

### DIFF
--- a/docs/release-notes/mongoid-8.0.txt
+++ b/docs/release-notes/mongoid-8.0.txt
@@ -634,3 +634,9 @@ ActiveRecord:
   - When reading a document from the database, the ``attributes_before_type_cast``
     hash contains the attributes as they appear in the database, as opposed to
     their ``demongoized`` form.
+
+
+Deprecated the ``geoHaystack``, ``geoSearch`` Options
+-----------------------------------------------------
+
+The ``geoHaystack`` and ``geoSearch`` options on indexes have been deprecated.

--- a/lib/config/locales/en.yml
+++ b/lib/config/locales/en.yml
@@ -238,7 +238,7 @@ en:
             \_\_language_override\n
             \_\_default_language\n
             \_\_collation\n
-            Valid types are: 1, -1, '2d', '2dsphere', 'geoHaystack', 'text', 'hashed'\n\n
+            Valid types are: 1, -1, '2d', '2dsphere', 'geoHaystack (deprecated)', 'text', 'hashed'\n\n
             Example:\n
             \_\_class Band\n
             \_\_\_\_include Mongoid::Document\n

--- a/lib/mongoid/indexable/validators/options.rb
+++ b/lib/mongoid/indexable/validators/options.rb
@@ -97,6 +97,11 @@ module Mongoid
             unless VALID_TYPES.include?(value)
               raise Errors::InvalidIndex.new(klass, spec, options)
             end
+
+            if value == "geoHaystack"
+              # TODO: Move this to Mongoid::Warnings as part of MONGOID-5419.
+              Mongoid.logger.warn("The geoHaystack type is deprecated.")
+            end
           end
         end
       end

--- a/spec/mongoid/indexable_spec.rb
+++ b/spec/mongoid/indexable_spec.rb
@@ -191,7 +191,7 @@ describe Mongoid::Indexable do
       end
     end
 
-    context "when using a custom discriminator_key" do 
+    context "when using a custom discriminator_key" do
       context "when indexes have not been added" do
         let(:klass) do
           Class.new do
@@ -202,15 +202,15 @@ describe Mongoid::Indexable do
             end
           end
         end
-  
+
         before do
           klass.add_indexes
         end
-  
+
         let(:spec) do
           klass.index_specification(dkey: 1)
         end
-  
+
         it "adds the _type index" do
           expect(spec.options).to eq(unique: false, background: true)
         end


### PR DESCRIPTION
These options were deprecated in Ruby driver version 2.13.0

There is no mention of `geoSearch` in Mongoid. 