### PR TITLE
[READY FOR REVIEW] MONGOID-5556: #tally should support splatting array results

### DIFF
--- a/docs/reference/queries.txt
+++ b/docs/reference/queries.txt
@@ -1600,6 +1600,9 @@ Mongoid also has some helpful methods on criteria.
        *This method accepts the dot notation, thus permitting referencing
        fields in embedded associations.*
 
+       *You may use ``splat_arrays: true`` arg to tally array values
+       individually.*
+
        *This method respects :ref:`field aliases <field-aliases>`,
        including those defined in embedded documents.*
 
@@ -1613,6 +1616,18 @@ Mongoid also has some helpful methods on criteria.
           # Using the earlier definition of Manager,
           # expands out to "managers.name" in the query:
           Band.all.tally('managers.n')
+
+          # By default, array results will be used verbatim as keys:
+          Band.all.tally(:genres)
+          # => { ['jazz', 'fusion'] => 1,
+          #      ['jazz'] => 4,
+          #      ['fusion', 'dance'] => 2 }
+
+          # Use `splat_arrays: true` to tally the array members instead:
+          Band.all.tally(:genres, splat_arrays: true)
+          # => { 'jazz' => 5,
+          #      'fusion' => 3,
+          #      'dance' => 2 }
 
    * - ``Criteria#third``
 

--- a/docs/release-notes/mongoid-9.0.txt
+++ b/docs/release-notes/mongoid-9.0.txt
@@ -191,6 +191,9 @@ Bug Fixes and Improvements
 
 This section will be for smaller bug fixes and improvements:
 
