### PR TITLE
MONGOID-5293 put legacy_attributes in 7.5 defaults

### DIFF
--- a/lib/mongoid/config/defaults.rb
+++ b/lib/mongoid/config/defaults.rb
@@ -39,8 +39,8 @@ module Mongoid
           load_defaults "7.4"
         when "7.4"
           # flags introduced in 7.5 - old functionality
-          self.overwrite_chained_operators = true
           self.legacy_attributes = true
+          self.overwrite_chained_operators = true
 
           load_defaults "7.5"
         when "7.5"

--- a/lib/mongoid/config/defaults.rb
+++ b/lib/mongoid/config/defaults.rb
@@ -40,11 +40,11 @@ module Mongoid
         when "7.4"
           # flags introduced in 7.5 - old functionality
           self.overwrite_chained_operators = true
+          self.legacy_attributes = true
 
           load_defaults "7.5"
         when "7.5"
           # flags introduced in 8.0 - old functionality
-          self.legacy_attributes = true
           self.map_big_decimal_to_decimal128 = false
         when "8.0"
           # All flag defaults currently reflect 8.0 behavior.

--- a/spec/mongoid/config/defaults_spec.rb
+++ b/spec/mongoid/config/defaults_spec.rb
@@ -40,26 +40,26 @@ describe Mongoid::Config::Defaults do
 
     shared_examples "turns off 7.5 flags" do
       it "turns off the 7.5 flags" do
+        expect(Mongoid.legacy_attributes).to be true
         expect(Mongoid.overwrite_chained_operators).to be true
       end
     end
 
     shared_examples "turns on 7.5 flags" do
       it "turns on the 7.5 flags" do
+        expect(Mongoid.legacy_attributes).to be false
         expect(Mongoid.overwrite_chained_operators).to be false
       end
     end
 
     shared_examples "turns off 8.0 flags" do
       it "turns off the 8.0 flags" do
-        expect(Mongoid.legacy_attributes).to be true
         expect(Mongoid.map_big_decimal_to_decimal128).to be false
       end
     end
 
     shared_examples "turns on 8.0 flags" do
       it "turns on the 8.0 flags" do
-        expect(Mongoid.legacy_attributes).to be false
         expect(Mongoid.map_big_decimal_to_decimal128).to be true
       end
     end


### PR DESCRIPTION
Once we've back ported `legacy_attributes` to 7.5, the defaults for 7.4 should have `legacy_attributes` true, and 7.5 should have `legacy_attributes` false (as per the current default).