### PR TITLE
MONGOID-5263: Fix/cleanup I18n fallback tests (without removing separate I18n test runs)

### DIFF
--- a/spec/integration/i18n_fallbacks_spec.rb
+++ b/spec/integration/i18n_fallbacks_spec.rb
@@ -3,23 +3,10 @@
 require 'spec_helper'
 
 describe 'i18n fallbacks' do
-  # These tests modify the environment
-  before(:all) do
-    unless %w(yes true 1).include?((ENV['TEST_I18N_FALLBACKS'] || '').downcase)
-      skip 'Set TEST_I18N_FALLBACKS=1 environment variable to run these tests'
-    end
-  end
-
-  before(:all) do
-    puts "I18n version: #{I18n::VERSION}"
-
-    require "i18n/backend/fallbacks"
-    I18n::Backend::Simple.send(:include, I18n::Backend::Fallbacks)
-  end
+  with_i18n_fallbacks
 
   context 'when fallbacks are enabled with a locale list' do
     before do
-      I18n.default_locale = :en
       I18n.fallbacks[:de] = [ :en ]
     end
 
@@ -36,7 +23,6 @@ describe 'i18n fallbacks' do
     end
 
     context 'when translation is missing in active locale and present in fallback locale' do
-
       it 'falls back on default locale' do
         product = Product.new
         I18n.locale = :en
@@ -44,7 +30,6 @@ describe 'i18n fallbacks' do
         I18n.locale = :de
         product.description.should == 'Marvelous!'
       end
-
     end
 
     context 'when translation is missing in all locales' do
@@ -64,7 +49,6 @@ describe 'i18n fallbacks' do
           I18n.locale = :ru
           product.description.should be nil
         end
-
       end
 
       context 'i18n 1.0' do
@@ -82,7 +66,6 @@ describe 'i18n fallbacks' do
           I18n.locale = :ru
           product.description.should == 'Marvelous!'
         end
-
       end
     end
   end

--- a/spec/mongoid/contextual/mongo_spec.rb
+++ b/spec/mongoid/contextual/mongo_spec.rb
@@ -660,13 +660,10 @@ describe Mongoid::Contextual::Mongo do
       end
 
       context 'when fallbacks are enabled with a locale list' do
-        require_fallbacks
+        with_i18n_fallbacks
 
-        around(:all) do |example|
-          prev_fallbacks = I18n.fallbacks.dup
+        before do
           I18n.fallbacks[:he] = [ :en ]
-          example.run
-          I18n.fallbacks = prev_fallbacks
         end
 
         let(:distinct) do

--- a/spec/mongoid/copyable_spec.rb
+++ b/spec/mongoid/copyable_spec.rb
@@ -166,7 +166,6 @@ describe Mongoid::Copyable do
       context "when cloning a document with multiple languages field" do
 
         before do
-          I18n.enforce_available_locales = false
           I18n.locale = 'pt_BR'
           person.desc = "descrição"
           person.addresses.first.name = "descrição"
@@ -218,7 +217,6 @@ describe Mongoid::Copyable do
         end
 
         before do
-          I18n.enforce_available_locales = false
           I18n.locale = 'pt_BR'
           person.addresses.type(ShipmentAddress).each { |address| address.shipping_name = "Título" }
           person.save!

--- a/spec/mongoid/criteria_spec.rb
+++ b/spec/mongoid/criteria_spec.rb
@@ -2059,13 +2059,10 @@ describe Mongoid::Criteria do
       end
 
       context 'when fallbacks are enabled with a locale list' do
-        require_fallbacks
+        with_i18n_fallbacks
 
-        around(:all) do |example|
-          prev_fallbacks = I18n.fallbacks.dup
+        before do
           I18n.fallbacks[:he] = [ :en ]
-          example.run
-          I18n.fallbacks = prev_fallbacks
         end
 
         let(:plucked) do

--- a/spec/mongoid/fields/localized_spec.rb
+++ b/spec/mongoid/fields/localized_spec.rb
@@ -83,12 +83,7 @@ describe Mongoid::Fields::Localized do
       context "when a locale is provided" do
 
         before do
-          I18n.enforce_available_locales = false
           ::I18n.locale = :de
-        end
-
-        after do
-          ::I18n.locale = :en
         end
 
         context "when the value exists" do
