### PR TITLE
MONGOID-5484 - Bugfix: Numeric strings should correctly evolve into BigDecimal (i.e. respecting map_big_decimal_to_decimal128)

### DIFF
--- a/lib/mongoid/criteria/queryable/extensions/big_decimal.rb
+++ b/lib/mongoid/criteria/queryable/extensions/big_decimal.rb
@@ -33,7 +33,7 @@ module Mongoid
                   end
                 # Always return on string for backwards compatibility with querying
                 # string-backed BigDecimal fields.
-                when BSON::Decimal128, String then obj
+                when BSON::Decimal128 then obj
                 else
                   if obj.numeric?
                     if Mongoid.map_big_decimal_to_decimal128

--- a/spec/mongoid/criteria/queryable/extensions/big_decimal_spec.rb
+++ b/spec/mongoid/criteria/queryable/extensions/big_decimal_spec.rb
@@ -142,14 +142,14 @@ describe BigDecimal do
       end
 
       context "when provided a numeric" do
-        it "returns a string" do
+        it "returns a BSON::Decimal128" do
           expect(described_class.evolve(1)).to eq(BSON::Decimal128.new('1'))
         end
       end
 
-      context "when provided a bogus value" do
-        it "returns the value" do
-          expect(described_class.evolve(:bogus)).to eq(:bogus)
+      context "when provided a valid string" do
+        it "returns a BSON::Decimal128" do
+          expect(described_class.evolve("1")).to eq(BSON::Decimal128.new('1'))
         end
       end
 
@@ -159,9 +159,9 @@ describe BigDecimal do
         end
       end
 
-      context "when provided a valid string" do
-        it "returns the string" do
-          expect(described_class.evolve("1")).to eq("1")
+      context "when provided a bogus value" do
+        it "returns the value" do
+          expect(described_class.evolve(:bogus)).to eq(:bogus)
         end
       end
     end

--- a/spec/mongoid/criteria/queryable/extensions/big_decimal_spec.rb
+++ b/spec/mongoid/criteria/queryable/extensions/big_decimal_spec.rb
@@ -149,7 +149,7 @@ describe BigDecimal do
 
       context "when provided a valid string" do
         it "returns a BSON::Decimal128" do
-          expect(described_class.evolve("1")).to eq(BSON::Decimal128.new('1'))
+          expect(described_class.evolve('1')).to eq(BSON::Decimal128.new('1'))
         end
       end
 

--- a/spec/mongoid/criteria_spec.rb
+++ b/spec/mongoid/criteria_spec.rb
@@ -2756,13 +2756,33 @@ describe Mongoid::Criteria do
             Band.create!(name: "Boards of Canada", sales: sales)
           end
 
-          let(:from_db) do
+          it "cannot find values when querying using a BigDecimal value" do
             Mongoid.map_big_decimal_to_decimal128 = true
-            Band.where(sales: sales.to_s).first
+            from_db = Band.where(sales: sales).first
+            expect(from_db).to eq(nil)
           end
 
-          it "finds the document by the big decimal value" do
-            expect(from_db).to eq(band)
+          it "cannot find values when querying using a string value" do
+            Mongoid.map_big_decimal_to_decimal128 = true
+            from_db = Band.where(sales: sales.to_s).first
+            expect(from_db).to eq(nil)
+          end
+
+          context "after converting value" do
+            before do
+              Mongoid.map_big_decimal_to_decimal128 = true
+              band.set(sales: band.sales)
+            end
+
+            it "can find values when querying using a BigDecimal value" do
+              from_db = Band.where(sales: sales).first
+              expect(from_db).to eq(band)
+            end
+
+            it "can find values when querying using a string value" do
+              from_db = Band.where(sales: sales.to_s).first
+              expect(from_db).to eq(band)
+            end
           end
         end
       end


### PR DESCRIPTION
Refer to MONGOID-5484

Note the logic in this PR correctly respects `Mongoid.map_big_decimal_to_decimal128`
- When false, BigDecimal is queried as string.
- When true, strings are evolved to Decimal128.