### PR TITLE
MONGOID-5467 MONGOID-5320 Change usage of ActiveModel::MissingAttributeError to Mongoid::Errors:AttributeNotLoaded

### DIFF
--- a/docs/reference/crud.txt
+++ b/docs/reference/crud.txt
@@ -657,7 +657,7 @@ Mongoid provides several ways of accessing field values.
 .. note::
 
   All of the access methods described below raise
-  ``ActiveModel::MissingAttributeError`` when the field being accessed is
+  ``Mongoid::Errors::AttributeNotLoaded`` when the field being accessed is
   :ref:`projected out <projection>`, either by virtue of not being included in
   :ref:`only <only>` or by virtue of being included in
   :ref:`without <without>`. This applies to both reads and writes.

--- a/docs/reference/queries.txt
+++ b/docs/reference/queries.txt
@@ -775,12 +775,12 @@ operation is sometimes called "projection".
   band = Band.only(:name).first
 
 Attempting to reference attributes which have not been loaded results in
-``ActiveModel::MissingAttributeError``.
+``Mongoid::Errors::AttributeNotLoaded``.
 
 .. code-block:: ruby
 
   band.label
-  # ActiveModel::MissingAttributeError (Missing attribute: 'label'.)
+  #=> raises Mongoid::Errors::AttributeNotLoaded
 
 Even though Mongoid currently allows writing to attributes that have not
 been loaded, such writes will not be persisted

--- a/docs/release-notes/mongoid-9.0.txt
+++ b/docs/release-notes/mongoid-9.0.txt
@@ -18,11 +18,11 @@ please consult GitHub releases for detailed release notes and JIRA for
 the complete list of issues fixed in each release, including bug fixes.
 
 
-Raise AttributeNotLoaded error for fields omitted from query
-------------------------------------------------------------
+Raise AttributeNotLoaded error when accessing fields omitted from query projection
+----------------------------------------------------------------------------------
 
 When attempting to access a field on a model instance which was
-excluded with ``.only`` or ``.without`` query projections methods
+excluded with the ``.only`` or ``.without`` query projections methods
 when the instance was loaded, Mongoid will now raise a
 ``Mongoid::Errors::AttributeNotLoaded`` error.
 

--- a/docs/release-notes/mongoid-9.0.txt
+++ b/docs/release-notes/mongoid-9.0.txt
@@ -1,0 +1,42 @@
+***********
+Mongoid 9.0
+***********
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+This page describes significant changes and improvements in Mongoid 9.0.
+The complete list of releases is available `on GitHub
+<https://github.com/mongodb/mongoid/releases>`_ and `in JIRA
+<https://jira.mongodb.org/projects/MONGOID?selectedItem=com.atlassian.jira.jira-projects-plugin:release-page>`_;
+please consult GitHub releases for detailed release notes and JIRA for
+the complete list of issues fixed in each release, including bug fixes.
+
+
+Raise AttributeNotLoaded error for fields omitted from query
+------------------------------------------------------------
+
+When attempting to access a field on a model instance which was
+excluded with ``.only`` or ``.without`` query projections methods
+when the instance was loaded, Mongoid will now raise a
+``Mongoid::Errors::AttributeNotLoaded`` error.
+
+.. code-block:: ruby
+
+  Band.only(:name).first.label
+  #=> raises Mongoid::Errors::AttributeNotLoaded
+
+  Band.without(:label).first.label = 'Sub Pop Records'
+  #=> raises Mongoid::Errors::AttributeNotLoaded
+
+In earlier Mongoid versions, the same conditions would raise an
+``ActiveModel::MissingAttributeError``. Please check your code for
+any Mongoid-specific usages of this class, and change them to
+``Mongoid::Errors::AttributeNotLoaded``. Note additionally that
+``AttributeNotLoaded`` inherits from ``Mongoid::Errors::MongoidError``,
+while ``ActiveModel::MissingAttributeError`` does not.

--- a/lib/config/locales/en.yml
+++ b/lib/config/locales/en.yml
@@ -23,6 +23,17 @@ en:
           resolution: "On the %{name} association on %{inverse} you must add an
             :inverse_of option to specify the exact association on %{klass}
             that is the opposite of %{name}."
