### PR TITLE
MONGOID-4500 Mongoid::Contextual::Aggregable::Memory should ignore nil values.

### DIFF
--- a/lib/mongoid/contextual/aggregable/memory.rb
+++ b/lib/mongoid/contextual/aggregable/memory.rb
@@ -27,9 +27,13 @@ module Mongoid
         #
         # @param [ Symbol ] field The field to average.
         #
-        # @return [ Float ] The average.
+        # @return [ Numeric ] The average.
         def avg(field)
-          any? ? sum(field).to_f / count.to_f : nil
+          total = count { |doc| !doc.send(field).nil? }
+          return nil unless total > 0
+
+          total = total.to_f if total.is_a?(Integer)
+          sum(field) / total
         end
 
         # Get the max value of the provided field. If provided a block, will
@@ -46,10 +50,12 @@ module Mongoid
         #
         # @param [ Symbol ] field The field to max.
         #
-        # @return [ Float, Document ] The max value or document with the max
+        # @return [ Numeric | Document ] The max value or document with the max
         #   value.
         def max(field = nil)
-          block_given? ? super() : aggregate_by(field, :max_by)
+          return super() if block_given?
+
+          aggregate_by(field, :max)
         end
 
         # Get the min value of the provided field. If provided a block, will
@@ -66,10 +72,12 @@ module Mongoid
         #
         # @param [ Symbol ] field The field to min.
         #
-        # @return [ Float, Document ] The min value or document with the min
+        # @return [ Numeric | Document ] The min value or document with the min
         #   value.
         def min(field = nil)
-          block_given? ? super() : aggregate_by(field, :min_by)
+          return super() if block_given?
+
+          aggregate_by(field, :min)
         end
 
         # Get the sum value of the provided field. If provided a block, will
@@ -83,13 +91,12 @@ module Mongoid
         #
         # @param [ Symbol ] field The field to sum.
         #
-        # @return [ Float ] The sum value.
+        # @return [ Numeric ] The sum value.
         def sum(field = nil)
-          if block_given?
-            super()
-          else
-            any? ? super(0) { |doc| doc.public_send(field) } : 0
-          end
+          return super() if block_given?
+          return 0 unless any?
+
+          aggregate_by(field, :sum)
         end
 
         private
@@ -99,14 +106,16 @@ module Mongoid
         # @api private
         #
         # @example Aggregate by the field and method.
-        #   aggregable.aggregate_by(:name, :min_by)
+        #   aggregable.aggregate_by(:likes, :min_by)
         #
         # @param [ Symbol ] field The field to aggregate on.
         # @param [ Symbol ] method The method (min_by or max_by).
         #
-        # @return [ Integer ] The aggregate.
+        # @return [ Numeric | nil ] The aggregate.
         def aggregate_by(field, method)
-          any? ? send(method) { |doc| doc.public_send(field) }.public_send(field) : nil
+          return nil unless any?
+
+          map { |doc| doc.public_send(field) }.compact.public_send(method)
         end
       end
     end

--- a/lib/mongoid/contextual/aggregable/memory.rb
+++ b/lib/mongoid/contextual/aggregable/memory.rb
@@ -94,9 +94,8 @@ module Mongoid
         # @return [ Numeric ] The sum value.
         def sum(field = nil)
           return super() if block_given?
-          return 0 unless any?
 
-          aggregate_by(field, :sum)
+          aggregate_by(field, :sum) || 0
         end
 
         private

--- a/spec/mongoid/contextual/aggregable/memory_spec.rb
+++ b/spec/mongoid/contextual/aggregable/memory_spec.rb
@@ -4,11 +4,11 @@ require "spec_helper"
 
 describe Mongoid::Contextual::Aggregable::Memory do
 
-  describe "#aggregates" do
-    let(:context) do
-      Mongoid::Contextual::Memory.new(criteria)
-    end
+  let(:context) do
+    Mongoid::Contextual::Memory.new(criteria)
+  end
 
+  describe "#aggregates" do
     subject { context.aggregates(:likes) }
 
     context 'when no documents found' do
@@ -46,289 +46,527 @@ describe Mongoid::Contextual::Aggregable::Memory do
 
   describe "#avg" do
 
-    context "when provided a single field" do
+    context "when the types are Integers" do
 
-      context "when there are matching documents" do
+      let!(:depeche) do
+        Band.create!(name: "Depeche Mode", likes: 1000)
+      end
 
