### PR TITLE
MONGOID-5415 Docs: Add code documentation guidelines

### DIFF
--- a/docs/contributing.txt
+++ b/docs/contributing.txt
@@ -1,0 +1,12 @@
+.. _contributing:
+
+************
+Contributing
+************
+
+.. default-domain:: mongodb
+
+.. toctree::
+  :titlesonly:
+
+  contributing/code-documentation

--- a/docs/contributing/code-documentation.txt
+++ b/docs/contributing/code-documentation.txt
@@ -48,8 +48,11 @@ Structure
     # @return [ Tiger ] The transmogrified result.
     def transmogrify(person)
 
-- **Private Methods:** Private methods do not require documentation,
-  however you may add it for clarification.
+- **Private Methods:** Private methods should be documented unless they are
+  so brief and straightforward that it is obvious what they do. Note that,
+  for example, a method may be brief and straightforward but the type of
+  its parameter may not be obvious, in which case the parameter needs to
+  be appropriately documented.
 
   .. code-block:: ruby
 
@@ -71,6 +74,10 @@ Structure
 - **API Private:** Classes and public methods which are not intended for
   external usage should be marked ``@api private``. This macro does not
   require a comment.
+  
+  Note that, because Mongoid's modules are mixed into application classes,
+  ``private`` visibility of a method does not necessarily indicate its
+  status as an API private method.
 
   .. code-block:: ruby
 
@@ -79,7 +86,7 @@ Structure
     # @api private
     def dont_call_me_from_outside
 
-- **Deprecation:** Use the ``@deprecated`` macro to indicated deprecated
+- **Deprecation:** Use the ``@deprecated`` macro to indicate deprecated
   functionality. This macro does not require a comment.
 
   .. code-block:: ruby
@@ -166,7 +173,8 @@ Type Declaration
     # @return [ Array<Symbol, Integer, Integer> ] A 3-member Array whose first
     #   element is a Symbol, and whose second and third elements are Integers.
 
-- **Array:** Use pipe ``|`` on the top level if the inner types cannot be mixed within the Array.
+- **Array:** Use pipe ``|`` on the top level if the inner types cannot be
+  mixed within the Array.
 
   .. code-block:: ruby
 
@@ -201,7 +209,7 @@ Type Declaration
     # @param [ TrueClass | FalseClass | NilClass ] bool A boolean or nil value.
     # @param [ Boolean ] bool A boolean value.
 
-- **Return Self:** Specify return value ``self`` where possible.
+- **Return Self:** Specify return value ``self`` where a method returns ``self``.
 
   .. code-block:: ruby
 
@@ -245,8 +253,8 @@ Type Declaration
 
     # @param [ [ String | Symbol ]... ] *fields A splat of mixed Symbols and Strings.
 
-- **Keyword Arguments:** Following YARD conventions, use ``@param`` for keyword arguments,
-  and specify keyword argument names as symbols.
+- **Keyword Arguments:** Following YARD conventions, use ``@param`` for keyword
+  arguments, and specify keyword argument names as symbols.
 
   .. code-block:: ruby
 
@@ -256,7 +264,8 @@ Type Declaration
     def search(query, exact_match: false, results_per_page: 10)
 
 - **Hash Options:** Define hash key-value options with ``@option`` macro
-  immediately following the Hash ``@param``. Note ``@option`` parameter names are symbols.
+  immediately following the Hash ``@param``. Note ``@option`` parameter names
+  are symbols.
 
   .. code-block:: ruby
 
@@ -265,10 +274,11 @@ Type Declaration
     # @option opts [ Integer ] :limit An Integer denoting the limit.
     def buy_groceries(opts = {})
 
-- **Double Splats:** Use double-star ``**`` in the parameter name to denote a keyword arg splat
-  (double splat).  Note that type does not need declared on the double-splat element,
-  as it is implicitly <Symbol, Object>. Instead, define value types with ``@option``
-  macro below. Note ``@option`` parameter names are symbols.
+- **Double Splats:** Use double-star ``**`` in the parameter name to denote a
+  keyword arg splat (double splat).  Note that type does not need declared on
+  the double-splat element,   as it is implicitly <Symbol, Object>. Instead,
+  define value types with ``@option``   macro below. Note ``@option`` parameter
+  names are symbols.
 
   .. code-block:: ruby
 

