### PR TITLE
MONGOID-5414 deprecate criteria cache functionality

### DIFF
--- a/docs/release-notes/mongoid-8.0.txt
+++ b/docs/release-notes/mongoid-8.0.txt
@@ -719,3 +719,12 @@ Support Dropped for the ``:id_sort`` Option on ``#first/last``
 
 Support for the ``:id_sort`` option on the ``#first`` and ``#last`` options has
 been dropped. These methods now only except a limit as a positional argument.
+
+
+Support Dropped for Mongoid::Criteria cache
+-------------------------------------------
+
+Support for individually caching criteria objects has been dropped in Mongoid 8.
+
+In order to get caching functionality, enable the Mongoid QueryCache. See the
+section on :ref:`QueryCache <query-cache>` for more details.

--- a/lib/mongoid/contextual/mongo.rb
+++ b/lib/mongoid/contextual/mongo.rb
@@ -42,10 +42,12 @@ module Mongoid
       # @example Is the context cached?
       #   context.cached?
       #
-      # @return [ true, false ] If the context is cached.
+      # @return [ false ] Always return false.
+      #
+      # @deprecated
       def cached?
         Mongoid::Warnings.warn_criteria_cache_deprecated
-        !!@cache
+        false
       end
 
       # Get the number of documents matching the query.
@@ -67,7 +69,7 @@ module Mongoid
       # @return [ Integer ] The number of matches.
       def count(options = {}, &block)
         return super(&block) if block_given?
-        try_cache(:count) { view.count_documents(options) }
+        view.count_documents(options)
       end
 
       # Get the estimated number of documents matching the query.
@@ -86,7 +88,7 @@ module Mongoid
         unless self.criteria.selector.empty?
           raise Mongoid::Errors::InvalidEstimatedCountCriteria.new(self.klass)
         end
-        try_cache(:estimated_count) { view.estimated_document_count(options) }
+        view.estimated_document_count(options)
       end
 
       # Delete all documents in the database that match the selector.
@@ -154,7 +156,6 @@ module Mongoid
           documents_for_iteration.each do |doc|
             yield_document(doc, &block)
           end
-          @cache_loaded = true
           self
         else
           to_enum
@@ -167,17 +168,11 @@ module Mongoid
       #   context.exists?
       #
       # @note We don't use count here since Mongo does not use counted
-      #   b-tree indexes, unless a count is already cached then that is
-      #   used to determine the value.
+      #   b-tree indexes.
       #
       # @return [ true, false ] If the count is more than zero.
       def exists?
-        return !documents.empty? if cached? && cache_loaded?
-        return @count > 0 if instance_variable_defined?(:@count)
-
-        try_cache(:exists) do
-          !!(view.projection(_id: 1).limit(1).first)
-        end
+        !!(view.projection(_id: 1).limit(1).first)
       end
 
       # Run an explain on the criteria.
@@ -258,14 +253,9 @@ module Mongoid
       #
       # @return [ Document ] The first document.
       def first(limit = nil)
-        if cached? && cache_loaded?
-          return limit ? documents.first(limit) : documents.first
-        end
-        try_numbered_cache(:first, limit) do
-          sort = view.sort || { _id: 1 }
-          if raw_docs = view.sort(sort).limit(limit || 1).to_a
-            process_raw_docs(raw_docs, limit)
-          end
+        sort = view.sort || { _id: 1 }
+        if raw_docs = view.sort(sort).limit(limit || 1).to_a
+          process_raw_docs(raw_docs, limit)
         end
       end
       alias :one :first
@@ -274,7 +264,6 @@ module Mongoid
       #
       # @api private
       def find_first
-        return documents.first if cached? && cache_loaded?
         if raw_doc = view.first
           doc = Factory.from_db(klass, raw_doc, criteria)
           eager_load([doc]).first
@@ -335,7 +324,7 @@ module Mongoid
       #
       # @param [ Criteria ] criteria The criteria.
       def initialize(criteria)