+        attribute_not_loaded:
+          message: "Attempted to access attribute '%{name}' on %{klass} which
+            was not loaded."
+          summary:
+            "You loaded an instance of %{klass} using a query projection method
+            such as `.only` or `.without`, then attempted to read or write an
+            attribute '%{name}' which was not included in the projection.
+            Mongoid intentionally prevents this to avoid overwriting data."
+          resolution: "Ensure your query projection methods such as `.only` and
+            `.without` include field '%{name}' when loading instances of %{klass},
+            or remove such projections methods entirely."
         callbacks:
           message: "Calling %{method} on %{klass} resulted in a false return
             from a callback."

--- a/lib/mongoid/association/accessors.rb
+++ b/lib/mongoid/association/accessors.rb
@@ -115,7 +115,7 @@ module Mongoid
         # during binding or when cascading callbacks. Whenever we retrieve
         # associations within the codebase, we use without_autobuild.
         if !without_autobuild? && association.embedded? && attribute_missing?(field_name)
-          raise ActiveModel::MissingAttributeError, "Missing attribute: '#{field_name}'"
+          raise Mongoid::Errors::AttributeNotLoaded.new(self.class, field_name)
         end
 
         if !reload && (value = ivar(name)) != false

--- a/lib/mongoid/attributes.rb
+++ b/lib/mongoid/attributes.rb
@@ -31,7 +31,7 @@ module Mongoid
     def attribute_present?(name)
       attribute = read_raw_attribute(name)
       !attribute.blank? || attribute == false
-    rescue ActiveModel::MissingAttributeError
+    rescue Mongoid::Errors::AttributeNotLoaded
       false
     end
 
@@ -165,7 +165,7 @@ module Mongoid
       field_name = database_field_name(name)
 
       if attribute_missing?(field_name)
-        raise ActiveModel::MissingAttributeError, "Missing attribute: '#{name}'"
+        raise Mongoid::Errors::AttributeNotLoaded.new(self.class, field_name)
       end
 
       if attribute_writable?(field_name)
@@ -291,7 +291,7 @@ module Mongoid
       normalized = database_field_name(name.to_s)
 
       if attribute_missing?(normalized)
-        raise ActiveModel::MissingAttributeError, "Missing attribute: '#{name}'"
+        raise Mongoid::Errors::AttributeNotLoaded.new(self.class, name)
       end
 
       if hash_dot_syntax?(normalized)

--- a/lib/mongoid/errors.rb
+++ b/lib/mongoid/errors.rb
@@ -2,6 +2,7 @@
 
 require "mongoid/errors/mongoid_error"
 require "mongoid/errors/ambiguous_relationship"
+require "mongoid/errors/attribute_not_loaded"
 require "mongoid/errors/callback"
 require "mongoid/errors/criteria_argument_required"
 require "mongoid/errors/document_not_destroyed"

--- a/lib/mongoid/errors/attribute_not_loaded.rb
+++ b/lib/mongoid/errors/attribute_not_loaded.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Mongoid
+  module Errors
+
+    # Raised when attempting to read or write an attribute which has
+    # not been loaded. This can occur when using `.only` or `.without`
+    # query projection methods.
+    #
+    # @note This class inherits ActiveModel::MissingAttributeError
+    #   for backwards compatibility.
+    #
+    # @example Getting a field which has not been loaded.
+    #   Band.only(:name).first.label
+    #   #=> raises Mongoid::Errors::AttributeNotLoaded
+    #
+    # @example Setting a field which has not been loaded.
+    #   Band.without(:label).first.label = 'Sub Pop Records'
+    #   #=> raises Mongoid::Errors::AttributeNotLoaded
+    #
+    # @param [ Class ] klass The model class.
+    # @param [ String | Symbol ] name The name of the attribute.
+    class AttributeNotLoaded < ::ActiveModel::MissingAttributeError
+      include ErrorComposable
+
+      def initialize(klass, name)
+        super(
+          compose_message("attribute_not_loaded", { klass: klass.name, name: name })
+        )
+      end
+    end
+  end
+end

--- a/lib/mongoid/errors/attribute_not_loaded.rb
+++ b/lib/mongoid/errors/attribute_not_loaded.rb
@@ -7,9 +7,6 @@ module Mongoid
     # not been loaded. This can occur when using `.only` or `.without`
     # query projection methods.
     #
