### PR TITLE
MONGOID-5442 - Rename #set_mul to #mul

### DIFF
--- a/lib/mongoid/contextual/atomic.rb
+++ b/lib/mongoid/contextual/atomic.rb
@@ -55,12 +55,12 @@ module Mongoid
       # Perform an atomic $mul operation on the matching documents.
       #
       # @example Perform the atomic multiplication.
-      #   context.set_mul(likes: 10)
+      #   context.mul(likes: 10)
       #
       # @param [ Hash ] factors The operations.
       #
       # @return [ nil ] Nil.
-      def set_mul(factors)
+      def mul(factors)
         view.update_many("$mul" => collect_operations(factors))
       end
 

--- a/lib/mongoid/persistable/multipliable.rb
+++ b/lib/mongoid/persistable/multipliable.rb
@@ -12,12 +12,12 @@ module Mongoid
       # be set to zero.
       #
       # @example Multiply the fields.
-      #   document.set_mul(score: 10, place: 1, lives: -10)
+      #   document.mul(score: 10, place: 1, lives: -10)
       #
       # @param [ Hash ] factors The field/factor multiplier pairs.
       #
       # @return [ Document ] The document.
-      def set_mul(factors)
+      def mul(factors)
         prepare_atomic_operation do |ops|
           process_atomic_operations(factors) do |field, value|
             factor = value.__to_inc__

--- a/spec/mongoid/contextual/atomic_spec.rb
+++ b/spec/mongoid/contextual/atomic_spec.rb
@@ -350,7 +350,7 @@ describe Mongoid::Contextual::Atomic do
     end
   end
 
-  describe "#set_mul" do
+  describe "#mul" do
 
     let!(:depeche_mode) { Band.create!(likes: 60) }
     let!(:smiths) { Band.create! }
@@ -359,7 +359,7 @@ describe Mongoid::Contextual::Atomic do
     let(:criteria) { Band.all }
     let(:context) { Mongoid::Contextual::Mongo.new(criteria) }
 
-    before { context.set_mul(likes: 10) }
+    before { context.mul(likes: 10) }
 
     context "when the field exists" do
 
@@ -378,7 +378,7 @@ describe Mongoid::Contextual::Atomic do
     context "when using the alias" do
 
       before do
-        context.set_mul(years: 2)
+        context.mul(years: 2)
       end
 
       it "muls the value and read from alias" do
@@ -400,7 +400,7 @@ describe Mongoid::Contextual::Atomic do
 
       let(:context) { Mongoid::Contextual::Mongo.new(criteria) }
 
-      before { context.set_mul(years: 2) }
+      before { context.mul(years: 2) }
 
       it "muls the value" do
         expect(depeche_mode.reload.years).to eq(6)

--- a/spec/mongoid/persistable/multipliable_spec.rb
+++ b/spec/mongoid/persistable/multipliable_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 
 describe Mongoid::Persistable::Multipliable do
 
-  describe "#set_mul" do
+  describe "#mul" do
 
     context "when the document is a root document" do
 
@@ -50,7 +50,7 @@ describe Mongoid::Persistable::Multipliable do
       context "when providing string fields" do
 
         let!(:op) do
-          person.set_mul("age" => 5, "score" => -5, "inte" => 30)
+          person.mul("age" => 5, "score" => -5, "inte" => 30)
         end
 
         it_behaves_like "a multipliable root document"
@@ -59,7 +59,7 @@ describe Mongoid::Persistable::Multipliable do
       context "when providing symbol fields" do
 
         let!(:op) do
-          person.set_mul(age: 5, score: -5, inte: 30)
+          person.mul(age: 5, score: -5, inte: 30)
         end
 
         it_behaves_like "a multipliable root document"
@@ -80,7 +80,7 @@ describe Mongoid::Persistable::Multipliable do
         end
 
         let!(:op) do
-          person.set_mul(age: positive, score: negative, inte: dynamic)
+          person.mul(age: positive, score: negative, inte: dynamic)
         end
 
         it_behaves_like "a multipliable root document"
@@ -135,7 +135,7 @@ describe Mongoid::Persistable::Multipliable do
       context "when providing string fields" do
 
         let!(:op) do
-          address.set_mul("number" => 5, "no" => -5, "house" => 30)
+          address.mul("number" => 5, "no" => -5, "house" => 30)
         end
 
         it_behaves_like "a multipliable embedded document"
@@ -144,7 +144,7 @@ describe Mongoid::Persistable::Multipliable do
       context "when providing symbol fields" do
 
         let!(:op) do
-          address.set_mul(number: 5, no: -5, house: 30)
+          address.mul(number: 5, no: -5, house: 30)
         end
 
         it_behaves_like "a multipliable embedded document"
@@ -165,7 +165,7 @@ describe Mongoid::Persistable::Multipliable do
         end
 
         let!(:op) do
-          address.set_mul(number: positive, no: negative, house: dynamic)
+          address.mul(number: positive, no: negative, house: dynamic)
         end
 
         it_behaves_like "a multipliable embedded document"
@@ -180,7 +180,7 @@ describe Mongoid::Persistable::Multipliable do
 
       it "marks a dirty change for the multiplied fields" do
         person.atomically do
-          person.set_mul age: 15, score: 2
+          person.mul age: 15, score: 2
           expect(person.changes).to eq({"age" => [10, 150], "score" => [100, 200]})
         end
       end
@@ -201,7 +201,7 @@ describe Mongoid::Persistable::Multipliable do
 
         it "persists the changes" do
           expect(person).to be_readonly
-          person.set_mul(age: 15, score: 2)
+          person.mul(age: 15, score: 2)
           expect(person.age).to eq(150)
           expect(person.score).to eq(200)
         end
@@ -217,7 +217,7 @@ describe Mongoid::Persistable::Multipliable do
         it "raises a ReadonlyDocument error" do
           expect(person).to be_readonly
           expect do
-            person.set_mul(age: 15, score: 2)
+            person.mul(age: 15, score: 2)
           end.to raise_error(Mongoid::Errors::ReadonlyDocument)
         end
       end


### PR DESCRIPTION
The operator method name `set_mul` is incongruent with `inc`, `bit`, `pop`, and other atomic operators. Unless there is a strong justification as to why the prefix `set_` should be introduced for the `mul` operator specifically (as there was for min/max disambiguation), we should stick with just `mul` to be consistent.