### PR TITLE
MONGOID-5565 Remove Ruby 2.6 from GH Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,16 +49,6 @@ jobs:
           gemfile: Gemfile
           experimental: false
         - mongodb: '6.0'
-          ruby: jruby-9.4
-          topology: replica_set
-          os: ubuntu-20.04
-          task: test
-          driver: current
-          rails:
-          i18n:
-          gemfile: Gemfile
-          experimental: false
-        - mongodb: '6.0'
           ruby: ruby-3.1
           topology: replica_set
           os: ubuntu-20.04
@@ -180,7 +170,7 @@ jobs:
           gemfile: Gemfile
           experimental: false
         - mongodb: '3.6'
-          ruby: ruby-2.6
+          ruby: ruby-2.7
           topology: replica_set
           os: ubuntu-18.04
           task: test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,9 +18,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - mongodb: '5.0'
-          ruby: ruby-3.1
-          topology: server
+        - mongodb: '6.0'
+          ruby: ruby-3.2
+          topology: replica_set
           os: ubuntu-20.04
           task: test
           driver: current
@@ -28,7 +28,7 @@ jobs:
           i18n:
           gemfile: Gemfile
           experimental: false
-        - mongodb: '5.0'
+        - mongodb: '6.0'
           ruby: ruby-3.1
           topology: replica_set
           os: ubuntu-20.04
@@ -38,17 +38,7 @@ jobs:
           i18n:
           gemfile: Gemfile
           experimental: false
-        - mongodb: '5.0'
-          ruby: ruby-3.0
-          topology: server
-          os: ubuntu-20.04
-          task: test
-          driver: current
-          rails:
-          i18n:
-          gemfile: Gemfile
-          experimental: false
-        - mongodb: '5.0'
+        - mongodb: '6.0'
           ruby: ruby-3.0
           topology: replica_set
           os: ubuntu-20.04
@@ -58,8 +48,8 @@ jobs:
           i18n:
           gemfile: Gemfile
           experimental: false
-        - mongodb: '5.0'
-          ruby: jruby-9.3
+        - mongodb: '6.0'
+          ruby: jruby-9.4
           topology: replica_set
           os: ubuntu-20.04
           task: test
@@ -68,67 +58,7 @@ jobs:
           i18n:
           gemfile: Gemfile
           experimental: false
-        - mongodb: '4.4'
-          ruby: ruby-2.7
-          topology: server
-          os: ubuntu-20.04
-          task: test
-          driver: current
-          rails:
-          i18n:
-          gemfile: Gemfile
-          experimental: false
-        - mongodb: '4.4'
-          ruby: ruby-2.7
-          topology: replica_set
-          os: ubuntu-20.04
-          task: test
-          driver: current
-          rails:
-          i18n:
-          gemfile: Gemfile
-          experimental: false
-        - mongodb: '4.0'
-          ruby: ruby-2.6
-          topology: server
-          os: ubuntu-18.04
-          task: test
-          driver: current
-          rails:
-          i18n:
-          gemfile: Gemfile
-          experimental: false
-        - mongodb: '4.0'
-          ruby: ruby-2.6
-          topology: replica_set
-          os: ubuntu-18.04
-          task: test
-          driver: current
-          rails:
-          i18n:
-          gemfile: Gemfile
-          experimental: false
-        - mongodb: '3.6'
-          ruby: ruby-2.6
-          topology: server
-          os: ubuntu-18.04
-          task: test
-          driver: current
-          rails:
-          i18n:
-          gemfile: Gemfile
-          experimental: false
-        - mongodb: '3.6'
-          ruby: ruby-2.6
-          topology: replica_set
-          os: ubuntu-18.04
-          task: test
-          driver: current
-          rails:
-          i18n:
-          gemfile: Gemfile
-          experimental: false
-        - mongodb: '5.0'
+        - mongodb: '6.0'
           ruby: ruby-3.1
           topology: replica_set
           os: ubuntu-20.04
