### PR TITLE
MONGOID-5488 - Bugfix: Date#__evolve_time__ should use the configured zone instead of Time.local (i.e. respecting Mongoid.use_activesupport_time_zone)

### DIFF
--- a/docs/release-notes/mongoid-9.0.txt
+++ b/docs/release-notes/mongoid-9.0.txt
@@ -43,7 +43,7 @@ while ``ActiveModel::MissingAttributeError`` does not.
 
 
 Use configured time zone to typecast Date to Time in queries
-------------------------------------------------------------------
+-------------------------------------------------------------
 
 When querying for a Time field using a Date value, Mongoid now correctly
 considers the ``Mongoid.use_activesupport_time_zone`` to perform type

--- a/docs/release-notes/mongoid-9.0.txt
+++ b/docs/release-notes/mongoid-9.0.txt
@@ -46,8 +46,8 @@ Use configured time zone to typecast Date to Time in queries
 -------------------------------------------------------------
 
 When querying for a Time field using a Date value, Mongoid now correctly
-considers the ``Mongoid.use_activesupport_time_zone`` to perform type
-conversion.
+considers the ``Mongoid.use_activesupport_time_zone`` configuration option
+to perform type conversion.
 
 .. code-block:: ruby
 

--- a/docs/release-notes/mongoid-9.0.txt
+++ b/docs/release-notes/mongoid-9.0.txt
@@ -40,3 +40,36 @@ any Mongoid-specific usages of this class, and change them to
 ``Mongoid::Errors::AttributeNotLoaded``. Note additionally that
 ``AttributeNotLoaded`` inherits from ``Mongoid::Errors::MongoidError``,
 while ``ActiveModel::MissingAttributeError`` does not.
+
+
+Use configured Rails time zone to typecast Date to Time in queries
+------------------------------------------------------------------
+
+When querying for a Time field using a Date value, Mongoid now correctly
+considers the ``Mongoid.use_activesupport_time_zone`` to perform type
+conversion.
+
+.. code-block:: ruby
+
+  Mongoid.use_activesupport_time_zone = true
+
+  class Magazine
+    include Mongoid::Document
+
+    field :published_at, type: Time
+  end
+
+  Time.zone = 'Asia/Tokyo'
+
+  Magazine.gte(published_at: Date.parse('2022-09-26'))
+  #=> will return all results on or after Sept 26th, 2022
+  #   at 0:00 in Asia/Tokyo time zone.
+
+In prior Mongoid versions, the above code would ignore the
+``Mongoid.use_activesupport_time_zone`` setting and behave as if
+it were false, i.e. always using the system time zone to perform
+the type conversion.
+
+Note that in prior Mongoid versions, typecasting Date to Time during
+persistence operations was already correctly using the
+``Mongoid.use_activesupport_time_zone`` setting.

--- a/docs/release-notes/mongoid-9.0.txt
+++ b/docs/release-notes/mongoid-9.0.txt
@@ -42,7 +42,7 @@ any Mongoid-specific usages of this class, and change them to
 while ``ActiveModel::MissingAttributeError`` does not.
 
 
-Use configured Rails time zone to typecast Date to Time in queries
+Use configured time zone to typecast Date to Time in queries
 ------------------------------------------------------------------
 
 When querying for a Time field using a Date value, Mongoid now correctly

--- a/lib/mongoid/criteria/queryable/extensions/date.rb
+++ b/lib/mongoid/criteria/queryable/extensions/date.rb
@@ -25,7 +25,7 @@ module Mongoid
           #
           # @return [ Time ] The date as a local time.
           def __evolve_time__
-            ::Time.local(year, month, day)
+            ::Time.configured.local(year, month, day).to_time
           end
 
           module ClassMethods

--- a/lib/mongoid/criteria/queryable/extensions/date.rb
+++ b/lib/mongoid/criteria/queryable/extensions/date.rb
@@ -23,9 +23,9 @@ module Mongoid
           # @example Evolve the date.
           #   date.__evolve_time__
           #
-          # @return [ Time ] The date as a local time.
+          # @return [ Time | ActiveSupport::TimeWithZone ] The date as a local time.
           def __evolve_time__
-            ::Time.configured.local(year, month, day).to_time
+            ::Time.configured.local(year, month, day)
           end
 
           module ClassMethods

--- a/spec/mongoid/criteria/queryable/extensions/date_spec.rb
+++ b/spec/mongoid/criteria/queryable/extensions/date_spec.rb
@@ -25,20 +25,54 @@ describe Date do
 
   describe "#__evolve_time__" do
 
-    let(:date) do
-      Date.new(2010, 1, 1)
+    context "when using ActiveSupport's time zone" do
+      include_context 'using AS time zone'
+
+      let(:date) do
+        Date.new(2010, 1, 1)
+      end
+
+      let(:expected_time) do
+        Time.zone.local(2010, 1, 1, 0, 0, 0, 0)
+      end
+
+      let(:evolved) do
+        date.__evolve_time__
+      end
+
+      it 'is an AS::TimeWithZone' do
+        expect(evolved.class).to eq(Time)
+      end
+
+      it 'is equal to expected time' do
+        expect(expected_time).to be_a(ActiveSupport::TimeWithZone)
+        expect(evolved).to eq(expected_time)
+      end
     end
 
-    let(:evolved) do
-      date.__evolve_time__
-    end
+    context "when not using ActiveSupport's time zone" do
+      include_context 'not using AS time zone'
 
-    let(:expected) do
-      Time.local(2010, 1, 1, 0, 0, 0)
-    end
+      let(:date) do
+        Date.new(2010, 1, 1)
+      end
 
-    it "returns the time" do
-      expect(evolved).to eq(expected)
+      let(:expected_time) do
+        Time.local(2010, 1, 1, 0, 0, 0, 0)
+      end
+
+      let(:evolved) do
+        date.__evolve_time__
+      end
+
+      it 'is a Time' do
+        expect(evolved.class).to eq(Time)
+      end
+
+      it 'is equal to expected time' do
+        expect(expected_time).to be_a(Time)
+        expect(evolved).to eq(expected_time)
+      end
     end
   end
 

--- a/spec/mongoid/criteria/queryable/extensions/date_spec.rb
+++ b/spec/mongoid/criteria/queryable/extensions/date_spec.rb
@@ -41,7 +41,7 @@ describe Date do
       end
 
       it 'is an AS::TimeWithZone' do
-        expect(evolved.class).to eq(Time)
+        expect(evolved.class).to eq(ActiveSupport::TimeWithZone)
       end
 
       it 'is equal to expected time' do


### PR DESCRIPTION
Currently `Date#__evolve_time__` uses "local" (not "UTC") which is not affected by Mongoid configuration.

This PR changes it to correct respect the `Mongoid.use_activesupport_time_zone` setting.

Refer to MONGOID-5488