### PR TITLE
MONGOID-5100 allow selector arguments for .exists?

### DIFF
--- a/docs/reference/queries.txt
+++ b/docs/reference/queries.txt
@@ -1248,6 +1248,8 @@ Mongoid also has some helpful methods on criteria.
 
           Band.exists?
           Band.where(name: "Photek").exists?
+          Band.exists?(name: "Photek")
+          Band.exists?(BSON::ObjectId('6320d96a3282a48cfce9e72c'))
 
    * - ``Criteria#fifth``
 

--- a/docs/reference/queries.txt
+++ b/docs/reference/queries.txt
@@ -1243,6 +1243,13 @@ Mongoid also has some helpful methods on criteria.
        *Determine if any matching documents exist. Will return true if there
        are 1 or more.*
 
+       ``#exists?`` *now takes a number of argument types:*
+
+       - ``Hash``: *A hash of conditions.*
+       - ``BSON::ObjectId``: *An _id to search for.*
+       - ``String``: *An _id corresponding to the given string to search for.*
+       - ``false``: *Always returns false.*
+
      -
         .. code-block:: ruby
 
@@ -1250,6 +1257,8 @@ Mongoid also has some helpful methods on criteria.
           Band.where(name: "Photek").exists?
           Band.exists?(name: "Photek")
           Band.exists?(BSON::ObjectId('6320d96a3282a48cfce9e72c'))
+          Band.exists?('6320d96a3282a48cfce9e72c')
+          Band.exists?(false)
 
    * - ``Criteria#fifth``
 

--- a/docs/reference/queries.txt
+++ b/docs/reference/queries.txt
@@ -1246,8 +1246,7 @@ Mongoid also has some helpful methods on criteria.
        ``#exists?`` *now takes a number of argument types:*
 
        - ``Hash``: *A hash of conditions.*
-       - ``BSON::ObjectId``: *An _id to search for.*
-       - ``String``: *An _id corresponding to the given string to search for.*
+       - ``Object``: *An _id to search for.*
        - ``false``: *Always returns false.*
 
      -

--- a/docs/reference/queries.txt
+++ b/docs/reference/queries.txt
@@ -1247,7 +1247,6 @@ Mongoid also has some helpful methods on criteria.
 
        - ``Hash``: *A hash of conditions.*
        - ``Object``: *An _id to search for.*
-       - ``false``: *Always returns false.*
 
      -
         .. code-block:: ruby
@@ -1257,7 +1256,6 @@ Mongoid also has some helpful methods on criteria.
           Band.exists?(name: "Photek")
           Band.exists?(BSON::ObjectId('6320d96a3282a48cfce9e72c'))
           Band.exists?('6320d96a3282a48cfce9e72c')
-          Band.exists?(false)
 
    * - ``Criteria#fifth``
 

--- a/docs/reference/queries.txt
+++ b/docs/reference/queries.txt
@@ -1247,6 +1247,7 @@ Mongoid also has some helpful methods on criteria.
 
        - ``Hash``: *A hash of conditions.*
        - ``Object``: *An _id to search for.*
+       - ``false``/``nil``: *Always returns false.*
 
      -
         .. code-block:: ruby
@@ -1256,6 +1257,8 @@ Mongoid also has some helpful methods on criteria.
           Band.exists?(name: "Photek")
           Band.exists?(BSON::ObjectId('6320d96a3282a48cfce9e72c'))
           Band.exists?('6320d96a3282a48cfce9e72c')
+          Band.exists?(false)
+          Band.exists?(nil)
 
    * - ``Criteria#fifth``
 

--- a/docs/release-notes/mongoid-8.1.txt
+++ b/docs/release-notes/mongoid-8.1.txt
@@ -286,11 +286,10 @@ Added method parameters to ``#exists?``
 ---------------------------------------
 
 Mongoid 8.1 introduces method paramters to the ``Contextual#exists?`` method.
-An _id, a hash of conditions, or false can now be included:
+An _id or a hash of conditions can now be included:
 
 .. code:: ruby
 
   Band.exists?
   Band.exists?(name: "The Rolling Stones")
   Band.exists?(BSON::ObjectId('6320d96a3282a48cfce9e72c'))