-    # @note This class inherits ActiveModel::MissingAttributeError
-    #   for backwards compatibility.
-    #
     # @example Getting a field which has not been loaded.
     #   Band.only(:name).first.label
     #   #=> raises Mongoid::Errors::AttributeNotLoaded
@@ -17,12 +14,15 @@ module Mongoid
     # @example Setting a field which has not been loaded.
     #   Band.without(:label).first.label = 'Sub Pop Records'
     #   #=> raises Mongoid::Errors::AttributeNotLoaded
-    #
-    # @param [ Class ] klass The model class.
-    # @param [ String | Symbol ] name The name of the attribute.
-    class AttributeNotLoaded < ::ActiveModel::MissingAttributeError
-      include ErrorComposable
+    class AttributeNotLoaded < MongoidError
 
+      # Create the new error.
+      #
+      # @example Instantiate the error.
+      #   AttributeNotLoaded.new(Person, "title")
+      #
+      # @param [ Class ] klass The model class.
+      # @param [ String | Symbol ] name The name of the attribute.
       def initialize(klass, name)
         super(
           compose_message("attribute_not_loaded", { klass: klass.name, name: name })

--- a/spec/mongoid/association/accessors_spec.rb
+++ b/spec/mongoid/association/accessors_spec.rb
@@ -625,7 +625,7 @@ describe Mongoid::Association::Accessors do
           it 'does not create an accessor for another field on the embedded document' do
             expect do
               persisted_person.passport.country
-            end.to raise_error(ActiveModel::MissingAttributeError)
+            end.to raise_error(Mongoid::Errors::AttributeNotLoaded, /Attempted to access attribute 'country' on Passport which was not loaded/)
           end
         end
 
@@ -655,7 +655,7 @@ describe Mongoid::Association::Accessors do
               it 'does not create an accessor for another field on the embedded document' do
                 expect do
                   persisted_person.passport.country
-                end.to raise_error(ActiveModel::MissingAttributeError)
+                end.to raise_error(Mongoid::Errors::AttributeNotLoaded, /Attempted to access attribute 'country' on Passport which was not loaded/)
               end
             end
 
@@ -717,7 +717,7 @@ describe Mongoid::Association::Accessors do
           it 'does not create an accessor for another field on the embedded document' do
             expect do
               persisted_person.phone_numbers.first.landline
-            end.to raise_error(ActiveModel::MissingAttributeError)
+            end.to raise_error(Mongoid::Errors::AttributeNotLoaded, /Attempted to access attribute 'landline' on Phone which was not loaded/)
           end
         end
 
@@ -746,7 +746,7 @@ describe Mongoid::Association::Accessors do
               it 'does not create an accessor for another field on the embedded document' do
                 expect do
                   persisted_person.phone_numbers.first.landline
-                end.to raise_error(ActiveModel::MissingAttributeError)
+                end.to raise_error(Mongoid::Errors::AttributeNotLoaded, /Attempted to access attribute 'landline' on Phone which was not loaded/)
               end
 
             end

--- a/spec/mongoid/association/embedded/embeds_many_query_spec.rb
+++ b/spec/mongoid/association/embedded/embeds_many_query_spec.rb
@@ -23,7 +23,7 @@ describe Mongoid::Association::Embedded::EmbedsMany do
       # has a default value specified in the model
       expect do
         legislator.b
-      end.to raise_error(ActiveModel::MissingAttributeError)
+      end.to raise_error(Mongoid::Errors::AttributeNotLoaded, /Attempted to access attribute 'b' on EmmLegislator which was not loaded/)
       expect(legislator.attributes.keys).to eq(['_id', 'a'])
     end
 
@@ -53,10 +53,10 @@ describe Mongoid::Association::Embedded::EmbedsMany do
         EmmCongress.where(name: 'foo').only(:_id).first
       end
 
-      it 'raises a MissingAttributeError' do
+      it 'raises AttributeNotLoaded' do
         expect do
           congress.legislators
-        end.to raise_error(ActiveModel::MissingAttributeError)
+        end.to raise_error(Mongoid::Errors::AttributeNotLoaded, /Attempted to access attribute 'legislators' on EmmCongress which was not loaded/)
       end
     end
   end

--- a/spec/mongoid/association/embedded/embeds_one_query_spec.rb
+++ b/spec/mongoid/association/embedded/embeds_one_query_spec.rb
@@ -21,7 +21,7 @@ describe Mongoid::Association::Embedded::EmbedsOne do
       # has a default value specified in the model
       expect do
         parent.child.b
-      end.to raise_error(ActiveModel::MissingAttributeError)
+      end.to raise_error(Mongoid::Errors::AttributeNotLoaded, /Attempted to access attribute 'b' on EomChild which was not loaded/)
       expect(parent.child.attributes.keys).to eq(['_id', 'a'])
     end
   end

--- a/spec/mongoid/association/referenced/belongs_to_query_spec.rb
+++ b/spec/mongoid/association/referenced/belongs_to_query_spec.rb
@@ -23,7 +23,7 @@ describe Mongoid::Association::Referenced::BelongsTo do
       # has a default value specified in the model
       expect do
         school.team
-      end.to raise_error(ActiveModel::MissingAttributeError)
+      end.to raise_error(Mongoid::Errors::AttributeNotLoaded)
       expect(student.attributes.keys).to eq(['_id', 'name'])
     end
 

--- a/spec/mongoid/association/referenced/has_and_belongs_to_many_query_spec.rb
+++ b/spec/mongoid/association/referenced/has_and_belongs_to_many_query_spec.rb
@@ -25,7 +25,7 @@ describe Mongoid::Association::Referenced::HasAndBelongsToMany do
       # has a default value specified in the model
       expect do
         signature.year
-      end.to raise_error(ActiveModel::MissingAttributeError)
+      end.to raise_error(Mongoid::Errors::AttributeNotLoaded)
       expect(signature.attributes.keys).to eq(['_id', 'name'])
     end
 

--- a/spec/mongoid/association/referenced/has_many_query_spec.rb
+++ b/spec/mongoid/association/referenced/has_many_query_spec.rb
@@ -23,7 +23,7 @@ describe Mongoid::Association::Referenced::HasMany do
       # has a default value specified in the model
       expect do
         student.grade
-      end.to raise_error(ActiveModel::MissingAttributeError)
+      end.to raise_error(Mongoid::Errors::AttributeNotLoaded)
       expect(student.attributes.keys).to eq(['_id', 'name'])
     end
 

--- a/spec/mongoid/association/referenced/has_one_query_spec.rb
+++ b/spec/mongoid/association/referenced/has_one_query_spec.rb
@@ -23,7 +23,7 @@ describe Mongoid::Association::Referenced::HasOne do
       # has a default value specified in the model
       expect do
         accreditation.year
-      end.to raise_error(ActiveModel::MissingAttributeError)
+      end.to raise_error(Mongoid::Errors::AttributeNotLoaded)
       expect(legislator.attributes.keys).to eq(['_id', 'degree'])
     end
 

--- a/spec/mongoid/attributes_spec.rb
+++ b/spec/mongoid/attributes_spec.rb
@@ -166,7 +166,7 @@ describe Mongoid::Attributes do
         it "raises an error" do
           expect {
             from_db.title
-          }.to raise_error(ActiveModel::MissingAttributeError)
+          }.to raise_error(Mongoid::Errors::AttributeNotLoaded, /Attempted to access attribute 'title' on Person which was not loaded/)
         end
 
         context "accessing via []" do
