### PR TITLE
MONGOID-5566 fix breaking app_spec.rb when run locally

### DIFF
--- a/spec/integration/app_spec.rb
+++ b/spec/integration/app_spec.rb
@@ -14,6 +14,11 @@ def gem_version_argument(version)
   "_#{version}_" if version
 end
 
+def insert_rails_gem_version(cmd)
+  gem_version = gem_version_argument(SpecConfig.instance.installed_rails_version)
+  cmd.tap { cmd[1,0] = gem_version if gem_version }
+end
+
 describe 'Mongoid application tests' do
   before(:all) do
     unless SpecConfig.instance.app_tests?
@@ -95,8 +100,7 @@ describe 'Mongoid application tests' do
 
     Dir.chdir(TMP_BASE) do
       FileUtils.rm_rf(name)
-      gem_version = gem_version_argument(SpecConfig.instance.installed_rails_version)
-      check_call(%W(rails #{gem_version} new #{name} --skip-spring --skip-active-record), env: clean_env)
+      check_call(insert_rails_gem_version(%W(rails new #{name} --skip-spring --skip-active-record)), env: clean_env)
 
       Dir.chdir(name) do
         adjust_rails_defaults

--- a/spec/integration/app_spec.rb
+++ b/spec/integration/app_spec.rb
@@ -265,7 +265,7 @@ describe 'Mongoid application tests' do
   def write_mongoid_yml
     # HACK: the driver does not provide a MongoDB URI parser and assembler,
     # and the Ruby standard library URI module doesn't handle multiple hosts.
-    parts = parse_mongodb_uri(SpecConfig.instance.safe_uri)
+    parts = parse_mongodb_uri(SpecConfig.instance.uri_str)
     parts[:database] = 'mongoid_test'
     uri = build_mongodb_uri(parts)
     p uri

--- a/spec/integration/app_spec.rb
+++ b/spec/integration/app_spec.rb
@@ -10,6 +10,10 @@ def check_call(cmd, **opts)
   Mrss::ChildProcessHelper.check_call(cmd, **opts)
 end
 
+def gem_version_argument(version)
+  "_#{version}_" if version
+end
+
 describe 'Mongoid application tests' do
   before(:all) do
     unless SpecConfig.instance.app_tests?
@@ -91,7 +95,8 @@ describe 'Mongoid application tests' do
 
     Dir.chdir(TMP_BASE) do
       FileUtils.rm_rf(name)
-      check_call(%W(rails new #{name} --skip-spring --skip-active-record), env: clean_env)
+      gem_version = gem_version_argument(SpecConfig.instance.installed_rails_version)
+      check_call(%W(rails #{gem_version} new #{name} --skip-spring --skip-active-record), env: clean_env)
 
       Dir.chdir(name) do
         adjust_rails_defaults

--- a/spec/support/spec_config.rb
+++ b/spec/support/spec_config.rb
@@ -5,31 +5,26 @@ require 'singleton'
 class SpecConfig
   include Singleton
 
+  DEFAULT_MONGODB_URI = "mongodb://127.0.0.1:27017"
+
   def initialize
     if ENV['MONGODB_URI']
       @uri_str = ENV['MONGODB_URI']
-      @uri = Mongo::URI.new(@uri_str)
+    else
+      STDERR.puts "Environment variable 'MONGODB_URI' is not set, so the default url will be used."
+      STDERR.puts "This may lead to unexpected test failures because service discovery will raise unexpected warnings."
+      STDERR.puts "Please consider providing the correct uri via MONGODB_URI environment variable."
+      @uri_str = DEFAULT_MONGODB_URI
     end
+    
+    @uri = Mongo::URI.new(@uri_str)
   end
 
   attr_reader :uri_str
   attr_reader :uri
 
   def addresses
-    if @uri
-      @uri.servers
-    else
-      STDERR.puts "Environment variable 'MONGODB_URI' is not set, so the default url will be used."
-      STDERR.puts "This may lead to unexpected test failures because service discovery will raise unexpected warnings."
-      STDERR.puts "Please consider providing the correct uri via MONGODB_URI environment variable."
-      ['127.0.0.1:27017']
-    end
-  end
-
-  # returns the URI string, or constructs one from the defaults if no URI
-  # string was given.
-  def safe_uri
-    @uri_str || "mongodb://#{addresses.first}"
+    @uri.servers
   end
 
   def mri?

--- a/spec/support/spec_config.rb
+++ b/spec/support/spec_config.rb
@@ -62,4 +62,19 @@ class SpecConfig
     end
     v || '6.1'
   end
+
+  # Scrapes the output of `gem list` to find which versions of Rails are
+  # installed, and looks for first one that best matches whatever rails version
+  # was requested (see `#rails_version`).
+  #
+  # @return [ String | nil ] the version of the requested Rails install, or
+  #    nil if nothing matches.
+  def installed_rails_version
+    output = `gem list --exact rails`
+    if output =~ /^rails \((.*)\)/
+      versions = $1.split(/,\s*/)
+      rails_version_re = /^#{rails_version}(?:\..*)?$/
+      versions.detect { |v| v =~ rails_version_re }
+    end
+  end
 end


### PR DESCRIPTION
When running `app_spec.rb` locally, if you have Rails 7+ installed, the spec fails because the wrong `rails` script is used to run `rails new`.

Also, if `MONGODB_URI` is not set, a parse error occurs in `app_spec.rb` because the `write_mongoid_yml` method expects `SpecConfig#safe_uri` to return a valid mongodb URI, which it does not if MONGODB_URI is not set. I've refactored that logic a bit in SpecConfig to make it work more robustly when that environment variable is not set.