### PR TITLE
MONGOID-5315 Accept formatted strings in Date/Time/DateTime.demongoize

### DIFF
--- a/docs/reference/fields.txt
+++ b/docs/reference/fields.txt
@@ -1068,18 +1068,18 @@ setter methods for fields of your custom type.
    venue = Venue.new(location: point) # This uses the Point#mongoize instance method.
    venue = Venue.new(location: [ 12, 24 ]) # This uses the Point.mongoize class method.
 
-.. note::
-
-  The ``mongoize`` method should return ``nil`` on values that are uncastable to
-  your custom type. See the section on :ref:`Uncastable Values <uncastable-values>`
-  for more details.
-
 The class method ``demongoize`` does the inverse of ``mongoize``. It takes the raw object
 from the MongoDB Ruby driver and converts it to an instance of your custom type.
 In this case, the database driver returns an ``Array`` and we instantiate a ``Point`` from it.
 The ``demongoize`` method is used when calling the getters of fields for your custom type.
 Note that in the example above, since ``demongoize`` calls ``Point.new``, a new instance of
 ``Point`` will be generated on each call to the getter.
+
+.. note::
+
+  The ``mongoize`` and ``demongoize`` methods should return ``nil`` on values
+  that are uncastable to your custom type. See the section on :ref:`Uncastable
+  Values <uncastable-values>` for more details.
 
 Lastly, the class method ``evolve`` is similar to ``mongoize``, however it is used
 when transforming objects for use in Mongoid query criteria.

--- a/docs/release-notes/mongoid-8.0.txt
+++ b/docs/release-notes/mongoid-8.0.txt
@@ -69,47 +69,53 @@ Some ``mongoize`` and ``demongoize`` methods were also changed to perform
 consistently with rails and the other ``mongoize`` and ``demongoize`` methods.
 The following is a table of the changes in functionality:
 
-+--------------+------------------------+------------------------+-------------------+
-| Field Type   | Situation              | Previous Functionality | New Functionality |
-+==============+========================+========================+===================+
-| Boolean      | When a non-boolean     | return ``false``       | return ``nil``    |
-|              | string is assigned:    |                        |                   |
-|              | "bogus value"          |                        |                   |
-+--------------+------------------------+------------------------+-------------------+
-| Array/Hash   | When a value that is   | raise ``InvalidValue`` | return ``nil``    |
-|              | not an array or hash   | error                  |                   |
-|              | is assigned            |                        |                   |
-+--------------+------------------------+------------------------+-------------------+
-| Set          | When a value that is   | raise ``NoMethodError``| return ``nil``    |
-|              | not a set is assigned: | Exception: undefined   |                   |
-|              | 1                      | method ``to_a`` for    |                   |
-|              |                        | 1:Integer              |                   |
-+--------------+------------------------+------------------------+-------------------+
-| Regexp       | When persisting and    | return a               | return a          |
-|              | reading a Regexp from  | ``BSON::Regexp::Raw``  | ``Regexp``        |
-|              | the database           |                        |                   |
-+--------------+------------------------+------------------------+-------------------+
-| Time/DateTime| When assigning a       | raise ``NoMethodError``| return ``nil``    |
-|              | bogus value: ``:bogus``| Exception: undefined   |                   |
-|              |                        | method ``to_i``        |                   |
-|              |                        | for :bogus:Symbol      |                   |
-+--------------+------------------------+------------------------+-------------------+
-| Time/DateTime| When demongoizing a    | raise ``NoMethodError``| "bogus":          |
-|              | non-Time value:        | Exception: undefined   | return ``nil``    |
-|              | "bogus",               | method ``getlocal``    |                   |
-|              | ``Date.today``         | for "bogus":String     | ``Date.today``:   |
-|              |                        |                        | return a          |
-|              |                        |                        | ``Time/DateTime`` |
-+--------------+------------------------+------------------------+-------------------+
-| Date         | When assigning or      | raise ``NoMethodError``| return ``nil``    |
-|              | demongoizing a bogus   | Exception: undefined   |                   |
-|              | value: :bogus          | method ``year``        |                   |
-|              |                        | for :bogus:Symbol      |                   |
-+--------------+------------------------+------------------------+-------------------+
-| All Other    | When an uncastable     | undefined behavior,    | return ``nil``    |
-| Types        | value is assigned      | occasionally raise     |                   |
-|              |                        | ``NoMethodError``      |                   |
-+--------------+------------------------+------------------------+-------------------+
++--------------+------------------------+------------------------+-----------------------+
+| Field Type   | Situation              | Previous Functionality | New Functionality     |
++==============+========================+========================+=======================+
+| Boolean      | When a non-boolean     | return ``false``       | return ``nil``        |
+|              | string is assigned:    |                        |                       |
+|              | "bogus value"          |                        |                       |
++--------------+------------------------+------------------------+-----------------------+
+| Array/Hash   | When a value that is   | raise ``InvalidValue`` | return ``nil``        |
+|              | not an array or hash   | error                  |                       |
+|              | is assigned            |                        |                       |
++--------------+------------------------+------------------------+-----------------------+
+| Set          | When a value that is   | raise ``NoMethodError``| return ``nil``        |
+|              | not a set is assigned: | Exception: undefined   |                       |
+|              | 1                      | method ``to_a`` for    |                       |
+|              |                        | 1:Integer              |                       |
++--------------+------------------------+------------------------+-----------------------+
+| Regexp       | When persisting and    | return a               | return a              |
+|              | reading a Regexp from  | ``BSON::Regexp::Raw``  | ``Regexp``            |
+|              | the database           |                        |                       |
++--------------+------------------------+------------------------+-----------------------+
+| Time/DateTime| When assigning a       | raise ``NoMethodError``| return ``nil``        |
+|              | bogus value: ``:bogus``| Exception: undefined   |                       |
+|              |                        | method ``to_i``        |                       |
+|              |                        | for :bogus:Symbol      |                       |
++--------------+------------------------+------------------------+-----------------------+
+| Time/DateTime| When demongoizing a    | raise ``NoMethodError``| "bogus":              |
+|              | non-Time value:        | Exception: undefined   | return ``nil``        |
+|              | "bogus",               | method ``getlocal``    |                       |
+|              | ``Date.today``         | for "bogus":String     | ``Date.today``:       |
+|              |                        |                        | return a              |
+|              |                        |                        | ``Time/DateTime``     |
++--------------+------------------------+------------------------+-----------------------+
+| Date         | When assigning or      | raise ``NoMethodError``| return ``nil``        |
+|              | demongoizing a bogus   | Exception: undefined   |                       |
+|              | value: :bogus          | method ``year``        |                       |
+|              |                        | for :bogus:Symbol      |                       |
++--------------+------------------------+------------------------+-----------------------+
+| Time/DateTime| When demongoizing a    | raise ``NoMethodError``| return a              |
+| /Date        | valid string:          | Exception: undefined   | ``Time/DateTime/Date``|
+|              | "2022-07-14 14:45:51   | method ``getlocal``    |                       |
+|              | -0400"                 | for "2022-07-14        |                       |
+|              |                        | 14:45:51 -0400":String |                       |
++--------------+------------------------+------------------------+-----------------------+
+| All Other    | When an uncastable     | undefined behavior,    | return ``nil``        |
+| Types        | value is assigned      | occasionally raise     |                       |
+|              |                        | ``NoMethodError``      |                       |
++--------------+------------------------+------------------------+-----------------------+
 
 .. note::
 