@@ -174,7 +174,7 @@ describe Mongoid::Attributes do
           it "raises an error" do
             expect {
               from_db["title"]
-            }.to raise_error(ActiveModel::MissingAttributeError)
+            }.to raise_error(Mongoid::Errors::AttributeNotLoaded, /Attempted to access attribute 'title' on Person which was not loaded/)
           end
         end
       end
@@ -188,7 +188,7 @@ describe Mongoid::Attributes do
         it "raises an error" do
           expect {
             from_db.title
-          }.to raise_error(ActiveModel::MissingAttributeError)
+          }.to raise_error(Mongoid::Errors::AttributeNotLoaded, /Attempted to access attribute 'title' on Person which was not loaded/)
         end
       end
     end
@@ -270,7 +270,7 @@ describe Mongoid::Attributes do
           it "raises an error" do
             expect {
               from_db[:title]
-            }.to raise_error(ActiveModel::MissingAttributeError)
+            }.to raise_error(Mongoid::Errors::AttributeNotLoaded, /Attempted to access attribute 'title' on Person which was not loaded/)
           end
         end
 
@@ -283,7 +283,7 @@ describe Mongoid::Attributes do
           it "raises an error" do
             expect {
               from_db[:title]
-            }.to raise_error(ActiveModel::MissingAttributeError)
+            }.to raise_error(Mongoid::Errors::AttributeNotLoaded, /Attempted to access attribute 'title' on Person which was not loaded/)
           end
         end
       end