--- a/docs/contributing/code-documentation.txt
+++ b/docs/contributing/code-documentation.txt
@@ -20,19 +20,91 @@ Mongoid uses its own flavor of `YARD <https://github.com/lsegal/yard>`_
 for code documentation. Please note the conventions outlined in this document.
 
 
+.. _code-documentation-structure:
+
+Structure
+---------
+
+- **Modules:** All class and module definitions should be preceded by
+  a documentation comment.
+
+  .. code-block:: ruby
+
+    # This is the documentation for the class. It's amazing
+    # what they do with corrugated cardboard these days.
+    class CardboardBox
+
+- **Methods:** All method definitions should be preceded by a documentation comment.
+  Use ``@param`` and ``@return`` to specify input(s) and output respectively.
+  For further details, refer to
+  :ref:`Type Declaration <code-documentation-type-declaration>` below.
+
+  .. code-block:: ruby
+
+    # Turn a person into whatever they'd like to be.
+    #
+    # @param [ Person ] person The human to transmogrify.
+    #
+    # @return [ Tiger ] The transmogrified result.
+    def transmogrify(person)
+
+- **Private Methods:** Private methods do not require documentation,
+  however you may add it for clarification.
+
+  .. code-block:: ruby
+
+    private
+
+    # Documentation is optional here.
+    def my_internal_method
+
+- **Notes:** Use the ``@note`` macro to explain caveats, edge cases,
+  and behavior which may surprise users.
+
+  .. code-block:: ruby
+
+    # Clear all stored data.
+    #
+    # @note This operation deletes data in the database.
+    def erase_data!
+
+- **API Private:** Classes and public methods which are not intended for
+  external usage should be marked ``@api private``. This macro does not
+  require a comment.
+
+  .. code-block:: ruby
+
+    # This is an internal-only method.
+    #
+    # @api private
+    def dont_call_me_from_outside
+
+- **Deprecation:** Use the ``@deprecated`` macro to indicated deprecated
+  functionality. This macro does not require a comment.
+
+  .. code-block:: ruby
+
+    # This is how we did things back in the day.
+    #
+    # @deprecated
+    def the_old_way
+
+
+.. _code-documentation-formatting:
+
 Formatting
 ----------
 
-- **Line Wrapping:** Use double-space indent when wrapping lines of macros
-  such as ``@param`` and ``@return``. Do not indent line wraps in the description.
+- **Line Wrapping:** Use double-space indent when wrapping lines of macros.
+  Do not indent line wraps in the description.
 
   .. code-block:: ruby
 
     # This is the description of the method. Line wraps in the description
     # should not be indented.
     #
-    # @return [ Symbol ] For macro functions, wraps must be double-space
-    #   indented on the second, third, etc. lines.
+    # @return [ Symbol ] For macros, wraps must be double-space indented
+    #   on the second, third, etc. lines.
 
 - **Whitespace:** Do not use leading/trailing empty comment lines,
   or more than one consecutive empty comment line.
@@ -56,8 +128,10 @@ Formatting
     def my_method(foo)
 
 
-Type Declarations
------------------
+.. _code-documentation-type-declaration:
+
+Type Declaration
+----------------
 
 - **Type Unions:** Use pipe ``|`` to denote a union of allowed types.
 
@@ -180,6 +254,16 @@ Type Declarations
     # @param [ Boolean ] :exact_match Whether to do an exact match
     # @param [ Integer ] :results_per_page Number of results
     def search(query, exact_match: false, results_per_page: 10)
+
+- **Hash Options:** Define hash key-value options with ``@option`` macro
+  immediately following the Hash ``@param``. Note ``@option`` parameter names are symbols.
+
+  .. code-block:: ruby
+
+    # @param opts [ Hash<Symbol, Object> ] The optional hash argument(s).
+    # @option opts [ String | Array<String> ] :items The items(s) as Strings to include.
+    # @option opts [ Integer ] :limit An Integer denoting the limit.
+    def buy_groceries(opts = {})
 
 - **Double Splats:** Use double-star ``**`` in the parameter name to denote a keyword arg splat
   (double splat).  Note that type does not need declared on the double-splat element,

--- a/docs/contributing/code-documentation.txt
+++ b/docs/contributing/code-documentation.txt
@@ -165,6 +165,12 @@ Type Declarations
     #   as the optional last arg.
     def say_hello(*args)
 
