### PR TITLE
MONGOID-5414 Remove caching on Mongoid::Contextual::Mongo#length

### DIFF
--- a/lib/mongoid/contextual/mongo.rb
+++ b/lib/mongoid/contextual/mongo.rb
@@ -324,7 +324,7 @@ module Mongoid
       #
       # @return [ Integer ] The number of documents.
       def length
-        @length ||= self.count
+        self.count
       end
       alias :size :length
 

--- a/spec/mongoid/contextual/mongo_spec.rb
+++ b/spec/mongoid/contextual/mongo_spec.rb
@@ -2587,12 +2587,7 @@ describe Mongoid::Contextual::Mongo do
         end
 
         context "when calling more than once with different limits" do
-          around do |ex|
-            temp = Mongo.broken_view_options
-            Mongo.broken_view_options = false
-            ex.run
-            Mongo.broken_view_options = temp
-          end
+          driver_config_override :broken_view_options, false
 
           it "does not cache the value" do
             expect(context.limit(1).send(method)).to eq(1)
@@ -2639,12 +2634,7 @@ describe Mongoid::Contextual::Mongo do
         end
 
         context "when calling more than once with different skips" do
-          around do |ex|
-            temp = Mongo.broken_view_options
-            Mongo.broken_view_options = false
-            ex.run
-            Mongo.broken_view_options = temp
-          end
+          driver_config_override :broken_view_options, false
 
           it "does not cache the value" do
             expect(context.skip(0).send(method)).to eq(1)

--- a/spec/mongoid/contextual/mongo_spec.rb
+++ b/spec/mongoid/contextual/mongo_spec.rb
@@ -2586,10 +2586,17 @@ describe Mongoid::Contextual::Mongo do
           expect(context.send(method)).to eq(2)
         end
 
-        context "when calling more than once" do
-          it "returns the cached value for subsequent calls" do
-            expect(context.view).to receive(:count_documents).once.and_return(2)
-            2.times { expect(context.send(method)).to eq(2) }
+        context "when calling more than once with different limits" do
+          around do |ex|
+            temp = Mongo.broken_view_options
+            Mongo.broken_view_options = false
+            ex.run
+            Mongo.broken_view_options = temp
+          end
+
+          it "does not cache the value" do
+            expect(context.limit(1).send(method)).to eq(1)
+            expect(context.limit(2).send(method)).to eq(2)
           end
         end
 
@@ -2631,10 +2638,17 @@ describe Mongoid::Contextual::Mongo do
           expect(context.send(method)).to eq(1)
         end
 
-        context "when calling more than once" do
-          it "returns the cached value for subsequent calls" do
-            expect(context.view).to receive(:count_documents).once.and_return(1)
-            2.times { expect(context.send(method)).to eq(1) }
+        context "when calling more than once with different skips" do
+          around do |ex|
+            temp = Mongo.broken_view_options
+            Mongo.broken_view_options = false
+            ex.run
+            Mongo.broken_view_options = temp
+          end
+
+          it "does not cache the value" do
+            expect(context.skip(0).send(method)).to eq(1)
+            expect(context.skip(1).send(method)).to eq(0)
           end
         end
 

--- a/spec/support/macros.rb
+++ b/spec/support/macros.rb
@@ -39,6 +39,28 @@ module Mongoid
       end
     end
 
+    def driver_config_override(key, value)
+      around do |example|
+        existing = Mongo.send(key)
+
+        Mongo.send("#{key}=", value)
+
+        example.run
+
+        Mongo.send("#{key}=", existing)
+      end
+    end
+
+    def with_driver_config_values(key, *values, &block)
+      values.each do |value|
+        context "when #{key} is #{value}" do
+          driver_config_override key, value
+
+          class_exec(value, &block)
+        end
+      end
+    end
+
     def restore_config_clients
       around do |example|
         # Duplicate the config because some tests mutate it.


### PR DESCRIPTION
Originally this method was cached because, before the view options were fixed to be passed into the count method, it was impossible to pass options into length. Now that it is possible to pass options into length, the following case would cause stale results to be returned:
```
crit = Band.all
crit.limit(5).length 
# => 5
crit.limit(3).length
# => 5
```
This is incorrect, and so I removed the caching from this method. 

The caching would get delegated to the query cache, but it seems like no caching is done on agg pipelines, which is what appears to be performed underneath the call to count.