@@ -299,7 +299,7 @@ describe Mongoid::Attributes do
           it "raises an error" do
             expect {
               from_db[:undefined_field]
-            }.to raise_error(ActiveModel::MissingAttributeError)
+            }.to raise_error(Mongoid::Errors::AttributeNotLoaded, /Attempted to access attribute 'undefined_field' on Person which was not loaded/)
           end
         end
 
@@ -312,7 +312,7 @@ describe Mongoid::Attributes do
           it "raises an error" do
             expect {
               from_db[:title]
-            }.to raise_error(ActiveModel::MissingAttributeError)
+            }.to raise_error(Mongoid::Errors::AttributeNotLoaded, /Attempted to access attribute 'title' on Person which was not loaded/)
           end
         end
 
@@ -364,10 +364,10 @@ describe Mongoid::Attributes do
           end
 
           context 'when retrieving a non-projected field' do
-            it 'raises MissingAttributeError' do
+            it 'raises AttributeNotLoaded' do
               expect do
                 from_db['name.first_name']
-              end.to raise_error(ActiveModel::MissingAttributeError)
+              end.to raise_error(Mongoid::Errors::AttributeNotLoaded, /Attempted to access attribute 'name.first_name' on Person which was not loaded/)
             end
           end
         end
@@ -488,7 +488,7 @@ describe Mongoid::Attributes do
           it "raises an error" do
             expect {
               from_db[:undefined_field] = 'x'
-            }.to raise_error(ActiveModel::MissingAttributeError)
+            }.to raise_error(Mongoid::Errors::AttributeNotLoaded, /Attempted to access attribute 'undefined_field' on Person which was not loaded/)
           end
         end
 
@@ -501,7 +501,7 @@ describe Mongoid::Attributes do
           it "raises an error" do
             expect {
               from_db[:title] = 'x'
-            }.to raise_error(ActiveModel::MissingAttributeError)
+            }.to raise_error(Mongoid::Errors::AttributeNotLoaded, /Attempted to access attribute 'title' on Person which was not loaded/)
           end
         end
 
@@ -1098,7 +1098,7 @@ describe Mongoid::Attributes do
         it "raises an error" do
           expect {
             from_db.read_attribute(:undefined_field)
-          }.to raise_error(ActiveModel::MissingAttributeError)
+          }.to raise_error(Mongoid::Errors::AttributeNotLoaded, /Attempted to access attribute 'undefined_field' on Person which was not loaded/)
         end
       end
 
@@ -1111,7 +1111,7 @@ describe Mongoid::Attributes do
         it "raises an error" do
           expect {
             from_db.read_attribute(:title)
-          }.to raise_error(ActiveModel::MissingAttributeError)
+          }.to raise_error(Mongoid::Errors::AttributeNotLoaded, /Attempted to access attribute 'title' on Person which was not loaded/)
         end
       end
 
@@ -1644,7 +1644,7 @@ describe Mongoid::Attributes do
         it "raises an error" do
           expect {
             from_db.write_attribute(:undefined_field, 'x')
-          }.to raise_error(ActiveModel::MissingAttributeError)
+          }.to raise_error(Mongoid::Errors::AttributeNotLoaded, /Attempted to access attribute 'undefined_field' on Person which was not loaded/)
         end
       end
 
@@ -1657,7 +1657,7 @@ describe Mongoid::Attributes do
         it "raises an error" do
           expect {
             from_db.write_attribute(:title, 'x')
-          }.to raise_error(ActiveModel::MissingAttributeError)
+          }.to raise_error(Mongoid::Errors::AttributeNotLoaded, /Attempted to access attribute 'title' on Person which was not loaded/)
         end
       end
 

