### PR TITLE
MONGOID-5563 Code Docs: Correctly use Mongoid::Association::Relatable instead of Mongoid::Association

### DIFF
--- a/lib/mongoid/association/accessors.rb
+++ b/lib/mongoid/association/accessors.rb
@@ -17,7 +17,7 @@ module Mongoid
       #
       # @param [ String | Symbol ] name The name of the association.
       # @param [ Hash | BSON::ObjectId ] object The id or attributes to use.
-      # @param [ Association ] association The association metadata.
+      # @param [ Mongoid::Association::Relatable ] association The association metadata.
       # @param [ Hash ] selected_fields Fields which were retrieved via #only.
       #   If selected_fields is specified, fields not listed in it will not be
       #   accessible in the built document.
@@ -34,7 +34,7 @@ module Mongoid
       #   person.create_relation(document, association)
       #
       # @param [ Document | Array<Document> ] object The association target.
-      # @param [ Association ] association The association metadata.
+      # @param [ Mongoid::Association::Relatable ] association The association metadata.
       # @param [ Hash ] selected_fields Fields which were retrieved via #only.
       #   If selected_fields is specified, fields not listed in it will not be
       #   accessible in the created association document.
@@ -99,7 +99,7 @@ module Mongoid
       #   document.get_relation(:name, association)
       #
       # @param [ Symbol ] name The name of the association.
-      # @param [ Association ] association The association metadata.
+      # @param [ Mongoid::Association::Relatable ] association The association metadata.
       # @param [ Object ] object The object used to build the association.
       # @param [ true | false ] reload If the association is to be reloaded.
       #
@@ -268,7 +268,7 @@ module Mongoid
       #   person.has_game?
       #   person.game?
       #
-      # @param [ Association ] association The association.
+      # @param [ Mongoid::Association::Relatable ] association The association.
       #
       # @return [ Class ] The model being set up.
       def self.define_existence_check!(association)
@@ -290,7 +290,7 @@ module Mongoid
       # @example Set up the getter for the association.
       #   Person.define_getter!(association)
       #
-      # @param [ Association ] association The association metadata for the association.
+      # @param [ Mongoid::Association::Relatable ] association The association metadata for the association.
       #
       # @return [ Class ] The class being set up.
       def self.define_getter!(association)
@@ -312,7 +312,7 @@ module Mongoid
       # @example Set up the ids getter for the association.
       #   Person.define_ids_getter!(association)
       #
-      # @param [ Association ] association The association metadata for the association.
+      # @param [ Mongoid::Association::Relatable ] association The association metadata for the association.
       #
       # @return [ Class ] The class being set up.
       def self.define_ids_getter!(association)
@@ -332,7 +332,7 @@ module Mongoid
       # @example Set up the setter for the association.
       #   Person.define_setter!(association)
       #
-      # @param [ Association ] association The association metadata for the association.
+      # @param [ Mongoid::Association::Relatable ] association The association metadata for the association.
       #
       # @return [ Class ] The class being set up.
       def self.define_setter!(association)
@@ -364,7 +364,7 @@ module Mongoid
       # @example Set up the id_setter for the association.
       #   Person.define_ids_setter!(association)
       #
-      #  @param [ Association ] association The association for the association.
+      #  @param [ Mongoid::Association::Relatable ] association The association for the association.
       #
       #  @return [ Class ] The class being set up.
       def self.define_ids_setter!(association)
@@ -383,7 +383,7 @@ module Mongoid
       # @example
       #   Person.define_builder!(association)
       #
-      # @param [ Association ] association The association for the association.
+      # @param [ Mongoid::Association::Relatable ] association The association for the association.
       #
       # @return [ Class ] The class being set up.
       def self.define_builder!(association)
@@ -408,7 +408,7 @@ module Mongoid
       # @example
       #   Person.define_creator!(association)
       #
-      # @param [ Association ] association The association for the association.
+      # @param [ Mongoid::Association::Relatable ] association The association for the association.
       #
       # @return [ Class ] The class being set up.
       def self.define_creator!(association)

--- a/lib/mongoid/association/bindable.rb
+++ b/lib/mongoid/association/bindable.rb
@@ -16,7 +16,7 @@ module Mongoid
       #
       # @param [ Document ] base The base of the binding.
       # @param [ Document | Array<Document> ] target The target of the binding.