-        @criteria, @klass, @cache = criteria, criteria.klass, criteria.options[:cache]
+        @criteria, @klass = criteria, criteria.klass
         @collection = @klass.collection
         criteria.send(:merge_type_selection)
         @view = collection.find(criteria.selector, session: _session)
@@ -359,15 +348,8 @@ module Mongoid
       #
       # @return [ Document ] The last document.
       def last(limit = nil)
-        if cached? && cache_loaded?
-          return limit ? documents.last(limit) : documents.last
-        end
-        res = try_numbered_cache(:last, limit) do
-          if raw_docs = view.sort(inverse_sorting).limit(limit || 1).to_a
-            process_raw_docs(raw_docs, limit)
-          end
-        end
-        res.is_a?(Array) ? res.reverse : res
+        raw_docs = view.sort(inverse_sorting).limit(limit || 1).to_a.reverse
+        process_raw_docs(raw_docs, limit)
       end
 
       # Returns the number of documents in the database matching
@@ -621,47 +603,6 @@ module Mongoid
 
       private
 
-      # yield the block given or return the cached value
-      #
-      # @param [ String, Symbol ] key The instance variable name
-      #
-      # @return the result of the block
-      def try_cache(key, &block)
-        unless cached?
-          yield
-        else
-          unless ret = instance_variable_get("@#{key}")
-            instance_variable_set("@#{key}", ret = yield)
-          end
-          ret
-        end
-      end
-
-      # yield the block given or return the cached value
-      #
-      # @param [ String, Symbol ] key The instance variable name
-      # @param [ Integer | nil ] n The number of documents requested or nil
-      #   if none is requested.
-      #
-      # @return [ Object ] The result of the block.
-      def try_numbered_cache(key, n, &block)
-        unless cached?
-          yield if block_given?
-        else
-          len = n || 1
-          ret = instance_variable_get("@#{key}")
-          if !ret || ret.length < len
-            instance_variable_set("@#{key}", ret = Array.wrap(yield))
-          elsif !n
-            ret.is_a?(Array) ? ret.first : ret
-          elsif ret.length > len
-            ret.first(n)
-          else
-            ret
-          end
-        end
-      end
-
       # Update the documents for the provided method.
       #
       # @api private
@@ -727,43 +668,6 @@ module Mongoid
         Hash[sort.map{|k, v| [k, -1*v]}]
       end
 
-      # Is the cache able to be added to?
-      #
-      # @api private
-      #
-      # @example Is the context cacheable?
-      #   context.cacheable?
-      #
-      # @return [ true, false ] If caching, and the cache isn't loaded.
-      def cacheable?
-        cached? && !cache_loaded?
-      end
-
-      # Is the cache fully loaded? Will be true if caching after one full
-      # iteration.
-      #
-      # @api private
-      #
-      # @example Is the cache loaded?
-      #   context.cache_loaded?
-      #
-      # @return [ true, false ] If the cache is loaded.
-      def cache_loaded?
-        !!@cache_loaded
-      end
-
-      # Get the documents for cached queries.
-      #
-      # @api private
-      #
-      # @example Get the cached documents.
-      #   context.documents
-      #
-      # @return [ Array<Document> ] The documents.
-      def documents
-        @documents ||= []
-      end
-
       # Get the documents the context should iterate. This follows 3 rules:
       #
       # 1. If the query is cached, and we already have documents loaded, use
@@ -779,7 +683,6 @@ module Mongoid
       #
       # @return [ Array<Document>, Mongo::Collection::View ] The docs to iterate.
       def documents_for_iteration
-        return documents if cached? && !documents.empty?
         return view unless eager_loadable?
         docs = view.map{ |doc| Factory.from_db(klass, doc, criteria) }
         eager_load(docs)
@@ -799,7 +702,6 @@ module Mongoid
         doc = document.respond_to?(:_id) ?
             document : Factory.from_db(klass, document, criteria)
         yield(doc)
-        documents.push(doc) if cacheable?
       end
 
       private

