### PR TITLE
MONGOID-5425 Verify string mongoization into Date, Time, DateTime with time zones

### DIFF
--- a/docs/reference/fields.txt
+++ b/docs/reference/fields.txt
@@ -269,6 +269,12 @@ assignment to a ``Time`` field:
 In the above example, the value was interpreted as the beginning of today in
 local time, because the application was not configured to use UTC times.
 
+.. note::
+
+  When the database contains a string value for a ``Time`` field, Mongoid
+  parses the string value using ``Time.parse`` which considers values without
+  time zones to be in local time.
+
 
 .. _field-type-date:
 
@@ -294,6 +300,13 @@ especially if an application operates with times in different time zones it is
 recommended to explicitly convert ``String``, ``Time`` and ``DateTime``
 objects to ``Date`` objects before assigning the values to fields of type
 ``Date``.
+
+.. note::
+
+  When the database contains a string value for a ``Date`` field, Mongoid
+  parses the string value using ``Time.parse``, discards the time portion of
+  the resulting ``Time`` object and uses the date portion. ``Time.parse``
+  considers values without time zones to be in local time.
 
 
 .. _field-type-date-time:
@@ -363,6 +376,12 @@ If a time zone is specified, it is respected:
     ticket.opened_at = 'Mar 4, 2018 10:00:00 +01:00'
     ticket.opened_at
     # => Sun, 04 Mar 2018 09:00:00 +0000
+
+.. note::
+
+  When the database contains a string value for a ``DateTime`` field, Mongoid
+  parses the string value using ``Time.parse`` which considers values without
+  time zones to be in local time.
 
 
 .. _field-type-regexp:

--- a/spec/mongoid/extensions/string_spec.rb
+++ b/spec/mongoid/extensions/string_spec.rb
@@ -114,6 +114,25 @@ describe Mongoid::Extensions::String do
         it_behaves_like 'maintains precision when mongoized'
       end
 
+      context "when the string is a valid time without time" do
+
+        let(:string) do
+          "2010-11-19"
+        end
+
+        let(:mongoized) do
+          string.__mongoize_time__
+        end
+
+        let(:expected_time) { Time.parse("2010-11-18 15:00:00 +0000").in_time_zone }
+
+        it "converts to the AS time zone" do
+          expect(mongoized.zone).to eq("JST")
+        end
+
+        it_behaves_like 'mongoizes to AS::TimeWithZone'
+      end
+
       context "when the string is an invalid time" do
 
         let(:string) do
@@ -169,6 +188,29 @@ describe Mongoid::Extensions::String do
 
         it_behaves_like 'mongoizes to Time'
         it_behaves_like 'maintains precision when mongoized'
+      end
+
+      context "when the string is a valid time without time" do
+
+        let(:string) do
+          "2010-11-19"
+        end
+
+        let(:mongoized) do
+          string.__mongoize_time__
+        end
+
+        let(:utc_offset) do
+          Time.now.utc_offset
+        end
+
+        let(:expected_time) { Time.parse("2010-11-19 05:00:00 +0000").in_time_zone }
+
+        it 'test operates in multiple time zones' do
+          expect(utc_offset).not_to eq(Time.zone.now.utc_offset)
+        end
+
+        it_behaves_like 'mongoizes to Time'
       end
 
       context "when the string is an invalid time" do

--- a/spec/mongoid/extensions/string_spec.rb
+++ b/spec/mongoid/extensions/string_spec.rb
@@ -204,7 +204,7 @@ describe Mongoid::Extensions::String do
           Time.now.utc_offset
         end
 
-        let(:expected_time) { Time.parse("2010-11-19 05:00:00 +0000").in_time_zone }
+        let(:expected_time) { Time.parse("2010-11-19 00:00:00 +0000") - Time.parse(string).utc_offset }
 
         it 'test operates in multiple time zones' do
           expect(utc_offset).not_to eq(Time.zone.now.utc_offset)