-        context "when the types are integers" do
+      let!(:tool) do
+        Band.create!(name: "Tool", likes: 500)
+      end
 
-          let!(:depeche) do
-            Band.create!(name: "Depeche Mode", likes: 1000)
-          end
-
-          let!(:tool) do
-            Band.create!(name: "Tool", likes: 500)
-          end
-
-          let(:criteria) do
-            Band.all.tap do |criteria|
-              criteria.documents = [ depeche, tool ]
-            end
-          end
-
-          let(:context) do
-            Mongoid::Contextual::Memory.new(criteria)
-          end
-
-          let(:avg) do
-            context.avg(:likes)
-          end
-
-          it "returns the avg of the provided field" do
-            expect(avg).to eq(750)
-          end
-        end
-
-        context "when the types are floats" do
-
-          let!(:depeche) do
-            Band.create!(name: "Depeche Mode", rating: 10)
-          end
-
-          let!(:tool) do
-            Band.create!(name: "Tool", rating: 5)
-          end
-
-          let(:criteria) do
-            Band.all.tap do |criteria|
-              criteria.documents = [ depeche, tool ]
-            end
-          end
-
-          let(:context) do
-            Mongoid::Contextual::Memory.new(criteria)
-          end
-
-          let(:avg) do
-            context.avg(:rating)
-          end
-
-          it "returns the avg of the provided field" do
-            expect(avg).to eq(7.5)
-          end
+      let(:criteria) do
+        Band.all.tap do |criteria|
+          criteria.documents = [ depeche, tool ]
         end
       end
 
-      context "when no documents match" do
+      let(:avg) do
+        context.avg(:likes)
+      end
+
+      it "returns the avg of the provided field" do
+        expect(avg).to eq(750)
+      end
+
+      it 'returns a float' do
+        avg.should be_a(Float)
+      end
+
+      context 'when integers are negative' do
 
         let!(:depeche) do
-          Band.create!(name: "Depeche Mode", likes: 1000)
+          Band.create!(name: "Depeche Mode", likes: -1000)
         end
 
-        let(:criteria) do
-          Band.where(name: "New Order")
+        it "returns the avg of the provided field" do
+          expect(avg).to eq(-250)
         end
 
-        let(:context) do
-          Mongoid::Contextual::Memory.new(criteria)
+        it 'returns a float' do
+          avg.should be_a(Float)
         end
+      end
+    end
 
-        let(:avg) do
-          context.avg(:likes)
-        end
+    context "when the types are Floats" do
 
-        it "returns nil" do
-          expect(avg).to be_nil
+      let!(:depeche) do
+        Band.create!(name: "Depeche Mode", rating: 10)
+      end
+
+      let!(:tool) do
+        Band.create!(name: "Tool", rating: 5)
+      end
+
+      let(:criteria) do
+        Band.all.tap do |criteria|
+          criteria.documents = [ depeche, tool ]
         end
+      end
+
+      let(:avg) do
+        context.avg(:rating)
+      end
+
+      it "returns the avg of the provided field" do
+        expect(avg).to eq(7.5)
+      end
+    end
+
+    context "when no documents match" do
+
+      let!(:depeche) do
+        Band.create!(name: "Depeche Mode", likes: 1000)
+      end
+
+      let(:criteria) do
+        Band.where(name: "New Order")
+      end
+
+      let(:avg) do
+        context.avg(:likes)
+      end
+
+      it "returns nil" do
+        expect(avg).to be_nil
+      end
+    end
+
+    context "when there are a mix of types" do
+
+      let!(:bands) do
+        [ Band.create!(name: "The Flaming Lips", mojo: 7.7),
+          Band.create!(name: "Spirit of the Beehive", mojo: 10),
+          Band.create!(name: "Justin Bieber", mojo: nil) ]
+      end
+
+      let(:criteria) do
+        Band.all.tap do |criteria|
+          criteria.documents = bands
+        end
+      end
+
+      let(:avg) do
+        context.avg(:mojo)
+      end
+
+      it "coerces types to calculate avg" do
+        expect(avg).to eq(8.85)
+      end
+
+      it "database only averages Numeric types" do
+        expect(Band.all.avg(:mojo)).to be_within(0.000001).of(8.85)
+      end
+    end
+
+    context "when there no numeric values" do
+
+      let!(:bands) do
+        [ Band.create!(name: "Justin Bieber", mojo: nil) ]
+      end
+
+      let(:criteria) do
+        Band.all.tap do |criteria|
+          criteria.documents = bands
+        end
+      end
+
+      let(:avg) do
+        context.avg(:mojo)
+      end
+
+      it "returns avg as nil" do
+        expect(avg).to be_nil
+      end
+
+      it "database returns avg as nil" do
+        expect(Band.all.avg(:mojo)).to eq(nil)
       end
     end
   end
 
   describe "#max" do
 
