### PR TITLE
MONGOID-5421: Mongoid::Contextual::Aggregable::Memory should do type coercion for String and Decimal128

### DIFF
--- a/docs/release-notes/mongoid-8.0.txt
+++ b/docs/release-notes/mongoid-8.0.txt
@@ -387,6 +387,54 @@ Mongoid 7 behavior:
   end
 
 
+``max``, ``min``, ``avg``, ``sum`` Aggregations On Embedded Documents
+---------------------------------------------------------------------
+
+Mongoid 8.0 converts fields of embedded documents that are being numerically
+aggregated (that is, aggregated using the ``max``, ``min``, ``avg`` and ``sum``
+methods) to numbers, if possible, prior to performing the aggregation.
+Any values which are not numeric are ignored.
+
+This conversion permits numeric aggregations over ``BigDecimal`` values stored
+in the database as strings.
+
+Mongoid 8.0 behavior:
+
+.. code-block:: ruby
+
+  class Cat
+    include Mongoid::Document
+
+    field :age, type: Integer
+
+    embeds_many :kittens
+  end
+
+  class Kitten
+    include Mongoid::Document
+
+    embedded_in :cat
+
+    field :age, type: Integer
+  end
+
+  Cat.create!(age: 12)
+  Cat.create!(age: '11')
+  Cat.create!(age: 'hello')
+
+  Cat.sum(:age)
+  # => 23
+
+  cat = Cat.create!
+
+  cat.kittens.create!(age: 12)
+  cat.kittens.create!(age: '11')
+  cat.kittens.create!(age: 'hello')
+
+  cat.kittens.sum(:age)
+  # => 23
+
+
 ``#pluck`` on Embedded Criteria Returns ``nil`` Values
 ------------------------------------------------------
 

--- a/lib/mongoid/extensions/decimal128.rb
+++ b/lib/mongoid/extensions/decimal128.rb
@@ -14,6 +14,16 @@ module Mongoid
         self
       end
 
+      # Is the BSON::Decimal128 a number?
+      #
+      # @example Is the object a number?.
+      #   object.numeric?
+      #
+      # @return [ true ] Always true.
+      def numeric?
+        true
+      end
+
       module ClassMethods
 
         # Evolve the object into a mongo-friendly value to query with.

--- a/spec/mongoid/contextual/aggregable/memory_spec.rb
+++ b/spec/mongoid/contextual/aggregable/memory_spec.rb
@@ -138,8 +138,11 @@ describe Mongoid::Contextual::Aggregable::Memory do
 
       let!(:bands) do
         [ Band.create!(name: "The Flaming Lips", mojo: 7.7),
+          Band.create!(name: "Spinal Tap", mojo: BigDecimal('11')),
           Band.create!(name: "Spirit of the Beehive", mojo: 10),
-          Band.create!(name: "Justin Bieber", mojo: nil) ]
+          Band.create!(name: "Burning Spear", mojo: '7.3'),
+          Band.create!(name: "Justin Bieber", mojo: nil),
+          Band.create!(name: "Alex G", mojo: "string") ]
       end
 
       let(:criteria) do
@@ -153,18 +156,21 @@ describe Mongoid::Contextual::Aggregable::Memory do
       end
 
       it "coerces types to calculate avg" do
-        expect(avg).to eq(8.85)
+        expect(avg).to eq(9.0)
       end
 
       it "database only averages Numeric types" do
-        expect(Band.all.avg(:mojo)).to be_within(0.000001).of(8.85)
+        expect(Band.all.avg(:mojo).to_big_decimal).to be_within(0.000001).of(9.566666)
       end
     end
 
     context "when there no numeric values" do
 
       let!(:bands) do
-        [ Band.create!(name: "Justin Bieber", mojo: nil) ]
+        [ Band.create!(name: "Sheena Easton", mojo: 9..5),
+          Band.create!(name: "Justin Bieber", mojo: nil),
+          Band.create!(name: "The Beatles", mojo: Date.yesterday),
+          Band.create!(name: "Alex G", mojo: "string") ]
       end
 
       let(:criteria) do
@@ -232,8 +238,11 @@ describe Mongoid::Contextual::Aggregable::Memory do
 
         let!(:bands) do
           [ Band.create!(name: "The Flaming Lips", mojo: 7.7),
+            Band.create!(name: "Spinal Tap", mojo: BigDecimal('11')),
             Band.create!(name: "Spirit of the Beehive", mojo: 10),
-            Band.create!(name: "Justin Bieber", mojo: nil) ]
+            Band.create!(name: "Burning Spear", mojo: '7.3'),
+            Band.create!(name: "Justin Bieber", mojo: nil),
+            Band.create!(name: "Alex G", mojo: "string") ]
         end
 
         let(:criteria) do
@@ -247,15 +256,18 @@ describe Mongoid::Contextual::Aggregable::Memory do
         end
 
         it "coerces types to calculate max" do
-          expect(max).to eq 10
-          expect(max).to be_a Integer
+          expect(max).to eq 11
+          expect(max).to be_a BigDecimal
         end
       end
 
       context "when there no numeric values" do
 
         let!(:bands) do
-          [ Band.create!(name: "Justin Bieber", mojo: nil) ]
+          [ Band.create!(name: "Sheena Easton", mojo: 9..5),
+            Band.create!(name: "Justin Bieber", mojo: nil),
+            Band.create!(name: "The Beatles", mojo: Date.yesterday),
+            Band.create!(name: "Alex G", mojo: "string") ]
         end
 
         let(:criteria) do