--- a/spec/mongoid/extensions/time_spec.rb
+++ b/spec/mongoid/extensions/time_spec.rb
@@ -301,7 +301,7 @@ describe Mongoid::Extensions::Time do
               Time.now.utc_offset
             end
 
-            let(:expected_time) { Time.parse("2010-11-19 05:00:00 +0000").in_time_zone }
+            let(:expected_time) { Time.parse("2010-11-19 00:00:00 +0000") - Time.parse(string).utc_offset }
 
             it 'test operates in multiple time zones' do
               expect(utc_offset).not_to eq(Time.zone.now.utc_offset)
@@ -458,7 +458,7 @@ describe Mongoid::Extensions::Time do
               Time.now.utc_offset
             end
 
-            let(:expected_time) { Time.parse("2010-11-19 05:00:00 +0000").in_time_zone }
+            let(:expected_time) { Time.parse("2010-11-19 00:00:00 +0000") - Time.parse(string).utc_offset }
 
             it 'test operates in multiple time zones' do
               expect(utc_offset).not_to eq(Time.zone.now.utc_offset)
@@ -639,7 +639,7 @@ describe Mongoid::Extensions::Time do
               Time.now.utc_offset
             end
 
-            let(:expected_time) { Time.parse("2010-11-19 05:00:00 +0000").in_time_zone }
+            let(:expected_time) { Time.parse("2010-11-19 00:00:00 +0000") - Time.parse(string).utc_offset }
 
             it 'test operates in multiple time zones' do
               expect(utc_offset).not_to eq(Time.zone.now.utc_offset)
@@ -792,7 +792,7 @@ describe Mongoid::Extensions::Time do
               Time.now.utc_offset
             end
 
-            let(:expected_time) { Time.parse("2010-11-19 05:00:00 +0000").in_time_zone }
+            let(:expected_time) { Time.parse("2010-11-19 00:00:00 +0000") - Time.parse(string).utc_offset }
 
             it 'test operates in multiple time zones' do
               expect(utc_offset).not_to eq(Time.zone.now.utc_offset)

--- a/spec/mongoid/extensions/time_spec.rb
+++ b/spec/mongoid/extensions/time_spec.rb
@@ -166,113 +166,316 @@ describe Mongoid::Extensions::Time do
 
     context "when the value is a string" do
 
-      context "when using active support's time zone" do
-        include_context 'using AS time zone'
+      context "when use_utc is false" do
+        config_override :use_utc, false
 
-        context "when the string is a valid time with time zone" do
+        context "when using active support's time zone" do
+          include_context 'using AS time zone'
 
-          let(:string) do
-            # JST is +0900
-            "2010-11-19 00:24:49.123457 +1100"
+          context "when the string is a valid time with time zone" do
+
+            let(:string) do
+              # JST is +0900
+              "2010-11-19 00:24:49.123457 +1100"
+            end
+
+            let(:mongoized) do
+              Time.demongoize(string)
+            end
+
+            let(:expected_time) { Time.parse("2010-11-18 13:24:49.123457 +0000").in_time_zone }
+
+            it "converts to the AS time zone" do
+              expect(mongoized.zone).to eq("JST")
+            end
+
+            it_behaves_like 'mongoizes to AS::TimeWithZone'
+            it_behaves_like 'maintains precision when mongoized'
           end
 
-          let(:mongoized) do
-            Time.demongoize(string)
+          context "when the string is a valid time without time zone" do
+
+            let(:string) do
+              "2010-11-19 00:24:49.123457"
+            end
+
+            let(:mongoized) do
+              Time.demongoize(string)
+            end
+
+            let(:expected_time) { Time.parse("2010-11-18 15:24:49.123457 +0000").in_time_zone }
+
+            it "converts to the AS time zone" do
+              expect(mongoized.zone).to eq("JST")
+            end
+
+            it_behaves_like 'mongoizes to AS::TimeWithZone'
+            it_behaves_like 'maintains precision when mongoized'
           end
 