+- **Splat Args:** Specify type unions with square brackets ``[ ]``.
+
+  .. code-block:: ruby
+
+    # @param [ [ String | Symbol ]... ] *fields A splat of mixed Symbols and Strings.
+
 - **Keyword Arguments:** Following YARD conventions, use ``@param`` for keyword arguments,
   and specify keyword argument names as symbols.
 

--- a/docs/contributing/code-documentation.txt
+++ b/docs/contributing/code-documentation.txt
@@ -23,11 +23,15 @@ for code documentation. Please note the conventions outlined in this document.
 Formatting
 ----------
 
-- **Line Wrapping:** Use double-space indent when wrapping lines.
+- **Line Wrapping:** Use double-space indent when wrapping lines of macros
+  such as ``@param`` and ``@return``. Do not indent line wraps in the description.
 
   .. code-block:: ruby
 
-    # @return [ Symbol ] This sentence is so long that it must be double-space
+    # This is the description of the method. When doing a line wrap in the
+    # description, you do not need to indent the wrapped line.
+    #
+    # @return [ Symbol ] For macro functions, wraps must be double-space
     #   indented on the second, third, etc. lines.
 
 - **Whitespace:** Do not use leading/trailing empty comment lines,

--- a/docs/contributing/code-documentation.txt
+++ b/docs/contributing/code-documentation.txt
@@ -28,8 +28,8 @@ Formatting
 
   .. code-block:: ruby
 
-    # This is the description of the method. When doing a line wrap in the
-    # description, you do not need to indent the wrapped line.
+    # This is the description of the method. Line wraps in the description
+    # should not be indented.
     #
     # @return [ Symbol ] For macro functions, wraps must be double-space
     #   indented on the second, third, etc. lines.