-  Band.exists?(false) # always false

--- a/docs/release-notes/mongoid-8.1.txt
+++ b/docs/release-notes/mongoid-8.1.txt
@@ -286,10 +286,12 @@ Added method parameters to ``#exists?``
 ---------------------------------------
 
 Mongoid 8.1 introduces method paramters to the ``Contextual#exists?`` method.
-An _id or a hash of conditions can now be included:
+An _id, a hash of conditions, or ``false``/``nil`` can now be included:
 
 .. code:: ruby
 
   Band.exists?
   Band.exists?(name: "The Rolling Stones")
   Band.exists?(BSON::ObjectId('6320d96a3282a48cfce9e72c'))
+  Band.exists?(false) # always false
+  Band.exists?(nil) # always false

--- a/docs/release-notes/mongoid-8.1.txt
+++ b/docs/release-notes/mongoid-8.1.txt
@@ -286,10 +286,11 @@ Added method parameters to ``#exists?``
 ---------------------------------------
 
 Mongoid 8.1 introduces method paramters to the ``Contextual#exists?`` method.
-An _id or a hash of conditions can now be included:
+An _id, a hash of conditions, or false can now be included:
 
 .. code:: ruby
 
   Band.exists?
   Band.exists?(name: "The Rolling Stones")
   Band.exists?(BSON::ObjectId('6320d96a3282a48cfce9e72c'))
+  Band.exists?(false) # always false

--- a/docs/release-notes/mongoid-8.1.txt
+++ b/docs/release-notes/mongoid-8.1.txt
@@ -245,8 +245,8 @@ for more details.
 Added ``readonly!`` method and ``legacy_readonly`` feature flag
 ---------------------------------------------------------------
 
-Mongoid 8.1 changes the meaning of read-only documents. In Mongoid 8.1 with 
-this feature flag turned off, a document becomes read-only when calling the 
+Mongoid 8.1 changes the meaning of read-only documents. In Mongoid 8.1 with
+this feature flag turned off, a document becomes read-only when calling the
 ``readonly!`` method:
 
 .. code:: ruby
@@ -261,8 +261,8 @@ this feature flag turned off, a document becomes read-only when calling the
 With this feature flag turned off, a ``ReadonlyDocument`` error will be
 raised when destroying or deleting, as well as when saving or updating.
 