-          let(:expected_time) { Time.parse("2010-11-18 13:24:49.123457 +0000").in_time_zone }
+          context "when the string is a valid time without time" do
 
-          it "converts to the AS time zone" do
-            expect(mongoized.zone).to eq("JST")
+            let(:string) do
+              "2010-11-19"
+            end
+
+            let(:mongoized) do
+              Time.demongoize(string)
+            end
+
+            let(:expected_time) { Time.parse("2010-11-18 15:00:00 +0000").in_time_zone }
+
+            it "converts to the AS time zone" do
+              expect(mongoized.zone).to eq("JST")
+            end
+
+            it_behaves_like 'mongoizes to AS::TimeWithZone'
           end
 
-          it_behaves_like 'mongoizes to AS::TimeWithZone'
-          it_behaves_like 'maintains precision when mongoized'
+          context "when the string is an invalid time" do
+
+            let(:string) do
+              "bogus"
+            end
+
+            it "returns nil" do
+              expect(Time.demongoize(string)).to be_nil
+            end
+          end
         end
 
-        context "when the string is a valid time without time zone" do
+        context "when not using active support's time zone" do
+          include_context 'not using AS time zone'
 
-          let(:string) do
-            "2010-11-19 00:24:49.123457"
+          context "when the string is a valid time with time zone" do
+
+            let(:string) do
+              "2010-11-19 00:24:49.123457 +1100"
+            end
+
+            let(:expected_time) { Time.parse("2010-11-18 13:24:49.123457 +0000").in_time_zone }
+
+            let(:mongoized) do
+              Time.demongoize(string)
+            end
+
+            it_behaves_like 'mongoizes to Time'
+            it_behaves_like 'maintains precision when mongoized'
           end
 
-          let(:mongoized) do
-            Time.demongoize(string)
+          context "when the string is a valid time without time zone" do
+
+            let(:string) do
+              "2010-11-19 00:24:49.123457"
+            end
+
+            let(:utc_offset) do
+              Time.now.utc_offset
+            end
+
+            let(:expected_time) { Time.parse("2010-11-19 00:24:49.123457 +0000") - Time.parse(string).utc_offset }
+
+            let(:mongoized) do
+              Time.demongoize(string)
+            end
+
+            it 'test operates in multiple time zones' do
+              expect(utc_offset).not_to eq(Time.zone.now.utc_offset)
+            end
+
+            it_behaves_like 'mongoizes to Time'
+            it_behaves_like 'maintains precision when mongoized'
           end
 
-          let(:expected_time) { Time.parse("2010-11-18 15:24:49.123457 +0000").in_time_zone }
+          context "when the string is a valid time without time" do
 
-          it "converts to the AS time zone" do
-            expect(mongoized.zone).to eq("JST")
+            let(:string) do
+              "2010-11-19"
+            end
+
+            let(:mongoized) do
+              Time.demongoize(string)
+            end
+
+            let(:utc_offset) do
+              Time.now.utc_offset
+            end
+
+            let(:expected_time) { Time.parse("2010-11-19 05:00:00 +0000").in_time_zone }
+
+            it 'test operates in multiple time zones' do
+              expect(utc_offset).not_to eq(Time.zone.now.utc_offset)
+            end
+
+            it_behaves_like 'mongoizes to Time'
           end
 
-          it_behaves_like 'mongoizes to AS::TimeWithZone'
-          it_behaves_like 'maintains precision when mongoized'
-        end
+          context "when the string is an invalid time" do
 
-        context "when the string is an invalid time" do
+            let(:string) do
+              "bogus"
+            end
 
-          let(:string) do
-            "bogus"
-          end
-
-          it "returns nil" do
-            expect(Time.demongoize(string)).to be_nil
+            it "returns nil" do
+              expect(Time.demongoize(string)).to be_nil
+            end
           end
         end
       end
 