-    context "when provided a single field" do
+    let!(:depeche) do
+      Band.create!(name: "Depeche Mode", likes: 1000)
+    end
 
-      let!(:depeche) do
-        Band.create!(name: "Depeche Mode", likes: 1000)
+    let!(:tool) do
+      Band.create!(name: "Tool", likes: 500)
+    end
+
+    let(:criteria) do
+      Band.all.tap do |crit|
+        crit.documents = [ depeche, tool ]
+      end
+    end
+
+    context "when provided a Symbol" do
+
+      let(:max) do
+        context.max(:likes)
       end
 
-      let!(:tool) do
-        Band.create!(name: "Tool", likes: 500)
+      it "returns the max of the provided field" do
+        expect(max).to eq(1000)
       end
 
-      let(:criteria) do
-        Band.all.tap do |crit|
-          crit.documents = [ depeche, tool ]
+      context "when no documents match" do
+
+        let(:criteria) do
+          Band.where(name: "New Order")
         end
-      end
-
-      let(:context) do
-        Mongoid::Contextual::Memory.new(criteria)
-      end
-
-      context "when provided a symbol" do
 
         let(:max) do
           context.max(:likes)
         end
 
-        it "returns the max of the provided field" do
-          expect(max).to eq(1000)
-        end
-
-        context "when no documents match" do
-
-          let(:criteria) do
-            Band.where(name: "New Order")
-          end
-
-          let(:context) do
-            Mongoid::Contextual::Memory.new(criteria)
-          end
-
-          let(:max) do
-            context.max(:likes)
-          end
-
-          it "returns nil" do
-            expect(max).to be_nil
-          end
+        it "returns nil" do
+          expect(max).to be_nil
         end
       end
 
-      context "when provided a block" do
+      context "when there are a mix of types" do
 
-        let(:max) do
-          context.max do |a, b|
-            a.likes <=> b.likes
+        let!(:bands) do
+          [ Band.create!(name: "The Flaming Lips", mojo: 7.7),
+            Band.create!(name: "Spirit of the Beehive", mojo: 10),
+            Band.create!(name: "Justin Bieber", mojo: nil) ]
+        end
+
+        let(:criteria) do
+          Band.all.tap do |criteria|
+            criteria.documents = bands
           end
         end
 
-        it "returns the document with the max value for the field" do
-          expect(max).to eq(depeche)
+        let(:max) do
+          context.max(:mojo)
         end
+
+        it "coerces types to calculate max" do
+          expect(max).to eq 10
+          expect(max).to be_a Integer
+        end
+      end
+
+      context "when there no numeric values" do
+
+        let!(:bands) do
+          [ Band.create!(name: "Justin Bieber", mojo: nil) ]
+        end
+
+        let(:criteria) do
+          Band.all.tap do |criteria|
+            criteria.documents = bands
+          end
+        end
+
+        let(:max) do
+          context.avg(:mojo)
+        end
+
+        it "returns max as nil" do
+          expect(max).to be_nil
+        end
+      end
+    end
+
+    context "when provided a block" do
+
+      let(:max) do
+        context.max do |a, b|
+          a.likes <=> b.likes
+        end
+      end
+
+      it "returns the document with the max value for the field" do
+        expect(max).to eq(depeche)
       end
     end
   end
 
   describe "#min" do
 
-    context "when provided a single field" do
+    let!(:depeche) do
+      Band.create!(name: "Depeche Mode", likes: 1000)
+    end
 
-      let!(:depeche) do
-        Band.create!(name: "Depeche Mode", likes: 1000)
+    let!(:tool) do
+      Band.create!(name: "Tool", likes: 500)
+    end
+
+    let(:criteria) do
+      Band.all.tap do |crit|
+        crit.documents = [ depeche, tool ]
+      end
+    end
+
+    context "when provided a Symbol" do
+
+      let(:min) do
+        context.min(:likes)
       end
 
-      let!(:tool) do
-        Band.create!(name: "Tool", likes: 500)
+      it "returns the min of the provided field" do
+        expect(min).to eq(500)
       end
 
