### PR TITLE
Fix two bugs in BigDecimal mongoization

### DIFF
--- a/lib/mongoid/extensions/big_decimal.rb
+++ b/lib/mongoid/extensions/big_decimal.rb
@@ -48,8 +48,6 @@ module Mongoid
             object.to_big_decimal
           elsif object.numeric?
             BigDecimal(object.to_s)
-          elsif object.numeric?
-            object.to_d
           end
         end
 
@@ -79,7 +77,7 @@ module Mongoid
             if object.is_a?(BSON::Decimal128) || object.numeric?
               object.to_s
             elsif !object.is_a?(String)
-              object.try(:to_d)
+              object.try(:to_d).to_s
             end
           end
         end


### PR DESCRIPTION
1. demongoize - has redundant elsif object.numeric?
2. mongoize - missing to_s in return condition when map_big_decimal_to_decimal128 is false