-      context "when not using active support's time zone" do
-        include_context 'not using AS time zone'
+      context "when use_utc is true" do
+        config_override :use_utc, true
 
-        context "when the string is a valid time with time zone" do
+        context "when using active support's time zone" do
+          include_context 'using AS time zone'
 
-          let(:string) do
-            "2010-11-19 00:24:49.123457 +1100"
+          context "when the string is a valid time with time zone" do
+
+            let(:string) do
+              # JST is +0900
+              "2010-11-19 00:24:49.123457 +1100"
+            end
+
+            let(:mongoized) do
+              Time.demongoize(string)
+            end
+
+            let(:expected_time) { Time.parse("2010-11-18 13:24:49.123457 +0000").in_time_zone }
+
+            it "converts to UTC" do
+              expect(mongoized.zone).to eq("UTC")
+            end
+
+            it_behaves_like 'mongoizes to AS::TimeWithZone'
+            it_behaves_like 'maintains precision when mongoized'
           end
 
-          let(:expected_time) { Time.parse("2010-11-18 13:24:49.123457 +0000").in_time_zone }
+          context "when the string is a valid time without time zone" do
 
-          let(:mongoized) do
-            Time.demongoize(string)
+            let(:string) do
+              "2010-11-19 00:24:49.123457"
+            end
+
+            let(:mongoized) do
+              Time.demongoize(string)
+            end
+
+            let(:expected_time) { Time.parse("2010-11-18 15:24:49.123457 +0000").in_time_zone }
+
+            it "converts to UTC" do
+              expect(mongoized.zone).to eq("UTC")
+            end
+
+            it_behaves_like 'mongoizes to AS::TimeWithZone'
+            it_behaves_like 'maintains precision when mongoized'
           end
 
-          it_behaves_like 'mongoizes to Time'
-          it_behaves_like 'maintains precision when mongoized'
+          context "when the string is a valid time without time" do
+
+            let(:string) do
+              "2010-11-19"
+            end
+
+            let(:mongoized) do
+              Time.demongoize(string)
+            end
+
+            let(:expected_time) { Time.parse("2010-11-18 15:00:00 +0000").in_time_zone }
+
+            it "converts to UTC" do
+              expect(mongoized.zone).to eq("UTC")
+            end
+
+            it_behaves_like 'mongoizes to AS::TimeWithZone'
+          end
+
+          context "when the string is an invalid time" do
+
+            let(:string) do
+              "bogus"
+            end
+
+            it "returns nil" do
+              expect(Time.demongoize(string)).to be_nil
+            end
+          end
         end
 
-        context "when the string is a valid time without time zone" do
+        context "when not using active support's time zone" do
+          include_context 'not using AS time zone'
 
-          let(:string) do
-            "2010-11-19 00:24:49.123457"
+          context "when the string is a valid time with time zone" do
+
+            let(:string) do
+              "2010-11-19 00:24:49.123457 +1100"
+            end
+
+            let(:expected_time) { Time.parse("2010-11-18 13:24:49.123457 +0000").in_time_zone }
+
+            let(:mongoized) do
+              Time.demongoize(string)
+            end
+
+            it_behaves_like 'mongoizes to Time'
+            it_behaves_like 'maintains precision when mongoized'
           end
 
-          let(:utc_offset) do
-            Time.now.utc_offset
+          context "when the string is a valid time without time zone" do
+
+            let(:string) do
+              "2010-11-19 00:24:49.123457"
+            end
+
+            let(:utc_offset) do
+              Time.now.utc_offset
+            end
+
+            let(:expected_time) { Time.parse("2010-11-19 00:24:49.123457 +0000") - Time.parse(string).utc_offset }
+
+            let(:mongoized) do
+              Time.demongoize(string)
+            end
+
+            it 'test operates in multiple time zones' do
+              expect(utc_offset).not_to eq(Time.zone.now.utc_offset)
+            end
+
+            it_behaves_like 'mongoizes to Time'
+            it_behaves_like 'maintains precision when mongoized'
           end
 