+- The ``.tally`` method can now take a keyword arg :splat_arrays
+  which tallies array values individually (using the ``$unwind`` operator.)
+  `MONGOID-5556 <https://jira.mongodb.org/browse/MONGOID-5556>`_.
 - The ``.unscoped`` method now also clears scopes declared using ``.with_scope``
   `MONGOID-5214 <https://jira.mongodb.org/browse/MONGOID-5214>`_.
 - When evolving a ``String`` to a ``BigDecimal`` (i.e. when querying a

--- a/lib/mongoid/contextual/memory.rb
+++ b/lib/mongoid/contextual/memory.rb
@@ -285,13 +285,23 @@ module Mongoid
       #   context.tally(:name)
       #
       # @param [ String | Symbol ] field Field to tally.
+      # @param [ Boolean ] :splat_arrays Whether to tally array
+      #   member values individually. Default false.
       #
       # @return [ Hash ] The hash of counts.
-      def tally(field)
-        return documents.each_with_object({}) do |d, acc|
+      def tally(field, splat_arrays: false)
+        documents.each_with_object({}) do |d, acc|
           v = retrieve_value_at_path(d, field)
-          acc[v] ||= 0
-          acc[v] += 1
+
+          if splat_arrays && v.is_a?(Array)
+            v.each do |vv|
+              acc[vv] ||= 0
+              acc[vv] += 1
+            end
+          else
+            acc[v] ||= 0
+            acc[v] += 1
+          end
         end
       end
 

--- a/lib/mongoid/contextual/memory.rb
+++ b/lib/mongoid/contextual/memory.rb
@@ -290,17 +290,17 @@ module Mongoid
       #
       # @return [ Hash ] The hash of counts.
       def tally(field, splat_arrays: false)
-        documents.each_with_object({}) do |d, acc|
-          v = retrieve_value_at_path(d, field)
+        documents.each_with_object({}) do |doc, tallies|
+          key = retrieve_value_at_path(doc, field)
 
-          if splat_arrays && v.is_a?(Array)
-            v.each do |vv|
-              acc[vv] ||= 0
-              acc[vv] += 1
+          if splat_arrays && value.is_a?(Array)
+            key.each do |array_value|
+              tallies[array_value] ||= 0
+              tallies[array_value] += 1
             end
           else
-            acc[v] ||= 0
-            acc[v] += 1
+            tallies[key] ||= 0
+            tallies[key] += 1
           end
         end
       end

--- a/lib/mongoid/contextual/memory.rb
+++ b/lib/mongoid/contextual/memory.rb
@@ -293,7 +293,7 @@ module Mongoid
         documents.each_with_object({}) do |doc, tallies|
           key = retrieve_value_at_path(doc, field)
 
-          if splat_arrays && value.is_a?(Array)
+          if splat_arrays && key.is_a?(Array)
             key.each do |array_value|
               tallies[array_value] ||= 0
               tallies[array_value] += 1

--- a/lib/mongoid/contextual/mongo.rb
+++ b/lib/mongoid/contextual/mongo.rb
@@ -485,7 +485,6 @@ module Mongoid
 
         collection.aggregate(pipeline).each_with_object({}) do |doc, tallies|
           val = doc["_id"]
-
           key = if val.is_a?(Array)
             val.map { |v| demongoize_with_field(fld, v, is_translation) }
           else

--- a/lib/mongoid/contextual/mongo.rb
+++ b/lib/mongoid/contextual/mongo.rb
@@ -473,7 +473,7 @@ module Mongoid
         name = klass.cleanse_localized_field_names(field)
         is_translation = "#{name}_translations" == field.to_s
 
-        # Add a $project stage when using $unwind with nested fields
+        # Must add a $project stage when using $unwind with nested fields
         projected = 'p' if splat_arrays && (is_translation || name.include?('.'))
 
         fld = klass.traverse_association_tree(name)

--- a/lib/mongoid/contextual/mongo.rb
+++ b/lib/mongoid/contextual/mongo.rb
@@ -465,6 +465,8 @@ module Mongoid
       #   # => { [ 1, 2 ] => 1 }
       #
       # @param [ String | Symbol ] field The field name.
+      # @param [ Boolean ] :splat_arrays Whether to tally array
+      #   member values individually. Default false.
       #
       # @return [ Hash ] The hash of counts.
       def tally(field, splat_arrays: false)

--- a/lib/mongoid/contextual/mongo.rb
+++ b/lib/mongoid/contextual/mongo.rb
@@ -473,7 +473,8 @@ module Mongoid
         name = klass.cleanse_localized_field_names(field)
         is_translation = "#{name}_translations" == field.to_s
 
-        # Must add a $project stage when using $unwind with nested fields
+        # Must add a $project stage when using $unwind with nested fields.
+        # See: https://jira.mongodb.org/browse/SERVER-59713
         projected = 'p' if splat_arrays && (is_translation || name.include?('.'))
 
         fld = klass.traverse_association_tree(name)

--- a/lib/mongoid/contextual/mongo.rb
+++ b/lib/mongoid/contextual/mongo.rb
@@ -473,7 +473,7 @@ module Mongoid
         name = klass.cleanse_localized_field_names(field)
         is_translation = "#{name}_translations" == field.to_s
 
-        # Must add a $project stage when using $unwind with nested fields.
+        # Must add a $project stage when using $unwind with nested fields due to a server bug.
         # See: https://jira.mongodb.org/browse/SERVER-59713
         projected = 'p' if splat_arrays && (is_translation || name.include?('.'))
 

--- a/lib/mongoid/contextual/mongo.rb
+++ b/lib/mongoid/contextual/mongo.rb
@@ -473,8 +473,8 @@ module Mongoid
         name = klass.cleanse_localized_field_names(field)
         is_translation = "#{name}_translations" == field.to_s
 
-        # Must add a $project stage when using $unwind with nested fields due to a server bug.
-        # See: https://jira.mongodb.org/browse/SERVER-59713
+        # Must add a $project stage when using $unwind with nested fields
+        # due to a bug in MongoDB. See: https://jira.mongodb.org/browse/SERVER-59713
         projected = 'p' if splat_arrays && (is_translation || name.include?('.'))
 
         fld = klass.traverse_association_tree(name)

--- a/lib/mongoid/contextual/mongo.rb
+++ b/lib/mongoid/contextual/mongo.rb
@@ -478,7 +478,7 @@ module Mongoid
 
         fld = klass.traverse_association_tree(name)
         pipeline = []
-        pipeline << { "$match" => view.filter } unless view.filter.blank?
+        pipeline << { "$match" => view.filter } if view.filter.present?
         pipeline << { "$project" => { "#{projected}" => "$#{name}" } } if projected
         pipeline << { "$unwind" => "$#{projected || name}" } if splat_arrays
         pipeline << { "$group" => { _id: "$#{projected || name}", counts: { "$sum": 1 } } }

--- a/lib/mongoid/contextual/none.rb
+++ b/lib/mongoid/contextual/none.rb
@@ -122,9 +122,12 @@ module Mongoid
       #   context.tally(:name)
       #
       # @param [ String | Symbol ] _field Field to tally.
+      # @param [ Boolean ] :splat_arrays Whether to tally array
+      #   member values individually. Default false.
+      # @param [ String | Symbol ] _field Field to tally.
       #
       # @return [ Hash ] An empty Hash.
-      def tally(_field)
+      def tally(_field, splat_arrays: false)
         {}
       end
 

--- a/spec/mongoid/contextual/memory_spec.rb
+++ b/spec/mongoid/contextual/memory_spec.rb
@@ -2071,7 +2071,6 @@ describe Mongoid::Contextual::Memory do
     let(:label2) {  Label.new(name: "Atlantic") }
     let(:label3) {  Label.new(name: "Columbia") }
 
-
     let(:band1) { Band.new(origin: "tally", name: "Depeche Mode", years: 30, sales: "1E2", label: label1, genres: genres1) }
     let(:band2) { Band.new(origin: "tally", name: "New Order", years: 30, sales: "2E3", label: label2, genres: genres2) }
     let(:band3) { Band.new(origin: "tally", name: "10,000 Maniacs", years: 30, sales: "1E2", label: label3, genres: genres3) }
@@ -2099,97 +2098,131 @@ describe Mongoid::Contextual::Memory do
       described_class.new(criteria2)
     end
 
-    context "when tallying a string" do
-      let(:tally) do
-        context.tally(:name)
-      end
+    let(:splat_arrays) { false }
 
-      it "returns the correct hash" do
-        expect(tally).to eq("Depeche Mode" => 1, "New Order" => 1, "10,000 Maniacs" => 1)
-      end
-    end
+    shared_examples_for "scalar value examples" do
 
-    context "using an aliased field" do
-      let(:tally) do
-        context.tally(:years)
-      end
-
-      it "returns the correct hash" do
-        expect(tally).to eq(30 => 3)
-      end
-    end
-
-    context "when tallying a demongoizable field" do
-      let(:tally) do
-        context.tally(:sales)
-      end
-
-      it "returns the correct hash" do
-        expect(tally).to eq(BigDecimal("1E2") => 2, BigDecimal("2E3") => 1)
-      end
-    end
-
-    context "when tallying a localized field" do
-      with_default_i18n_configs
-
-      let(:d1) { Dictionary.new(description: 'en1') }
-      let(:d2) { Dictionary.new(description: 'en1') }
-      let(:d3) { Dictionary.new(description: 'en1') }
-      let(:d4) { Dictionary.new(description: 'en2') }
-
-      before do
-        I18n.locale = :en
-        d1
-        d2
-        d3
-        d4
-        I18n.locale = :de
-        d1.description = 'de1'
-        d2.description = 'de1'
-        d3.description = 'de2'
-        d4.description = 'de3'
-        I18n.locale = :en
-      end
-
-      let(:criteria) do
-        Dictionary.all.tap do |crit|
-          crit.documents = [ d1, d2, d3, d4 ]
-        end
-      end
-
-      context "when getting the demongoized field" do
-        let(:tallied) do
-          context.tally(:description)
-        end
-
-        it "returns the translation for the current locale" do
-          expect(tallied).to eq("en1" => 3, "en2" => 1)
-        end
-      end
-
-      context "when getting a specific locale" do
-        let(:tallied) do
-          context.tally("description.de")
-        end
-
-        it "returns the translation for the the specific locale" do
-          expect(tallied).to eq("de1" => 2, "de2" => 1, "de3" => 1)
-        end
-      end
-
-      context "when getting the full hash" do
-        let(:tallied) do
-          context.tally("description_translations")
+      context "when tallying a string" do
+        let(:tally) do
+          context.tally(:name, splat_arrays: splat_arrays)
         end
 
         it "returns the correct hash" do
-          expect(tallied).to eq(
-            {"de" => "de1", "en" => "en1" } => 2,
-            {"de" => "de2", "en" => "en1" } => 1,
-            {"de" => "de3", "en" => "en2" } => 1
-          )
+          expect(tally).to eq("Depeche Mode" => 1, "New Order" => 1, "10,000 Maniacs" => 1)
         end
       end
+
+      context "using an aliased field" do
+        let(:tally) do
+          context.tally(:years, splat_arrays: splat_arrays)
+        end
+
+        it "returns the correct hash" do
+          expect(tally).to eq(30 => 3)
+        end
+      end
+
+      context "when tallying a demongoizable field" do
+        let(:tally) do
+          context.tally(:sales, splat_arrays: splat_arrays)
+        end
+
+        it "returns the correct hash" do
+          expect(tally).to eq(BigDecimal("1E2") => 2, BigDecimal("2E3") => 1)
+        end
+      end
+
+      context "when tallying a localized field" do
+        with_default_i18n_configs
+
+        let(:d1) { Dictionary.new(description: 'en1') }
+        let(:d2) { Dictionary.new(description: 'en1') }
+        let(:d3) { Dictionary.new(description: 'en1') }
+        let(:d4) { Dictionary.new(description: 'en2') }
+
+        before do
+          I18n.locale = :en
+          d1
+          d2
+          d3
+          d4
+          I18n.locale = :de
+          d1.description = 'de1'
+          d2.description = 'de1'
+          d3.description = 'de2'
+          d4.description = 'de3'
+          I18n.locale = :en
+        end
+
+        let(:criteria) do
+          Dictionary.all.tap do |crit|
+            crit.documents = [ d1, d2, d3, d4 ]
+          end
+        end
+
+        context "when getting the demongoized field" do
+          let(:tallied) do
+            context.tally(:description, splat_arrays: splat_arrays)
+          end
+
+          it "returns the translation for the current locale" do
+            expect(tallied).to eq("en1" => 3, "en2" => 1)
+          end
+        end
+
+        context "when getting a specific locale" do
+          let(:tallied) do
+            context.tally("description.de", splat_arrays: splat_arrays)
+          end
+
+          it "returns the translation for the the specific locale" do
+            expect(tallied).to eq("de1" => 2, "de2" => 1, "de3" => 1)
+          end
+        end
+
+        context "when getting the full hash" do
+          let(:tallied) do
+            context.tally("description_translations", splat_arrays: splat_arrays)
+          end
+
+          it "returns the correct hash" do
+            expect(tallied).to eq(
+              {"de" => "de1", "en" => "en1" } => 2,
+              {"de" => "de2", "en" => "en1" } => 1,
+              {"de" => "de3", "en" => "en2" } => 1
+            )
+          end
+        end
+      end
+
+      context "when some keys are missing" do
+
+        let(:criteria) do
+          Band.where(origin: "tally").all.tap do |crit|
+            crit.documents = [ band1, band2, band3 ]
+            3.times{ crit.documents << Band.new(origin: "tally") }
+          end
+        end
+
+        let(:tally) do
+          context.tally(:name, splat_arrays: splat_arrays)
+        end
+
+        it "returns the correct hash" do
+          expect(tally).to eq("Depeche Mode" => 1,
+                              "New Order" => 1,
+                              "10,000 Maniacs" => 1,
+                              nil => 3)
+        end
+      end
+    end
+
+    it_behaves_like 'scalar value examples'
+
+    context 'when :splat_arrays is true' do
+      let(:splat_arrays) { true }
+
+      it_behaves_like 'scalar value examples'
     end
 
     context "when tallying an embedded localized field" do
@@ -2227,7 +2260,7 @@ describe Mongoid::Contextual::Memory do
 
       context "when getting the demongoized field" do
         let(:tallied) do
-          context.tally("addresses.name")
+          context.tally("addresses.name", splat_arrays: splat_arrays)
         end
 
         it "returns the translation for the current locale" do
@@ -2236,11 +2269,21 @@ describe Mongoid::Contextual::Memory do
             [ "en1", "en3" ] => 1,
           )
         end
