### PR TITLE
MONGOID-5436 switch the meaning of legacy_triple_equals

### DIFF
--- a/lib/mongoid/equality.rb
+++ b/lib/mongoid/equality.rb
@@ -44,9 +44,9 @@ module Mongoid
     # @return [ true | false ] True if the classes are equal, false if not.
     def ===(other)
       if Mongoid.legacy_triple_equals
-        super
-      else
         other.class == Class ? self.class === other : self == other
+      else
+        super
       end
     end
 
@@ -73,9 +73,9 @@ module Mongoid
       # @return [ true | false ] True if the classes are equal, false if not.
       def ===(other)
         if Mongoid.legacy_triple_equals
-          other.is_a?(self)
-        else
           other.class == Class ? self <= other : other.is_a?(self)
+        else
+          other.is_a?(self)
         end
       end
     end

--- a/spec/mongoid/equality_spec.rb
+++ b/spec/mongoid/equality_spec.rb
@@ -85,8 +85,8 @@ describe Mongoid::Equality do
 
   describe ".===" do
 
-    context "when legacy_triple_equals is set" do
-      config_override :legacy_triple_equals, true
+    context "when legacy_triple_equals is not set" do
+      config_override :legacy_triple_equals, false
 
       context "when comparable is an instance of this document" do
 
@@ -128,8 +128,8 @@ describe Mongoid::Equality do
       end
     end
 
-    context "when legacy_triple_equals is not set" do
-      config_override :legacy_triple_equals, false
+    context "when legacy_triple_equals is set" do
+      config_override :legacy_triple_equals, true
 
       context "when comparable is an instance of this document" do
 
@@ -205,8 +205,8 @@ describe Mongoid::Equality do
 
         context "when the class is the same" do
 
-          it "returns false" do
-            expect(person === Person).to be false
+          it "returns true" do
+            expect(person === Person).to be true
           end
         end
 
@@ -219,8 +219,8 @@ describe Mongoid::Equality do
 
         context "when the class is a superclass" do
 
-          it "returns false" do
-            expect(Doctor.new === Person).to be false
+          it "returns true" do
+            expect(Doctor.new === Person).to be true
           end
         end
       end
@@ -256,8 +256,8 @@ describe Mongoid::Equality do
       context "when comparing to a class" do
         context "when the class is the same" do
 
-          it "returns true" do
-            expect(person === Person).to be true
+          it "returns false" do
+            expect(person === Person).to be false
           end
         end
 
@@ -270,8 +270,8 @@ describe Mongoid::Equality do
 
         context "when the class is a superclass" do
 
-          it "returns true" do
-            expect(Doctor.new === Person).to be true
+          it "returns false" do
+            expect(Doctor.new === Person).to be false
           end
         end
       end


### PR DESCRIPTION
This is obviously a hugely breaking change. I'm not sure how we want to proceed with this. 

This is a problem on: master, 8.0-stable, 7.5-stable and 7.4-stable

#5172 incorrectly changed this.