--- a/lib/mongoid/contextual/mongo.rb
+++ b/lib/mongoid/contextual/mongo.rb
@@ -37,19 +37,6 @@ module Mongoid
       # @attribute [r] view The Mongo collection view.
       attr_reader :view
 
-      # Is the context cached?
-      #
-      # @example Is the context cached?
-      #   context.cached?
-      #
-      # @return [ false ] Always return false.
-      #
-      # @deprecated
-      def cached?
-        Mongoid::Warnings.warn_criteria_cache_deprecated
-        false
-      end
-
       # Get the number of documents matching the query.
       #
       # @example Get the number of matching documents.

--- a/lib/mongoid/criteria.rb
+++ b/lib/mongoid/criteria.rb
@@ -121,6 +121,8 @@ module Mongoid
     #   criteria.cache
     #
     # @return [ Criteria ] The cloned criteria.
+    #
+    # @deprecated
     def cache
       Mongoid::Warnings.warn_criteria_cache_deprecated
       clone
@@ -132,6 +134,8 @@ module Mongoid
     #   criteria.cached?
     #
     # @return [ true, false ] If the criteria is flagged as cached.
+    #
+    # @deprecated
     def cached?
       Mongoid::Warnings.warn_criteria_cache_deprecated
       false

--- a/lib/mongoid/criteria.rb
+++ b/lib/mongoid/criteria.rb
@@ -112,35 +112,6 @@ module Mongoid
       entries.as_json(options)
     end
 
-    # Tells the criteria that the cursor that gets returned needs to be
-    # cached. This is so multiple iterations don't hit the database multiple
-    # times, however this is not advisable when working with large data sets
-    # as the entire results will get stored in memory.
-    #
-    # @example Flag the criteria as cached.
-    #   criteria.cache
-    #
-    # @return [ Criteria ] The cloned criteria.
-    #
-    # @deprecated
-    def cache
-      Mongoid::Warnings.warn_criteria_cache_deprecated
-      clone
-    end
-
-    # Will return true if the cache option has been set.
-    #
-    # @example Is the criteria cached?
-    #   criteria.cached?
-    #
-    # @return [ true, false ] If the criteria is flagged as cached.
-    #
-    # @deprecated
-    def cached?
-      Mongoid::Warnings.warn_criteria_cache_deprecated
-      false
-    end
-
     # Get the documents from the embedded criteria.
     #
     # @example Get the documents.

--- a/lib/mongoid/criteria.rb
+++ b/lib/mongoid/criteria.rb
@@ -123,9 +123,7 @@ module Mongoid
     # @return [ Criteria ] The cloned criteria.
     def cache
       Mongoid::Warnings.warn_criteria_cache_deprecated
-      crit = clone
-      crit.options.merge!(cache: true)
-      crit
+      clone
     end
 
     # Will return true if the cache option has been set.
@@ -136,7 +134,7 @@ module Mongoid
     # @return [ true, false ] If the criteria is flagged as cached.
     def cached?
       Mongoid::Warnings.warn_criteria_cache_deprecated
-      options[:cache] == true
+      false
     end
 
     # Get the documents from the embedded criteria.

--- a/lib/mongoid/warnings.rb
+++ b/lib/mongoid/warnings.rb
@@ -24,6 +24,6 @@ module Mongoid
     warning :geo_haystack_deprecated, 'The geoHaystack type is deprecated.'
     warning :as_json_compact_deprecated, '#as_json :compact option is deprecated. Please call #compact on the returned Hash object instead.'
     warning :symbol_type_deprecated, 'The BSON Symbol type is deprecated by MongoDB. Please use String or StringifiedSymbol field types instead of the Symbol field type'
-    warning :criteria_cache_deprecated, 'The criteria cache has been deprecated and will be removed in Mongoid 8. Please enable the Mongoid QueryCache to have caching functionality.'
+    warning :criteria_cache_deprecated, 'The criteria cache has been deprecated and will no longer do any caching. Please enable the Mongoid QueryCache to have caching functionality.'
   end
 end