+
+        context "when :splat_arrays true" do
+          let(:splat_arrays) { true }
+
+          it "returns the correct hash" do
+            expect(tallied).to eq({ "en1" => 2,
+                                    "en2" => 1,
+                                    "en3" => 1 })
+          end
+        end
       end
 
       context "when getting a specific locale" do
         let(:tallied) do
-          context.tally("addresses.name.de")
+          context.tally("addresses.name.de", splat_arrays: splat_arrays)
         end
 
         it "returns the translation for the the specific locale" do
@@ -2249,11 +2292,21 @@ describe Mongoid::Contextual::Memory do
             [ "de1", "de3" ] => 1,
           )
         end
+
+        context "when :splat_arrays true" do
+          let(:splat_arrays) { true }
+
+          it "returns the correct hash" do
+            expect(tallied).to eq({ "de1" => 2,
+                                    "de2" => 1,
+                                    "de3" => 1 })
+          end
+        end
       end
 
       context "when getting the full hash" do
         let(:tallied) do
-          context.tally("addresses.name_translations")
+          context.tally("addresses.name_translations", splat_arrays: splat_arrays)
         end
 
         it "returns the correct hash" do
@@ -2262,12 +2315,22 @@ describe Mongoid::Contextual::Memory do
             [{ "de" => "de1", "en" => "en1" }, { "de" => "de3", "en" => "en3" }] => 1,
           )
         end
