### PR TITLE
MONGOID-5331 Document hash assignment to associations

### DIFF
--- a/docs/reference/associations.txt
+++ b/docs/reference/associations.txt
@@ -906,6 +906,7 @@ example:
 This works for ``embeds_one``, ``embeds_many``, and ``embedded_in`` associations.
 Note that you cannot assign hashes to referenced associations.
 
+
 Common Behavior
 ===============
 

--- a/docs/reference/associations.txt
+++ b/docs/reference/associations.txt
@@ -875,12 +875,14 @@ documents that exist in the application:
   band.tours.destroy_all
 
 
+.. _hash-assignment:
+
 Hash Assignment
 ---------------
 
 Embedded associations allow the user to assign a ``Hash`` instead of a document
-to an association. On assignment, this hash is coerced into the class of the
-document for the association that it's being assigned to. Take the following
+to an association. On assignment, this hash is coerced into a document of the
+class of the association that it's being assigned to. Take the following
 example:
 
 .. code:: ruby

--- a/docs/reference/associations.txt
+++ b/docs/reference/associations.txt
@@ -875,6 +875,35 @@ documents that exist in the application:
   band.tours.destroy_all
 
 
+Hash Assignment
+---------------
+
+Embedded associations allow the user to assign a ``Hash`` instead of a document
+to an association. On assignment, this hash is coerced into the class of the
+document for the association that it's being assigned to. Take the following
+example:
+
+.. code:: ruby
+
+  class Band
+    include Mongoid::Document
+    embeds_many :albums
+  end
+
+  class Album
+    include Mongoid::Document
+    field :name, type: String
+    embedded_in :band
+  end
+
+  band = Band.create!
+  band.albums = [ { name: "Narrow Stairs" }, { name: "Transatlanticism" } ]
+  p band.albums
+  # => [ #<Album _id: 633c71e93282a4357bb608e5, name: "Narrow Stairs">, #<Album _id: 633c71e93282a4357bb608e6, name: "Transatlanticism"> ]
+
+This works for ``embeds_one``, ``embeds_many``, and ``embedded_in`` associations.
+Note that you cannot assign hashes to referenced associations.
+
 Common Behavior
 ===============
 

--- a/docs/release-notes/mongoid-8.1.txt
+++ b/docs/release-notes/mongoid-8.1.txt
@@ -341,3 +341,34 @@ This time, the value for the ``:age`` field is maintained.
   The default for the ``:replace`` option will be changed to ``false`` in
   Mongoid 9.0, therefore it is recommended to explicitly specify this option
   while using ``#upsert`` in 8.1 for easier upgradability.
+
+
+Allow Hash Assignment to ``embedded_in``
+----------------------------------------
+
+Mongoid 8.1 allows the assignment of a hash to an ``embedded_in`` association.
+On assignment, the hash will be coerced into a document of the class of the
+association that it is being assigned to. This functionality already exists
+for ``embeds_one`` and ``embeds_many`` associations. Consider the following
+example:
+
+.. code:: ruby
+
+  class Band
+    include Mongoid::Document
+    field :name, type: String
+    embeds_many :albums
+  end
+
+  class Album
+    include Mongoid::Document
+    embedded_in :band
+  end
+
+  album = Album.new
+  album.band = { name: "Death Cab For Cutie" }
+  p album.band
+  # => <Band _id: 633c74113282a438a15d2b56, name: "Death Cab For Cutie">
+
+See the section on :ref:`Hash Assignment on Embedded Associations <hash-assignment>`
+for more details

--- a/lib/mongoid/association/embedded/batchable.rb
+++ b/lib/mongoid/association/embedded/batchable.rb
@@ -97,7 +97,7 @@ module Mongoid
         # @example Batch replace the documents.
         #   batchable.batch_replace([ doc_one, doc_two ])
         #
-        # @param [ Array<Document> ] docs The docs to replace with.
+        # @param [ Array<Document> | Array<Hash> ] docs The docs to replace with.
         #
         # @return [ Array<Hash> ] The inserts.
         def batch_replace(docs)
@@ -235,7 +235,7 @@ module Mongoid
         # @example Normalize the docs.
         #   batchable.normalize_docs(docs)
         #
-        # @param [ Array<Hash | Document> ] docs The docs to normalize.
+        # @param [ Array<Document> | Array<Hash> ] docs The docs to normalize.
         #
         # @return [ Array<Document> ] The docs.
         def normalize_docs(docs)