--- a/lib/mongoid/warnings.rb
+++ b/lib/mongoid/warnings.rb
@@ -24,6 +24,5 @@ module Mongoid
     warning :geo_haystack_deprecated, 'The geoHaystack type is deprecated.'
     warning :as_json_compact_deprecated, '#as_json :compact option is deprecated. Please call #compact on the returned Hash object instead.'
     warning :symbol_type_deprecated, 'The BSON Symbol type is deprecated by MongoDB. Please use String or StringifiedSymbol field types instead of the Symbol field type'
-    warning :criteria_cache_deprecated, 'The criteria cache has been deprecated and will no longer do any caching. Please enable the Mongoid QueryCache to have caching functionality.'
   end
 end

--- a/spec/mongoid/contextual/mongo_spec.rb
+++ b/spec/mongoid/contextual/mongo_spec.rb
@@ -44,39 +44,6 @@ describe Mongoid::Contextual::Mongo do
     end
   end
 
-  describe "#cached?" do
-
-    context "when the criteria is cached" do
-
-      let(:criteria) do
-        Band.all.cache
-      end
-
-      let(:context) do
-        described_class.new(criteria)
-      end
-
-      it "always returns false" do
-        expect(context).to_not be_cached
-      end
-    end
-
-    context "when the criteria is not cached" do
-
-      let(:criteria) do
-        Band.all
-      end
-
-      let(:context) do
-        described_class.new(criteria)
-      end
-
-      it "returns false" do
-        expect(context).to_not be_cached
-      end
-    end
-  end
-
   describe "#count" do
 
     let!(:depeche) do
@@ -2187,14 +2154,15 @@ describe Mongoid::Contextual::Mongo do
         end
       end
 
-      context "when calling #first then #last" do
+      context "when calling #first then #last and the query cache is enabled" do
+        query_cache_enabled
 
         let(:context) do
           described_class.new(criteria)
         end
 
         let(:criteria) do
-          Band.all.cache
+          Band.all
         end
 
         before do
@@ -2209,8 +2177,10 @@ describe Mongoid::Contextual::Mongo do
           let(:before_limit) { 2 }
           let(:limit) { 1 }
 
-          it "gets the correct document" do
-            expect(docs).to eq([rolling_stones])
+          it "gets the correct document and hits the database" do
+            expect_query(1) do
+              expect(docs).to eq([rolling_stones])
+            end
           end
         end
       end
@@ -2530,14 +2500,15 @@ describe Mongoid::Contextual::Mongo do
       end
     end
 
-    context "when calling #last then #first" do
+    context "when calling #last then #first and the query cache is enabled" do
+      query_cache_enabled
 
       let(:context) do
         described_class.new(criteria)
       end
 
       let(:criteria) do
-        Band.all.cache
+        Band.all
       end
 
       before do
@@ -2553,8 +2524,9 @@ describe Mongoid::Contextual::Mongo do
         let(:limit) { 1 }
 
         it "hits the database" do
-          expect(context).to receive(:view).twice.and_call_original
-          docs
+          expect_query(1) do
+            docs
+          end
         end
 
         it "gets the correct document" do

--- a/spec/mongoid/contextual/mongo_spec.rb
+++ b/spec/mongoid/contextual/mongo_spec.rb
@@ -56,8 +56,8 @@ describe Mongoid::Contextual::Mongo do
         described_class.new(criteria)
       end
 
-      it "returns true" do
-        expect(context).to be_cached
+      it "always returns false" do
+        expect(context).to_not be_cached
       end
     end
 
@@ -102,15 +102,17 @@ describe Mongoid::Contextual::Mongo do
       end
     end
 
-    context "when context is cached" do
+    context "when the query cache is enabled" do
+      query_cache_enabled
 
       let(:context) do
-        described_class.new(criteria.cache)
+        described_class.new(criteria)
       end
 