-      # @param [ Association ] association The association metadata.
+      # @param [ Mongoid::Association::Relatable ] association The association metadata.
       def initialize(base, target, association)
         @_base, @_target, @_association = base, target, association
       end

--- a/lib/mongoid/association/builders.rb
+++ b/lib/mongoid/association/builders.rb
@@ -39,7 +39,7 @@ module Mongoid
       # @example
       #   Person.define_builder!(association)
       #
-      # @param [ Association ] association The association metadata for the association.
+      # @param [ Mongoid::Association::Relatable ] association The association metadata.
       #
       # @return [ Class ] The class being set up.
       def self.define_builder!(association)
@@ -63,7 +63,7 @@ module Mongoid
       # @example
       #   Person.define_creator!(association)
       #
-      # @param [ Association ] association The association metadata for the association.
+      # @param [ Mongoid::Association::Relatable ] association The association metadata.
       #
       # @return [ Class ] The class being set up.
       def self.define_creator!(association)

--- a/lib/mongoid/association/depending.rb
+++ b/lib/mongoid/association/depending.rb
@@ -44,7 +44,7 @@ module Mongoid
       # @example Set up cascading information
       #   Mongoid::Association::Depending.define_dependency!(association)
       #
-      # @param [ Association ] association The association metadata.
+      # @param [ Mongoid::Association::Relatable ] association The association metadata.
       #
       # @return [ Class ] The class of the document.
       def self.define_dependency!(association)

--- a/lib/mongoid/association/eager_loadable.rb
+++ b/lib/mongoid/association/eager_loadable.rb
@@ -24,7 +24,8 @@ module Mongoid
       # recursively to load the associations of the given documents'
       # subdocuments.
       #
-      # @param [ Array<Association> ] associations The associations to load.
+      # @param [ Array<Mongoid::Association::Relatable> ] associations
+      #   The associations to load.
       # @param [ Array<Document> ] document The documents.
       def preload(associations, docs)
         assoc_map = associations.group_by(&:inverse_class_name)

--- a/lib/mongoid/association/embedded/embedded_in/proxy.rb
+++ b/lib/mongoid/association/embedded/embedded_in/proxy.rb
@@ -14,7 +14,7 @@ module Mongoid
           #
           # @param [ Document ] base The document the association hangs off of.
           # @param [ Document ] target The target (parent) of the association.
-          # @param [ Association ] association The association metadata.
+          # @param [ Mongoid::Association::Relatable ] association The association metadata.
           #
           # @return [ In ] The proxy.
           def initialize(base, target, association)

--- a/lib/mongoid/association/embedded/embeds_many/proxy.rb
+++ b/lib/mongoid/association/embedded/embeds_many/proxy.rb
@@ -251,7 +251,7 @@ module Mongoid
           #
           # @param [ Document ] base The document this association hangs off of.
           # @param [ Array<Document> ] target The child documents of the association.
-          # @param [ Association ] association The association metadata
+          # @param [ Mongoid::Association::Relatable ] association The association metadata.
           #
           # @return [ Many ] The proxy.
           def initialize(base, target, association)

--- a/lib/mongoid/association/embedded/embeds_one/proxy.rb
+++ b/lib/mongoid/association/embedded/embeds_one/proxy.rb
@@ -25,7 +25,7 @@ module Mongoid
           #
           # @param [ Document ] base The document this association hangs off of.
           # @param [ Document ] target The child document in the association.
-          # @param [ Association ] association The association metadata.
+          # @param [ Mongoid::Association::Relatable ] association The association metadata.
           def initialize(base, target, association)
             init(base, target, association) do
               characterize_one(_target)

--- a/lib/mongoid/association/nested/many.rb
+++ b/lib/mongoid/association/nested/many.rb
@@ -40,7 +40,7 @@ module Mongoid
         # @example Initialize the builder.
         #   Many.new(association, attributes, options)
         #
-        # @param [ Association ] association The association metadata.
+        # @param [ Mongoid::Association::Relatable ] association The association metadata.
         # @param [ Hash ] attributes The attributes hash to attempt to set.
         # @param [ Hash ] options The options defined.
         def initialize(association, attributes, options = {})

--- a/lib/mongoid/association/nested/one.rb
+++ b/lib/mongoid/association/nested/one.rb
@@ -41,7 +41,7 @@ module Mongoid
         # @example Instantiate the builder.
         #   One.new(association, attributes)
         #