+
+        context "when :splat_arrays true" do
+          let(:splat_arrays) { true }
+
+          it "returns the correct hash" do
+            expect(tallied).to eq({ { "de" => "de1", "en" => "en1" } => 2,
+                                    { "de" => "de2", "en" => "en2" } => 1,
+                                    { "de" => "de3", "en" => "en3" } => 1 })
+          end
+        end
       end
     end
 
     context "when tallying an embedded field" do
       let(:tally) do
-        context.tally("label.name")
+        context.tally("label.name", splat_arrays: splat_arrays)
       end
 
       it "returns the correct hash" do
@@ -2278,7 +2341,7 @@ describe Mongoid::Contextual::Memory do
     context "when tallying an element in an embeds_many field" do
 
       let(:tally) do
-        context2.tally("fanatics.age")
+        context2.tally("fanatics.age", splat_arrays: splat_arrays)
       end
 
       it "returns the correct hash" do
@@ -2287,12 +2350,22 @@ describe Mongoid::Contextual::Memory do
           [1, 3] => 1
         )
       end
+
+      context "when :splat_arrays true" do
+        let(:splat_arrays) { true }
+
+        it "returns the correct hash" do
+          expect(tally).to eq(1 => 3,
+                              2 => 2,
+                              3 => 1)
+        end
+      end
     end
 
     context "when tallying an embeds_many field" do
 
       let(:tally) do
