### PR TITLE
MONGOID-5504 Clear changes after :touch

### DIFF
--- a/docs/release-notes/mongoid-9.0.txt
+++ b/docs/release-notes/mongoid-9.0.txt
@@ -17,6 +17,30 @@ The complete list of releases is available `on GitHub
 please consult GitHub releases for detailed release notes and JIRA for
 the complete list of issues fixed in each release, including bug fixes.
 
+``touch`` method now clears changed state
+-----------------------------------------
+
+In Mongoid 8.x and older ``touch`` method leaves models in the changed state:
+
+.. code-block:: ruby
+
+  # Mongoid 8.x behaviour
+  band = Band.create!
+  band.touch
+  band.changed? # => true
+  band.changes # => {"updated_at"=>[2023-01-30 13:12:57.477191135 UTC, 2023-01-30 13:13:11.482975646 UTC]}
+
+Starting from 9.0 Mongoid now correctly clears changed state after using ``touch``
+method.
+
+.. code-block:: ruby
+
+  # Mongoid 9.0 behaviour
+  band = Band.create!
+  band.touch
+  band.changed? # => false
+  band.changes # => {}
+
 Sandbox Mode for Rails Console
 ------------------------------
 

--- a/lib/mongoid/touchable.rb
+++ b/lib/mongoid/touchable.rb
@@ -54,6 +54,11 @@ module Mongoid
         touches
       end
 
+      # Clears changes for the model caused by touch operation.
+      #
+      # @param [ Symbol ] field The name of an additional field to update.
+      #
+      # @api private
       def _clear_touch_updates(field = nil)
         remove_change(:updated_at)
         remove_change(field) if field

--- a/lib/mongoid/touchable.rb
+++ b/lib/mongoid/touchable.rb
@@ -23,10 +23,14 @@ module Mongoid
       def touch(field = nil)
         return false if _root.new_record?
 
-        touches = _gather_touch_updates(Time.configured.now, field)
-        _root.send(:persist_atomic_operations, '$set' => touches) if touches.present?
+        begin
+          touches = _gather_touch_updates(Time.configured.now, field)
+          _root.send(:persist_atomic_operations, '$set' => touches) if touches.present?
+          _run_touch_callbacks_from_root
+        ensure
+          _clear_touch_updates(field)
+        end
 
-        _run_touch_callbacks_from_root
         true
       end
 
@@ -48,6 +52,12 @@ module Mongoid
         touches = _extract_touches_from_atomic_sets(field) || {}
         touches.merge!(_parent._gather_touch_updates(now) || {}) if _touchable_parent?
         touches
+      end
+
+      def _clear_touch_updates(field = nil)
+        remove_change(:updated_at)
+        remove_change(field) if field
+        _parent._clear_touch_updates if _touchable_parent?
       end
 
       # Recursively runs :touch callbacks for the document and its parents,


### PR DESCRIPTION
While working on https://jira.mongodb.org/browse/MONGOID-5504, I realized that `touch` method leaves the object in the changes state:
```ruby
band = Band.create!
band.changed? # => false
band.update(name: 'John')
band.changed? # => false
band.touch
band.changed? # => true
band.changes # => {"updated_at"=>[2023-01-30 13:12:57.477191135 UTC, 2023-01-30 13:13:11.482975646 UTC]}
```

This leads to the problem described in https://jira.mongodb.org/browse/MONGOID-5504.

This behavior seems to be as designed - https://github.com/mongodb/mongoid/blob/master/spec/mongoid/touchable_spec.rb#L258. However, I believe that this behavior should be changed to be consistent with other updating operations.