-        # @param [ Association ] association The association metadata.
+        # @param [ Mongoid::Association::Relatable ] association The association metadata.
         # @param [ Hash ] attributes The attributes hash to attempt to set.
         # @param [ Hash ] options The options defined.
         def initialize(association, attributes, options)

--- a/lib/mongoid/association/proxy.rb
+++ b/lib/mongoid/association/proxy.rb
@@ -49,7 +49,7 @@ module Mongoid
       #
       # @param [ Document ] base The base document on the proxy.
       # @param [ Document | Array<Document> ] target The target of the proxy.
-      # @param [ Association ] association The association metadata.
+      # @param [ Mongoid::Association::Relatable ] association The association metadata.
       def init(base, target, association)
         @_base, @_target, @_association = base, target, association
         yield(self) if block_given?
@@ -188,7 +188,7 @@ module Mongoid
         #   Proxy.apply_ordering(criteria, association)
         #
         # @param [ Criteria ] criteria The criteria to modify.
-        # @param [ Association ] association The association metadata.
+        # @param [ Mongoid::Association::Relatable ] association The association metadata.
         #
         # @return [ Criteria ] The ordered criteria.
         def apply_ordering(criteria, association)

--- a/lib/mongoid/association/referenced/auto_save.rb
+++ b/lib/mongoid/association/referenced/auto_save.rb
@@ -43,7 +43,7 @@ module Mongoid
         # @example Define the autosave method:
         #   Association::Referenced::Autosave.define_autosave!(association)
         #
-        # @param [ Association ] association The association for which autosaving is enabled.
+        # @param [ Mongoid::Association::Relatable ] association The association for which autosaving is enabled.
         #
         # @return [ Class ] The association's owner class.
         def self.define_autosave!(association)

--- a/lib/mongoid/association/referenced/belongs_to.rb
+++ b/lib/mongoid/association/referenced/belongs_to.rb
@@ -51,7 +51,7 @@ module Mongoid
 
         # The list of association complements.
         #
-        # @return [ Array<Association> ] The association complements.
+        # @return [ Array<Mongoid::Association::Relatable> ] The association complements.
         def relation_complements
           @relation_complements ||= [ HasMany, HasOne ].freeze
         end

--- a/lib/mongoid/association/referenced/belongs_to/proxy.rb
+++ b/lib/mongoid/association/referenced/belongs_to/proxy.rb
@@ -20,7 +20,7 @@ module Mongoid
           # @param [ Document ] base The document this association hangs off of.
           # @param [ Document | Array<Document> ] target The target (parent) of the
           #   association.
-          # @param [ Association ] association The association object.
+          # @param [ Mongoid::Association::Relatable ] association The association object.
           def initialize(base, target, association)
             init(base, target, association) do
               characterize_one(_target)
@@ -100,7 +100,7 @@ module Mongoid
             #
             # @example Get the eager loader object
             #
-            # @param [ Association ] association The association object.
+            # @param [ Mongoid::Association::Relatable ] association The association object.
             # @param [ Array<Document> ] docs The array of documents.
             def eager_loader(association, docs)
               Eager.new(association, docs)

--- a/lib/mongoid/association/referenced/counter_cache.rb
+++ b/lib/mongoid/association/referenced/counter_cache.rb
@@ -88,7 +88,7 @@ module Mongoid
         # @example Add the touchable.
         #   Mongoid::Association::Referenced::CounterCache.define_callbacks!(association)
         #
-        # @param [ Association ] association The association.
+        # @param [ Mongoid::Association::Relatable ] association The association.
         #
         # @return [ Class ] The association's owning class.
         def self.define_callbacks!(association)

--- a/lib/mongoid/association/referenced/eager.rb
+++ b/lib/mongoid/association/referenced/eager.rb
@@ -13,8 +13,9 @@ module Mongoid
           # @example Create the new belongs to eager load preloader.
           #   BelongsTo.new(association, parent_docs)
           #
-          # @param [ Array<Association> ] associations Associations to eager load
-          # @param [ Array<Document> ] docs Documents to preload the associations
+          # @param [ Array<Mongoid::Association::Relatable> ] associations
+          #   Associations to eager load.
+          # @param [ Array<Document> ] docs Documents to preload the associations.
           #
           # @return [ Base ] The eager load preloader
           def initialize(associations, docs)
@@ -152,7 +153,7 @@ module Mongoid
           # @example Shift the current association.
           #   loader.shift_association
           #