-      it "returns the count cached value after first call" do
-        expect(context.view).to receive(:count_documents).once.and_return(1)
-        2.times { expect(context.count).to eq(1) }
+      it "only executes the count query once" do
+        expect_query(1) do
+          2.times { expect(context.count).to eq(1) }
+        end
       end
     end
 
@@ -217,16 +219,18 @@ describe Mongoid::Contextual::Mongo do
       end
     end
 
-    context "when context is cached" do
+    context "when the query cache is enabled" do
+      query_cache_enabled
 
       let(:context) do
-        described_class.new(criteria.cache)
+        described_class.new(criteria)
       end
 
-      it "returns the count cached value after first call" do
-        expect(context.view).to receive(:estimated_document_count).once.and_return(1)
-        2.times do
-          context.estimated_count
+      it "the results are not cached" do
+        expect_query(2) do
+          2.times do
+            context.estimated_count
+          end
         end
       end
     end
@@ -1450,51 +1454,15 @@ describe Mongoid::Contextual::Mongo do
         described_class.new(criteria)
       end
 
-      context "when exists? already called" do
+      context "when exists? already called and query cache is enabled" do
+        query_cache_enabled
 
         before do
           context.exists?
         end
 
-        it "hits the database again" do
-          expect(context).to receive(:view).once.and_call_original
-          expect(context).to be_exists
-        end
-      end
-    end
-
-    context "when caching is enabled" do
-
-      let(:criteria) do
-        Band.where(name: "Depeche Mode").cache
-      end
-
-      let(:context) do
-        described_class.new(criteria)
-      end
-
-      context "when the cache is loaded" do
-
-        before do
-          context.to_a
-        end
-
-        it "does not hit the database" do
-          expect(context).to receive(:view).never
-          expect(context).to be_exists
-        end
-      end
-
-      context "when the cache is not loaded" do
-
-        context "when a count has been executed" do
-
-          before do
-            context.count
-          end
-
-          it "does not hit the database" do
-            expect(context).to receive(:view).never
+        it "does not hit the database again" do
+          expect_no_queries do
             expect(context).to be_exists
           end
         end
@@ -2045,26 +2013,15 @@ describe Mongoid::Contextual::Mongo do
         end
       end
 
-      context "when the context is cached" do
+      context "when the query cache is enabled" do
+        query_cache_enabled
 
         let(:criteria) do
-          Band.where(name: "Depeche Mode").cache
+          Band.where(name: "Depeche Mode")
         end
 
         let(:context) do
           described_class.new(criteria)
-        end
-
-        context "when the cache is loaded" do
-
-          before do
-            context.to_a
-          end
-
-          it "returns the first document without touching the database" do
-            expect(context).to receive(:view).never
-            expect(context.send(method)).to eq(depeche_mode)
-          end
         end
 
         context "when first method was called before" do
@@ -2074,8 +2031,9 @@ describe Mongoid::Contextual::Mongo do
           end
 
           it "returns the first document without touching the database" do
-            expect(context).to receive(:view).never
-            expect(context.send(method)).to eq(depeche_mode)
+            expect_no_queries do
+              expect(context.send(method)).to eq(depeche_mode)
+            end
           end
         end
       end
@@ -2129,77 +2087,21 @@ describe Mongoid::Contextual::Mongo do
           end
         end
 
-        context "when the context is cached" do
+        context "when the query cache is enabled" do
 
           let(:context) do
             described_class.new(criteria)
           end
 
