### PR TITLE
MONGOID-5164 Use None criteria instead of $in with empty list in HABTM association

### DIFF
--- a/lib/mongoid/association/referenced/has_and_belongs_to_many.rb
+++ b/lib/mongoid/association/referenced/has_and_belongs_to_many.rb
@@ -264,7 +264,12 @@ module Mongoid
         def query_criteria(id_list)
           crit = relation_class.criteria
           crit = crit.apply_scope(scope)
-          crit = crit.all_of(primary_key => {"$in" => id_list || []})
+          crit = if id_list
+            crit.all_of(primary_key => { "$in" => id_list })
+          else
+            crit.all.to_a
+            crit.none
+          end
           with_ordering(crit)
         end
       end

--- a/lib/mongoid/association/referenced/has_and_belongs_to_many.rb
+++ b/lib/mongoid/association/referenced/has_and_belongs_to_many.rb
@@ -267,7 +267,6 @@ module Mongoid
           crit = if id_list
             crit.all_of(primary_key => { "$in" => id_list })
           else
-            crit.all.to_a
             crit.none
           end
           with_ordering(crit)

--- a/lib/mongoid/association/referenced/has_and_belongs_to_many.rb
+++ b/lib/mongoid/association/referenced/has_and_belongs_to_many.rb
@@ -263,8 +263,8 @@ module Mongoid
 
         def query_criteria(id_list)
           crit = relation_class.criteria
-          crit = crit.apply_scope(scope)
           crit = if id_list
+            crit = crit.apply_scope(scope)
             crit.all_of(primary_key => { "$in" => id_list })
           else
             crit.none

--- a/spec/mongoid/association/referenced/has_and_belongs_to_many/buildable_spec.rb
+++ b/spec/mongoid/association/referenced/has_and_belongs_to_many/buildable_spec.rb
@@ -111,7 +111,7 @@ describe Mongoid::Association::Referenced::HasAndBelongsToMany::Buildable do
         end
 
         let(:criteria) do
-          Preference.all_of("_id" => { "$in" => [] })
+          Preference.none
         end
 
         it "a criteria object" do


### PR DESCRIPTION
There is no behavior change here, as no query was being executed anyway (as per this [line](https://github.com/mongodb/mongoid/blob/master/lib/mongoid/association/referenced/has_many/enumerable.rb#L484))... I wouldn't mind closing this as won't do, or if we want to do this because it's cleaner. 

MONGOID-5164