-          # @return [ Association ] The association object.
+          # @return [ Mongoid::Association::Relatable ] The association metadata.
           def shift_association
             @association = @associations.shift
           end

--- a/lib/mongoid/association/referenced/has_and_belongs_to_many.rb
+++ b/lib/mongoid/association/referenced/has_and_belongs_to_many.rb
@@ -53,7 +53,7 @@ module Mongoid
 
         # The list of association complements.
         #
-        # @return [ Array<Association> ] The association complements.
+        # @return [ Array<Mongoid::Association::Relatable> ] The association complements.
         def relation_complements
           @relation_complements ||= [ self.class ].freeze
         end

--- a/lib/mongoid/association/referenced/has_and_belongs_to_many/proxy.rb
+++ b/lib/mongoid/association/referenced/has_and_belongs_to_many/proxy.rb
@@ -321,7 +321,7 @@ module Mongoid
             #
             # @example Get the eager loader object
             #
-            # @param [ Association ] association The association object.
+            # @param [ Mongoid::Association::Relatable ] association The association metadata.
             # @param [ Array<Document> ] docs The array of documents.
             def eager_loader(association, docs)
               Eager.new(association, docs)

--- a/lib/mongoid/association/referenced/has_many.rb
+++ b/lib/mongoid/association/referenced/has_many.rb
@@ -46,7 +46,7 @@ module Mongoid
 
         # The list of association complements.
         #
-        # @return [ Array<Association> ] The association complements.
+        # @return [ Array<Mongoid::Association::Relatable> ] The association complements.
         def relation_complements
           @relation_complements ||= [ Referenced::BelongsTo ].freeze
         end

--- a/lib/mongoid/association/referenced/has_many/proxy.rb
+++ b/lib/mongoid/association/referenced/has_many/proxy.rb
@@ -218,7 +218,7 @@ module Mongoid
           #
           # @param [ Document ] base The document this association hangs off of.
           # @param [ Array<Document> ] target The target of the association.
-          # @param [ Association ] association The association metadata.
+          # @param [ Mongoid::Association::Relatable ] association The association metadata.
           def initialize(base, target, association)
             enum = HasMany::Enumerable.new(target, base, association)
             init(base, enum, association) do

--- a/lib/mongoid/association/referenced/has_one.rb
+++ b/lib/mongoid/association/referenced/has_one.rb
@@ -41,7 +41,7 @@ module Mongoid
 
         # The list of association complements.
         #
-        # @return [ Array<Association> ] The association complements.
+        # @return [ Array<Mongoid::Association::Relatable> ] The association complements.
         def relation_complements
           @relation_complements ||= [ Referenced::BelongsTo ].freeze
         end

--- a/lib/mongoid/association/referenced/has_one/nested_builder.rb
+++ b/lib/mongoid/association/referenced/has_one/nested_builder.rb
@@ -40,7 +40,7 @@ module Mongoid
           # @example Instantiate the builder.
           #   One.new(association, attributes)
           #
-          # @param [ Association ] association The association metadata.
+          # @param [ Mongoid::Association::Relatable ] association The association metadata.
           # @param [ Hash ] attributes The attributes hash to attempt to set.
           # @param [ Hash ] options The options defined.
           def initialize(association, attributes, options)

--- a/lib/mongoid/association/referenced/has_one/proxy.rb
+++ b/lib/mongoid/association/referenced/has_one/proxy.rb
@@ -17,7 +17,7 @@ module Mongoid
           #
           # @param [ Document ] base The document this association hangs off of.
           # @param [ Document ] target The target (child) of the association.
-          # @param [ Association ] association The association metadata.
+          # @param [ Mongoid::Association::Relatable ] association The association metadata.
           def initialize(base, target, association)
             init(base, target, association) do
               raise_mixed if klass.embedded? && !klass.cyclic?

--- a/lib/mongoid/association/referenced/syncable.rb
+++ b/lib/mongoid/association/referenced/syncable.rb
@@ -14,7 +14,7 @@ module Mongoid
         # @example Are the foreign keys syncable?
         #   document._syncable?(association)
         #
-        # @param [ Association ] association The association metadata.
+        # @param [ Mongoid::Association::Relatable ] association The association metadata.
         #
         # @return [ true | false ] If we can sync.
         def _syncable?(association)
@@ -48,7 +48,7 @@ module Mongoid
         # @example Update the inverse keys.
         #   document.remove_inverse_keys(association)
         #