-      let(:criteria) do
-        Band.all.tap do |crit|
-          crit.documents = [ depeche, tool ]
+      context "when no documents match" do
+
+        let(:criteria) do
+          Band.where(name: "New Order")
         end
-      end
-
-      let(:context) do
-        Mongoid::Contextual::Memory.new(criteria)
-      end
-
-      context "when provided a symbol" do
 
         let(:min) do
           context.min(:likes)
         end
 
-        it "returns the min of the provided field" do
-          expect(min).to eq(500)
-        end
-
-        context "when no documents match" do
-
-          let(:criteria) do
-            Band.where(name: "New Order")
-          end
-
-          let(:context) do
-            Mongoid::Contextual::Memory.new(criteria)
-          end
-
-          let(:min) do
-            context.min(:likes)
-          end
-
-          it "returns nil" do
-            expect(min).to be_nil
-          end
+        it "returns nil" do
+          expect(min).to be_nil
         end
       end
 
-      context "when provided a block" do
+      context "when there are a mix of types" do
 
-        let(:min) do
-          context.min do |a, b|
-            a.likes <=> b.likes
+        let!(:bands) do
+          [ Band.create!(name: "The Flaming Lips", mojo: 7.7),
+            Band.create!(name: "Spirit of the Beehive", mojo: 10),
+            Band.create!(name: "Justin Bieber", mojo: nil) ]
+        end
+
+        let(:criteria) do
+          Band.all.tap do |criteria|
+            criteria.documents = bands
           end
         end
 
-        it "returns the document with the min value for the field" do
-          expect(min).to eq(tool)
+        let(:min) do
+          context.min(:mojo)
         end
+
+        it "coerces types to calculate min" do
+          expect(min).to eq 7.7
+          expect(min).to be_a Float
+        end
+      end
+
+      context "when there no numeric values" do
+
+        let!(:bands) do
+          [ Band.create!(name: "Justin Bieber", mojo: nil) ]
+        end
+
+        let(:criteria) do
+          Band.all.tap do |criteria|
+            criteria.documents = bands
+          end
+        end
+
+        let(:min) do
+          context.min(:mojo)
+        end
+
+        it "returns min as nil" do
+          expect(min).to be_nil
+        end
+      end
+    end
+
+    context "when provided a block" do
+
+      let(:min) do
+        context.min do |a, b|
+          a.likes <=> b.likes
+        end
+      end
+
+      it "returns the document with the min value for the field" do
+        expect(min).to eq(tool)
       end
     end
   end
 
   describe "#sum" do
 
-    context "when provided a single field" do
+    let!(:depeche) do
+      Band.create!(name: "Depeche Mode", likes: 1000)
+    end
 
-      let!(:depeche) do
-        Band.create!(name: "Depeche Mode", likes: 1000)
+    let!(:tool) do
+      Band.create!(name: "Tool", likes: 500)
+    end
+
+    let(:criteria) do
+      Band.all.tap do |crit|
+        crit.documents = [ depeche, tool ]
+      end
+    end
+
+    context 'when values are integers' do
+
+      let(:sum) do
+        context.sum(:likes)
       end
 
-      let!(:tool) do
-        Band.create!(name: "Tool", likes: 500)
-      end
+      shared_examples 'sums and returns an integer' do
+        it 'sums' do
+          sum.should == 1500
+        end
 
-      let(:criteria) do
-        Band.all.tap do |crit|
-          crit.documents = [ depeche, tool ]
+        it 'returns integer' do
+          sum.should be_a(Integer)
         end
       end
 
-      let(:context) do
-        Mongoid::Contextual::Memory.new(criteria)
+      include_examples 'sums and returns an integer'
+
+      context 'when values are numeric strings' do
+
+        let!(:depeche) do
+          Band.create!(name: "Depeche Mode", likes: '1000')
+        end
+
+        include_examples 'sums and returns an integer'
       end
 