--- a/lib/mongoid/association/embedded/embedded_in/buildable.rb
+++ b/lib/mongoid/association/embedded/embedded_in/buildable.rb
@@ -15,8 +15,8 @@ module Mongoid
           # @example Build the document.
           #   Builder.new(meta, attrs).build
           #
-          # @param [ Object ] base The object.
-          # @param [ Object ] object The parent hash or document.
+          # @param [ Document ] base The object.
+          # @param [ Document | Hash ] object The parent hash or document.
           # @param [ String ] type Not used in this context.
           # @param [ Hash ] selected_fields Fields which were retrieved via
           #   #only. If selected_fields are specified, fields not listed in it

--- a/lib/mongoid/association/embedded/embedded_in/proxy.rb
+++ b/lib/mongoid/association/embedded/embedded_in/proxy.rb
@@ -30,7 +30,7 @@ module Mongoid
           # @example Substitute the new document.
           #   person.name.substitute(new_name)
           #
-          # @param [ Document ] replacement A document to replace the target.
+          # @param [ Document | Hash ] replacement A document to replace the target.
           #
           # @return [ Document | nil ] The association or nil.
           def substitute(replacement)
@@ -40,6 +40,7 @@ module Mongoid
               return nil
             end
             _base.new_record = true
+            replacement = Factory.build(klass, replacement) if replacement.is_a?(::Hash)
             self._target = replacement
             bind_one
             self

--- a/lib/mongoid/association/embedded/embeds_many/buildable.rb
+++ b/lib/mongoid/association/embedded/embeds_many/buildable.rb
@@ -17,8 +17,9 @@ module Mongoid
           # @example Build the documents.
           #   Builder.new(meta, attrs).build
           #
-          # @param [ Object ] base The base object.
-          # @param [ Object ] object The object to use to build the association.
+          # @param [ Document ] base The base object.
+          # @param [ Array<Document> | Array<Hash> ] object The object to use
+          #   to build the association.
           # @param [ String ] type Not used in this context.
           # @param [ Hash ] selected_fields Fields which were retrieved via
           #   #only. If selected_fields are specified, fields not listed in it

--- a/lib/mongoid/association/embedded/embeds_many/proxy.rb
+++ b/lib/mongoid/association/embedded/embeds_many/proxy.rb
@@ -332,7 +332,7 @@ module Mongoid
           # @example Substitute the association's target.
           #   person.addresses.substitute([ address ])
           #
-          # @param [ Array<Document> ] docs The replacement docs.
+          # @param [ Array<Document> | Array<Hash> ] docs The replacement docs.
           #
           # @return [ Many ] The proxied association.
           def substitute(docs)

--- a/lib/mongoid/association/embedded/embeds_one/buildable.rb
+++ b/lib/mongoid/association/embedded/embeds_one/buildable.rb
@@ -17,7 +17,7 @@ module Mongoid
           #   Builder.new(meta, attrs).build
           #
           # @param [ Document ] base The document this association hangs off of.
-          # @param [ Document ] object The related document.
+          # @param [ Document | Hash ] object The related document.
           # @param [ String ] _type Not used in this context.
           # @param [ Hash ] selected_fields Fields which were retrieved via
           #   #only. If selected_fields are specified, fields not listed in it

--- a/lib/mongoid/association/embedded/embeds_one/proxy.rb
+++ b/lib/mongoid/association/embedded/embeds_one/proxy.rb
@@ -43,7 +43,7 @@ module Mongoid
           # @example Substitute the new document.
           #   person.name.substitute(new_name)
           #
-          # @param [ Document ] replacement A document to replace the target.
+          # @param [ Document | Hash ] replacement A document to replace the target.
           #
           # @return [ Document | nil ] The association or nil.
           def substitute(replacement)

--- a/spec/mongoid/association/embedded/embedded_in/proxy_spec.rb
+++ b/spec/mongoid/association/embedded/embedded_in/proxy_spec.rb
@@ -630,7 +630,7 @@ describe Mongoid::Association::Embedded::EmbeddedIn::Proxy do
     end
   end
 
-  context "when assigning an association with a hash" do
+  context "when replacing an association with a hash" do
     let(:building_address) { BuildingAddress.new }
 
     before do