-        # @param [ Association ] association The association.
+        # @param [ Mongoid::Association::Relatable ] association The association metadata.
         #
         # @return [ Object ] The updated values.
         def remove_inverse_keys(association)
@@ -63,7 +63,7 @@ module Mongoid
         # @example Update the inverse keys
         #   document.update_inverse_keys(association)
         #
-        # @param [ Association ] association The document association.
+        # @param [ Mongoid::Association::Relatable ] association The association metadata.
         #
         # @return [ Object ] The updated values.
         def update_inverse_keys(association)
@@ -98,7 +98,7 @@ module Mongoid
           # @example Set up the syncing.
           #   Person._synced(association)
           #
-          # @param [ Association ] association The association metadata.
+          # @param [ Mongoid::Association::Relatable ] association The association metadata.
           def _synced(association)
             unless association.forced_nil_inverse?
               synced_save(association)
@@ -117,7 +117,7 @@ module Mongoid
           # @example Set up the save syncing.
           #   Person.synced_save(association)
           #
-          # @param [ Association ] association The association metadata.
+          # @param [ Mongoid::Association::Relatable ] association The association metadata.
           #
           # @return [ Class ] The class getting set up.
           def synced_save(association)
@@ -136,7 +136,7 @@ module Mongoid
           # @example Set up the destroy syncing.
           #   Person.synced_destroy(association)
           #
-          # @param [ Association ] association The association metadata.
+          # @param [ Mongoid::Association::Relatable ] association The association metadata.
           #
           # @return [ Class ] The class getting set up.
           def synced_destroy(association)

--- a/lib/mongoid/association/reflections.rb
+++ b/lib/mongoid/association/reflections.rb
@@ -15,7 +15,7 @@ module Mongoid
       #
       # @param [ String | Symbol ] name The name of the association to find.
       #
-      # @return [ Association ] The matching association metadata.
+      # @return [ Mongoid::Association::Relatable ] The matching association metadata.
       def reflect_on_association(name)
         self.class.reflect_on_association(name)
       end
@@ -27,7 +27,7 @@ module Mongoid
       #
       # @param [ Symbol... ] *macros The association macros.
       #
-      # @return [ Array<Association> ] The matching association metadata.
+      # @return [ Array<Mongoid::Association::Relatable> ] The matching association metadata.
       def reflect_on_all_association(*macros)
         self.class.reflect_on_all_associations(*macros)
       end
@@ -41,7 +41,7 @@ module Mongoid
         #
         # @param [ String | Symbol ] name The name of the association to find.
         #
-        # @return [ Association ] The matching association metadata.
+        # @return [ Mongoid::Association::Relatable ] The matching association metadata.
         def reflect_on_association(name)
           relations[name.to_s]
         end
@@ -53,7 +53,7 @@ module Mongoid
         #
         # @param [ Symbol... ] *macros The association macros.
         #
-        # @return [ Array<Association> ] The matching association metadata.
+        # @return [ Array<Mongoid::Association::Relatable> ] The matching association metadata.
         def reflect_on_all_associations(*macros)
           all_associations = relations.values
           unless macros.empty?

--- a/lib/mongoid/association/relatable.rb
+++ b/lib/mongoid/association/relatable.rb
@@ -113,7 +113,7 @@ module Mongoid
       # @param [ Object ] other The other model class or model object to use when
       #   determining inverses.
       #
-      # @return [ Association ] The inverse's association metadata.
+      # @return [ Mongoid::Association::Relatable ] The inverse's association metadata.
       def inverse_association(other = nil)
         (other || relation_class).relations[inverse(other)]
       end

--- a/lib/mongoid/atomic/paths/embedded/many.rb
+++ b/lib/mongoid/atomic/paths/embedded/many.rb
@@ -45,7 +45,7 @@ module Mongoid
             # trying to store the empty list.
             #
             # @param [ Document ] parent The parent document to store in.
-            # @param [ Association ] association The association.
+            # @param [ Mongoid::Association::Relatable ] association The association metadata.
             #
             # @return [ String ] The position string.
             def position_without_document(parent, association)

--- a/lib/mongoid/attributes/nested.rb
+++ b/lib/mongoid/attributes/nested.rb
@@ -76,7 +76,7 @@ module Mongoid
         # @example Add the autosave if appropriate.
         #   Person.autosave_nested_attributes(metadata)
         #