--- a/lib/mongoid/extensions/date.rb
+++ b/lib/mongoid/extensions/date.rb
@@ -39,7 +39,15 @@ module Mongoid
         #
         # @return [ Date | nil ] The object as a date or nil.
         def demongoize(object)
-          return nil if object.nil?
+          return if object.nil?
+          if object.is_a?(String)
+            object = begin
+              object.__mongoize_time__
+            rescue ArgumentError
+              nil
+            end
+          end
+
           if object.acts_like?(:time) || object.acts_like?(:date)
             ::Date.new(object.year, object.month, object.day)
           end

--- a/lib/mongoid/extensions/time.rb
+++ b/lib/mongoid/extensions/time.rb
@@ -52,9 +52,15 @@ module Mongoid
             Mongoid::Config.use_utc? ? object : object.getlocal
           elsif object.acts_like?(:date)
             ::Date.demongoize(object).to_time
+          elsif object.is_a?(String)
+            begin
+              object.__mongoize_time__
+            rescue ArgumentError
+              nil
+            end
           end
 
-          return unless time
+          return if time.nil?
 
           if Mongoid::Config.use_activesupport_time_zone?
             time.in_time_zone(Mongoid.time_zone)

--- a/spec/mongoid/extensions/date_spec.rb
+++ b/spec/mongoid/extensions/date_spec.rb
@@ -77,12 +77,11 @@ describe Mongoid::Extensions::Date do
       end
     end
 
-    context "when demongoizing a castable value" do
+    context "when demongoizing a string" do
 
       let(:date) { "2022-07-11 14:03:42 -0400" }
 
       it "returns a date" do
-        pending "MONGOID-5315"
         expect(Date.demongoize(date)).to eq(date.to_date)
       end
     end

--- a/spec/mongoid/extensions/date_time_spec.rb
+++ b/spec/mongoid/extensions/date_time_spec.rb
@@ -73,6 +73,15 @@ describe Mongoid::Extensions::DateTime do
         end
       end
     end
+
+    context "when demongoizing a string" do
+
+      let(:date) { "2022-07-11 14:03:42 -0400" }
+
+      it "returns a date" do
+        expect(DateTime.demongoize(date)).to eq(date.to_datetime)
+      end
+    end
   end
 
   describe ".mongoize" do


### PR DESCRIPTION
I've decided to just use the String#__mongoize_time__ method to parse strings as it takes care of parsing the time in the configured time zone. The following outcomes result: 
- If given a string without a timezone, it is interpreted in the current configured time zone
- When given a string with a timezone, it is interpreted in that time zone, and then converted to the configured time zone
- Time/ActiveSupport::TimeWithZone correctly returned based on flag