### PR TITLE
Clean up a method that was missed in in #5521

### DIFF
--- a/lib/mongoid/contextual/atomic.rb
+++ b/lib/mongoid/contextual/atomic.rb
@@ -240,10 +240,6 @@ module Mongoid
           operations[database_field_name(field)] = { "$each" => Array.wrap(value).mongoize }
         end
       end
-
-      def translate_date_type(type)
-        Mongoid::Persistable::Datable.translate_date_field_spec(type)
-      end
     end
   end
 end


### PR DESCRIPTION
This method should have been removed when the current_date code was removed.

Original ticket: https://jira.mongodb.org/browse/MONGOID-5442