### PR TITLE
MONGOID-5016 default embedded touch to true

### DIFF
--- a/docs/release-notes/mongoid-9.0.txt
+++ b/docs/release-notes/mongoid-9.0.txt
@@ -191,6 +191,24 @@ persistence operation per parent document, even when using multiple
 levels of nested embedded documents.
 
 
+``embedded_in`` associations now default to ``touch: true``
+-----------------------------------------------------------
+
+Updating an embedded subdocument will now automatically touch the parent,
+unless you explicitly set ``touch: false`` on the relation:
+
+.. code-block:: ruby
+
+  class Address
+    include Mongoid::Document
+    include Mongoid::Timestamps
+
+    embedded_in :mall, touch: false
+  end
+
+For all other associations, the default remains ``touch: false``.
+
+
 Flipped default for ``:replace`` option in ``#upsert``
 ------------------------------------------------------
 

--- a/lib/mongoid/association/accessors.rb
+++ b/lib/mongoid/association/accessors.rb
@@ -341,12 +341,11 @@ module Mongoid
           klass.re_define_method("#{name}=") do |object|
             without_autobuild do
               if value = get_relation(name, association, object)
-                if value.respond_to?(:substitute)
-                  set_relation(name, value.substitute(object.substitutable))
-                else
-                  value = __build__(name, value, association)
-                  set_relation(name, value.substitute(object.substitutable))
+                if !value.respond_to?(:substitute)
+                  value = __build__(name, value, association) 
                 end
+
+                set_relation(name, value.substitute(object.substitutable))
               else
                 __build__(name, object.substitutable, association)
               end

--- a/lib/mongoid/association/embedded/embedded_in.rb
+++ b/lib/mongoid/association/embedded/embedded_in.rb
@@ -34,6 +34,7 @@ module Mongoid
         #
         # @return [ self ]
         def setup!
+          setup_defaults!
           setup_instance_methods!
           @owner_class.embedded = true
           self
@@ -91,6 +92,11 @@ module Mongoid
         end
 
         private
+
+        # Set up default values for any options used by this association.
+        def setup_defaults!
+          @options[:touch] = true unless @options.key?(:touch)
+        end
 
         def setup_instance_methods!
           define_getter!

--- a/lib/mongoid/association/embedded/embeds_one/proxy.rb
+++ b/lib/mongoid/association/embedded/embeds_one/proxy.rb
@@ -83,6 +83,15 @@ module Mongoid
               unbind_one
               unless replacement
                 update_attributes_hash(replacement)
+
+                # when `touch: true` is the default (see MONGOID-5016), creating
+                # an embedded document will touch the parent, and will cause the
+                # _descendants list to be initialized and memoized. If the object
+                # is then deleted, we need to make sure and un-memoize that list,
+                # otherwise when the update happens, the memoized _descendants list
+                # gets used and the "deleted" subdocument gets added again.
+                _reset_memoized_descendants!
+
                 return nil
               end
               replacement = Factory.build(klass, replacement) if replacement.is_a?(::Hash)

--- a/lib/mongoid/attributes/processing.rb
+++ b/lib/mongoid/attributes/processing.rb
@@ -116,6 +116,7 @@ module Mongoid
       def process_pending
         process_nested and process_relations
         pending_nested.clear and pending_relations.clear
+        _reset_memoized_descendants!
       end
 
       # Process all the pending associations that needed to wait until ids were set

--- a/lib/mongoid/persistable/updatable.rb
+++ b/lib/mongoid/persistable/updatable.rb
@@ -103,21 +103,11 @@ module Mongoid
         process_flagged_destroys
         update_children = cascadable_children(:update)
         process_touch_option(options, update_children) do
-          run_callbacks(:commit, with_children: true, skip_if: -> { in_transaction? }) do
-            run_callbacks(:save, with_children: false) do
-              run_callbacks(:update, with_children: false) do
-                run_callbacks(:persist_parent, with_children: false) do
-                  _mongoid_run_child_callbacks(:save) do
-                    _mongoid_run_child_callbacks(:update, children: update_children) do
-                      result = yield(self)
-                      self.previously_new_record = false
-                      post_process_persist(result, options)
-                      true
-                    end
-                  end
-                end
-              end
-            end
+          run_all_callbacks_for_update(update_children) do
+            result = yield(self)
+            self.previously_new_record = false
+            post_process_persist(result, options)
+            true
           end
         end
       end
@@ -216,6 +206,28 @@ module Mongoid
           end
         end
       end