-        context2.tally("fanatics")
+        context2.tally("fanatics", splat_arrays: splat_arrays)
       end
 
       it "returns the correct hash" do
@@ -2302,12 +2375,21 @@ describe Mongoid::Contextual::Memory do
           fans3 => 1,
         )
       end
+
+      context "when :splat_arrays true" do
+        let(:splat_arrays) { true }
+
+        it "returns the correct hash" do
+          exp = [fans1, fans2, fans3].flatten.index_with(1)
+          expect(tally).to eq(exp)
+        end
+      end
     end
 
     context "when tallying a field of type array" do
 
       let(:tally) do
-        context2.tally("genres")
+        context2.tally("genres", splat_arrays: splat_arrays)
       end
 
       it "returns the correct hash" do
@@ -2316,12 +2398,22 @@ describe Mongoid::Contextual::Memory do
           [1, 3] => 1
         )
       end
+
+      context "when :splat_arrays true" do
+        let(:splat_arrays) { true }
+
+        it "returns the correct hash" do
+          expect(tally).to eq(1 => 3,
+                              2 => 2,
+                              3 => 1)
+        end
+      end
     end
 
     context "when tallying an element from an array of hashes" do
 
       let(:tally) do
-        context.tally("genres.x")
+        context.tally("genres.x", splat_arrays: splat_arrays)
       end
 
       it "returns the correct hash without the nil keys" do
