### PR TITLE
Fix failing app_spec tests in evergreen

### DIFF
--- a/spec/integration/app_spec.rb
+++ b/spec/integration/app_spec.rb
@@ -272,7 +272,7 @@ describe 'Mongoid application tests' do
     gemfile_lines << "gem 'mongoid', path: '#{File.expand_path(BASE)}'\n"
     if rails_version
       gemfile_lines.delete_if do |line|
-        line =~ /rails/ || line =~ /concurrent_ruby/
+        line =~ /rails/ || line =~ /concurrent-ruby/
       end
       if rails_version == 'master'
         gemfile_lines << "gem 'rails', git: 'https://github.com/rails/rails'\n"

--- a/spec/integration/app_spec.rb
+++ b/spec/integration/app_spec.rb
@@ -272,13 +272,14 @@ describe 'Mongoid application tests' do
     gemfile_lines << "gem 'mongoid', path: '#{File.expand_path(BASE)}'\n"
     if rails_version
       gemfile_lines.delete_if do |line|
-        line =~ /rails/
+        line =~ /rails/ || line =~ /concurrent_ruby/
       end
       if rails_version == 'master'
         gemfile_lines << "gem 'rails', git: 'https://github.com/rails/rails'\n"
       else
         gemfile_lines << "gem 'rails', '~> #{rails_version}.0'\n"
       end
+      gemfile_lines << "gem 'concurrent-ruby', '>= 1.0.5', '< 1.2'"
     end
     File.open('Gemfile', 'w') do |f|
       f << gemfile_lines.join


### PR DESCRIPTION
When `rails new` is run during the app specs, it sets up a new Rails app with a default dependency on concurrent-ruby version 1.2.0. However, this version of concurrent-ruby is too new for Mongoid, which requires ">= 1.0.5, < 1.2". So when this test is run in evergreen, it fails because it can't resolve the dependency.

To fix this, I ensured the new Gemfile has an explicit dependency on the correct version of concurrent-ruby.