### PR TITLE
MONGOID-5453 Add .none_of query method

### DIFF
--- a/docs/reference/queries.txt
+++ b/docs/reference/queries.txt
@@ -428,7 +428,7 @@ The conditions are hoisted to the top level if possible:
 .. _none-of:
 
 ``none_of`` Behavior
--------------------
+--------------------
 
 ``none_of`` adds a negated disjunction ("nor") built from its arguments to
 the existing conditions in the criteria. For example:

--- a/docs/reference/queries.txt
+++ b/docs/reference/queries.txt
@@ -324,7 +324,7 @@ conditions are added to the criteria:
   Band.where(name: 1).or(name: 2).selector
   # => {"$or"=>[{"name"=>"1"}, {"name"=>"2"}]}
 
-``any_of``, ``nor`` and ``not`` behave similarly, with ``not`` producing
+``any_of``, ``none_of``, ``nor`` and ``not`` behave similarly, with ``not`` producing
 different query shapes as described below.
 
 When ``and``, ``or`` and ``nor`` logical operators are used, they
@@ -423,6 +423,20 @@ The conditions are hoisted to the top level if possible:
 
   Band.where(label: /Trust/).any_of({name: 'Astral Projection'})
   # => {"label"=>/Trust/, "name"=>"Astral Projection"}
+
+
+.. _none-of:
+
+``none_of`` Behavior
+-------------------
+
+``none_of`` adds a negated disjunction ("nor") built from its arguments to
+the existing conditions in the criteria. For example:
+
+.. code-block:: ruby
+
+  Band.where(label: /Trust/).none_of({name: 'Astral Projection'}, {name: /Best/})
+  # => {"label"=>/Trust/, "$nor"=>[{"name"=>"Astral Projection"}, {"name"=>/Best/}]}
 
 
 ``not`` Behavior

--- a/docs/release-notes/mongoid-8.1.txt
+++ b/docs/release-notes/mongoid-8.1.txt
@@ -372,3 +372,29 @@ example:
 
 See the section on :ref:`Hash Assignment on Embedded Associations <hash-assignment>`
 for more details
+
+
+Added ``none_of`` Query Method
+------------------------------
+
+With the addition of ``none_of``, Mongoid 8.1 allows queries to exclude
+conditions in bulk. The emitted query will encapsulate the specified 
+criteria in a ``$nor`` operation. For example:
+
+.. code:: ruby
+
+  class Building
+    include Mongoid::Document
+    field :city, type: String
+    field :height, type: Integer
+    field :purpose, type: String
+    field :occupancy, type: Integer
+  end
+
+  Building.where(city: 'Portland').
+    none_of(:height.lt => 100,
+            :purpose => 'apartment',
+            :occupancy.gt => 2500)
+
+This would query all buildings in Portland, excluding apartments, buildings less than
+100 units tall, and buildings with an occupancy greater than 2500 people.


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/MONGOID-5453

This adds a new query method, `#none_of`, which works as the opposite of `#any_of`. It will wrap all of the criteria it is given in a `$nor` operator.