-          let(:expected_time) { Time.parse("2010-11-19 00:24:49.123457 +0000") - Time.parse(string).utc_offset }
+          context "when the string is a valid time without time" do
 
-          let(:mongoized) do
-            Time.demongoize(string)
+            let(:string) do
+              "2010-11-19"
+            end
+
+            let(:mongoized) do
+              Time.demongoize(string)
+            end
+
+            let(:utc_offset) do
+              Time.now.utc_offset
+            end
+
+            let(:expected_time) { Time.parse("2010-11-19 05:00:00 +0000").in_time_zone }
+
+            it 'test operates in multiple time zones' do
+              expect(utc_offset).not_to eq(Time.zone.now.utc_offset)
+            end
+
+            it_behaves_like 'mongoizes to Time'
           end
 
-          it 'test operates in multiple time zones' do
-            expect(utc_offset).not_to eq(Time.zone.now.utc_offset)
-          end
+          context "when the string is an invalid time" do
 
-          it_behaves_like 'mongoizes to Time'
-          it_behaves_like 'maintains precision when mongoized'
-        end
+            let(:string) do
+              "bogus"
+            end
 
-        context "when the string is an invalid time" do
-
-          let(:string) do
-            "bogus"
-          end
-
-          it "returns nil" do
-            expect(Time.demongoize(string)).to be_nil
+            it "returns nil" do
+              expect(Time.demongoize(string)).to be_nil
+            end
           end
         end
       end
@@ -303,63 +506,310 @@ describe Mongoid::Extensions::Time do
       end
     end
 
-    context "when given a string" do
+    context "when the value is a string" do
 
-      context "when the string is a valid time" do
+      context "when use_utc is false" do
+        config_override :use_utc, false
 
-        it "converts to a utc time" do
-          expect(Time.mongoize(time.to_s).utc_offset).to eq(0)
-        end
+        context "when using active support's time zone" do
+          include_context 'using AS time zone'
 
-        it "serializes with time parsing" do
-          expect(Time.mongoize(time.to_s)).to eq(Time.parse(time.to_s).utc)
-        end
+          context "when the string is a valid time with time zone" do
 
-        it "returns a local date from the string" do
-          expect(Time.mongoize(time.to_s)).to eq(
-            Time.local(time.year, time.month, time.day, time.hour, time.min, time.sec)
-          )
-        end
-      end
+            let(:string) do
+              # JST is +0900
+              "2010-11-19 00:24:49.123457 +1100"
+            end
 
-      context "when the string is an invalid time" do
+            let(:mongoized) do
+              Time.mongoize(string)
+            end
 
-        let(:mongoized) do
-          Time.mongoize("time")
-        end
+            let(:expected_time) { Time.parse("2010-11-18 13:24:49.123457 +0000").in_time_zone }
 
-        it "returns nil" do
-          expect(mongoized).to be_nil
-        end
-      end
+            it "converts to UTC" do
+              expect(mongoized.zone).to eq("UTC")
+            end
 
-      context "when using the ActiveSupport time zone" do
-        config_override :use_activesupport_time_zone, true
+            it_behaves_like 'maintains precision when mongoized'
+          end
 
-        before do
-          # if this is actually your time zone, the following tests are useless
-          Time.zone = "Stockholm"
-        end
+          context "when the string is a valid time without time zone" do
 
-        after do
-          Time.zone = nil
-        end
+            let(:string) do
+              "2010-11-19 00:24:49.123457"
+            end
 
-        context "when the local time is not observing daylight saving" do
+            let(:mongoized) do
+              Time.mongoize(string)
+            end
 