@@ -333,8 +345,11 @@ describe Mongoid::Contextual::Aggregable::Memory do
 
         let!(:bands) do
           [ Band.create!(name: "The Flaming Lips", mojo: 7.7),
+            Band.create!(name: "Spinal Tap", mojo: BigDecimal('11')),
             Band.create!(name: "Spirit of the Beehive", mojo: 10),
-            Band.create!(name: "Justin Bieber", mojo: nil) ]
+            Band.create!(name: "Burning Spear", mojo: '7.3'),
+            Band.create!(name: "Justin Bieber", mojo: nil),
+            Band.create!(name: "Alex G", mojo: "string") ]
         end
 
         let(:criteria) do
@@ -348,7 +363,7 @@ describe Mongoid::Contextual::Aggregable::Memory do
         end
 
         it "coerces types to calculate min" do
-          expect(min).to eq 7.7
+          expect(min).to eq 7.3
           expect(min).to be_a Float
         end
       end
@@ -356,7 +371,10 @@ describe Mongoid::Contextual::Aggregable::Memory do
       context "when there no numeric values" do
 
         let!(:bands) do
-          [ Band.create!(name: "Justin Bieber", mojo: nil) ]
+          [ Band.create!(name: "Sheena Easton", mojo: 9..5),
+            Band.create!(name: "Justin Bieber", mojo: nil),
+            Band.create!(name: "The Beatles", mojo: Date.yesterday),
+            Band.create!(name: "Alex G", mojo: "string") ]
         end
 
         let(:criteria) do
@@ -509,8 +527,13 @@ describe Mongoid::Contextual::Aggregable::Memory do
 
         let!(:bands) do
           [ Band.create!(name: "The Flaming Lips", mojo: 7.7),
+            Band.create!(name: "Spinal Tap", mojo: BigDecimal('11')),
             Band.create!(name: "Spirit of the Beehive", mojo: 10),
-            Band.create!(name: "Justin Bieber", mojo: nil) ]
+            Band.create!(name: "Burning Spear", mojo: '7.3'),
+            Band.create!(name: "Justin Bieber", mojo: nil),
+            Band.create!(name: "Sheena Easton", mojo: 9..5),
+            Band.create!(name: "The Beatles", mojo: Date.yesterday),
+            Band.create!(name: "Alex G", mojo: "string") ]
         end
 
         let(:criteria) do
@@ -524,19 +547,22 @@ describe Mongoid::Contextual::Aggregable::Memory do
         end
 
         it "coerces types to calculate sum" do
-          expect(sum).to eq 17.7
-          expect(sum).to be_a Float
+          expect(sum).to eq 36
+          expect(sum).to be_a BigDecimal
         end
 
         it "database only sums Float and Integer types" do
-          expect(Band.all.sum(:mojo)).to be_within(Float::EPSILON).of(17.7)
+          expect(Band.all.sum(:mojo).to_big_decimal).to be_within(Float::EPSILON).of(28.7)
         end
       end
 
       context "when there no numeric values" do
 
         let!(:bands) do
-          [ Band.create!(name: "Justin Bieber", mojo: nil) ]
+          [ Band.create!(name: "Sheena Easton", mojo: 9..5),
+            Band.create!(name: "Justin Bieber", mojo: nil),
+            Band.create!(name: "The Beatles", mojo: Date.yesterday),
+            Band.create!(name: "Alex G", mojo: "string") ]
         end
 
         let(:criteria) do

--- a/spec/mongoid/contextual/aggregable/memory_table.yml
+++ b/spec/mongoid/contextual/aggregable/memory_table.yml
@@ -25,6 +25,11 @@ sets:
         sum: !ruby/object:BigDecimal 18:0.602e4
         min: !ruby/object:BigDecimal 18:-0.3394e4
         max: !ruby/object:BigDecimal 18:0.4553e4
+      object:
+        avg: 752.5
+        sum: 6020
+        min: -3394
+        max: 4553
 
   floats:
     values:
@@ -48,6 +53,11 @@ sets:
         sum: !ruby/object:BigDecimal 27:-0.208666345e3
         min: !ruby/object:BigDecimal 18:-0.974332e3
         max: !ruby/object:BigDecimal 18:0.53253323e3
+      object:
+        avg: -52.16658625
+        sum: -208.666345
+        min: -974.332
+        max: 532.53323
 
   mixed:
     values:
@@ -86,3 +96,8 @@ sets:
         sum: !ruby/object:BigDecimal 27:-0.1047842116e6
         min: !ruby/object:BigDecimal 18:-0.97676e5
         max: !ruby/object:BigDecimal 18:0.745596e4
+      object:
+        avg: !ruby/object:BigDecimal 27:-0.7484586540e4
+        sum: !ruby/object:BigDecimal 27:-0.1047842116e6
+        min: !ruby/object:BigDecimal 18:-0.97676e5
+        max: 7455.96

--- a/spec/mongoid/contextual/aggregable/memory_table_spec.rb
+++ b/spec/mongoid/contextual/aggregable/memory_table_spec.rb
@@ -31,7 +31,8 @@ describe Mongoid::Contextual::Aggregable::Memory do
 
       { integer: :views,
         float: :rating,
-        big_decimal: :sales }.each do |type, field|
+        big_decimal: :sales,
+        object: :mojo }.each do |type, field|
 
         %i[sum avg min max].each do |method|
           context "#{type.to_s.camelize} field :#{method}" do


### PR DESCRIPTION
Replaces https://github.com/mongodb/mongoid/pull/5038

Not really sure this is needed at this point but putting here for review.