--- a/spec/mongoid/criteria_projection_spec.rb
+++ b/spec/mongoid/criteria_projection_spec.rb
@@ -21,7 +21,7 @@ describe Mongoid::Criteria do
         it "limits the returned fields" do
           expect {
             criteria.first.name
-          }.to raise_error(ActiveModel::MissingAttributeError)
+          }.to raise_error(Mongoid::Errors::AttributeNotLoaded, /Attempted to access attribute 'name' on Band which was not loaded/)
         end
 
         it "does not add _type to the fields" do
@@ -55,7 +55,7 @@ describe Mongoid::Criteria do
         it "excludes the non included fields" do
           expect {
             criteria.first.active
-          }.to raise_error(ActiveModel::MissingAttributeError)
+          }.to raise_error(Mongoid::Errors::AttributeNotLoaded, /Attempted to access attribute 'active' on Band which was not loaded/)
         end
 
         it "does not add _type to the fields" do
@@ -214,8 +214,8 @@ describe Mongoid::Criteria do
           expect(dictionary.description_translations.keys).to_not include('de', 'en')
         end
 
-        it 'raises an ActiveModel::MissingAttributeError when attempting to access the field' do
-          expect{dictionary.description}.to raise_error ActiveModel::MissingAttributeError
+        it 'raises an Mongoid::Errors::AttributeNotLoaded when attempting to access the field' do
+          expect{dictionary.description}.to raise_error Mongoid::Errors::AttributeNotLoaded
         end
       end
 
@@ -359,7 +359,7 @@ describe Mongoid::Criteria do
         it 'does not return id' do
           lambda do
             instance.id
-          end.should raise_error(ActiveModel::MissingAttributeError)
+          end.should raise_error(Mongoid::Errors::AttributeNotLoaded, /Attempted to access attribute 'id' on Shirt which was not loaded/)
         end
       end
 

--- a/spec/mongoid/document_query_spec.rb
+++ b/spec/mongoid/document_query_spec.rb
@@ -14,11 +14,11 @@ describe Mongoid::Document do
     it 'populates specified fields only' do
       expect do
         person.title
-      end.to raise_error(ActiveModel::MissingAttributeError)
+      end.to raise_error(Mongoid::Errors::AttributeNotLoaded, /Attempted to access attribute 'title' on Person which was not loaded/)
       # has a default value specified in the model
       expect do
         person.age
-      end.to raise_error(ActiveModel::MissingAttributeError)
+      end.to raise_error(Mongoid::Errors::AttributeNotLoaded, /Attempted to access attribute 'age' on Person which was not loaded/)
       expect(person.attributes.keys).to eq(['_id', 'username'])
     end
 
@@ -27,7 +27,7 @@ describe Mongoid::Document do
 
       expect do
         person.age
-      end.to raise_error(ActiveModel::MissingAttributeError)
+      end.to raise_error(Mongoid::Errors::AttributeNotLoaded)
       person.age = 42
       expect(person.age).to be 42
       person.save!
@@ -82,7 +82,7 @@ describe Mongoid::Document do
       it 'prohibits the retrieval' do
         lambda do
           person.pet.name
-        end.should raise_error(ActiveModel::MissingAttributeError)
+        end.should raise_error(Mongoid::Errors::AttributeNotLoaded, /Attempted to access attribute 'name' on Animal which was not loaded/)
       end
     end
   end

--- a/spec/mongoid/errors/attribute_not_loaded_spec.rb
+++ b/spec/mongoid/errors/attribute_not_loaded_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Mongoid::Errors::AttributeNotLoaded do
+
+  describe "#message" do
+
+    let(:error) do
+      described_class.new(Band, :label)
+    end
+
+    it "contains the problem in the message" do
+      expect(error.message).to include(
+        "Attempted to access attribute 'label' on Band which was not loaded."
+      )
+    end
+
+    it "contains the summary in the message" do
+      expect(error.message).to include(
+        "You loaded an instance of Band using a query projection method"
+      )
+    end
+
+    it "contains the resolution in the message" do
+      expect(error.message).to include(
+        "Ensure your query projection methods such as `.only` and `.without`"
+      )
+    end
+  end
+end