--- a/docs/contributing/code-documentation.txt
+++ b/docs/contributing/code-documentation.txt
@@ -1,0 +1,184 @@
+.. _code-documentation:
+
+******************
+Code Documentation
+******************
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+
+Code Documentation
+==================
+
+Mongoid uses its own flavor of `YARD <https://github.com/lsegal/yard>`_
+for code documentation. Please note the conventions outlined in this document.
+
+
+Formatting
+----------
+
+- **Line Wrapping:** Use double-space indent when wrapping lines.
+
+  .. code-block:: ruby
+
+    # @return [ Symbol ] This sentence is so long that it must be double-space
+    #   indented on the second, third, etc. lines.
+
+- **Whitespace:** Do not use leading/trailing empty comment lines,
+  or more than one consecutive empty comment line.
+
+  .. code-block:: ruby
+
+    # GOOD:
+    # @return [ Symbol ] The return value
+    def my_method
+
+    # BAD:
+    # @return [ Symbol ] The return value
+    #
+    def my_method
+
+    # BAD:
+    # @param [ Symbol ] foo The input value
+    #
+    #
+    # @return [ Symbol ] The return value
+    def my_method(foo)
+
+
+Type Declarations
+-----------------
+
+- **Type Unions:** Use pipe ``|`` to denote a union of allowed types.
+
+  .. code-block:: ruby
+
+    # @param [ Symbol | String ] name Either a Symbol or a String.
+
+- **Nested Types:** Use angle brackets ``< >`` to denote type nesting.
+
+  .. code-block:: ruby
+
+    # @param [ Array<Symbol> ] array An Array of symbols.
+
+- **Hash:** Use comma ``,`` to denote the key and value types.
+
+  .. code-block:: ruby
+
+    # @param [ Hash<Symbol, Integer> ] hash A Hash whose keys are Symbols,
+    #   and whose values are Integers.
+
+- **Array:** Use pipe ``|`` to denote a union of allowed types.
+
+  .. code-block:: ruby
+
+    # @param [ Array<Symbol | String> ] array An Array whose members must
+    #   be either Symbols or Strings.
+
+- **Array:** Use comma ``,`` to denote the types of each position in a tuple.
+
+  .. code-block:: ruby
+
+    # @return [ Array<Symbol, Integer, Integer> ] A 3-member Array whose first
+    #   element is a Symbol, and whose second and third elements are Integers.
+
+- **Array:** Use pipe ``|`` on the top level if the inner types cannot be mixed within the Array.
+
+  .. code-block:: ruby
+
+    # @param [ Array<Symbol> | Array<Hash> ] array An Array containing only
+    #   Symbols, or an Array containing only Hashes. The Array may not contain
+    #   a mix of Symbols and Hashes.
+
+- **Nested Types:** For clarity, use square brackets ``[ ]`` to denote nested unions
+  when commas are also used.
+
+  .. code-block:: ruby
+
+    # @param [ Hash<Symbol, [ true | false ]> ] hash A Hash whose keys are Symbols,
+    #   and whose values are boolean values.
+
+- **Ruby Values:** Specific values may be denoted in the type using Ruby syntax.
+
+  .. code-block:: ruby
+
+    # @param [ :before | :after ] timing One of the Symbol values :before or :after.
+
+- **True, False, and Nil:** Use ``true``, ``false``, and ``nil`` rather than
+  ``TrueClass``, ``FalseClass``, and ``NilClass``. Do not use ``Boolean`` as a type
+  since it does not exist in Ruby.
+
+  .. code-block:: ruby
+
+    # GOOD:
+    # @param [ true | false | nil ] bool A boolean or nil value.
+
+    # BAD:
+    # @param [ TrueClass | FalseClass | NilClass ] bool A boolean or nil value.
+    # @param [ Boolean ] bool A boolean value.
+
+- **Return Self:** Specify return value ``self`` where possible.
+
+  .. code-block:: ruby
+
+    # @return [ self ] Returns the object itself.
+
+- **Splat Args:** Use three-dot ellipses ``...`` in the type declaration and
+  star ``*`` in the parameter name to denote a splat.
+
+  .. code-block:: ruby
+
+    # @param [ String... ] *items The list of items name(s) as Strings.
+    def buy_groceries(*items)
+
+- **Splat Args:** Do not use ``Array`` as the type unless each arg is actually an Array.
+
+  .. code-block:: ruby
+
+    # BAD:
+    # @param [ Array<String> ] *items The list of items name(s) as Strings.
+    def buy_groceries(*items)
+
+    buy_groceries("Cheese", "Crackers", "Wine")
+
+    # OK:
+    # @param [ Array<String>... ] *arrays One or more arrays containing name parts.
+    def set_people_names(*arrays)
+
+    set_people_names(["Harlan", "Sanders"], ["Jane", "K", ""Doe"], ["Jim", "Beam"])
+
+- **Splat Args:** Use comma ``,`` to denote positionality in a splat.
+
+  .. code-block:: ruby
+
+    # @param [ Symbol..., Hash ] *args A list of names, followed by a hash
+    #   as the optional last arg.
+    def say_hello(*args)
+
+- **Keyword Arguments:** Following YARD conventions, use ``@param`` for keyword arguments,
+  and specify keyword argument names as symbols.
+
+  .. code-block:: ruby
+
+    # @param [ String ] query The search string
+    # @param [ Boolean ] :exact_match Whether to do an exact match
+    # @param [ Integer ] :results_per_page Number of results
+    def search(query, exact_match: false, results_per_page: 10)
+
+- **Double Splats:** Use double-star ``**`` in the parameter name to denote a keyword arg splat
+  (double splat).  Note that type does not need declared on the double-splat element,
+  as it is implicitly <Symbol, Object>. Instead, define value types with ``@option``
+  macro below. Note ``@option`` parameter names are symbols.
+
+  .. code-block:: ruby
+
+    # @param **kwargs The optional keyword argument(s).
+    # @option **kwargs [ String | Array<String> ] :items The items(s) as Strings to include.
+    # @option **kwargs [ Integer ] :limit An Integer denoting the limit.
+    def buy_groceries(**kwargs)

--- a/docs/index.txt
+++ b/docs/index.txt
@@ -18,6 +18,7 @@ for MongoDB in Ruby.
   working-with-data
   API <https://mongodb.com/docs/mongoid/master/api/>
   release-notes
+  contributing
   additional-resources
   ecosystem
 


### PR DESCRIPTION
This adds a new "Contributing" section to the top-level of docs, with a single page "Code Documentation" in this PR.

(Contributing section was also requested in [MONGOID-5082](https://jira.mongodb.org/browse/MONGOID-5082). Not sure if this would be better to add to Ruby Driver rather than Mongoid.)

Comments/opinions/etc. welcome. This PR can be merged anytime.

Things to add in future:
- [ ] @yield for blocks
- [ ] @raise
- [ ] @todo
- [ ] More ideas from https://gist.github.com/phansch/db18a595d2f5f1ef16646af72fe1fb0e