-          context "when the whole context is loaded" do
-
-            before do
-              context.to_a
-            end
-
-            context "when all of the documents are cached" do
-
-              let(:criteria) do
-                Band.all.cache
-              end
-
-              context "when requesting all of the documents" do
-
-                let(:docs) do
-                  context.send(method, 3)
-                end
-
-                it "returns all of the documents without touching the database" do
-                  expect(context).to receive(:view).never
-                  expect(docs).to eq([ depeche_mode, new_order, rolling_stones ])
-                end
-              end
-
-              context "when requesting fewer than all of the documents" do
-
-                let(:docs) do
-                  context.send(method, 2)
-                end
-
-                it "returns all of the documents without touching the database" do
-                  expect(context).to receive(:view).never
-                  expect(docs).to eq([ depeche_mode, new_order ])
-                end
-              end
-            end
-
-            context "when only one document is cached" do
-
-              let(:criteria) do
-                Band.where(name: "Depeche Mode").cache
-              end
-
-              context "when requesting one document" do
-
-                let(:docs) do
-                  context.send(method, 1)
-                end
-
-                it "returns one document without touching the database" do
-                  expect(context).to receive(:view).never
-                  expect(docs).to eq([ depeche_mode ])
-                end
-              end
-            end
-          end
-
-          context "when the first method was called before" do
+          context "when calling first beforehand" do
+            query_cache_enabled
 
             let(:context) do
               described_class.new(criteria)
             end
 
             let(:criteria) do
-              Band.all.cache
+              Band.all
             end
 
             before do
@@ -2217,8 +2119,9 @@ describe Mongoid::Contextual::Mongo do
                 let(:limit) { 3 }
 
                 it "returns all documents without touching the database" do
-                  expect(context).to receive(:view).never
-                  expect(docs).to eq([ depeche_mode, new_order, rolling_stones ])
+                  expect_no_queries do
+                    expect(docs).to eq([ depeche_mode, new_order, rolling_stones ])
+                  end
                 end
               end
 
@@ -2226,8 +2129,9 @@ describe Mongoid::Contextual::Mongo do
                 let(:limit) { 2 }
 
                 it "returns the correct documents without touching the database" do
-                  expect(context).to receive(:view).never
-                  expect(docs).to eq([ depeche_mode, new_order ])
+                  expect_no_queries do
+                    expect(docs).to eq([ depeche_mode, new_order ])
+                  end
                 end
               end
             end
@@ -2239,8 +2143,9 @@ describe Mongoid::Contextual::Mongo do
                 let(:limit) { 2 }
 
                 it "returns the correct documents without touching the database" do
-                  expect(context).to receive(:view).never
-                  expect(docs).to eq([ depeche_mode, new_order ])
+                  expect_no_queries do
+                    expect(docs).to eq([ depeche_mode, new_order ])
+                  end
                 end
               end
 
@@ -2248,8 +2153,9 @@ describe Mongoid::Contextual::Mongo do
                 let(:limit) { 3 }
 
                 it "returns the correct documents and touches the database" do
-                  expect(context).to receive(:view).twice.and_call_original
-                  expect(docs).to eq([ depeche_mode, new_order, rolling_stones ])
+                  expect_query(1) do
+                    expect(docs).to eq([ depeche_mode, new_order, rolling_stones ])
+                  end
                 end
               end
             end
@@ -2261,8 +2167,9 @@ describe Mongoid::Contextual::Mongo do
                 let(:limit) { 1 }
 
                 it "returns the correct documents without touching the database" do
-                  expect(context).to receive(:view).never
-                  expect(docs).to eq([ depeche_mode ])
+                  expect_no_queries do
+                    expect(docs).to eq([ depeche_mode ])
+                  end
                 end
               end
 
@@ -2270,8 +2177,9 @@ describe Mongoid::Contextual::Mongo do
                 let(:limit) { 3 }
 
                 it "returns the correct documents and touches the database" do
-                  expect(context).to receive(:view).twice.and_call_original
-                  expect(docs).to eq([ depeche_mode, new_order, rolling_stones ])
+                  expect_query(1) do
+                    expect(docs).to eq([ depeche_mode, new_order, rolling_stones ])
+                  end
                 end
               end
             end
@@ -2448,26 +2356,15 @@ describe Mongoid::Contextual::Mongo do
       end
     end
 
-    context "when the context is cached" do
+    context "when the query cache is enabled" do
+      query_cache_enabled
 
       let(:criteria) do