+
+      # Consolidates all the callback invocations into a single place, to
+      # avoid cluttering the logic in #prepare_update.
+      #
+      # @param [ Array<Document> ] update_children The children that the
+      #   :update callbacks will be executed on.
+      def run_all_callbacks_for_update(update_children)
+        run_callbacks(:commit, with_children: true, skip_if: -> { in_transaction? }) do
+          run_callbacks(:save, with_children: false) do
+            run_callbacks(:update, with_children: false) do
+              run_callbacks(:persist_parent, with_children: false) do
+                _mongoid_run_child_callbacks(:save) do
+                  _mongoid_run_child_callbacks(:update, children: update_children) do
+                    yield
+                  end # _mongoid_run_child_callbacks :update
+                end # _mongoid_run_child_callbacks :save
+              end # :persist_parent
+            end # :update
+          end # :save
+        end # :commit
+      end
+
     end
   end
 end

--- a/lib/mongoid/touchable.rb
+++ b/lib/mongoid/touchable.rb
@@ -2,8 +2,28 @@
 
 module Mongoid
   module Touchable
-
     module InstanceMethods
+
+      # Suppresses the invocation of touch callbacks, for the class that
+      # includes this module, for the duration of the block.
+      #
+      # @example Suppress touch callbacks on Person documents:
+      #   person.suppress_touch_callbacks { ... }
+      #
+      # @api private
+      def suppress_touch_callbacks
+        Touchable.suppress_touch_callbacks(self.class.name) { yield }
+      end
+
+      # Queries whether touch callbacks are being suppressed for the class
+      # that includes this module.
+      #
+      # @return [ true | false ] Whether touch callbacks are suppressed.
+      #
+      # @api private
+      def touch_callbacks_suppressed?
+        Touchable.touch_callbacks_suppressed?(self.class.name)
+      end
 
       # Touch the document, in effect updating its updated_at timestamp and
       # optionally the provided field to the current time. If any belongs_to
@@ -45,7 +65,10 @@ module Mongoid
       #
       # @api private
       def _gather_touch_updates(now, field = nil)
+        return if touch_callbacks_suppressed?
+
         field = database_field_name(field)
+
         write_attribute(:updated_at, now) if respond_to?("updated_at=")
         write_attribute(field, now) if field
 
@@ -71,6 +94,7 @@ module Mongoid
       #
       # @api private
       def _run_touch_callbacks_from_root
+        return if touch_callbacks_suppressed?
         _parent._run_touch_callbacks_from_root if _touchable_parent?
         run_callbacks(:touch)
       end
@@ -131,7 +155,40 @@ module Mongoid
       end
     end
 
+    # Suppresses touch callbacks for the named class, for the duration of
+    # the associated block.
+    #
+    # @api private
+    def suppress_touch_callbacks(name)
+      save, touch_callback_statuses[name] = touch_callback_statuses[name], true
+      yield
+    ensure
+      touch_callback_statuses[name] = save
+    end
+
+    # Queries whether touch callbacks are being suppressed for the named
+    # class.
+    #
+    # @return [ true | false ] Whether touch callbacks are suppressed.
+    #
+    # @api private
+    def touch_callbacks_suppressed?(name)
+      touch_callback_statuses[name]
+    end
+
     private
+
+    # The key to use to store the active touch callback suppression statuses
+    SUPPRESS_TOUCH_CALLBACKS_KEY = "[mongoid]:suppress-touch-callbacks"
+
+    # Returns a hash to be used to store and query the various touch callback
+    # suppression statuses for different classes.
+    #
+    # @return [ Hash ] The hash that contains touch callback suppression
+    #   statuses
+    def touch_callback_statuses
+      Thread.current[SUPPRESS_TOUCH_CALLBACKS_KEY] ||= {}
+    end
 
     # Define the method that will get called for touching belongs_to
     # associations.
@@ -153,12 +210,11 @@ module Mongoid
                            [ association.relation_class ]
                          end
 
-      relation_classes.each { |c| c.send(:include, InstanceMethods) }
       method_name = "touch_#{name}_after_create_or_destroy"
       association.inverse_class.class_eval do
         define_method(method_name) do
           without_autobuild do
-            if relation = __send__(name)
+            if !touch_callbacks_suppressed? && relation = __send__(name)
               # This looks up touch_field at runtime, rather than at method definition time.
               # If touch_field is nil, it will only touch the default field (updated_at).
               relation.touch(association.touch_field)

--- a/spec/integration/associations/embedded_spec.rb
+++ b/spec/integration/associations/embedded_spec.rb
@@ -178,8 +178,6 @@ describe 'embedded associations' do
         let(:parent) { EomParent.create! }
 
         it 'updates' do