@@ -2329,6 +2421,16 @@ describe Mongoid::Contextual::Memory do
           [1, 2] => 2,
           [1, 3] => 1
         )
+      end
+
+      context "when :splat_arrays true" do
+        let(:splat_arrays) { true }
+
+        it "returns the correct hash" do
+          expect(tally).to eq(1 => 3,
+                              2 => 2,
+                              3 => 1)
+        end
       end
     end
 
@@ -2343,7 +2445,7 @@ describe Mongoid::Contextual::Memory do
       end
 
       let(:tally) do
-        context.tally("genres.x")
+        context.tally("genres.x", splat_arrays: splat_arrays)
       end
 
       it "returns the correct hash without the nil keys" do
@@ -2352,6 +2454,16 @@ describe Mongoid::Contextual::Memory do
           [1, 3] => 1,
           [1, 1] => 1,
         )
+      end
+
+      context "when :splat_arrays true" do
+        let(:splat_arrays) { true }
+
+        it "returns the correct hash without the nil keys" do
+          expect(tally).to eq(1 => 5,
+                              2 => 2,
+                              3 => 1)
+        end
       end
     end
 
@@ -2367,7 +2479,7 @@ describe Mongoid::Contextual::Memory do
       end
 
       let(:tally) do
-        context.tally("array")
+        context.tally("array", splat_arrays: splat_arrays)
       end
 
       it "returns the correct hash" do
@@ -2376,12 +2488,22 @@ describe Mongoid::Contextual::Memory do
           [1, 3] => 1
         )
       end
+
+      context "when :splat_arrays true" do
+        let(:splat_arrays) { true }
+
+        it "returns the correct hash without the nil keys" do
+          expect(tally).to eq(1 => 2,
+                              2 => 1,
+                              3 => 1)
+        end
+      end
     end
 
     context "when going multiple levels deep in arrays" do
 
       let(:tally) do
-        context.tally("genres.y.z")
+        context.tally("genres.y.z", splat_arrays: splat_arrays)
       end
 
       it "returns the correct hash" do
@@ -2389,13 +2511,23 @@ describe Mongoid::Contextual::Memory do
           [1, 2] => 2,
           [1, 3] => 1
         )
+      end
+
+      context "when :splat_arrays true" do
+        let(:splat_arrays) { true }
+
+        it "returns the correct hash without the nil keys" do
+          expect(tally).to eq(1 => 3,
+                              2 => 2,
+                              3 => 1)
+        end
       end
     end
 
     context "when going multiple levels deep in an array" do
 
       let(:tally) do
-        context.tally("genres.y.z")
+        context.tally("genres.y.z", splat_arrays: splat_arrays)
       end
 
       it "returns the correct hash" do
@@ -2403,6 +2535,16 @@ describe Mongoid::Contextual::Memory do
           [1, 2] => 2,
           [1, 3] => 1
         )
+      end
+
+      context "when :splat_arrays true" do
+        let(:splat_arrays) { true }
+
+        it "returns the correct hash without the nil keys" do
+          expect(tally).to eq(1 => 3,
+                              2 => 2,
+                              3 => 1)
+        end
       end
     end
 
@@ -2419,7 +2561,7 @@ describe Mongoid::Contextual::Memory do
       end
 
       let(:tally) do
-        context.tally("addresses.code.deepest.array.y.z")
+        context.tally("addresses.code.deepest.array.y.z", splat_arrays: splat_arrays)
       end
 
       it "returns the correct hash" do
@@ -2427,6 +2569,15 @@ describe Mongoid::Contextual::Memory do
           [ [ 1, 2 ] ] => 2,
           [ [ 1, 3 ] ] => 1
         )
+      end
+
+      context "when :splat_arrays true" do
+        let(:splat_arrays) { true }
+
+        it "returns the correct hash without the nil keys" do
+          expect(tally).to eq([ 1, 2 ] => 2,
+                              [ 1, 3 ] => 1)
+        end
       end
     end
 