-          it "returns the local time" do
-            expect(Time.mongoize('2010-11-19 5:00:00')).to eq(
-              Time.utc(2010, 11, 19, 4)
-            )
+            let(:expected_time) { Time.parse("2010-11-18 15:24:49.123457 +0000").in_time_zone }
+
+            it "converts to UTC" do
+              expect(mongoized.zone).to eq("UTC")
+            end
+
+            it_behaves_like 'maintains precision when mongoized'
+          end
+
+          context "when the string is a valid time without time" do
+
+            let(:string) do
+              "2010-11-19"
+            end
+
+            let(:mongoized) do
+              Time.mongoize(string)
+            end
+
+            let(:expected_time) { Time.parse("2010-11-18 15:00:00 +0000").in_time_zone }
+
+            it "converts to UTC" do
+              expect(mongoized.zone).to eq("UTC")
+            end
+          end
+
+          context "when the string is an invalid time" do
+
+            let(:string) do
+              "bogus"
+            end
+
+            it "returns nil" do
+              expect(Time.mongoize(string)).to be_nil
+            end
           end
         end
 
-        context "when the local time is observing daylight saving" do
+        context "when not using active support's time zone" do
+          include_context 'not using AS time zone'
 
-          it "returns the local time" do
-            expect(Time.mongoize('2010-9-19 5:00:00')).to eq(
-              Time.utc(2010, 9, 19, 3)
-            )
+          context "when the string is a valid time with time zone" do
+
+            let(:string) do
+              "2010-11-19 00:24:49.123457 +1100"
+            end
+
+            let(:expected_time) { Time.parse("2010-11-18 13:24:49.123457 +0000").in_time_zone }
+
+            let(:mongoized) do
+              Time.mongoize(string)
+            end
+
+            it_behaves_like 'mongoizes to Time'
+            it_behaves_like 'maintains precision when mongoized'
+          end
+
+          context "when the string is a valid time without time zone" do
+
+            let(:string) do
+              "2010-11-19 00:24:49.123457"
+            end
+
+            let(:utc_offset) do
+              Time.now.utc_offset
+            end
+
+            let(:expected_time) { Time.parse("2010-11-19 00:24:49.123457 +0000") - Time.parse(string).utc_offset }
+
+            let(:mongoized) do
+              Time.mongoize(string)
+            end
+
+            it 'test operates in multiple time zones' do
+              expect(utc_offset).not_to eq(Time.zone.now.utc_offset)
+            end
+
+            it_behaves_like 'mongoizes to Time'
+            it_behaves_like 'maintains precision when mongoized'
+          end
+
+          context "when the string is a valid time without time" do
+
+            let(:string) do
+              "2010-11-19"
+            end
+
+            let(:mongoized) do
+              Time.mongoize(string)
+            end
+
+            let(:utc_offset) do
+              Time.now.utc_offset
+            end
+
+            let(:expected_time) { Time.parse("2010-11-19 05:00:00 +0000").in_time_zone }
+
+            it 'test operates in multiple time zones' do
+              expect(utc_offset).not_to eq(Time.zone.now.utc_offset)
+            end
+
+            it_behaves_like 'mongoizes to Time'
+          end
+
+          context "when the string is an invalid time" do
+
+            let(:string) do
+              "bogus"
+            end
+
+            it "returns nil" do
+              expect(Time.mongoize(string)).to be_nil
+            end
+          end
+        end
+      end
+
+      context "when use_utc is true" do
+        config_override :use_utc, true
+
+        context "when using active support's time zone" do
+          include_context 'using AS time zone'
+
+          context "when the string is a valid time with time zone" do
+
+            let(:string) do
+              # JST is +0900
+              "2010-11-19 00:24:49.123457 +1100"
+            end
+
+            let(:mongoized) do
+              Time.mongoize(string)
+            end
+
+            let(:expected_time) { Time.parse("2010-11-18 13:24:49.123457 +0000").in_time_zone }
+
+            it "converts to UTC" do
+              expect(mongoized.zone).to eq("UTC")
+            end
+
+            it_behaves_like 'maintains precision when mongoized'
+          end
+
+          context "when the string is a valid time without time zone" do
+
+            let(:string) do
+              "2010-11-19 00:24:49.123457"
+            end
+
+            let(:mongoized) do
+              Time.mongoize(string)
+            end
+
+            let(:expected_time) { Time.parse("2010-11-18 15:24:49.123457 +0000").in_time_zone }
+
+            it "converts to UTC" do
+              expect(mongoized.zone).to eq("UTC")
+            end
+
+            it_behaves_like 'maintains precision when mongoized'
+          end
+
+          context "when the string is a valid time without time" do
+
+            let(:string) do
+              "2010-11-19"
+            end
+
+            let(:mongoized) do
+              Time.mongoize(string)
+            end
+
+            let(:expected_time) { Time.parse("2010-11-18 15:00:00 +0000").in_time_zone }
+
+            it "converts to UTC" do
+              expect(mongoized.zone).to eq("UTC")
+            end
+          end
+
+          context "when the string is an invalid time" do
+
+            let(:string) do
+              "bogus"
+            end
+
+            it "returns nil" do
+              expect(Time.mongoize(string)).to be_nil
+            end
+          end
+        end
+
+        context "when not using active support's time zone" do
+          include_context 'not using AS time zone'
+
+          context "when the string is a valid time with time zone" do
+
+            let(:string) do
+              "2010-11-19 00:24:49.123457 +1100"
+            end
+
+            let(:expected_time) { Time.parse("2010-11-18 13:24:49.123457 +0000").in_time_zone }
+
+            let(:mongoized) do
+              Time.mongoize(string)
+            end
+
+            it_behaves_like 'mongoizes to Time'
+            it_behaves_like 'maintains precision when mongoized'
+          end
+
+          context "when the string is a valid time without time zone" do
+
+            let(:string) do
+              "2010-11-19 00:24:49.123457"
+            end
+
+            let(:utc_offset) do
+              Time.now.utc_offset
+            end
+
+            let(:expected_time) { Time.parse("2010-11-19 00:24:49.123457 +0000") - Time.parse(string).utc_offset }
+
+            let(:mongoized) do
+              Time.mongoize(string)
+            end
+
+            it 'test operates in multiple time zones' do
+              expect(utc_offset).not_to eq(Time.zone.now.utc_offset)
+            end
+
+            it_behaves_like 'mongoizes to Time'
+            it_behaves_like 'maintains precision when mongoized'
+          end
+
+          context "when the string is a valid time without time" do
+
+            let(:string) do
+              "2010-11-19"
+            end
+
+            let(:mongoized) do
+              Time.mongoize(string)
+            end
+
+            let(:utc_offset) do
+              Time.now.utc_offset
+            end
+
+            let(:expected_time) { Time.parse("2010-11-19 05:00:00 +0000").in_time_zone }
+
+            it 'test operates in multiple time zones' do
+              expect(utc_offset).not_to eq(Time.zone.now.utc_offset)
+            end
+
+            it_behaves_like 'mongoizes to Time'
+          end
+
+          context "when the string is an invalid time" do
+
+            let(:string) do
+              "bogus"
+            end
+
+            it "returns nil" do
+              expect(Time.mongoize(string)).to be_nil
+            end
           end
         end
       end


### PR DESCRIPTION
MONGOID-5425
Some things to note:
- Time always mongoizes to utc. It seems like we only store dates in the db as UTC
- I didn't write expansive DateTime tests because DateTime just calls the Time.(de)mongoize methods
- I didn't write Date tests, because as far as I can tell Dates aren't affected by time zones: 
```
irb(main):005:0> Date.parse("2022-07-11 14:03:42 +1500")
=> Mon, 11 Jul 2022
irb(main):006:0> Date.parse("2022-07-11 14:03:42 -1500")
=> Mon, 11 Jul 2022
```