-      context "when provided a symbol" do
+      context 'when values are negative integers' do
+
+        let!(:depeche) do
+          Band.create!(name: "Depeche Mode", likes: -1000)
+        end
+
+        shared_examples 'sums and returns an integer' do
+          it 'sums' do
+            sum.should == -500
+          end
+
+          it 'returns integer' do
+            sum.should be_a(Integer)
+          end
+        end
+
+        include_examples 'sums and returns an integer'
+
+        context 'when values are negative numeric strings' do
+
+          let!(:depeche) do
+            Band.create!(name: "Depeche Mode", likes: '-1000')
+          end
+
+          include_examples 'sums and returns an integer'
+        end
+      end
+    end
+
+    context 'when values are floats' do
+
+      let!(:depeche) do
+        Band.create!(name: "Depeche Mode", likes: 1000.0)
+      end
+
+      let(:sum) do
+        context.sum(:likes)
+      end
+
+      it 'sums' do
+        sum.should == 1500
+      end
+
+      it 'returns integer' do
+        sum.should be_a(Integer)
+      end
+    end
+
+    context "when provided a Symbol" do
+
+      let(:sum) do
+        context.sum(:likes)
+      end
+
+      it "returns the sum of the provided field" do
+        expect(sum).to eq(1500)
+      end
+
+      context "when no documents match" do
+
+        let(:criteria) do
+          Band.where(name: "New Order")
+        end
 
         let(:sum) do
           context.sum(:likes)
         end
 
-        it "returns the sum of the provided field" do
-          expect(sum).to eq(1500)
-        end
-
-        context "when no documents match" do
-
-          let(:criteria) do
-            Band.where(name: "New Order")
-          end
-
-          let(:context) do
-            Mongoid::Contextual::Memory.new(criteria)
-          end
-
-          let(:sum) do
-            context.sum(:likes)
-          end
-
-          it "returns zero" do
-            expect(sum).to eq(0)
-          end
+        it "returns zero" do
+          expect(sum).to eq(0)
         end
       end
 
-      context "when provided a block" do
+      context "when there are a mix of types" do
+
+        let!(:bands) do
+          [ Band.create!(name: "The Flaming Lips", mojo: 7.7),
+            Band.create!(name: "Spirit of the Beehive", mojo: 10),
+            Band.create!(name: "Justin Bieber", mojo: nil) ]
+        end
+
+        let(:criteria) do
+          Band.all.tap do |criteria|
+            criteria.documents = bands
+          end
+        end
 
         let(:sum) do
-          context.sum(&:likes)
+          context.sum(:mojo)
         end
 
-        it "returns the sum for the provided block" do
-          expect(sum).to eq(1500)
+        it "coerces types to calculate sum" do
+          expect(sum).to eq 17.7
+          expect(sum).to be_a Float
         end
+
+        it "database only sums Float and Integer types" do
+          expect(Band.all.sum(:mojo)).to be_within(Float::EPSILON).of(17.7)
+        end
+      end
+
+      context "when there no numeric values" do
+
+        let!(:bands) do
+          [ Band.create!(name: "Justin Bieber", mojo: nil) ]
+        end
+
+        let(:criteria) do
+          Band.all.tap do |criteria|
+            criteria.documents = bands
+          end
+        end
+
+        let(:sum) do
+          context.sum(:mojo)
+        end
+
+        it "returns sum as zero" do
+          expect(sum).to eq 0
+        end
+
+        it "database returns sum as zero" do
+          expect(Band.all.sum(:mojo)).to eq(0)
+        end
+      end
+    end
+
+    context "when provided a block" do
+
+      let(:sum) do
+        context.sum(&:likes)
+      end
+
+      it "returns the sum for the provided block" do
+        expect(sum).to eq(1500)
       end
     end
   end

--- a/spec/mongoid/contextual/aggregable/memory_table.yml
+++ b/spec/mongoid/contextual/aggregable/memory_table.yml
@@ -53,15 +53,15 @@ sets:
     values:
       - 233
       - '-974.332'
-      - ~
+      - ~ # ignored
       - 532.45642
       - '-5675'
       - 348.434
-      - 'Foobar'
+      - 'Foobar' # ignored
       - -3394
       - -493
-      - ''
-      - '0 1 2 3'
+      - '' # ignored
+      - '0 1 2 3' # ignored
       - !ruby/object:BigDecimal 18:0.53245642e3
       - -5675
       - '0.434'
@@ -69,7 +69,7 @@ sets:
       - 0.434
       - 7455.96
       - -0.0544
-      - '   '
+      - '   ' # ignored
     expected:
       integer:
         avg: -7484.7857