@@ -117,10 +112,7 @@ describe Mongoid::Fields::Localized do
 
           context "when using fallbacks" do
 
-            before(:all) do
-              require "i18n/backend/fallbacks"
-              I18n::Backend::Simple.send(:include, I18n::Backend::Fallbacks)
-            end
+            with_i18n_fallbacks
 
             context "when fallbacks are defined" do
 
@@ -275,10 +267,7 @@ describe Mongoid::Fields::Localized do
 
           context "when using fallbacks" do
 
-            before(:all) do
-              require "i18n/backend/fallbacks"
-              I18n::Backend::Simple.send(:include, I18n::Backend::Fallbacks)
-            end
+            with_i18n_fallbacks
 
             context "when fallbacks are defined" do
 
@@ -436,12 +425,7 @@ describe Mongoid::Fields::Localized do
       context 'when the type is Boolean' do
 
         before do
-          I18n.enforce_available_locales = false
           ::I18n.locale = :de
-        end
-
-        after do
-          ::I18n.locale = :en
         end
 
         context "when the value is false" do
@@ -476,10 +460,7 @@ describe Mongoid::Fields::Localized do
 
         context "when fallbacks are defined" do
 
-          before(:all) do
-            require "i18n/backend/fallbacks"
-            I18n::Backend::Simple.send(:include, I18n::Backend::Fallbacks)
-          end
+          with_i18n_fallbacks
 
           context "when the lookup does not need to use fallbacks" do
 

--- a/spec/mongoid/fields_spec.rb
+++ b/spec/mongoid/fields_spec.rb
@@ -17,7 +17,6 @@ describe Mongoid::Fields do
 
         before do
           product.description = "test"
-          I18n.enforce_available_locales = false
           ::I18n.locale = :de
           product.description = "The best"
         end

--- a/spec/mongoid/persistable/updatable_spec.rb
+++ b/spec/mongoid/persistable/updatable_spec.rb
@@ -237,13 +237,8 @@ describe Mongoid::Persistable::Updatable do
       end
 
       before do
-        I18n.enforce_available_locales = false
         ::I18n.locale = :de
         product.update_attribute(:description, "Die Bombe")
-      end
-
-      after do
-        ::I18n.locale = :en
       end
 
       let(:attributes) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -122,8 +122,6 @@ ActiveSupport::Inflector.inflections do |inflect|
   inflect.singular("address_components", "address_component")
 end
 
-I18n.config.enforce_available_locales = false
-
 # The user must be created before any of the tests are loaded, until
 # https://jira.mongodb.org/browse/MONGOID-4827 is implemented.
 client = Mongo::Client.new(SpecConfig.instance.addresses, server_selection_timeout: 3.03)
@@ -159,6 +157,13 @@ RSpec.configure do |config|
     Mongoid.default_client.collections.each do |coll|
       coll.delete_many
     end
+  end
+
+  config.before(:each) do
+    I18n.locale = :en
+    I18n.default_locale = :en
+    I18n.fallbacks = []
+    I18n.enforce_available_locales = false
   end
 end
 

--- a/spec/support/macros.rb
+++ b/spec/support/macros.rb
@@ -2,6 +2,10 @@
 
 module Mongoid
   module Macros
+    class I18nBackendWithFallbacks < I18n::Backend::Simple
+      include I18n::Backend::Fallbacks
+    end
+
     def use_spec_mongoid_config
       around do |example|
         config_path = File.join(File.dirname(__FILE__), "..", "config", "mongoid.yml")
@@ -36,6 +40,22 @@ module Mongoid
 
           class_exec(value, &block)
         end
+      end
+    end
+
+    def with_i18n_fallbacks
+      before(:all) do
+        unless %w(yes true 1).include?((ENV['TEST_I18N_FALLBACKS'] || '').downcase)
+          skip 'Set TEST_I18N_FALLBACKS=1 environment variable to run these tests'
+        end
+      end
+
+      around do |example|
+        old_backend = I18n.backend
+        I18n.backend = I18nBackendWithFallbacks.new
+        example.run
+      ensure
+        I18n.backend = old_backend
       end
     end
 


### PR DESCRIPTION
This is a rework of https://github.com/mongodb/mongoid/pull/5221. It fixes issues with I18n tests in current specs, without changing the Evergreen config.