@@ -138,7 +68,7 @@ jobs:
           i18n:
           gemfile: gemfiles/driver_master.gemfile
           experimental: true
-        - mongodb: '5.0'
+        - mongodb: '6.0'
           ruby: ruby-3.0
           topology: replica_set
           os: ubuntu-20.04
@@ -148,38 +78,8 @@ jobs:
           i18n:
           gemfile: gemfiles/driver_stable.gemfile
           experimental: false
-        - mongodb: '4.0'
-          ruby: ruby-2.6
-          topology: replica_set
-          os: ubuntu-18.04
-          task: test
-          driver: oldstable
-          rails:
-          i18n:
-          gemfile: gemfiles/driver_oldstable.gemfile
-          experimental: false
-        - mongodb: '4.0'
-          ruby: ruby-2.6
-          topology: replica_set
-          os: ubuntu-18.04
-          task: test
-          driver: min
-          rails:
-          i18n:
-          gemfile: gemfiles/driver_min.gemfile
-          experimental: false
-        - mongodb: '3.6'
-          ruby: ruby-2.6
-          topology: server
-          os: ubuntu-18.04
-          task: test
-          driver: min
-          rails:
-          i18n:
-          gemfile: gemfiles/driver_min.gemfile
-          experimental: false
-        - mongodb: '5.0'
-          ruby: ruby-3.1
+        - mongodb: '6.0'
+          ruby: ruby-3.2
           topology: server
           os: ubuntu-20.04
           task: test
@@ -188,7 +88,7 @@ jobs:
           i18n:
           gemfile: gemfiles/rails-7.0.gemfile
           experimental: false
-        - mongodb: '5.0'
+        - mongodb: '6.0'
           ruby: ruby-3.1
           topology: server
           os: ubuntu-20.04
@@ -198,7 +98,7 @@ jobs:
           i18n:
           gemfile: gemfiles/rails-6.1.gemfile
           experimental: false
-        - mongodb: '5.0'
+        - mongodb: '6.0'
           ruby: ruby-3.0
           topology: server
           os: ubuntu-20.04
@@ -208,7 +108,7 @@ jobs:
           i18n:
           gemfile: gemfiles/rails-7.0.gemfile
           experimental: false
-        - mongodb: '5.0'
+        - mongodb: '6.0'
           ruby: ruby-3.0
           topology: server
           os: ubuntu-20.04
@@ -218,7 +118,7 @@ jobs:
           i18n:
           gemfile: gemfiles/rails-6.1.gemfile
           experimental: false
-        - mongodb: '5.0'
+        - mongodb: '6.0'
           ruby: ruby-3.0
           topology: server
           os: ubuntu-20.04
@@ -228,47 +128,7 @@ jobs:
           i18n:
           gemfile: gemfiles/rails-6.0.gemfile
           experimental: false
-        - mongodb: '4.0'
-          ruby: ruby-2.7
-          topology: server
-          os: ubuntu-18.04
-          task: test
-          driver: current
-          rails: '5.2'
-          i18n:
-          gemfile: gemfiles/rails-5.2.gemfile
-          experimental: false
-        - mongodb: '4.4'
-          ruby: ruby-2.6
-          topology: server
-          os: ubuntu-20.04
-          task: test
-          driver: current
-          rails:
-          i18n: '1.0'
-          gemfile: gemfiles/i18n-1.0.gemfile
-          experimental: false
-        - mongodb: '4.2'
-          ruby: ruby-2.6
-          topology: server
-          os: ubuntu-18.04
-          task: test
-          driver: current
-          rails:
-          i18n: '1.0'
-          gemfile: gemfiles/i18n-1.0.gemfile
-          experimental: false
-        - mongodb: '4.2'
-          ruby: ruby-2.6
-          topology: server
-          os: ubuntu-18.04
-          task: test
-          driver: current
-          rails:
-          i18n: current
-          gemfile: Gemfile
-          experimental: false
-        - mongodb: '5.0'
+        - mongodb: '6.0'
           ruby: ruby-2.7
           topology: server
           os: ubuntu-20.04