-        Band.where(name: "Depeche Mode").cache
+        Band.where(name: "Depeche Mode")
       end
 
       let(:context) do
         described_class.new(criteria)
-      end
-
-      context "when the cache is loaded" do
-
-        before do
-          context.to_a
-        end
-
-        it "returns the last document without touching the database" do
-          expect(context).to receive(:view).never
-          expect(context.last).to eq(depeche_mode)
-        end
       end
 
       context "when last method was called before" do
@@ -2477,8 +2374,9 @@ describe Mongoid::Contextual::Mongo do
         end
 
         it "returns the last document without touching the database" do
-          expect(context).to receive(:view).never
-          expect(context.last).to eq(depeche_mode)
+          expect_no_queries do
+            expect(context.last).to eq(depeche_mode)
+          end
         end
       end
     end
@@ -2538,71 +2436,15 @@ describe Mongoid::Contextual::Mongo do
           described_class.new(criteria)
         end
 
-        context "when the whole context is loaded" do
-
-          before do
-            context.to_a
-          end
-
-          context "when all of the documents are cached" do
-
-            let(:criteria) do
-              Band.all.cache
-            end
-
-            context "when requesting all of the documents" do
-
-              let(:docs) do
-                context.last(3)
-              end
-
-              it "returns all of the documents without touching the database" do
-                expect(context).to receive(:view).never
-                expect(docs).to eq([ depeche_mode, new_order, rolling_stones ])
-              end
-            end
-
-            context "when requesting fewer than all of the documents" do
-
-              let(:docs) do
-                context.last(2)
-              end
-
-              it "returns all of the documents without touching the database" do
-                expect(context).to receive(:view).never
-                expect(docs).to eq([ new_order, rolling_stones ])
-              end
-            end
-          end
-
-          context "when only one document is cached" do
-
-            let(:criteria) do
-              Band.where(name: "Depeche Mode").cache
-            end
-
-            context "when requesting one document" do
-
-              let(:docs) do
-                context.last(1)
-              end
-
-              it "returns one document without touching the database" do
-                expect(context).to receive(:view).never
-                expect(docs).to eq([ depeche_mode ])
-              end
-            end
-          end
-        end
-
-        context "when the last method was called before" do
+        context "when query cache is enabled" do
+          query_cache_enabled
 
           let(:context) do
             described_class.new(criteria)
           end
 
           let(:criteria) do
-            Band.all.cache
+            Band.all
           end
 
           before do
@@ -2619,18 +2461,20 @@ describe Mongoid::Contextual::Mongo do
             context "when getting all of the documents" do
               let(:limit) { 3 }
 
-              it "returns all documents without touching the database" do
-                expect(context).to receive(:view).never
-                expect(docs).to eq([ depeche_mode, new_order, rolling_stones ])
+              it "returns all documents without touching the db" do
+                expect_no_queries do
+                  expect(docs).to eq([ depeche_mode, new_order, rolling_stones ])
+                end
               end
             end
 
             context "when getting fewer documents" do
               let(:limit) { 2 }
 
-              it "returns the correct documents without touching the database" do
-                expect(context).to receive(:view).never
-                expect(docs).to eq([ new_order, rolling_stones ])
+              it "returns the correct documents without touching the db" do
+                expect_no_queries do
+                  expect(docs).to eq([ new_order, rolling_stones ])
+                end
               end
             end
           end
@@ -2641,9 +2485,10 @@ describe Mongoid::Contextual::Mongo do
             context "when getting the same number of documents" do
               let(:limit) { 2 }
 
-              it "returns the correct documents without touching the database" do
-                expect(context).to receive(:view).never
-                expect(docs).to eq([ new_order, rolling_stones ])
+              it "returns the correct documents without touching the db" do
+                expect_no_queries do
+                  expect(docs).to eq([ new_order, rolling_stones ])
+                end
               end
             end
 
@@ -2651,8 +2496,9 @@ describe Mongoid::Contextual::Mongo do
               let(:limit) { 3 }
 
               it "returns the correct documents and touches the database" do