--- a/spec/mongoid/association/embedded/embedded_in/proxy_spec.rb
+++ b/spec/mongoid/association/embedded/embedded_in/proxy_spec.rb
@@ -640,7 +640,7 @@ describe Mongoid::Association::Embedded::EmbeddedIn::Proxy do
 
     it "creates the objects correctly" do
       expect(building_address.building).to be_a(Building)
-      expect(building_address.building.name).to eq("Empire Station")
+      expect(building_address.building.name).to eq("Empire State")
     end
   end
 end

--- a/spec/mongoid/association/embedded/embedded_in/proxy_spec.rb
+++ b/spec/mongoid/association/embedded/embedded_in/proxy_spec.rb
@@ -616,4 +616,31 @@ describe Mongoid::Association::Embedded::EmbeddedIn::Proxy do
       end
     end
   end
+
+  context "when assigning a hash" do
+    let(:building_address) { BuildingAddress.new }
+
+    before do
+      building_address.building = { name: "Chrysler" }
+    end
+
+    it "creates the objects correctly" do
+      expect(building_address.building).to be_a(Building)
+      expect(building_address.building.name).to eq("Chrysler")
+    end
+  end
+
+  context "when assigning an association with a hash" do
+    let(:building_address) { BuildingAddress.new }
+
+    before do
+      building_address.building = { name: "Chrysler" }
+      building_address.building = { name: "Empire State" }
+    end
+
+    it "creates the objects correctly" do
+      expect(building_address.building).to be_a(Building)
+      expect(building_address.building.name).to eq("Empire Station")
+    end
+  end
 end

--- a/spec/mongoid/association/embedded/embeds_many/proxy_spec.rb
+++ b/spec/mongoid/association/embedded/embeds_many/proxy_spec.rb
@@ -4840,4 +4840,19 @@ describe Mongoid::Association::Embedded::EmbedsMany::Proxy do
       expect(from_db.company_tags.size).to eq(2)
     end
   end
+
+  context "when assigning hashes" do
+    let(:user) { EmmUser.create! }
+
+    before do
+      user.orders = [ { sku: 1 }, { sku: 2 } ]
+    end
+
+    it "creates the objects correctly" do
+      expect(user.orders.first).to be_a(EmmOrder)
+      expect(user.orders.last).to be_a(EmmOrder)
+
+      expect(user.orders.map(&:sku).sort).to eq([ 1, 2 ])
+    end
+  end
 end

--- a/spec/mongoid/association/embedded/embeds_one/proxy_spec.rb
+++ b/spec/mongoid/association/embedded/embeds_one/proxy_spec.rb
@@ -202,7 +202,7 @@ describe Mongoid::Association::Embedded::EmbedsOne::Proxy do
             end
           end
         end
-        
+
         context 'when the original document does not need to be unset because it will be replaced by the $set' do
 
           let!(:pet_owner) do
@@ -1020,6 +1020,19 @@ describe Mongoid::Association::Embedded::EmbedsOne::Proxy do
 
     it "parent successfully embeds an invalid child" do
       expect(building.building_address).to be_a(BuildingAddress)
+    end
+  end
+
+  context "when assigning a hash" do
+    let(:building) { Building.create! }
+
+    before do
+      building.building_address = { city: "NYC" }
+    end
+
+    it "creates the objects correctly" do
+      expect(building.building_address).to be_a(BuildingAddress)
+      expect(building.building_address.city).to eq("NYC")
     end
   end
 end

--- a/spec/support/models/artist.rb
+++ b/spec/support/models/artist.rb
@@ -87,5 +87,4 @@ class Artist
   def after_remove_album(album)
     @after_remove_referenced_called = true
   end
-
 end

--- a/spec/support/models/building.rb
+++ b/spec/support/models/building.rb
@@ -3,6 +3,8 @@
 class Building
   include Mongoid::Document
 
+  field :name
+
   embeds_one :building_address, validate: false
   embeds_many :contractors
 end

--- a/spec/support/models/building.rb
+++ b/spec/support/models/building.rb
@@ -3,7 +3,7 @@
 class Building
   include Mongoid::Document
 
-  field :name
+  field :name, type: String
 
   embeds_one :building_address, validate: false
   embeds_many :contractors


### PR DESCRIPTION
Turns out this only works for embedded associations (but not `embedded_in` until this PR), but they cannot possible work for referenced associations, since any non document assigned to a referenced association is interpreted as a queryable item for retrieving the base document. 

I don't think we need to add this functionality for referenced association, and we know that referenced and embedded associations are not the same.