@@ -278,7 +138,7 @@ jobs:
           i18n:
           gemfile: gemfiles/rails-5.2.gemfile
           experimental: false
-        - mongodb: '5.0'
+        - mongodb: '6.0'
           ruby: jruby-9.3
           topology: server
           os: ubuntu-20.04
@@ -288,6 +148,49 @@ jobs:
           i18n:
           gemfile: gemfiles/rails-6.0.gemfile
           experimental: false
+
+        - mongodb: '5.0'
+          ruby: ruby-3.1
+          topology: replica_set
+          os: ubuntu-20.04
+          task: test
+          driver: current
+          rails:
+          i18n:
+          gemfile: Gemfile
+          experimental: false
+        - mongodb: '4.4'
+          ruby: ruby-2.7
+          topology: replica_set
+          os: ubuntu-20.04
+          task: test
+          driver: current
+          rails:
+          i18n:
+          gemfile: Gemfile
+          experimental: false
+        - mongodb: '4.0'
+          ruby: ruby-2.7
+          topology: replica_set
+          os: ubuntu-18.04
+          task: test
+          driver: current
+          rails:
+          i18n:
+          gemfile: Gemfile
+          experimental: false
+        - mongodb: '3.6'
+          ruby: ruby-2.7
+          topology: replica_set
+          os: ubuntu-18.04
+          task: test
+          driver: current
+          rails:
+          i18n:
+          gemfile: Gemfile
+          experimental: false
+
+
     steps:
     - name: repo checkout
       uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         include:
         - mongodb: '6.0'
-          ruby: ruby-3.2
+          ruby: ruby-3.1
           topology: replica_set
           os: ubuntu-20.04
           task: test
@@ -69,7 +69,7 @@ jobs:
           gemfile: gemfiles/driver_stable.gemfile
           experimental: false
         - mongodb: '6.0'
-          ruby: ruby-3.2
+          ruby: ruby-3.1
           topology: server
           os: ubuntu-20.04
           task: test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -180,7 +180,7 @@ jobs:
           gemfile: Gemfile
           experimental: false
         - mongodb: '3.6'
-          ruby: ruby-2.7
+          ruby: ruby-2.6
           topology: replica_set
           os: ubuntu-18.04
           task: test

--- a/spec/mongoid/clients_spec.rb
+++ b/spec/mongoid/clients_spec.rb
@@ -1163,7 +1163,7 @@ describe Mongoid::Clients do
         Band.create!(name: 'Led Zeppelin')
       end
 
-      it 'does not create extra symbols symbols' do
+      it 'does not create extra symbols' do
         first_band.with(write: { w: 0, j: false }) do |band|
           band.set(active: false)
         end
@@ -1171,7 +1171,7 @@ describe Mongoid::Clients do
         second_band.with(write: { w: 0, j: false }) do |band|
           band.set(active: false)
         end
-        expect(Symbol.all_symbols.size).to eq(initial_symbols_count)
+        expect(Symbol.all_symbols.size).to be <= initial_symbols_count
       end
 
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ require 'lite_spec_helper'
 MODELS = File.join(File.dirname(__FILE__), "support/models")
 $LOAD_PATH.unshift(MODELS)
 
+require 'logger'
 require "action_controller"
 require 'rspec/retry'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,6 @@ require 'lite_spec_helper'
 MODELS = File.join(File.dirname(__FILE__), "support/models")
 $LOAD_PATH.unshift(MODELS)
 
-require 'logger'
 require "action_controller"
 require 'rspec/retry'
 


### PR DESCRIPTION
For some reason ruby 2.6 and jruby 9.3 configurations of github actions install an ancient version of actionpack (1.4). This situation is not reproducible neither on evergreen or locally. Therefore, it must be a GH actions issue.

Since we have coverage for these ruby versions on evergreen, it seems safe to remove them from GH actions.

This PR also reduces the amount of GH actions tasks and introduces mongodb 6.0.