--- a/spec/mongoid/contextual/aggregable/memory_table.yml
+++ b/spec/mongoid/contextual/aggregable/memory_table.yml
@@ -1,0 +1,88 @@
+sets:
+  integers:
+    values:
+      - 324
+      - 4553
+      - -74
+      - 634
+      - 0
+      - 3484
+      - -3394
+      - 493
+    expected:
+      integer:
+        avg: 752.5
+        sum: 6020
+        min: -3394
+        max: 4553
+      float:
+        avg: 752.5
+        sum: 6020.0
+        min: -3394.0
+        max: 4553.0
+      big_decimal:
+        avg: !ruby/object:BigDecimal 36:0.7525e3
+        sum: !ruby/object:BigDecimal 18:0.602e4
+        min: !ruby/object:BigDecimal 18:-0.3394e4
+        max: !ruby/object:BigDecimal 18:0.4553e4
+
+  floats:
+    values:
+      - 233.132425
+      - -974.332
+      - 532.53323
+      - 0
+    expected:
+      integer:
+        avg: -52.25
+        sum: -209
+        min: -974
+        max: 532
+      float:
+        avg: -52.16658625
+        sum: -208.666345
+        min: -974.332
+        max: 532.53323
+      big_decimal:
+        avg: !ruby/object:BigDecimal 45:-0.5216658625e2
+        sum: !ruby/object:BigDecimal 27:-0.208666345e3
+        min: !ruby/object:BigDecimal 18:-0.974332e3
+        max: !ruby/object:BigDecimal 18:0.53253323e3
+
+  mixed:
+    values:
+      - 233
+      - '-974.332'
+      - ~
+      - 532.45642
+      - '-5675'
+      - 348.434
+      - 'Foobar'
+      - -3394
+      - -493
+      - ''
+      - '0 1 2 3'
+      - !ruby/object:BigDecimal 18:0.53245642e3
+      - -5675
+      - '0.434'
+      - !ruby/object:BigDecimal 18:-0.97676e5
+      - 0.434
+      - 7455.96
+      - -0.0544
+      - '   '
+    expected:
+      integer:
+        avg: -7484.7857
+        sum: -104787
+        min: -97676
+        max: 7455
+      float:
+        avg: -7484.5865
+        sum: -104784.2116
+        min: -97676.0
+        max: 7455.96
+      big_decimal:
+        avg: !ruby/object:BigDecimal 27:-0.7484586540e4
+        sum: !ruby/object:BigDecimal 27:-0.1047842116e6
+        min: !ruby/object:BigDecimal 18:-0.97676e5
+        max: !ruby/object:BigDecimal 18:0.745596e4

--- a/spec/mongoid/contextual/aggregable/memory_table_spec.rb
+++ b/spec/mongoid/contextual/aggregable/memory_table_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Mongoid::Contextual::Aggregable::Memory do
+
+  let(:criteria) do
+    Band.all.tap do |crit|
+      crit.documents = documents
+    end
+  end
+
+  let(:context) do
+    Mongoid::Contextual::Memory.new(criteria)
+  end
+
+  file = File.read(File.join(File.dirname(__FILE__), 'memory_table.yml'))
+  table = if RUBY_VERSION.start_with?("2.5")
+            YAML.safe_load(file, [BigDecimal])
+          else
+            YAML.safe_load(file, permitted_classes: [BigDecimal])
+          end.deep_symbolize_keys.fetch(:sets)
+
+  table.each do |name, spec|
+    context "DB values are #{name}" do
+      let(:documents) do
+        spec[:values].map do |value|
+          Band.create!({ name: 'Foobar', views: value, rating: value, sales: value, mojo: value })
+        end
+      end
+
+      { integer: :views,
+        float: :rating,
+        big_decimal: :sales }.each do |type, field|
+
+        %i[sum avg min max].each do |method|
+          context "#{type.to_s.camelize} field :#{method}" do
+            let(:expected) do
+              spec.dig(:expected, type, method)
+            end
+
+            let(:result) do
+              context.send(method, field)
+            end
+
+            it 'produces the expected result' do
+              if result.is_a?(Integer)
+                expect(result).to eq expected
+              else
+                expect(result).to be_within(0.001).of(expected)
+              end
+            end
+
+            it 'produces the expected type' do
+              expect(result).to be_a expected.class
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/support/models/band.rb
+++ b/spec/support/models/band.rb
@@ -20,6 +20,7 @@ class Band
   field :y, as: :years, type: Integer
   field :founded, type: Date
   field :deleted, type: Boolean
+  field :mojo, type: Object
   field :fans
 
   embeds_many :records, cascade_callbacks: true


### PR DESCRIPTION
This change makes the in-memory behavior closer to MongoDB's native operators.

This PR is a pared-back version of https://github.com/mongodb/mongoid/pull/5038 which contains only nil changes and not type conversion. I hope this can be merged.