-                expect(context).to receive(:view).twice.and_call_original
-                expect(docs).to eq([ depeche_mode, new_order, rolling_stones ])
+                expect_query(1) do
+                  expect(docs).to eq([ depeche_mode, new_order, rolling_stones ])
+                end
               end
             end
           end
@@ -2664,8 +2510,9 @@ describe Mongoid::Contextual::Mongo do
               let(:limit) { 1 }
 
               it "returns the correct documents without touching the database" do
-                expect(context).to receive(:view).never
-                expect(docs).to eq([ rolling_stones ])
+                expect_no_queries do
+                  expect(docs).to eq([ rolling_stones ])
+                end
               end
             end
 
@@ -2673,8 +2520,9 @@ describe Mongoid::Contextual::Mongo do
               let(:limit) { 3 }
 
               it "returns the correct documents and touches the database" do
-                expect(context).to receive(:view).twice.and_call_original
-                expect(docs).to eq([ depeche_mode, new_order, rolling_stones ])
+                expect_query(1) do
+                  expect(docs).to eq([ depeche_mode, new_order, rolling_stones ])
+                end
               end
             end
           end

--- a/spec/mongoid/criteria_spec.rb
+++ b/spec/mongoid/criteria_spec.rb
@@ -495,17 +495,6 @@ describe Mongoid::Criteria do
     end
   end
 
-  describe "#cache" do
-
-    let(:criteria) do
-      Band.where(name: "Depeche Mode")
-    end
-
-    it "sets the cache option to be false" do
-      expect(criteria.cache).to_not be_cached
-    end
-  end
-
   describe "#context" do
 
     context "when the model is embedded" do

--- a/spec/mongoid/criteria_spec.rb
+++ b/spec/mongoid/criteria_spec.rb
@@ -383,10 +383,11 @@ describe Mongoid::Criteria do
       Person.create!
     end
 
-    context "when no eager loading is involved" do
+    context "when the query cache is enabled" do
+      query_cache_enabled
 
       let(:criteria) do
-        Person.all.cache
+        Person.all
       end
 
       before do
@@ -394,17 +395,19 @@ describe Mongoid::Criteria do
       end
 
       it "does not hit the database after first iteration" do
-        expect(criteria.context.view).to receive(:each).never
-        criteria.each do |doc|
-          expect(doc).to eq(person)
+        expect_no_queries do
+          criteria.each do |doc|
+            expect(doc).to eq(person)
+          end
         end
       end
     end
 
     context "when the criteria is eager loading" do
+      query_cache_enabled
 
       let(:criteria) do
-        Person.includes(:posts).cache
+        Person.includes(:posts)
       end
 
       before do
@@ -412,9 +415,10 @@ describe Mongoid::Criteria do
       end
 
       it "does not hit the database after first iteration" do
-        expect(criteria.context.view).to receive(:each).never
-        criteria.each do |doc|
-          expect(doc).to eq(person)
+        expect_no_queries do
+          criteria.each do |doc|
+            expect(doc).to eq(person)
+          end
         end
       end
     end
@@ -497,8 +501,8 @@ describe Mongoid::Criteria do
       Band.where(name: "Depeche Mode")
     end
 
-    it "sets the cache option to true" do
-      expect(criteria.cache).to be_cached
+    it "sets the cache option to be false" do
+      expect(criteria.cache).to_not be_cached
     end
   end
 

--- a/spec/support/macros.rb
+++ b/spec/support/macros.rb
@@ -47,5 +47,13 @@ module Mongoid
         Mongoid::Config.send(:clients=, old_config)
       end
     end
+
+    def query_cache_enabled
+      around do |example|
+        Mongoid::QueryCache.cache do
+          example.run
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
MONGOID-5414

This PR keeps the cache and cached? methods but removes all of their functionality. Do you think it would be better to remove these methods outright and put a warning in 7.5?

The failing distros are driver min, which will stop failing once we merge MONGOID-5429