-        # @param [ Association ] association The existing association metadata.
+        # @param [ Mongoid::Association::Relatable ] association The existing association metadata.
         def autosave_nested_attributes(association)
           # In order for the autosave functionality to work properly, the association needs to be
           # marked as autosave despite the fact that the option isn't present. Because the method

--- a/lib/mongoid/criteria/includable.rb
+++ b/lib/mongoid/criteria/includable.rb
@@ -32,16 +32,16 @@ module Mongoid
 
       # Get a list of criteria that are to be executed for eager loading.
       #
-      # @return [ Array<Association> ] The inclusions.
+      # @return [ Array<Mongoid::Association::Relatable> ] The inclusions.
       def inclusions
         @inclusions ||= []
       end
 
       # Set the inclusions for the criteria.
       #
-      # @param [ Array<Association> ] value The inclusions.
+      # @param [ Array<Mongoid::Association::Relatable> ] value The inclusions.
       #
-      # @return [ Array<Association> ] The new inclusions.
+      # @return [ Array<Mongoid::Association::Relatable> ] The new inclusions.
       def inclusions=(value)
         @inclusions = value
       end
@@ -50,7 +50,7 @@ module Mongoid
 
       # Add an inclusion definition to the list of inclusions for the criteria.
       #
-      # @param [ Association ] association The association.
+      # @param [ Mongoid::Association::Relatable ] association The association metadata.
       # @param [ String ] parent The name of the association above this one in
       #   the inclusion tree, if it is a nested inclusion.
       def add_inclusion(association, parent = nil)

--- a/lib/mongoid/extensions/array.rb
+++ b/lib/mongoid/extensions/array.rb
@@ -124,7 +124,7 @@ module Mongoid
         # @example Mongoize the object.
         #   Array.__mongoize_fk__(constraint, object)
         #
-        # @param [ Association ] association The association metadata.
+        # @param [ Mongoid::Association::Relatable ] association The association metadata.
         # @param [ Object ] object The object to convert.
         #
         # @return [ Array ] The array of ids.

--- a/lib/mongoid/extensions/object.rb
+++ b/lib/mongoid/extensions/object.rb
@@ -206,7 +206,7 @@ module Mongoid
         # @example Convert the object to a fk.
         #   Object.__mongoize_fk__(association, object)
         #
-        # @param [ Association ] association The association metadata.
+        # @param [ Mongoid::Association::Relatable ] association The association metadata.
         # @param [ Object ] object The object to convert.
         #
         # @return [ Object ] The converted object.

--- a/lib/mongoid/touchable.rb
+++ b/lib/mongoid/touchable.rb
@@ -115,7 +115,7 @@ module Mongoid
     # @example Add the touchable.
     #   Model.define_touchable!(assoc)
     #
-    # @param [ Association ] association The association metadata.
+    # @param [ Mongoid::Association::Relatable ] association The association metadata.
     #
     # @return [ Class ] The model class.
     def define_touchable!(association)
@@ -143,7 +143,7 @@ module Mongoid
     #   Model.define_relation_touch_method(:band, :band_updated_at)
     #
     # @param [ Symbol ] name The name of the association.
-    # @param [ Association ] association The association metadata.
+    # @param [ Mongoid::Association::Relatable ] association The association metadata.
     #
     # @return [ Symbol ] The method name.
     def define_relation_touch_method(name, association)

--- a/lib/mongoid/validatable.rb
+++ b/lib/mongoid/validatable.rb
@@ -118,7 +118,7 @@ module Mongoid
       # @example Set up validation.
       #   Person.validates_relation(association)
       #
-      # @param [ Association ] association The association metadata.
+      # @param [ Mongoid::Association::Relatable ] association The association metadata.
       def validates_relation(association)
         if association.validate?
           validates_associated(association.name)


### PR DESCRIPTION
**This PR is code-doc changes only, it does not change any logic**

`Mongoid::Association` is poorly named. It is actually a **mixin** included in the `Mongoid::Document` class, which makes a document capable of being associated. (`Mongoid::Associable` would be a far better name, as the general practice is for mixins to end in `-able` suffix.)

The association metadata classes like `HasOne`, `EmbedsMany`, etc. do **not** inherit from `Mongoid::Association`. Instead, these `include Mongoid::Association::Relatable` mixin as their common base.

Therefore, where docs currently reference type `Association` (i.e. metadata) it is **incorrect**, we should replace it with `Mongoid::Association::Relatable`.