-Prior to Mongoid 8.1 and in 8.1 with the ``legacy_readonly`` feature flag 
-turned on, documents become read-only when they are projected (i.e. using 
+Prior to Mongoid 8.1 and in 8.1 with the ``legacy_readonly`` feature flag
+turned on, documents become read-only when they are projected (i.e. using
 ``#only`` or ``#without``).
 
 .. code:: ruby
@@ -278,7 +278,18 @@ turned on, documents become read-only when they are projected (i.e. using
   band.destroy # => raises ReadonlyDocument error
 
 Note that with this feature flag on, a ``ReadonlyDocument`` error will only be
-raised when destroying or deleting, and not on saving or updating. See the 
+raised when destroying or deleting, and not on saving or updating. See the
 section on :ref:`Read-only Documents <readonly-documents>` for more details.
 
 
+Added method parameters to ``#exists?``
+---------------------------------------
+
+Mongoid 8.1 introduces method paramters to the ``Contextual#exists?`` method.
+An _id or a hash of conditions can now be included:
+
+.. code:: ruby
+
+  Band.exists?
+  Band.exists?(name: "The Rolling Stones")
+  Band.exists?(BSON::ObjectId('6320d96a3282a48cfce9e72c'))

--- a/lib/mongoid/contextual/memory.rb
+++ b/lib/mongoid/contextual/memory.rb
@@ -117,14 +117,12 @@ module Mongoid
       #   context.exists?(name: "...")
       #
       # @param [ Hash | Object | false ] id_or_conditions an _id to
-      #   search for, a hash of conditions, or false.
+      #   search for or a hash of conditions.
       #
       # @return [ true | false ] If the count is more than zero.
-      #   Always false if passed false.
       def exists?(id_or_conditions = nil)
         case id_or_conditions
         when nil then any?
-        when false then false
         when Hash then Memory.new(criteria.where(id_or_conditions)).exists?
         else Memory.new(criteria.where(_id: id_or_conditions)).exists?
         end

--- a/lib/mongoid/contextual/memory.rb
+++ b/lib/mongoid/contextual/memory.rb
@@ -116,7 +116,7 @@ module Mongoid
       # @example Do any documents exist for given conditions.
       #   context.exists?(name: "...")
       #
-      # @param [ Hash | BSON::ObjectId | String ] id_or_conditions an _id to
+      # @param [ Hash | Object | false ] id_or_conditions an _id to
       #   search for, a hash of conditions, or false.
       #
       # @return [ true | false ] If the count is more than zero.

--- a/lib/mongoid/contextual/memory.rb
+++ b/lib/mongoid/contextual/memory.rb
@@ -110,9 +110,16 @@ module Mongoid
       # @example Do any documents exist for the context.
       #   context.exists?
       #
+      # @param [ Hash | BSON::ObjectId | String ] id_or_conditions an _id to
+      #   search for, or a hash of conditions.
+      #
       # @return [ true | false ] If the count is more than zero.
-      def exists?
-        any?
+      def exists?(id_or_conditions = nil)
+        case id_or_conditions
+        when nil then any?
+        when Hash then Memory.new(criteria.where(id_or_conditions)).exists?
+        else Memory.new(criteria.where(_id: id_or_conditions)).exists?
+        end
       end
 
       # Get the first document in the database for the criteria's selector.

--- a/lib/mongoid/contextual/memory.rb
+++ b/lib/mongoid/contextual/memory.rb
@@ -117,12 +117,14 @@ module Mongoid
       #   context.exists?(name: "...")
       #
       # @param [ Hash | BSON::ObjectId | String ] id_or_conditions an _id to
-      #   search for, or a hash of conditions.
+      #   search for, a hash of conditions, or false.
       #
       # @return [ true | false ] If the count is more than zero.
+      #   Always false if passed false.
       def exists?(id_or_conditions = nil)
         case id_or_conditions
         when nil then any?
+        when false then false
         when Hash then Memory.new(criteria.where(id_or_conditions)).exists?
         else Memory.new(criteria.where(_id: id_or_conditions)).exists?
         end

--- a/lib/mongoid/contextual/memory.rb
+++ b/lib/mongoid/contextual/memory.rb
@@ -110,6 +110,12 @@ module Mongoid
       # @example Do any documents exist for the context.
       #   context.exists?
       #
+      # @example Do any documents exist for given _id.
+      #   context.exists?(BSON::ObjectId(...))
+      #
+      # @example Do any documents exist for given conditions.
+      #   context.exists?(name: "...")
+      #
       # @param [ Hash | BSON::ObjectId | String ] id_or_conditions an _id to
       #   search for, or a hash of conditions.
       #

--- a/lib/mongoid/contextual/memory.rb
+++ b/lib/mongoid/contextual/memory.rb
@@ -117,12 +117,14 @@ module Mongoid
       #   context.exists?(name: "...")
       #
       # @param [ Hash | Object | false ] id_or_conditions an _id to
-      #   search for or a hash of conditions.
+      #   search for, a hash of conditions, nil or false.
       #
       # @return [ true | false ] If the count is more than zero.
-      def exists?(id_or_conditions = nil)
+      #   Always false if passed nil or false.
+      def exists?(id_or_conditions = :none)
         case id_or_conditions
-        when nil then any?
+        when :none then any?
+        when nil, false then false
         when Hash then Memory.new(criteria.where(id_or_conditions)).exists?
         else Memory.new(criteria.where(_id: id_or_conditions)).exists?
         end

--- a/lib/mongoid/contextual/mongo.rb
+++ b/lib/mongoid/contextual/mongo.rb
@@ -158,6 +158,12 @@ module Mongoid
       # @example Do any documents exist for the context.
       #   context.exists?
       #
+      # @example Do any documents exist for given _id.
+      #   context.exists?(BSON::ObjectId(...))
+      #
+      # @example Do any documents exist for given conditions.
+      #   context.exists?(name: "...")
+      #
       # @note We don't use count here since Mongo does not use counted
       #   b-tree indexes.
       #

--- a/lib/mongoid/contextual/mongo.rb
+++ b/lib/mongoid/contextual/mongo.rb
@@ -167,7 +167,7 @@ module Mongoid
       # @note We don't use count here since Mongo does not use counted
       #   b-tree indexes.
       #
-      # @param [ Hash | BSON::ObjectId | String ] id_or_conditions an _id to
+      # @param [ Hash | Object | false ] id_or_conditions an _id to
       #   search for, a hash of conditions, or false.
       #
       # @return [ true | false ] If the count is more than zero.

--- a/lib/mongoid/contextual/mongo.rb
+++ b/lib/mongoid/contextual/mongo.rb
@@ -168,14 +168,12 @@ module Mongoid
       #   b-tree indexes.
       #
       # @param [ Hash | Object | false ] id_or_conditions an _id to
-      #   search for, a hash of conditions, or false.
+      #   search for or a hash of conditions.
       #
       # @return [ true | false ] If the count is more than zero.
-      #   Always false if passed false.
       def exists?(id_or_conditions = nil)
         case id_or_conditions
         when nil then !!(view.projection(_id: 1).limit(1).first)
-        when false then false
         when Hash then Mongo.new(criteria.where(id_or_conditions)).exists?
         else Mongo.new(criteria.where(_id: id_or_conditions)).exists?
         end

--- a/lib/mongoid/contextual/mongo.rb
+++ b/lib/mongoid/contextual/mongo.rb
@@ -161,9 +161,16 @@ module Mongoid
       # @note We don't use count here since Mongo does not use counted
       #   b-tree indexes.
       #
+      # @param [ Hash | BSON::ObjectId | String ] id_or_conditions an _id to
+      #   search for, or a hash of conditions.
+      #
       # @return [ true | false ] If the count is more than zero.
-      def exists?
-        !!(view.projection(_id: 1).limit(1).first)
+      def exists?(id_or_conditions = nil)
+        case id_or_conditions
+        when nil then !!(view.projection(_id: 1).limit(1).first)
+        when Hash then Mongo.new(criteria.where(id_or_conditions)).exists?
+        else Mongo.new(criteria.where(_id: id_or_conditions)).exists?
+        end
       end
 
       # Run an explain on the criteria.

--- a/lib/mongoid/contextual/mongo.rb
+++ b/lib/mongoid/contextual/mongo.rb
@@ -168,12 +168,14 @@ module Mongoid
       #   b-tree indexes.
       #
       # @param [ Hash | Object | false ] id_or_conditions an _id to
-      #   search for or a hash of conditions.
+      #   search for, a hash of conditions, nil or false.
       #
       # @return [ true | false ] If the count is more than zero.
-      def exists?(id_or_conditions = nil)
+      #   Always false if passed nil or false.
+      def exists?(id_or_conditions = :none)
         case id_or_conditions
-        when nil then !!(view.projection(_id: 1).limit(1).first)
+        when :none then !!(view.projection(_id: 1).limit(1).first)
+        when nil, false then false
         when Hash then Mongo.new(criteria.where(id_or_conditions)).exists?
         else Mongo.new(criteria.where(_id: id_or_conditions)).exists?
         end

--- a/lib/mongoid/contextual/mongo.rb
+++ b/lib/mongoid/contextual/mongo.rb
@@ -173,6 +173,7 @@ module Mongoid
       # @return [ true | false ] If the count is more than zero.
       #   Always false if passed nil or false.
       def exists?(id_or_conditions = :none)
+        return false if self.view.limit == 0
         case id_or_conditions
         when :none then !!(view.projection(_id: 1).limit(1).first)
         when nil, false then false

--- a/lib/mongoid/contextual/mongo.rb
+++ b/lib/mongoid/contextual/mongo.rb
@@ -168,12 +168,14 @@ module Mongoid
       #   b-tree indexes.
       #
       # @param [ Hash | BSON::ObjectId | String ] id_or_conditions an _id to
-      #   search for, or a hash of conditions.
+      #   search for, a hash of conditions, or false.
       #
       # @return [ true | false ] If the count is more than zero.
+      #   Always false if passed false.
       def exists?(id_or_conditions = nil)
         case id_or_conditions
         when nil then !!(view.projection(_id: 1).limit(1).first)
+        when false then false
         when Hash then Mongo.new(criteria.where(id_or_conditions)).exists?
         else Mongo.new(criteria.where(_id: id_or_conditions)).exists?
         end

--- a/lib/mongoid/contextual/none.rb
+++ b/lib/mongoid/contextual/none.rb
@@ -80,6 +80,12 @@ module Mongoid
       # @example Do any documents exist in the null context.
       #   context.exists?
       #
+      # @example Do any documents exist for given _id.
+      #   context.exists?(BSON::ObjectId(...))
+      #
+      # @example Do any documents exist for given conditions.
+      #   context.exists?(name: "...")
+      #
       # @param [ Hash | BSON::ObjectId | String ] id_or_conditions an _id to
       #   search for, or a hash of conditions.
       #

--- a/lib/mongoid/contextual/none.rb
+++ b/lib/mongoid/contextual/none.rb
@@ -87,7 +87,7 @@ module Mongoid
       #   context.exists?(name: "...")
       #
       # @param [ Hash | BSON::ObjectId | String ] id_or_conditions an _id to
-      #   search for, or a hash of conditions.
+      #   search for, a hash of conditions, or false.
       #
       # @return [ false ] Always false.
       def exists?(id_or_conditions = nil); false; end

--- a/lib/mongoid/contextual/none.rb
+++ b/lib/mongoid/contextual/none.rb
@@ -80,8 +80,11 @@ module Mongoid
       # @example Do any documents exist in the null context.
       #   context.exists?
       #
+      # @param [ Hash | BSON::ObjectId | String ] id_or_conditions an _id to
+      #   search for, or a hash of conditions.
+      #
       # @return [ false ] Always false.
-      def exists?; false; end
+      def exists?(id_or_conditions = nil); false; end
 
       # Pluck the field values in null context.
       #

--- a/lib/mongoid/contextual/none.rb
+++ b/lib/mongoid/contextual/none.rb
@@ -86,7 +86,7 @@ module Mongoid
       # @example Do any documents exist for given conditions.
       #   context.exists?(name: "...")
       #
-      # @param [ Hash | BSON::ObjectId | String ] id_or_conditions an _id to
+      # @param [ Hash | Object | false ] id_or_conditions an _id to
       #   search for, a hash of conditions, or false.
       #
       # @return [ false ] Always false.

--- a/lib/mongoid/contextual/none.rb
+++ b/lib/mongoid/contextual/none.rb
@@ -87,10 +87,10 @@ module Mongoid
       #   context.exists?(name: "...")
       #
       # @param [ Hash | Object | false ] id_or_conditions an _id to
-      #   search for or a hash of conditions.
+      #   search for, a hash of conditions, nil or false.
       #
       # @return [ false ] Always false.
-      def exists?(id_or_conditions = nil); false; end
+      def exists?(id_or_conditions = :none); false; end
 
       # Pluck the field values in null context.
       #

--- a/lib/mongoid/contextual/none.rb
+++ b/lib/mongoid/contextual/none.rb
@@ -87,7 +87,7 @@ module Mongoid
       #   context.exists?(name: "...")
       #
       # @param [ Hash | Object | false ] id_or_conditions an _id to
-      #   search for, a hash of conditions, or false.
+      #   search for or a hash of conditions.
       #
       # @return [ false ] Always false.
       def exists?(id_or_conditions = nil); false; end

--- a/lib/mongoid/findable.rb
+++ b/lib/mongoid/findable.rb
@@ -108,10 +108,11 @@ module Mongoid
     #   Person.exists?(name: "...")
     #
     # @param [ Hash | Object | false ] id_or_conditions an _id to
-    #   search for or a hash of conditions.
+    #   search for, a hash of conditions, nil or false.
     #
     # @return [ true | false ] If any documents exist for the conditions.
-    def exists?(id_or_conditions = nil)
+    #   Always false if passed nil or false.
+    def exists?(id_or_conditions = :none)
       with_default_scope.exists?(id_or_conditions)
     end
 

--- a/lib/mongoid/findable.rb
+++ b/lib/mongoid/findable.rb
@@ -101,6 +101,12 @@ module Mongoid
     # @example Do any documents exist for the conditions?
     #   Person.exists?
     #
+    # @example Do any documents exist for given _id.
+    #   Person.exists?(BSON::ObjectId(...))
+    #
+    # @example Do any documents exist for given conditions.
+    #   Person.exists?(name: "...")
+    #
     # @param [ Hash | BSON::ObjectId ] id_or_conditions an _id to
     #   search for, or a hash of conditions.
     #

--- a/lib/mongoid/findable.rb
+++ b/lib/mongoid/findable.rb
@@ -107,7 +107,7 @@ module Mongoid
     # @example Do any documents exist for given conditions.
     #   Person.exists?(name: "...")
     #
-    # @param [ Hash | BSON::ObjectId ] id_or_conditions an _id to
+    # @param [ Hash | Object | false ] id_or_conditions an _id to
     #   search for, a hash of conditions, or false.
     #
     # @return [ true | false ] If any documents exist for the conditions.

--- a/lib/mongoid/findable.rb
+++ b/lib/mongoid/findable.rb
@@ -108,10 +108,9 @@ module Mongoid
     #   Person.exists?(name: "...")
     #
     # @param [ Hash | Object | false ] id_or_conditions an _id to
-    #   search for, a hash of conditions, or false.
+    #   search for or a hash of conditions.
     #
     # @return [ true | false ] If any documents exist for the conditions.
-    #   Always false if passed false.
     def exists?(id_or_conditions = nil)
       with_default_scope.exists?(id_or_conditions)
     end

--- a/lib/mongoid/findable.rb
+++ b/lib/mongoid/findable.rb
@@ -108,9 +108,10 @@ module Mongoid
     #   Person.exists?(name: "...")
     #
     # @param [ Hash | BSON::ObjectId ] id_or_conditions an _id to
-    #   search for, or a hash of conditions.
+    #   search for, a hash of conditions, or false.
     #
     # @return [ true | false ] If any documents exist for the conditions.
+    #   Always false if passed false.
     def exists?(id_or_conditions = nil)
       with_default_scope.exists?(id_or_conditions)
     end

--- a/lib/mongoid/findable.rb
+++ b/lib/mongoid/findable.rb
@@ -101,9 +101,12 @@ module Mongoid
     # @example Do any documents exist for the conditions?
     #   Person.exists?
     #
+    # @param [ Hash | BSON::ObjectId ] id_or_conditions an _id to
+    #   search for, or a hash of conditions.
+    #
     # @return [ true | false ] If any documents exist for the conditions.
-    def exists?
-      with_default_scope.exists?
+    def exists?(id_or_conditions = nil)
+      with_default_scope.exists?(id_or_conditions)
     end
 
     # Finds a +Document+ or multiple documents by their _id values.

--- a/spec/mongoid/contextual/memory_spec.rb
+++ b/spec/mongoid/contextual/memory_spec.rb
@@ -915,6 +915,32 @@ describe Mongoid::Contextual::Memory do
         end
       end
     end
+
+    context "when passing false" do
+
+      let(:criteria) do
+        Band.criteria.tap do |crit|
+          crit.documents = [ band ]
+        end
+      end
+
+      it "returns false" do
+        expect(criteria.exists?(false)).to be false
+      end
+    end
+
+    context "when passing nil" do
+
+      let(:criteria) do
+        Band.criteria.tap do |crit|
+          crit.documents = [ band ]
+        end
+      end
+
+      it "returns false" do
+        expect(criteria.exists?(nil)).to be false
+      end
+    end
   end
 
   [ :first, :one ].each do |method|

--- a/spec/mongoid/contextual/memory_spec.rb
+++ b/spec/mongoid/contextual/memory_spec.rb
@@ -915,19 +915,6 @@ describe Mongoid::Contextual::Memory do
         end
       end
     end
-
-    context "when passing false" do
-
-      let(:criteria) do
-        Band.criteria.tap do |crit|
-          crit.documents = [ band ]
-        end
-      end
-
-      it "returns false" do
-        expect(criteria.exists?(false)).to be false
-      end
-    end
   end
 
   [ :first, :one ].each do |method|

--- a/spec/mongoid/contextual/memory_spec.rb
+++ b/spec/mongoid/contextual/memory_spec.rb
@@ -915,6 +915,19 @@ describe Mongoid::Contextual::Memory do
         end
       end
     end
+
+    context "when passing false" do
+
+      let(:criteria) do
+        Band.criteria.tap do |crit|
+          crit.documents = [ band ]
+        end
+      end
+
+      it "returns false" do
+        expect(criteria.exists?(false)).to be false
+      end
+    end
   end
 
   [ :first, :one ].each do |method|

--- a/spec/mongoid/contextual/memory_spec.rb
+++ b/spec/mongoid/contextual/memory_spec.rb
@@ -766,19 +766,15 @@ describe Mongoid::Contextual::Memory do
       Address.new(street: "friedel")
     end
 
-    let!(:band) do
-      Band.create!(name: "Depeche Mode", active: true)
+    let(:criteria) do
+      Address.where(street: "hobrecht").tap do |crit|
+        crit.documents = [ hobrecht, friedel ]
+      end
     end
 
     context "when not passing options" do
 
       context "when there are matching documents" do
-
-        let(:criteria) do
-          Address.where(street: "hobrecht").tap do |crit|
-            crit.documents = [ hobrecht, friedel ]
-          end
-        end
 
         let(:context) do
           described_class.new(criteria)
@@ -824,39 +820,33 @@ describe Mongoid::Contextual::Memory do
 
     context "when passing an _id" do
 
-      let(:criteria) do
-        Band.criteria.tap do |crit|
-          crit.documents = [ band ]
-        end
-      end
-
       context "when its of type BSON::ObjectId" do
 
         context "when calling it on an empty criteria" do
 
           it "returns true" do
-            expect(Band.exists?(band._id)).to be true
+            expect(criteria.exists?(hobrecht._id)).to be true
           end
         end
 
         context "when calling it on a criteria that includes the object" do
 
           it "returns true" do
-            expect(Band.where(name: band.name).exists?(band._id)).to be true
+            expect(criteria.where(street: hobrecht.street).exists?(hobrecht._id)).to be true
           end
         end
 
         context "when calling it on a criteria that does not include the object" do
 
           it "returns false" do
-            expect(Band.where(name: "bogus").exists?(band._id)).to be false
+            expect(criteria.where(street: "bogus").exists?(hobrecht._id)).to be false
           end
         end
 
         context "when the id does not exist" do
 
           it "returns false" do
-            expect(Band.exists?(BSON::ObjectId.new)).to be false
+            expect(criteria.exists?(BSON::ObjectId.new)).to be false
           end
         end
       end
@@ -866,14 +856,14 @@ describe Mongoid::Contextual::Memory do
         context "when the id exists" do
 
           it "returns true" do
-            expect(Band.exists?(band._id.to_s)).to be true
+            expect(criteria.exists?(hobrecht._id.to_s)).to be true
           end
         end
 
         context "when the id does not exist" do
 
           it "returns false" do
-            expect(Band.exists?(BSON::ObjectId.new.to_s)).to be false
+            expect(criteria.exists?(BSON::ObjectId.new.to_s)).to be false
           end
         end
       end
@@ -881,48 +871,36 @@ describe Mongoid::Contextual::Memory do
 
     context "when passing a hash" do
 
-      let(:criteria) do
-        Band.criteria.tap do |crit|
-          crit.documents = [ band ]
-        end
-      end
-
       context "when calling it on an empty criteria" do
 
         it "returns true" do
-          expect(Band.exists?(name: band.name)).to be true
+          expect(criteria.exists?(street: hobrecht.street)).to be true
         end
       end
 
       context "when calling it on a criteria that includes the object" do
 
         it "returns true" do
-          expect(Band.where(active: true).exists?(name: band.name)).to be true
+          expect(criteria.where(_id: hobrecht._id).exists?(street: hobrecht.street)).to be true
         end
       end
 
       context "when calling it on a criteria that does not include the object" do
 
         it "returns false" do
-          expect(Band.where(active: false).exists?(name: band.name)).to be false
+          expect(criteria.where(_id: BSON::ObjectId.new).exists?(street: hobrecht.street)).to be false
         end
       end
 
       context "when the conditions don't match" do
 
         it "returns false" do
-          expect(Band.exists?(name: "bogus")).to be false
+          expect(criteria.exists?(street: "bogus")).to be false
         end
       end
     end
 
     context "when passing false" do
-
-      let(:criteria) do
-        Band.criteria.tap do |crit|
-          crit.documents = [ band ]
-        end
-      end
 
       it "returns false" do
         expect(criteria.exists?(false)).to be false
@@ -931,14 +909,15 @@ describe Mongoid::Contextual::Memory do
 
     context "when passing nil" do
 
-      let(:criteria) do
-        Band.criteria.tap do |crit|
-          crit.documents = [ band ]
-        end
-      end
-
       it "returns false" do
         expect(criteria.exists?(nil)).to be false
+      end
+    end
+
+    context "when the limit is 0" do
+
+      it "returns false" do
+        expect(criteria.limit(0).exists?).to be false
       end
     end
   end

--- a/spec/mongoid/contextual/mongo_spec.rb
+++ b/spec/mongoid/contextual/mongo_spec.rb
@@ -1551,13 +1551,6 @@ describe Mongoid::Contextual::Mongo do
         end
       end
     end
-
-    context "when passing false" do
-
-      it "returns false" do
-        expect(Band.exists?(false)).to be false
-      end
-    end
   end
 
   describe "#explain" do

--- a/spec/mongoid/contextual/mongo_spec.rb
+++ b/spec/mongoid/contextual/mongo_spec.rb
@@ -1551,6 +1551,20 @@ describe Mongoid::Contextual::Mongo do
         end
       end
     end
+
+    context "when passing false" do
+
+      it "returns false" do
+        expect(Band.exists?(false)).to be false
+      end
+    end
+
+    context "when passing nil" do
+
+      it "returns false" do
+        expect(Band.exists?(nil)).to be false
+      end
+    end
   end
 
   describe "#explain" do

--- a/spec/mongoid/contextual/mongo_spec.rb
+++ b/spec/mongoid/contextual/mongo_spec.rb
@@ -1565,6 +1565,20 @@ describe Mongoid::Contextual::Mongo do
         expect(Band.exists?(nil)).to be false
       end
     end
+
+    context "when the limit is 0" do
+
+      it "returns false" do
+        expect(Band.limit(0).exists?).to be false
+      end
+    end
+
+    context "when the criteria limit is 0" do
+
+      it "returns false" do
+        expect(Band.criteria.limit(0).exists?).to be false
+      end
+    end
   end
 
   describe "#explain" do

--- a/spec/mongoid/contextual/mongo_spec.rb
+++ b/spec/mongoid/contextual/mongo_spec.rb
@@ -1551,6 +1551,13 @@ describe Mongoid::Contextual::Mongo do
         end
       end
     end
+
+    context "when passing false" do
+
+      it "returns false" do
+        expect(Band.exists?(false)).to be false
+      end
+    end
   end
 
   describe "#explain" do


### PR DESCRIPTION
`#exists?` now takes a number of argument types:
- `Hash`: A hash of conditions.
- `Object`: An _id to search for.
- ``false``/``nil``: Always returns false.

I've decided to follow Rails' lead on `nil`/`false`... automatically returning `false` on `nil` makes sense, since in actuality what you're doing is checking for a `nil` or `false` _id. If that returned true, it would make no sense. 