### PR TITLE
Allow concurrent-ruby versions >= 1.2

### DIFF
--- a/mongoid.gemspec
+++ b/mongoid.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |s|
   # See: https://github.com/rails/rails/pull/43951
   s.add_dependency("activemodel", ['>=5.1', '<7.1', '!= 7.0.0'])
   s.add_dependency("mongo", ['>=2.18.0', '<3.0.0'])
-  s.add_dependency("concurrent-ruby", ['>= 1.0.5', '<1.2'])
+  s.add_dependency("concurrent-ruby", ['>= 1.0.5', '< 2.0'])
 
   # The ruby2_keywords gem is recommended for handling argument delegation issues,
   # especially if support for 2.6 or prior is required.


### PR DESCRIPTION
Mongoid was previously restricting concurrent-ruby versions to be < 1.2. This caused problems recently in evergreen with the release of concurrent-ruby 1.2.0. There do not appear to be any incompatibilities in 1.2.0, so it should be okay to be more permissive with which concurrent-ruby versions we support.