### PR TITLE
MONGOID-5428 Make feature flag connected to Mongo.broken_view_options

### DIFF
--- a/docs/reference/configuration.txt
+++ b/docs/reference/configuration.txt
@@ -340,6 +340,17 @@ for details on driver options.
       # (default: false)
       #broken_updates: true
 
+      # This option delegates to Mongo's broken_view_options flag. Modifying
+      # Mongo.broken_view_options, will also modify Mongoid.broken_view_options,
+      # however, it will not modify Mongoid::Config.settings.
+      #
+      # When this flag is turned off, inline options will be correctly
+      # propagated to Mongoid finder methods. When this flag is turned
+      # on those options will be ignored. For example, with this flag turned
+      # off, Band.all.limit(1).count will take the limit into account, while
+      # when this flag is turned on, that limit is ignored. (default: false)
+      #broken_view_options: false
+
       # Time objects in Ruby have nanosecond precision, whereas MongoDB server
       # can only store times with millisecond precision. Set this option to
       # true to truncate times to millisecond precision when performing

--- a/docs/reference/configuration.txt
+++ b/docs/reference/configuration.txt
@@ -349,6 +349,9 @@ for details on driver options.
       # on those options will be ignored. For example, with this flag turned
       # off, Band.all.limit(1).count will take the limit into account, while
       # when this flag is turned on, that limit is ignored. (default: false)
+      #
+      # Note that when Mongoid is loaded, it will set the driver's option
+      # value to Mongoid's default value.
       #broken_view_options: false
 
       # Time objects in Ruby have nanosecond precision, whereas MongoDB server

--- a/lib/mongoid/config.rb
+++ b/lib/mongoid/config.rb
@@ -125,6 +125,10 @@ module Mongoid
     # always return a Hash.
     option :legacy_attributes, default: false
 
+    # When this flag is set to false, the view options will be correctly
+    # propagated to readable methods.
+    option :broken_view_options, default: false
+
     # Has Mongoid been configured? This is checking that at least a valid
     # client config exists.
     #

--- a/lib/mongoid/config/options.rb
+++ b/lib/mongoid/config/options.rb
@@ -30,13 +30,13 @@ module Mongoid
 
         class_eval do
           # log_level accessor is defined specially below
-          unless name.to_sym == :log_level
+          unless name == :log_level
             define_method(name) do
               settings[name]
             end
           end
 
-          if name.to_sym == :broken_view_options
+          if name == :broken_view_options
             Mongo.send("#{name}=", options[:default])
             define_method("#{name}=") do |value|
               Mongo.send("#{name}=", value)

--- a/lib/mongoid/config/options.rb
+++ b/lib/mongoid/config/options.rb
@@ -95,7 +95,10 @@ module Mongoid
           Mongo.send(name)
         end
 
+        # This causes the driver option to be set to Mongoid's default
+        # when Mongoid is loaded.
         Mongo.send("#{name}=", options[:default])
+
         define_method("#{name}=") do |value|
           Mongo.send("#{name}=", value)
           settings[name] = value

--- a/lib/mongoid/config/options.rb
+++ b/lib/mongoid/config/options.rb
@@ -36,8 +36,16 @@ module Mongoid
             end
           end
 
-          define_method("#{name}=") do |value|
-            settings[name] = value
+          if name.to_sym == :broken_view_options
+            Mongo.send("#{name}=", options[:default])
+            define_method("#{name}=") do |value|
+              Mongo.send("#{name}=", value)
+              settings[name] = value
+            end
+          else
+            define_method("#{name}=") do |value|
+              settings[name] = value
+            end
           end
 
           define_method("#{name}?") do

--- a/spec/mongoid/config_spec.rb
+++ b/spec/mongoid/config_spec.rb
@@ -349,6 +349,28 @@ describe Mongoid::Config do
     it_behaves_like "a config option"
   end
 
+  context 'when setting the broken_view_options option in the config' do
+    let(:option) { :broken_view_options }
+    let(:default) { false }
+
+    it_behaves_like "a config option"
+
+    context "when broken_view_options default assigned" do
+
+      it "is assigned in the Mongo flag" do
+        expect(Mongo.broken_view_options).to be false
+      end
+    end
+
+    context "when assigning to the broken_view_options" do
+      config_override :broken_view_options, true
+
+      it "also assigns to the Mongo flag" do
+        expect(Mongo.broken_view_options).to be true
+      end
+    end
+  end
+
   describe "#load!" do
 
     before(:all) do