@@ -2454,7 +2605,7 @@ describe Mongoid::Contextual::Memory do
       end
 
       let(:tally) do
-        context.tally("addresses.code.deepest.array.y.z")
+        context.tally("addresses.code.deepest.array.y.z", splat_arrays: splat_arrays)
       end
 
       it "returns the correct hash" do
@@ -2463,28 +2614,14 @@ describe Mongoid::Contextual::Memory do
           [ [ 1, 3 ], [ 1, 3 ] ] => 1
         )
       end
-    end
 
-    context "when some keys are missing" do
+      context "when :splat_arrays true" do
+        let(:splat_arrays) { true }
 
-      let(:criteria) do
-        Band.where(origin: "tally").all.tap do |crit|
-          crit.documents = [ band1, band2, band3 ]
-          3.times{ crit.documents << Band.new(origin: "tally") }
+        it "returns the correct hash without the nil keys" do
+          expect(tally).to eq([ 1, 2 ] => 4,
+                              [ 1, 3 ] => 2)
         end
-      end
-
-      let(:tally) do
-        context.tally(:name)
-      end
-
-      it "returns the correct hash" do
-        expect(tally).to eq(
-          "Depeche Mode" => 1,
-          "New Order" => 1,
-          "10,000 Maniacs" => 1,
-          nil => 3
-        )
       end
     end
 
@@ -2500,7 +2637,7 @@ describe Mongoid::Contextual::Memory do
       end
 
       let(:tally) do
-        context.tally("name.translations.language")
+        context.tally("name.translations.language", splat_arrays: splat_arrays)
       end
 
       it "returns the correct hash" do
@@ -2508,6 +2645,16 @@ describe Mongoid::Contextual::Memory do
           [1, 2] => 2,
           [1, 3] => 1
         )
+      end
+
+      context "when :splat_arrays true" do
+        let(:splat_arrays) { true }
+
+        it "returns the correct hash without the nil keys" do
+          expect(tally).to eq(1 => 3,
+                              2 => 2,
+                              3 => 1)
+        end
       end
     end
   end

--- a/spec/mongoid/contextual/mongo_spec.rb
+++ b/spec/mongoid/contextual/mongo_spec.rb
@@ -947,12 +947,10 @@ describe Mongoid::Contextual::Mongo do
         end
   
         it "returns the correct hash" do
-          expect(tally).to eq(
-                             "Depeche Mode" => 1,
-                             "New Order" => 1,
-                             "10,000 Maniacs" => 1,
-                             nil => 3
-                           )
+          expect(tally).to eq("Depeche Mode" => 1,
+                              "New Order" => 1,
+                              "10,000 Maniacs" => 1,
+                              nil => 3)
         end
       end
     

--- a/spec/mongoid/contextual/mongo_spec.rb
+++ b/spec/mongoid/contextual/mongo_spec.rb
@@ -1040,6 +1040,20 @@ describe Mongoid::Contextual::Mongo do
       end
     end
 
+    context "when tallying a field of type array with splat_arrays true" do
+      let(:criteria) { Band.where(origin: "tally2") }
+
+      let(:tally) do
+        criteria.tally("genres", splat_arrays: true)
+      end
+
+      it "returns the correct hash" do
+        expect(tally).to eq(1 => 3,
+                            2 => 2,
+                            3 => 1)
+      end
+    end
+
     context "when tallying an element from an array of hashes" do
       let(:criteria) { Band.where(origin: "tally") }
 

--- a/spec/mongoid/contextual/none_spec.rb
+++ b/spec/mongoid/contextual/none_spec.rb
@@ -78,6 +78,10 @@ describe Mongoid::Contextual::None do
     it "returns an empty hash" do
       expect(context.tally(:id)).to eq({})
     end
+
+    it "ignores :splat_arrays arg" do
+      expect(context.tally(:id, splat_arrays: true)).to eq({})
+    end
   end
 
   describe "#first" do


### PR DESCRIPTION
This uses the `$unwind` aggregation operator under the hood.

It turned out pretty nicely, it works for embedded and localized fields too.

Using this code I was able to run an array tally on a collection with 100,000,000 docs in 5 minutes 😎 