--- a/spec/mongoid/interceptable_spec.rb
+++ b/spec/mongoid/interceptable_spec.rb
@@ -2360,14 +2360,14 @@ describe Mongoid::Interceptable do
   # was fixed by using `.pluck` over `.only`. Look at MONGOID-5306 for a more
   # detailed explanation.
   context "when accessing _ids in validate and access an association in after_initialize" do
-    it "doesn't raise a MissingAttributeError" do
+    it "doesn't raise AttributeNotLoaded" do
       company = InterceptableCompany.create!
       shop = InterceptableShop.create!(company: company)
       user = InterceptableUser.new
       user.company = company
       expect do
         user.save!
-      end.to_not raise_error(ActiveModel::MissingAttributeError)
+      end.to_not raise_error(Mongoid::Errors::AttributeNotLoaded)
     end
   end
 end

--- a/spec/mongoid/persistable/savable_spec.rb
+++ b/spec/mongoid/persistable/savable_spec.rb
@@ -467,7 +467,7 @@ describe Mongoid::Persistable::Savable do
         expect {
           person.username = 'unloaded-attribute'
           person.save
-        }.to raise_error(ActiveModel::MissingAttributeError)
+        }.to raise_error(Mongoid::Errors::AttributeNotLoaded, /Attempted to access attribute 'username' on Person which was not loaded/)
       end
 
       context 'when the changed attribute is aliased' do

--- a/spec/mongoid/persistable/settable_spec.rb
+++ b/spec/mongoid/persistable/settable_spec.rb
@@ -522,20 +522,20 @@ describe Mongoid::Persistable::Settable do
     end
 
     context 'field exists in database' do
-      it "raises MissingAttributeError" do
+      it "raises AttributeNotLoaded" do
         lambda do
           agent.set(title: '008')
-        end.should raise_error(ActiveModel::MissingAttributeError)
+        end.should raise_error(Mongoid::Errors::AttributeNotLoaded, /Attempted to access attribute 'title' on Agent which was not loaded/)
 
         expect(agent.reload.title).to eq 'Double-Oh Eight'
       end
     end
 
     context 'field does not exist in database' do
-      it "raises MissingAttributeError" do
+      it "raises AttributeNotLoaded" do
         lambda do
           agent.set(number: '008')
-        end.should raise_error(ActiveModel::MissingAttributeError)
+        end.should raise_error(Mongoid::Errors::AttributeNotLoaded, /Attempted to access attribute 'number' on Agent which was not loaded/)
 
         expect(agent.reload.read_attribute(:number)).to be nil
       end

--- a/spec/mongoid/persistable/updatable_spec.rb
+++ b/spec/mongoid/persistable/updatable_spec.rb
@@ -429,7 +429,7 @@ describe Mongoid::Persistable::Updatable do
         it 'does not allow the field to be updated' do
           expect {
             person.update_attribute(:title, 'Esteemed')
-          }.to raise_exception(ActiveModel::MissingAttributeError)
+          }.to raise_exception(Mongoid::Errors::AttributeNotLoaded, /Attempted to access attribute 'title' on Person which was not loaded/)
         end
 
         it 'does not persist the change' do
@@ -441,7 +441,7 @@ describe Mongoid::Persistable::Updatable do
           it 'does not allow the field to be updated' do
             expect {
               person.update_attribute('title', 'Esteemed')
-            }.to raise_exception(ActiveModel::MissingAttributeError)
+            }.to raise_exception(Mongoid::Errors::AttributeNotLoaded, /Attempted to access attribute 'title' on Person which was not loaded/)
           end
 
           it 'does not persist the change' do


### PR DESCRIPTION
This an alternate implementation of MONGOID-5320 than the one in https://github.com/mongodb/mongoid/pull/5360. **I prefer to merge this one if possible.**

In this PR, I've simply changed ActiveModel::MissingAttributeError to Mongoid::Errors:AttributeNotLoaded which inherits MongoidError, and added a release note for Mongoid 9.0.

In the other PR, I made the same error inherit ActiveModel::MissingAttributeError. Pick your poison.