-          pending 'https://jira.mongodb.org/browse/MONGOID-3252'
-
           first_updated_at = parent.updated_at
 
           parent.child = EomChild.new
@@ -193,8 +191,6 @@ describe 'embedded associations' do
         let(:parent) { EmmCongress.create! }
 
         it 'updates' do
-          pending 'https://jira.mongodb.org/browse/MONGOID-3252'
-
           first_updated_at = parent.updated_at
 
           parent.legislators << EmmLegislator.new
@@ -238,8 +234,6 @@ describe 'embedded associations' do
         let(:parent) { EomParent.create!(child: EomChild.new) }
 
         it 'updates' do
-          pending 'https://jira.mongodb.org/browse/MONGOID-3252'
-
           first_updated_at = parent.updated_at
 
           parent.child = nil

--- a/spec/mongoid/association/embedded/embedded_in_spec.rb
+++ b/spec/mongoid/association/embedded/embedded_in_spec.rb
@@ -156,20 +156,27 @@ describe Mongoid::Association::Embedded::EmbeddedIn do
   describe '#touchable?' do
 
     context 'when :touch is in the options' do
-
-      let(:options) do
-        { touch: true}
+      shared_examples_for ':touch is in the options' do
+        it 'returns the value in the options' do
+          expect(association.send(:touchable?)).to be(options[:touch])
+        end
       end
 
-      it 'returns true' do
-        expect(association.send(:touchable?)).to be(true)
+      context 'when the option is true' do
+        let(:options) { { touch: true } }
+        it_behaves_like ':touch is in the options'
+      end
+
+      context 'when the option is true' do
+        let(:options) { { touch: false } }
+        it_behaves_like ':touch is in the options'
       end
     end
 
     context 'when :touch is not in the options' do
 
-      it 'return false' do
-        expect(association.send(:touchable?)).to be(false)
+      it 'return the default value' do
+        expect(association.send(:touchable?)).to be(true)
       end
     end
   end
@@ -582,7 +589,11 @@ describe Mongoid::Association::Embedded::EmbeddedIn do
     context 'when the :class_name option is specified' do
 
       let(:options) do
-        { class_name: 'OtherContainer' }
+        # `touch: true` is the default (see MONGOID-5016), which means by
+        # default, callbacks are added to the referenced class. In this case,
+        # the class does not exist, so we must explicitly set `touch: false`
+        # to prevent Mongoid from attempting to load the bogus class.
+        { touch: false, class_name: 'OtherContainer' }
       end
 
       it 'returns the class name option' do

--- a/spec/mongoid/association/embedded/embedded_in_spec.rb
+++ b/spec/mongoid/association/embedded/embedded_in_spec.rb
@@ -167,7 +167,7 @@ describe Mongoid::Association::Embedded::EmbeddedIn do
         it_behaves_like ':touch is in the options'
       end
 
-      context 'when the option is true' do
+      context 'when the option is false' do
         let(:options) { { touch: false } }
         it_behaves_like ':touch is in the options'
       end

--- a/spec/mongoid/association/embedded/embeds_many_models.rb
+++ b/spec/mongoid/association/embedded/embeds_many_models.rb
@@ -172,7 +172,11 @@ class EmmHatch
   include Mongoid::Document
 
   # No :class_name option on this association intentionally.
-  embedded_in :tank
+  # Also, re: MONGOID-5016, `touch: true` is the default, which means Mongoid
+  # will try to load the associated class in order to add relevant callbacks.
+  # We must set `touch: false` here to avoid Mongoid trying to load a
+  # non-existent class.
+  embedded_in :tank, touch: false
 end
 
 class EmmPost
@@ -235,4 +239,3 @@ class EmmChild
   field :order, type: Integer
   field :t
 end
-

--- a/spec/mongoid/association/embedded/embeds_one_models.rb
+++ b/spec/mongoid/association/embedded/embeds_one_models.rb
@@ -50,7 +50,11 @@ class EomDnlChild
   include Mongoid::Document
 
   embedded_in :parent, class_name: 'EomDnlParent'
-  embedded_in :missing_parent, class_name: 'EomDnlMissingParent'
+
+  # `touch: false` is necessary here because Touchable tries to reference the
+  # associated class when it adds the callbacks for touching. See MONGOID-5016
+  # re: `touch: true` as the default for embedded_in associations.
+  embedded_in :missing_parent, touch: false, class_name: 'EomDnlMissingParent'
 end
 
 class EomAddress

