### PR TITLE
MONGOID-5547 create index needs to load models

### DIFF
--- a/lib/mongoid.rb
+++ b/lib/mongoid.rb
@@ -21,6 +21,7 @@ require "mongoid/version"
 require "mongoid/deprecable"
 require "mongoid/config"
 require "mongoid/persistence_context"
+require "mongoid/loadable"
 require "mongoid/loggable"
 require "mongoid/clients"
 require "mongoid/document"
@@ -41,6 +42,7 @@ I18n.load_path << File.join(File.dirname(__FILE__), "config", "locales", "en.yml
 module Mongoid
   extend Forwardable
   extend Loggable
+  extend Loadable
   extend self
   extend Clients::Sessions::ClassMethods
 
@@ -70,7 +72,7 @@ module Mongoid
   #
   #     config.preload_models = true
   #
-  # @return [ Config ] The configuration object.
+  # @return [ Config ] The xuration object.
   def configure(&block)
     return Config unless block_given?
 

--- a/lib/mongoid/loadable.rb
+++ b/lib/mongoid/loadable.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module Mongoid
+
+  # Defines how Mongoid can autoload all defined models.
+  module Loadable
+    # Search a list of model paths to get every model and require it, so
+    # that indexing and inheritance work in both development and production
+    # with the same results.
+    #
+    # @example Load all the application models from default model paths.
+    #   Mongoid.load_models
+    #
+    # @example Load all application models from a non-standard set of paths.
+    #   Mongoid.load_models(%w( ./models ./admin/models ))
+    #
+    # @param [ Array ] paths The list of paths that should be looked in
+    #   for model files. These must either be absolute paths, or relative to
+    #   the current working directory.
+    def load_models(paths = model_paths)
+      paths.each do |path|
+        if preload_models.resizable?
+          files = preload_models.map { |model| "#{path}/#{model.underscore}.rb" }
+        else
+          files = Dir.glob("#{path}/**/*.rb")
+        end
+
+        files.sort.each do |file|
+          load_model(file.gsub(/^#{path}\// , "").gsub(/\.rb$/, ""))
+        end
+      end
+    end
+
+    # A convenience method for loading a model's file. If Rails'
+    # `require_dependency` method exists, it will be used; otherwise
+    # `require` will be used.
+    #
+    # @example Load the model.
+    #   Mongoid.load_model("/mongoid/behavior")
+    #
+    # @param [ String ] file The base filename.
+    #
+    # @api private
+    def load_model(file)
+      if defined? require_dependency
+        require_dependency(file)
+      else
+        require(file)
+      end
+    end
+
+    # Returns the array of paths where the application's model definitions
+    # are located. If Rails is loaded, this defaults to the configured
+    # "app/models" paths (e.g. `config.paths["app/models"]`); otherwise, it
+    # defaults to `%w(./app/models ./lib/models)`.
+    #
+    # Note that these paths are the *roots* of the directory hierarchies where
+    # the models are located; it is not necessary to indicate every subdirectory,
+    # as long as these root paths are located in `$LOAD_PATH`.
+    #
+    # @return [ Array<String> ] the array of model paths
+    def model_paths
+      @model_paths ||= defined?(Rails) ?
+        Rails.application.config.paths["app/models"].expanded :
+        %w( ./app/models ./lib/models )
+    end
+
+    # Sets the model paths to the given array of paths. These are the paths
+    # where the application's model definitions are located.
+    #
+    # @param [ Array<String> ] paths The list of model paths
+    def model_paths=(paths)
+      @model_paths = paths
+    end
+  end
+
+end

--- a/lib/mongoid/tasks/database.rake
+++ b/lib/mongoid/tasks/database.rake
@@ -3,6 +3,7 @@
 namespace :db do
   namespace :mongoid do
     task :load_models do
+      ::Mongoid.load_models
     end
 
     desc "Create collections for Mongoid models"

--- a/lib/rails/mongoid.rb
+++ b/lib/rails/mongoid.rb
@@ -13,18 +13,7 @@ module Rails
     #
     # @param [ Application ] app The rails application.
     def load_models(app)
-      app.config.paths["app/models"].expanded.each do |path|
-        preload = ::Mongoid.preload_models
-        if preload.resizable?
-          files = preload.map { |model| "#{path}/#{model.underscore}.rb" }
-        else
-          files = Dir.glob("#{path}/**/*.rb")
-        end
-
-        files.sort.each do |file|
-          load_model(file.gsub("#{path}/" , "").gsub(".rb", ""))
-        end
-      end
+      ::Mongoid.load_models(app.config.paths["app/models"].expanded)
     end
 
     # Conditionally calls `Rails::Mongoid.load_models(app)` if the
@@ -33,23 +22,6 @@ module Rails
     # @param [ Application ] app The rails application.
     def preload_models(app)
       load_models(app) if ::Mongoid.preload_models
-    end
-
-    private
-
-    # I don't want to mock out kernel for unit testing purposes, so added this
-    # method as a convenience.
-    #
-    # @example Load the model.
-    #   Mongoid.load_model("/mongoid/behavior")
-    #
-    # @param [ String ] file The base filename.
-    def load_model(file)
-      begin
-        require_dependency(file)
-      rescue Exception => e
-        Logger.new(STDERR).warn(e.message)
-      end
     end
   end
 end

--- a/spec/mongoid/loading_spec.rb
+++ b/spec/mongoid/loading_spec.rb
@@ -21,19 +21,10 @@ describe Mongoid::Loadable do
     before { Mongoid.model_paths = nil }
 
     context "when Rails is defined" do
-      let(:mock_application) do
-        OpenStruct.new(
-          config: OpenStruct.new(
-            paths: { "app/models" => OpenStruct.new(expanded: [ "app/models" ]) }
-          )
-        )
-      end
-
       around do |example|
         FeatureSandbox.quarantine do
+          require "support/rails_mock"
           require "rails/mongoid"
-          Rails.extend Mongoid::Loadable::RailsApplication  
-          Rails.application = mock_application
           example.run
         end
       end

--- a/spec/mongoid/loading_spec.rb
+++ b/spec/mongoid/loading_spec.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require "ostruct"
+require "spec_helper"
+require "support/feature_sandbox"
+
+describe Mongoid::Loadable do
+  let(:model_root) do
+    File.absolute_path(
+      File.join(
+        File.dirname(__FILE__),
+        "../support/models/sandbox"
+      ))
+  end
+
+  let(:app_models_root) { File.join(model_root, "app/models") }
+  let(:lib_models_root) { File.join(model_root, "lib/models") }
+
+  describe "#model_paths" do
+    # reset model_paths to the default value
+    before { Mongoid.model_paths = nil }
+
+    context "when Rails is defined" do
+      let(:mock_application) do
+        OpenStruct.new(
+          config: OpenStruct.new(
+            paths: { "app/models" => OpenStruct.new(expanded: [ "app/models" ]) }
+          )
+        )
+      end
+
+      around do |example|
+        FeatureSandbox.quarantine do
+          require "rails/mongoid"
+          Rails.extend Mongoid::Loadable::RailsApplication  
+          Rails.application = mock_application
+          example.run
+        end
+      end
+
+      it "should return Rails' \"app/models\" paths" do
+        expect(Mongoid.model_paths).to be == %w( app/models )
+      end
+    end
+
+    context "when Rails is not defined" do
+      it "should return Mongoid's default model paths" do
+        expect(Mongoid.model_paths).to be == %w( ./app/models ./lib/models )
+      end
+    end
+
+    context "when explicitly set" do
+      before { Mongoid.model_paths = %w( /infra/models ) }
+      
+      it "should return the given value" do
+        expect(Mongoid.model_paths).to be == %w( /infra/models )
+      end
+    end
+  end
+
+  describe "#load_models" do
+    around :each do |example|
+      FeatureSandbox.quarantine do
+        Mongoid.model_paths = nil
+        example.run
+      end
+    end
+
+    context "when using default paths" do
+      around(:each) do |example|
+        $LOAD_PATH.concat [ app_models_root, lib_models_root ]
+
+        Dir.chdir(model_root) do
+          Mongoid.load_models
+          example.run
+        end
+      end
+
+      it "should find models in the default paths" do
+        expect(defined? AppModelsMessage).to be == "constant"
+        expect(defined? LibModelsMessage).to be == "constant"
+        expect(defined? SandboxMessage).to be_nil
+      end
+    end
+
+    context "when using custom model_paths" do
+      before do
+        Mongoid.model_paths = [ app_models_root ]
+        $LOAD_PATH.concat [ app_models_root ]
+        Mongoid.load_models
+      end
+
+      it "should find models in the specified paths" do
+        expect(defined? AppModelsMessage).to be == "constant"
+        expect(defined? LibModelsMessage).to be_nil
+        expect(defined? SandboxMessage).to be_nil
+      end
+    end
+
+    context "when passing paths directly" do
+      before do
+        $LOAD_PATH.concat [ model_root ]
+        Mongoid.load_models([ model_root ])
+      end
+
+      it "should find models in the specified paths" do
+        expect(defined? AppModelsMessage).to be == "constant"
+        expect(defined? LibModelsMessage).to be == "constant"
+        expect(defined? SandboxMessage).to be == "constant"
+        expect(defined? SandboxComment).to be == "constant"
+      end
+    end
+  end
+end
+
+module Mongoid::Loadable::RailsApplication
+  attr_accessor :application
+end

--- a/spec/mongoid/tasks/database_rake_spec.rb
+++ b/spec/mongoid/tasks/database_rake_spec.rb
@@ -2,11 +2,7 @@
 
 require "rake"
 require "spec_helper"
-
-unless defined?(Rails)
-  module Rails
-  end
-end
+require "support/feature_sandbox"
 
 shared_context "rake task" do
   let(:task_name) { self.class.top_level_description }
@@ -56,10 +52,11 @@ end
 shared_context "rails rake task" do
   let(:task_file) { "mongoid/railties/database" }
 
-  let(:application) do
-    app = double("application")
-    allow(app).to receive(:eager_load!)
-    app
+  around do |example|
+    FeatureSandbox.quarantine do
+      require "support/rails_mock"
+      example.run
+    end
   end
 end
 
@@ -98,7 +95,6 @@ describe "db:seed" do
   end
 
   it "works" do
-    expect(Rails).to receive(:root).and_return(".")
     task.invoke
   end
 end
@@ -123,19 +119,11 @@ describe "db:setup" do
     expect(task.prerequisites).to include("db:seed")
   end
 
-  it_behaves_like "create_indexes" do
-
-    before do
-      expect(Rails).to receive(:root).and_return(".")
-      expect(Rails).to receive(:application).and_return(application)
-    end
-  end
+  it_behaves_like "create_indexes"
 
   it "works" do
     expect(Mongoid::Tasks::Database).to receive(:create_indexes)
     expect(Mongoid::Tasks::Database).to receive(:create_collections)
-    expect(Rails).to receive(:root).and_return(".")
-    expect(Rails).to receive(:application).and_return(application)
     task.invoke
   end
 end
@@ -153,7 +141,6 @@ describe "db:reset" do
   end
 
   it "works" do
-    expect(Rails).to receive(:root).and_return(".")
     task.invoke
   end
 end
@@ -180,11 +167,7 @@ describe "db:test:prepare" do
   include_context "rake task"
   include_context "rails rake task"
 
-  it_behaves_like "create_indexes" do
-    before do
-      expect(Rails).to receive(:application).and_return(application)
-    end
-  end
+  it_behaves_like "create_indexes"
 
   it "calls mongoid:create_indexes" do
     expect(task.prerequisites).to include("mongoid:create_indexes")
@@ -195,7 +178,6 @@ describe "db:test:prepare" do
   end
 
   it "works" do
-    expect(Rails).to receive(:application).and_return(application)
     expect(Mongoid::Tasks::Database).to receive(:create_indexes)
     expect(Mongoid::Tasks::Database).to receive(:create_collections)
     task.invoke
@@ -218,10 +200,6 @@ describe "db:mongoid:create_indexes" do
   context "when using rails task" do
     include_context "rails rake task"
 
-    before do
-      expect(Rails).to receive(:application).and_return(application)
-    end
-
     it_behaves_like "create_indexes"
   end
 end
@@ -241,10 +219,6 @@ describe "db:mongoid:create_collections" do
 
   context "when using rails task" do
     include_context "rails rake task"
-
-    before do
-      expect(Rails).to receive(:application).and_return(application)
-    end
 
     it_behaves_like "create_collections"
   end
@@ -266,10 +240,6 @@ describe "db:mongoid:create_collections:force" do
   context "when using rails task" do
     include_context "rails rake task"
 
-    before do
-      expect(Rails).to receive(:application).and_return(application)
-    end
-
     it_behaves_like "force create_collections"
   end
 end
@@ -288,10 +258,6 @@ describe "db:mongoid:remove_undefined_indexes" do
 
   context "when using rails task" do
     include_context "rails rake task"
-
-    before do
-      expect(Rails).to receive(:application).and_return(application)
-    end
 
     it "receives remove_undefined_indexes" do
       expect(Mongoid::Tasks::Database).to receive(:remove_undefined_indexes)
@@ -314,10 +280,6 @@ describe "db:mongoid:remove_indexes" do
 
   context "when using rails task" do
     include_context "rails rake task"
-
-    before do
-      expect(Rails).to receive(:application).and_return(application)
-    end
 
     it "receives remove_indexes" do
       expect(Mongoid::Tasks::Database).to receive(:remove_indexes)

--- a/spec/rails/mongoid_spec.rb
+++ b/spec/rails/mongoid_spec.rb
@@ -1,48 +1,40 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+require "support/feature_sandbox"
 
 describe "Rails::Mongoid" do
+  let(:model_root) do
+    File.absolute_path(
+      File.join(
+        File.dirname(__FILE__),
+        "../support/models/sandbox"
+      ))
+  end
 
-  before(:all) do
-    require "rails/mongoid"
-    ::Mongoid.models.delete_if do |model|
-      ![ User, Account, Address, AddressNumber ].include?(model)
+  around :each do |example|
+    FeatureSandbox.quarantine do
+      require "rails/mongoid"
+      $LOAD_PATH.push(model_root)
+      example.run
     end
   end
 
   describe ".preload_models" do
+    let(:app) { double(config: config) }
+    let(:config) { double(paths: paths) }
+    let(:paths) { { "app/models" => path } }
+    let(:path) { double(expanded: [ model_root ]) }
 
-    let(:app) do
-      double(config: config)
-    end
-
-    let(:config) do
-      double(paths: paths)
-    end
-
-    let(:paths) do
-      double('[]' => path)
-    end
-
-    let(:path) do
-      double(expanded: [ "/rails/root/app/models" ])
-    end
+    before { Rails::Mongoid.preload_models(app) }
 
     context "when preload models config is false" do
       config_override :preload_models, false
 
-      let(:files) do
-        [
-          "/rails/root/app/models/user.rb",
-          "/rails/root/app/models/address.rb"
-        ]
-      end
-
       it "does not load any models" do
-        allow(Dir).to receive(:glob).with("/rails/root/app/models/**/*.rb").and_return(files)
-        expect(Rails::Mongoid).to receive(:load_model).never
-        Rails::Mongoid.preload_models(app)
+        expect(defined? SandboxMessage).to be_nil
+        expect(defined? SandboxUser).to be_nil
+        expect(defined? SandboxComment).to be_nil
       end
     end
 
@@ -50,95 +42,11 @@ describe "Rails::Mongoid" do
       config_override :preload_models, true
 
       context "when all models are in the models directory" do
-
-        let(:files) do
-          [
-            "/rails/root/app/models/user.rb",
-            "/rails/root/app/models/address.rb"
-          ]
+        it "requires the models" do
+          expect(SandboxMessage.ancestors).to include(Mongoid::Document)
+          expect(SandboxUser.ancestors).to include(Mongoid::Document)
+          expect(SandboxComment.ancestors).to include(Mongoid::Document)
         end
-
-        before do
-          expect(Dir).to receive(:glob).with("/rails/root/app/models/**/*.rb").and_return(files)
-        end
-
-        it "requires the models by basename" do
-          expect(Rails::Mongoid).to receive(:load_model).with("address")
-          expect(Rails::Mongoid).to receive(:load_model).with("user")
-          Rails::Mongoid.preload_models(app)
-        end
-      end
-
-      context "when models exist in subdirectories" do
-
-        let(:files) do
-          [ "/rails/root/app/models/mongoid/behavior.rb" ]
-        end
-
-        before do
-          expect(Dir).to receive(:glob).with("/rails/root/app/models/**/*.rb").and_return(files)
-        end
-
-        it "requires the models by subdirectory and basename" do
-          expect(Rails::Mongoid).to receive(:load_model).with("mongoid/behavior")
-          Rails::Mongoid.preload_models(app)
-        end
-      end
-    end
-  end
-
-  describe ".load_models" do
-
-    let(:app) do
-      double(config: config)
-    end
-
-    let(:config) do
-      double(paths: paths)
-    end
-
-    let(:paths) do
-      double('[]' => path)
-    end
-
-    let(:path) do
-      double(expanded: [ "/rails/root/app/models" ])
-    end
-
-    context "even when preload models config is false" do
-      config_override :preload_models, false
-
-      let(:files) do
-        [
-          "/rails/root/app/models/user.rb",
-          "/rails/root/app/models/address.rb"
-        ]
-      end
-
-      it "loads all models" do
-        allow(Dir).to receive(:glob).with("/rails/root/app/models/**/*.rb").and_return(files)
-        expect(Rails::Mongoid).to receive(:load_model).with("address")
-        expect(Rails::Mongoid).to receive(:load_model).with("user")
-        Rails::Mongoid.load_models(app)
-      end
-    end
-
-    context "when list of models to load was configured" do
-      config_override :preload_models, %w(user AddressNumber)
-
-      let(:files) do
-        [
-          "/rails/root/app/models/user.rb",
-          "/rails/root/app/models/address.rb"
-        ]
-      end
-
-      it "loads selected models only" do
-        allow(Dir).to receive(:glob).with("/rails/root/app/models/**/*.rb").and_return(files)
-        expect(Rails::Mongoid).to receive(:load_model).with("user")
-        expect(Rails::Mongoid).to receive(:load_model).with("address_number")
-        expect(Rails::Mongoid).to receive(:load_model).with("address").never
-        Rails::Mongoid.load_models(app)
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -101,16 +101,6 @@ Dir[ File.join(MODELS, "*.rb") ].sort.each do |file|
   autoload name.camelize.to_sym, name
 end
 
-module Rails
-  class Application
-  end
-end
-
-module MyApp
-  class Application < Rails::Application
-  end
-end
-
 module Mongoid
   class Query
     include Mongoid::Criteria::Queryable

--- a/spec/support/feature_sandbox.rb
+++ b/spec/support/feature_sandbox.rb
@@ -1,0 +1,47 @@
+class FeatureSandbox
+  class <<self
+    def start_quarantine
+      { constants: Object.constants.dup,
+        features: $LOADED_FEATURES.dup,
+        load_path: $LOAD_PATH.dup }
+    end
+
+    def end_quarantine(state)
+      restore_load_path(state[:load_path])
+      unload_features($LOADED_FEATURES - state[:features])
+      unload_constants(Object, Object.constants - state[:constants])
+    end
+
+    def quarantine
+      state = start_quarantine
+      yield
+    ensure
+      end_quarantine(state)
+    end
+
+    private
+
+    def restore_load_path(list)
+      $LOAD_PATH.replace(list)
+    end
+
+    def unload_features(list)
+      list.each do |path|
+        $LOADED_FEATURES.delete(path)
+      end
+    end
+
+    def unload_constants(parent, list)
+      list.each do |name|
+        obj = parent.const_get(name)
+        if obj.is_a?(Module) && obj.constants(false).any?
+          unload_constants(obj, obj.constants(false))
+        end
+
+        Mongoid.deregister_model(obj) if obj.is_a?(Mongoid::Document)
+
+        parent.send(:remove_const, name)
+      end
+    end
+  end
+end

--- a/spec/support/models/sandbox/app/models/app_models_message.rb
+++ b/spec/support/models/sandbox/app/models/app_models_message.rb
@@ -1,0 +1,3 @@
+class AppModelsMessage
+  include Mongoid::Document
+end

--- a/spec/support/models/sandbox/lib/models/lib_models_message.rb
+++ b/spec/support/models/sandbox/lib/models/lib_models_message.rb
@@ -1,0 +1,3 @@
+class LibModelsMessage
+  include Mongoid::Document
+end

--- a/spec/support/models/sandbox/sandbox_message.rb
+++ b/spec/support/models/sandbox/sandbox_message.rb
@@ -1,0 +1,3 @@
+class SandboxMessage
+  include Mongoid::Document
+end

--- a/spec/support/models/sandbox/sandbox_user.rb
+++ b/spec/support/models/sandbox/sandbox_user.rb
@@ -1,0 +1,3 @@
+class SandboxUser
+  include Mongoid::Document
+end

--- a/spec/support/models/sandbox/subdir/sandbox_comment.rb
+++ b/spec/support/models/sandbox/subdir/sandbox_comment.rb
@@ -1,0 +1,3 @@
+class SandboxComment
+  include Mongoid::Document
+end

--- a/spec/support/rails_mock.rb
+++ b/spec/support/rails_mock.rb
@@ -1,8 +1,31 @@
 # A simplistic mock object to stand in for Rails, instead of adding an
 # otherwise unnecessary dependency on Rails itself.
 
+require "ostruct"
+
 module Rails
-  def self.logger
-    ::Logger.new($stdout)
+  extend self
+  
+  attr_accessor :env
+  attr_accessor :root
+  attr_accessor :logger
+  attr_accessor :application
+
+  module Application
+    extend self
+
+    attr_accessor :config
+
+    def eager_load!
+    end
   end
 end
+
+Rails.env = "development"
+Rails.root = "."
+Rails.logger = Logger.new($stdout)
+Rails.application = Rails::Application
+
+Rails.application.config = OpenStruct.new(
+  paths: { "app/models" => OpenStruct.new(expanded: [ "app/models" ]) }
+)

--- a/spec/support/rails_mock.rb
+++ b/spec/support/rails_mock.rb
@@ -1,0 +1,8 @@
+# A simplistic mock object to stand in for Rails, instead of adding an
+# otherwise unnecessary dependency on Rails itself.
+
+module Rails
+  def self.logger
+    ::Logger.new($stdout)
+  end
+end

--- a/spec/support/sinatra_mock.rb
+++ b/spec/support/sinatra_mock.rb
@@ -1,0 +1,6 @@
+module Sinatra
+  module Base
+    extend self
+    def environment; :staging; end
+  end
+end


### PR DESCRIPTION
The `:load_models` task for the rake tasks was a no-op, presumably because back in 2014 some work was done to decouple the tasks from Rails, but the model loading code was never completely decoupled.

This PR implements model loading for non-Rails apps, adding a `model_paths` option that will use the Rails configuration if present, and will fall back to some sane defaults otherwise (`./app/models` and `./lib/models`).

In order to make sure this works correctly under environments with and without Rails, I also added a new helper for testing, called `FeatureSandbox`, which can quarantine a code block in a test to ensure that the load paths, loaded features, and constants are all reset back to their original value when the block finishes.

ref: https://jira.mongodb.org/browse/MONGOID-5547