### PR TITLE
MONGOID-5562 Remove BSON::Document#transform_keys hack

### DIFF
--- a/lib/mongoid/extensions.rb
+++ b/lib/mongoid/extensions.rb
@@ -19,19 +19,6 @@ class BSON::ObjectId
   end
 end
 
-class BSON::Document
-  # We need to override this as ActiveSupport creates a new Object, instead of a new Hash
-  # see https://github.com/rails/rails/commit/f1bad130d0c9bd77c94e43b696adca56c46a66aa
-  def transform_keys
-    return enum_for(:transform_keys) unless block_given?
-    result = {}
-    each_key do |key|
-      result[yield(key)] = self[key]
-    end
-    result
-  end
-end
-
 require "mongoid/extensions/array"
 require "mongoid/extensions/big_decimal"
 require "mongoid/extensions/binary"


### PR DESCRIPTION
This hack can be removed as Mongoid requires Rails 5.1+ and the issue was fixed in Mongoid 5.0.

See: https://github.com/rails/rails/pull/24517

Should be fine to merge if tests pass.