--- a/spec/mongoid/config_spec.rb
+++ b/spec/mongoid/config_spec.rb
@@ -233,6 +233,12 @@ describe Mongoid::Config do
       end
     end
 
+    around do |ex|
+      temp = Mongoid.send(option)
+      ex.run
+      Mongoid.send("#{option}=", temp)
+    end
+
     context 'when the value is false' do
 
       let(:conf) do
@@ -353,14 +359,14 @@ describe Mongoid::Config do
     let(:option) { :broken_view_options }
     let(:default) { false }
 
-    it_behaves_like "a config option"
-
     context "when broken_view_options default assigned" do
 
       it "is assigned in the Mongo flag" do
         expect(Mongo.broken_view_options).to be false
       end
     end
+
+    it_behaves_like "a config option"
 
     context "when assigning to the broken_view_options" do
       config_override :broken_view_options, true

--- a/spec/mongoid/config_spec.rb
+++ b/spec/mongoid/config_spec.rb
@@ -378,12 +378,31 @@ describe Mongoid::Config do
 
     context "when assiging through options=" do
 
-      before do
+      around do |ex|
+        expect(Mongoid.broken_view_options).to be false
+        temp = Mongo.broken_view_options
         Mongoid.options = { broken_view_options: true }
+        ex.run
+        Mongo.broken_view_options = temp
       end
 
       it "also assigns the Mongo flag" do
         expect(Mongo.broken_view_options).to be true
+      end
+    end
+
+    context "when modifying the mongo flag" do
+
+      around do |ex|
+        expect(Mongoid.broken_view_options).to be false
+        temp = Mongo.broken_view_options
+        Mongo.broken_view_options = true
+        ex.run
+        Mongo.broken_view_options = temp
+      end
+
+      it "modifies the Mongoid flag" do
+        expect(Mongoid.broken_view_options).to be true
       end
     end
   end

--- a/spec/mongoid/config_spec.rb
+++ b/spec/mongoid/config_spec.rb
@@ -375,6 +375,17 @@ describe Mongoid::Config do
         expect(Mongo.broken_view_options).to be true
       end
     end
+
+    context "when assiging through options=" do
+
+      before do
+        Mongoid.options = { broken_view_options: true }
+      end
+
+      it "also assigns the Mongo flag" do
+        expect(Mongo.broken_view_options).to be true
+      end
+    end
   end
 
   describe "#load!" do

--- a/spec/mongoid/contextual/mongo_spec.rb
+++ b/spec/mongoid/contextual/mongo_spec.rb
@@ -2762,8 +2762,20 @@ describe Mongoid::Contextual::Mongo do
           described_class.new(criteria)
         end
 
-        it "returns the number of documents that match" do
-          expect(context.send(method)).to eq(2)
+        context "when broken_view_options is true" do
+          config_override :broken_view_options, true
+
+          it "returns the number of documents that match" do
+            expect(context.send(method)).to eq(2)
+          end
+        end
+
+        context "when broken_view_options is false" do
+          config_override :broken_view_options, false
+
+          it "returns the number of documents that match" do
+            expect(context.send(method)).to eq(1)
+          end
         end
 
         context "when calling more than once" do
@@ -2790,8 +2802,20 @@ describe Mongoid::Contextual::Mongo do
               context.entries
             end
 
-            it "resets the length on each full iteration" do
-              expect(context.size).to eq(2)
+            context "when broken_view_options is true" do
+              config_override :broken_view_options, true
+
+              it "resets the length on each full iteration" do
+                expect(context.size).to eq(2)
+              end
+            end
+
+            context "when broken_view_options is false" do
+              config_override :broken_view_options, false
+
+              it "resets the length on each full iteration" do
+                expect(context.size).to eq(1)
+              end
             end
           end
         end


### PR DESCRIPTION
This PR won't work until 2.18 is released. Driver master works! That's a good sign.