### PR TITLE
MONGOID-5334 ensure localized demongoization works with symbol keys

### DIFF
--- a/lib/mongoid/fields/localized.rb
+++ b/lib/mongoid/fields/localized.rb
@@ -14,9 +14,8 @@ module Mongoid
       #
       # @return [ Object ] The value for the current locale.
       def demongoize(object)
-        if object
-          type.demongoize(lookup(object))
-        end
+        return if object.nil?
+        type.demongoize(lookup(object))
       end
 
       # Is the field localized or not?
@@ -86,7 +85,10 @@ module Mongoid
         end
         return value unless value.nil?
         if fallbacks? && ::I18n.respond_to?(:fallbacks)
-          object[::I18n.fallbacks[locale].map(&:to_s).find{ |loc| object.has_key?(loc) }]
+          fallback_key = ::I18n.fallbacks[locale].find do |loc|
+            object.has_key?(loc.to_s) || object.has_key?(loc)
+          end
+          object[fallback_key.to_s] || object[fallback_key]
         end
       end
     end

--- a/lib/mongoid/fields/localized.rb
+++ b/lib/mongoid/fields/localized.rb
@@ -15,7 +15,10 @@ module Mongoid
       # @return [ Object ] The value for the current locale.
       def demongoize(object)
         return if object.nil?
-        type.demongoize(lookup(object))
+        case object
+        when Hash
+          type.demongoize(lookup(object))
+        end
       end
 
       # Is the field localized or not?
@@ -86,7 +89,7 @@ module Mongoid
         return value unless value.nil?
         if fallbacks? && ::I18n.respond_to?(:fallbacks)
           fallback_key = ::I18n.fallbacks[locale].find do |loc|
-            object.has_key?(loc.to_s) || object.has_key?(loc)
+            object.key?(loc.to_s) || object.key?(loc)
           end
           object[fallback_key.to_s] || object[fallback_key]
         end

--- a/lib/mongoid/fields/localized.rb
+++ b/lib/mongoid/fields/localized.rb
@@ -15,10 +15,7 @@ module Mongoid
       # @return [ Object ] The value for the current locale.
       def demongoize(object)
         return if object.nil?
-        case object
-        when Hash
-          type.demongoize(lookup(object))
-        end
+        type.demongoize(lookup(object))
       end
 
       # Is the field localized or not?

--- a/spec/mongoid/fields/localized_spec.rb
+++ b/spec/mongoid/fields/localized_spec.rb
@@ -102,6 +102,17 @@ describe Mongoid::Fields::Localized do
           end
         end
 
+        context "when key is a symbol" do
+
+          let(:value) do
+            field.demongoize({ :de => "This is a test" })
+          end
+
+          it "returns the string from the set locale" do
+            expect(value).to eq("This is a test")
+          end
+        end
+
         context "when the value does not exist" do
 
           context "when not using fallbacks" do
@@ -135,6 +146,17 @@ describe Mongoid::Fields::Localized do
 
                 let(:value) do
                   field.demongoize({ "en" => "testing" })
+                end
+
+                it "returns the fallback translation" do
+                  expect(value).to eq("testing")
+                end
+              end
+
+              context "when the fallback translation exists and is a symbol" do
+
+                let(:value) do
+                  field.demongoize({ :es => "testing" })
                 end
 
                 it "returns the fallback translation" do


### PR DESCRIPTION
Only use case would be if the user modified the translations hash directly, but there were already some places that checked for both string and symbol keys so I just made it work in fallbacks too.