### PR TITLE
Fix for rails runtime logging

### DIFF
--- a/lib/mongoid/railties/controller_runtime.rb
+++ b/lib/mongoid/railties/controller_runtime.rb
@@ -43,7 +43,7 @@ module Mongoid
           def log_process_action(payload)
             messages = super
             mongoid_runtime = payload[:mongoid_runtime]
-            messages << ("MongoDB: %.1fms" % mongoid_runtime.to_f) if mongoid_runtime
+            messages << ("MongoDB: %.1fms" % (mongoid_runtime * 1000.0)) if mongoid_runtime
             messages
           end
 


### PR DESCRIPTION
Simple fix to show the runtime in ms as expected.

When runtime is actually 0.16633599996566772 (seconds)
Before:
INF | Completed 200 OK in 4987ms (Views: 0.2ms | MongoDB: 0.2ms | Allocations: 220793)
After:
INF | Completed 200 OK in 4987ms (Views: 0.2ms | MongoDB: 166.3ms | Allocations: 220793)
