### PR TITLE
MONGOID-5433 Replace calls of Time#to_s(format) with Time#to_formatted_s

### DIFF
--- a/lib/mongoid/cacheable.rb
+++ b/lib/mongoid/cacheable.rb
@@ -15,7 +15,7 @@ module Mongoid
     # plural model name.
     #
     # If new_record?     - will append /new
-    # If not             - will append /id-updated_at.to_s(cache_timestamp_format)
+    # If not             - will append /id-updated_at.to_formatted_s(cache_timestamp_format)
     # Without updated_at - will append /id
     #
     # This is usually called inside a cache() block
@@ -26,7 +26,7 @@ module Mongoid
     # @return [ String ] the string with or without updated_at
     def cache_key
       return "#{model_key}/new" if new_record?
-      return "#{model_key}/#{_id}-#{updated_at.utc.to_s(cache_timestamp_format)}" if do_or_do_not(:updated_at)
+      return "#{model_key}/#{_id}-#{updated_at.utc.to_formatted_s(cache_timestamp_format)}" if do_or_do_not(:updated_at)
       "#{model_key}/#{_id}"
     end
   end

--- a/spec/mongoid/cacheable_spec.rb
+++ b/spec/mongoid/cacheable_spec.rb
@@ -45,7 +45,7 @@ describe Mongoid::Cacheable do
         context "with the default cache_timestamp_format" do
 
           let!(:updated_at) do
-            document.updated_at.utc.to_s(:nsec)
+            document.updated_at.utc.to_formatted_s(:nsec)
           end
 
           it "has the id and updated_at key name" do
@@ -64,7 +64,7 @@ describe Mongoid::Cacheable do
           end
 
           let!(:updated_at) do
-            document.updated_at.utc.to_s(:number)
+            document.updated_at.utc.to_formatted_s(:number)
           end
 
           it "has the id and updated_at key name" do
@@ -103,7 +103,7 @@ describe Mongoid::Cacheable do
       end
 
       let!(:updated_at) do
-        agent.updated_at.utc.to_s(:nsec)
+        agent.updated_at.utc.to_formatted_s(:nsec)
       end
 
       it "has the id and updated_at key name" do


### PR DESCRIPTION
I think that if we backport this to 7.3 we shouldn't have any problems in the future. 7.3 is the last version that supports Rails 7.

MONGOID-5433