--- a/spec/mongoid/touchable_spec.rb
+++ b/spec/mongoid/touchable_spec.rb
@@ -171,11 +171,6 @@ describe Mongoid::Touchable do
 
     context "when no relations have touch options" do
 
-      before do
-        Person.send(:include, Mongoid::Touchable::InstanceMethods)
-        Agent.send(:include, Mongoid::Touchable::InstanceMethods)
-      end
-
       context "when no updated at is defined" do
 
         let(:person) do
@@ -395,11 +390,6 @@ describe Mongoid::Touchable do
 
       context "when the relation is a parent of an embedded doc" do
 
-        before do
-          Page.send(:include, Mongoid::Touchable::InstanceMethods)
-          Edit.send(:include, Mongoid::Touchable::InstanceMethods)
-        end
-
         let(:page) do
           WikiPage.create!(title: "test")
         end
@@ -419,10 +409,6 @@ describe Mongoid::Touchable do
       end
 
       context "when the parent of embedded doc has cascade callbacks" do
-
-        before do
-          Band.send(:include, Mongoid::Touchable::InstanceMethods)
-        end
 
         let!(:book) do
           Book.new

--- a/spec/support/models/favorite.rb
+++ b/spec/support/models/favorite.rb
@@ -4,5 +4,11 @@ class Favorite
   include Mongoid::Document
   field :title
   validates_uniqueness_of :title, case_sensitive: false
-  embedded_in :perp, inverse_of: :favorites
+
+  # See MONGOID-5016. The default for `touch` is now `true` for embedded_in
+  # associations, which causes the referenced class to be loaded eagerly so
+  # the relevant callbacks can be added. As `perp` is not a real class, we
+  # need to explicitly set `touch: false` here, to avoid Mongoid trying to
+  # load it.
+  embedded_in :perp, touch: false, inverse_of: :favorites
 end


### PR DESCRIPTION
This PR changes the default for the `embedded_in` relation from `touch: false` to `touch: true`, meaning that changing a subdocument will result in the parent being touched.

This resulted in a surprising number of broken tests, and most surprisingly, revealed a couple of bugs, as well, both of which have been addressed in this PR.

## Bug No. 1: The Memoized `_descendants` List

The first bug was a result of the `_descendants` list being memoized when first referenced. Given a system of models, and a series of operations like the following:

```ruby
class Person
  include Mongoid::Document
  include Mongoid::Timestamps

  field :name, type: String
  embeds_one :hometown
end

class Hometown
  include Mongoid::Document
  include Mongoid::Timestamps

  field :name, type: String
  embedded_in :person
end

bob = Person.create(name: "Bob")
home = bob.create_hometown(name: "Chicago")

bob.hometown = nil # <-- should destroy the hometown
bob.save!

p bob.hometown # <-- but it wasn't destroyed!
```
In the above sequence, with the default (and implicit) `touch: true` on the `embedded_in` relation, the hometown wouldn't actually be destroyed--calling `save!` would "resurrect" it. This was because of the `_descendants` list being initialized and memoized during the `create_hometown` call; when `#save!` was called later, that memoized list still had the newly created Hometown instance in it, which was marked as a new record as part of the substitution process, and it was therefore be _readded_ to the database!

The solution was to make sure to reset the memoized `_descendants` list after setting the hometown attribute to `nil`.

## Bug No. 2: `save` with `touch: false` doesn't override the implicit `touch: true`

When saving a subdocument, and explicitly specifying `save(touch: false)`, the parent document was being touched. Consider the following model system and operations:

```ruby
class Book
  include Mongoid::Document
  include Mongoid::Timestamps

  field :title, type: String

  # omitting `cascade_callbacks` revealed a related bug, where the touch callback was also being called; I'm
  # considering both scenarios under the same heading...
  embeds_many :covers, cascade_callbacks: true
end

class Cover
  include Mongoid::Document
  include Mongoid::Timestamps

  field :color, type: String
  embedded_in :book 
end

book = Book.create(covers: [ Cover.new(color: "blue") ])

sleep 1 # wait long enough for time-of-update to be different from time-of-create
cover = book.covers.first
cover.color = "green"

book.save!(touch: false) # should NOT push the touch up to the parent...

# ...but it does!
book.reload
puts "created at: #{book.created_at}"
puts "updated at: #{book.updated_at}"
```
The issue here is that the `timeless` scope was being reset as soon as the `updated_at` field was updated, and the touch callbacks were occurring *after* that. The solution was to add a small system for suppressing touch callbacks within a block, and then ensuring the entire update happens within such a block.