### PR TITLE
MONGOID-5565 - Fix Github Actions CI for Ruby 2.6 and JRuby 9.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,9 +18,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - mongodb: '6.0'
+        - mongodb: '5.0'
           ruby: ruby-3.1
-          topology: replica_set
+          topology: server
           os: ubuntu-20.04
           task: test
           driver: current
@@ -28,120 +28,49 @@ jobs:
           i18n:
           gemfile: Gemfile
           experimental: false
-        - mongodb: '6.0'
-          ruby: ruby-3.1
-          topology: replica_set
-          os: ubuntu-20.04
-          task: test
-          driver: current
-          rails:
-          i18n:
-          gemfile: Gemfile
-          experimental: false
-        - mongodb: '6.0'
-          ruby: ruby-3.0
-          topology: replica_set
-          os: ubuntu-20.04
-          task: test
-          driver: current
-          rails:
-          i18n:
-          gemfile: Gemfile
-          experimental: false
-        - mongodb: '6.0'
-          ruby: ruby-3.1
-          topology: replica_set
-          os: ubuntu-20.04
-          task: test
-          driver: master
-          rails:
-          i18n:
-          gemfile: gemfiles/driver_master.gemfile
-          experimental: true
-        - mongodb: '6.0'
-          ruby: ruby-3.0
-          topology: replica_set
-          os: ubuntu-20.04
-          task: test
-          driver: stable
-          rails:
-          i18n:
-          gemfile: gemfiles/driver_stable.gemfile
-          experimental: false
-        - mongodb: '6.0'
-          ruby: ruby-3.1
-          topology: server
-          os: ubuntu-20.04
-          task: test
-          driver: current
-          rails: '7.0'
-          i18n:
-          gemfile: gemfiles/rails-7.0.gemfile
-          experimental: false
-        - mongodb: '6.0'
-          ruby: ruby-3.1
-          topology: server
-          os: ubuntu-20.04
-          task: test
-          driver: current
-          rails: '6.1'
-          i18n:
-          gemfile: gemfiles/rails-6.1.gemfile
-          experimental: false
-        - mongodb: '6.0'
-          ruby: ruby-3.0
-          topology: server
-          os: ubuntu-20.04
-          task: test
-          driver: current
-          rails: '7.0'
-          i18n:
-          gemfile: gemfiles/rails-7.0.gemfile
-          experimental: false
-        - mongodb: '6.0'
-          ruby: ruby-3.0
-          topology: server
-          os: ubuntu-20.04
-          task: test
-          driver: current
-          rails: '6.1'
-          i18n:
-          gemfile: gemfiles/rails-6.1.gemfile
-          experimental: false
-        - mongodb: '6.0'
-          ruby: ruby-3.0
-          topology: server
-          os: ubuntu-20.04
-          task: test
-          driver: current
-          rails: '6.0'
-          i18n:
-          gemfile: gemfiles/rails-6.0.gemfile
-          experimental: false
-        - mongodb: '6.0'
-          ruby: ruby-2.7
-          topology: server
-          os: ubuntu-20.04
-          task: test
-          driver: current
-          rails: '5.2'
-          i18n:
-          gemfile: gemfiles/rails-5.2.gemfile
-          experimental: false
-        - mongodb: '6.0'
-          ruby: jruby-9.3
-          topology: server
-          os: ubuntu-20.04
-          task: test
-          driver: current
-          rails: '6.0'
-          i18n:
-          gemfile: gemfiles/rails-6.0.gemfile
-          experimental: false
-
         - mongodb: '5.0'
           ruby: ruby-3.1
           topology: replica_set
+          os: ubuntu-20.04
+          task: test
+          driver: current
+          rails:
+          i18n:
+          gemfile: Gemfile
+          experimental: false
+        - mongodb: '5.0'
+          ruby: ruby-3.0
+          topology: server
+          os: ubuntu-20.04
+          task: test
+          driver: current
+          rails:
+          i18n:
+          gemfile: Gemfile
+          experimental: false
+        - mongodb: '5.0'
+          ruby: ruby-3.0
+          topology: replica_set
+          os: ubuntu-20.04
+          task: test
+          driver: current
+          rails:
+          i18n:
+          gemfile: Gemfile
+          experimental: false
+        - mongodb: '5.0'
+          ruby: jruby-9.3
+          topology: replica_set
+          os: ubuntu-20.04
+          task: test
+          driver: current
+          rails:
+          i18n:
+          gemfile: Gemfile
+          experimental: false
+        - mongodb: '4.4'
+          ruby: ruby-2.7
+          topology: server
           os: ubuntu-20.04
           task: test
           driver: current
@@ -160,7 +89,17 @@ jobs:
           gemfile: Gemfile
           experimental: false
         - mongodb: '4.0'
-          ruby: ruby-2.7
+          ruby: ruby-2.6
+          topology: server
+          os: ubuntu-18.04
+          task: test
+          driver: current
+          rails:
+          i18n:
+          gemfile: Gemfile
+          experimental: false
+        - mongodb: '4.0'
+          ruby: ruby-2.6
           topology: replica_set
           os: ubuntu-18.04
           task: test
@@ -170,7 +109,17 @@ jobs:
           gemfile: Gemfile
           experimental: false
         - mongodb: '3.6'
-          ruby: ruby-2.7
+          ruby: ruby-2.6
+          topology: server
+          os: ubuntu-18.04
+          task: test
+          driver: current
+          rails:
+          i18n:
+          gemfile: Gemfile
+          experimental: false
+        - mongodb: '3.6'
+          ruby: ruby-2.6
           topology: replica_set
           os: ubuntu-18.04
           task: test
@@ -179,7 +128,166 @@ jobs:
           i18n:
           gemfile: Gemfile
           experimental: false
-
+        - mongodb: '5.0'
+          ruby: ruby-3.1
+          topology: replica_set
+          os: ubuntu-20.04
+          task: test
+          driver: master
+          rails:
+          i18n:
+          gemfile: gemfiles/driver_master.gemfile
+          experimental: true
+        - mongodb: '5.0'
+          ruby: ruby-3.0
+          topology: replica_set
+          os: ubuntu-20.04
+          task: test
+          driver: stable
+          rails:
+          i18n:
+          gemfile: gemfiles/driver_stable.gemfile
+          experimental: false
+        - mongodb: '4.0'
+          ruby: ruby-2.6
+          topology: replica_set
+          os: ubuntu-18.04
+          task: test
+          driver: oldstable
+          rails:
+          i18n:
+          gemfile: gemfiles/driver_oldstable.gemfile
+          experimental: false
+        - mongodb: '4.0'
+          ruby: ruby-2.6
+          topology: replica_set
+          os: ubuntu-18.04
+          task: test
+          driver: min
+          rails:
+          i18n:
+          gemfile: gemfiles/driver_min.gemfile
+          experimental: false
+        - mongodb: '3.6'
+          ruby: ruby-2.6
+          topology: server
+          os: ubuntu-18.04
+          task: test
+          driver: min
+          rails:
+          i18n:
+          gemfile: gemfiles/driver_min.gemfile
+          experimental: false
+        - mongodb: '5.0'
+          ruby: ruby-3.1
+          topology: server
+          os: ubuntu-20.04
+          task: test
+          driver: current
+          rails: '7.0'
+          i18n:
+          gemfile: gemfiles/rails-7.0.gemfile
+          experimental: false
+        - mongodb: '5.0'
+          ruby: ruby-3.1
+          topology: server
+          os: ubuntu-20.04
+          task: test
+          driver: current
+          rails: '6.1'
+          i18n:
+          gemfile: gemfiles/rails-6.1.gemfile
+          experimental: false
+        - mongodb: '5.0'
+          ruby: ruby-3.0
+          topology: server
+          os: ubuntu-20.04
+          task: test
+          driver: current
+          rails: '7.0'
+          i18n:
+          gemfile: gemfiles/rails-7.0.gemfile
+          experimental: false
+        - mongodb: '5.0'
+          ruby: ruby-3.0
+          topology: server
+          os: ubuntu-20.04
+          task: test
+          driver: current
+          rails: '6.1'
+          i18n:
+          gemfile: gemfiles/rails-6.1.gemfile
+          experimental: false
+        - mongodb: '5.0'
+          ruby: ruby-3.0
+          topology: server
+          os: ubuntu-20.04
+          task: test
+          driver: current
+          rails: '6.0'
+          i18n:
+          gemfile: gemfiles/rails-6.0.gemfile
+          experimental: false
+        - mongodb: '4.0'
+          ruby: ruby-2.7
+          topology: server
+          os: ubuntu-18.04
+          task: test
+          driver: current
+          rails: '5.2'
+          i18n:
+          gemfile: gemfiles/rails-5.2.gemfile
+          experimental: false
+        - mongodb: '4.4'
+          ruby: ruby-2.6
+          topology: server
+          os: ubuntu-20.04
+          task: test
+          driver: current
+          rails:
+          i18n: '1.0'
+          gemfile: gemfiles/i18n-1.0.gemfile
+          experimental: false
+        - mongodb: '4.2'
+          ruby: ruby-2.6
+          topology: server
+          os: ubuntu-18.04
+          task: test
+          driver: current
+          rails:
+          i18n: '1.0'
+          gemfile: gemfiles/i18n-1.0.gemfile
+          experimental: false
+        - mongodb: '4.2'
+          ruby: ruby-2.6
+          topology: server
+          os: ubuntu-18.04
+          task: test
+          driver: current
+          rails:
+          i18n: current
+          gemfile: Gemfile
+          experimental: false
+        - mongodb: '5.0'
+          ruby: ruby-2.7
+          topology: server
+          os: ubuntu-20.04
+          task: test
+          driver: current
+          rails: '5.2'
+          i18n:
+          gemfile: gemfiles/rails-5.2.gemfile
+          experimental: false
+        - mongodb: '5.0'
+          ruby: jruby-9.3
+          topology: server
+          os: ubuntu-20.04
+          task: test
+          driver: current
+          rails: '6.0'
+          i18n:
+          gemfile: gemfiles/rails-6.0.gemfile
+          experimental: false
 
     steps:
     - name: repo checkout
@@ -198,7 +306,9 @@ jobs:
         BUNDLE_GEMFILE: "${{matrix.gemfile}}"
       with:
         ruby-version: "${{matrix.ruby}}"
-        bundler: 2
+        bundler: 2.4.7
+    - name: rubygems
+      run: gem update --system
     - name: bundle
       run: bundle install --jobs 4 --retry 3
       env:

--- a/Gemfile
+++ b/Gemfile
@@ -6,8 +6,8 @@ require_relative './gemfiles/standard'
 
 standard_dependencies
 
-gem 'actionpack'
-gem 'activemodel'
+gem 'actionpack', '>= 5.1'
+gem 'activemodel', '>= 5.1'
 
 i18n_versions = ['~> 1.0', '>= 1.1']
 if RUBY_PLATFORM =~ /java/

--- a/gemfiles/bson_master.gemfile
+++ b/gemfiles/bson_master.gemfile
@@ -4,8 +4,8 @@ gemspec path: '..'
 gem 'bson', git: "https://github.com/mongodb/bson-ruby"
 gem 'mongo'
 
-gem 'actionpack', '~> 5.2'
-gem 'activemodel', '~> 5.2'
+gem 'actionpack', '>= 5.1'
+gem 'activemodel', '>= 5.1'
 
 gemspec path: '..'
 

--- a/gemfiles/bson_master.gemfile
+++ b/gemfiles/bson_master.gemfile
@@ -4,7 +4,8 @@ gemspec path: '..'
 gem 'bson', git: "https://github.com/mongodb/bson-ruby"
 gem 'mongo'
 
-gem 'actionpack'
+gem 'actionpack', '~> 5.2'
+gem 'activemodel', '~> 5.2'
 
 gemspec path: '..'
 

--- a/gemfiles/bson_min.gemfile
+++ b/gemfiles/bson_min.gemfile
@@ -4,8 +4,8 @@ gemspec path: '..'
 gem 'bson', '4.14.0'
 gem 'mongo'
 
-gem 'actionpack', '~> 5.2'
-gem 'activemodel', '~> 5.2'
+gem 'actionpack', '>= 5.1'
+gem 'activemodel', '>= 5.1'
 
 gemspec path: '..'
 

--- a/gemfiles/bson_min.gemfile
+++ b/gemfiles/bson_min.gemfile
@@ -4,7 +4,8 @@ gemspec path: '..'
 gem 'bson', '4.14.0'
 gem 'mongo'
 
-gem 'actionpack'
+gem 'actionpack', '~> 5.2'
+gem 'activemodel', '~> 5.2'
 
 gemspec path: '..'
 

--- a/gemfiles/driver_master.gemfile
+++ b/gemfiles/driver_master.gemfile
@@ -3,8 +3,8 @@ source "https://rubygems.org"
 gem 'bson', git: "https://github.com/mongodb/bson-ruby", branch: '4-stable'
 gem 'mongo', git: "https://github.com/mongodb/mongo-ruby-driver"
 
-gem 'actionpack', '~> 7.0'
-gem 'activemodel', '~> 7.0'
+gem 'actionpack', '>= 5.1'
+gem 'activemodel', '>= 5.1'
 
 gemspec path: '..'
 

--- a/gemfiles/driver_master.gemfile
+++ b/gemfiles/driver_master.gemfile
@@ -3,7 +3,8 @@ source "https://rubygems.org"
 gem 'bson', git: "https://github.com/mongodb/bson-ruby", branch: '4-stable'
 gem 'mongo', git: "https://github.com/mongodb/mongo-ruby-driver"
 
-gem 'actionpack'
+gem 'actionpack', '~> 7.0'
+gem 'activemodel', '~> 7.0'
 
 gemspec path: '..'
 

--- a/gemfiles/driver_master_jruby.gemfile
+++ b/gemfiles/driver_master_jruby.gemfile
@@ -7,8 +7,8 @@ source "https://rubygems.org"
 # This gemfile only specifies driver git source.
 gem 'mongo', git: "https://github.com/mongodb/mongo-ruby-driver"
 
-gem 'actionpack', '~> 7.0'
-gem 'activemodel', '~> 7.0'
+gem 'actionpack', '>= 5.1'
+gem 'activemodel', '>= 5.1'
 
 # https://github.com/jruby/jruby/issues/6573
 gem 'i18n', '~> 1.0', '< 1.8.8'

--- a/gemfiles/driver_master_jruby.gemfile
+++ b/gemfiles/driver_master_jruby.gemfile
@@ -7,7 +7,9 @@ source "https://rubygems.org"
 # This gemfile only specifies driver git source.
 gem 'mongo', git: "https://github.com/mongodb/mongo-ruby-driver"
 
-gem 'actionpack'
+gem 'actionpack', '~> 7.0'
+gem 'activemodel', '~> 7.0'
+
 # https://github.com/jruby/jruby/issues/6573
 gem 'i18n', '~> 1.0', '< 1.8.8'
 

--- a/gemfiles/driver_min.gemfile
+++ b/gemfiles/driver_min.gemfile
@@ -2,7 +2,8 @@ source "https://rubygems.org"
 
 gem 'mongo', git: "https://github.com/mongodb/mongo-ruby-driver", branch: '2.18-stable'
 
-gem 'actionpack'
+gem 'actionpack', '~> 5.2'
+gem 'activemodel', '~> 5.2'
 
 gemspec path: '..'
 

--- a/gemfiles/driver_min.gemfile
+++ b/gemfiles/driver_min.gemfile
@@ -2,8 +2,8 @@ source "https://rubygems.org"
 
 gem 'mongo', git: "https://github.com/mongodb/mongo-ruby-driver", branch: '2.18-stable'
 
-gem 'actionpack', '~> 5.2'
-gem 'activemodel', '~> 5.2'
+gem 'actionpack', '>= 5.1'
+gem 'activemodel', '>= 5.1'
 
 gemspec path: '..'
 

--- a/gemfiles/driver_min_jruby.gemfile
+++ b/gemfiles/driver_min_jruby.gemfile
@@ -5,8 +5,8 @@ source "https://rubygems.org"
 # bson with JRuby, just test the driver then
 gem 'mongo', git: "https://github.com/mongodb/mongo-ruby-driver", branch: '2.18-stable'
 
-gem 'actionpack', '~> 5.2'
-gem 'activemodel', '~> 5.2'
+gem 'actionpack', '>= 5.1'
+gem 'activemodel', '>= 5.1'
 
 # https://github.com/jruby/jruby/issues/6573
 gem 'i18n', '~> 1.0', '< 1.8.8'

--- a/gemfiles/driver_min_jruby.gemfile
+++ b/gemfiles/driver_min_jruby.gemfile
@@ -5,7 +5,9 @@ source "https://rubygems.org"
 # bson with JRuby, just test the driver then
 gem 'mongo', git: "https://github.com/mongodb/mongo-ruby-driver", branch: '2.18-stable'
 
-gem 'actionpack'
+gem 'actionpack', '~> 5.2'
+gem 'activemodel', '~> 5.2'
+
 # https://github.com/jruby/jruby/issues/6573
 gem 'i18n', '~> 1.0', '< 1.8.8'
 

--- a/gemfiles/driver_oldstable.gemfile
+++ b/gemfiles/driver_oldstable.gemfile
@@ -2,7 +2,8 @@ source "https://rubygems.org"
 
 gem 'mongo', git: "https://github.com/mongodb/mongo-ruby-driver", branch: '2.18-stable'
 
-gem 'actionpack'
+gem 'actionpack', '~> 5.2'
+gem 'activemodel', '~> 5.2'
 
 gemspec path: '..'
 

--- a/gemfiles/driver_oldstable.gemfile
+++ b/gemfiles/driver_oldstable.gemfile
@@ -2,8 +2,8 @@ source "https://rubygems.org"
 
 gem 'mongo', git: "https://github.com/mongodb/mongo-ruby-driver", branch: '2.18-stable'
 
-gem 'actionpack', '~> 5.2'
-gem 'activemodel', '~> 5.2'
+gem 'actionpack', '>= 5.1'
+gem 'activemodel', '>= 5.1'
 
 gemspec path: '..'
 

--- a/gemfiles/driver_oldstable_jruby.gemfile
+++ b/gemfiles/driver_oldstable_jruby.gemfile
@@ -5,8 +5,8 @@ source "https://rubygems.org"
 # bson with JRuby, just test the driver then
 gem 'mongo', git: "https://github.com/mongodb/mongo-ruby-driver", branch: '2.18-stable'
 
-gem 'actionpack', '~> 5.2'
-gem 'activemodel', '~> 5.2'
+gem 'actionpack', '>= 5.1'
+gem 'activemodel', '>= 5.1'
 
 # https://github.com/jruby/jruby/issues/6573
 gem 'i18n', '~> 1.0', '< 1.8.8'

--- a/gemfiles/driver_oldstable_jruby.gemfile
+++ b/gemfiles/driver_oldstable_jruby.gemfile
@@ -5,7 +5,9 @@ source "https://rubygems.org"
 # bson with JRuby, just test the driver then
 gem 'mongo', git: "https://github.com/mongodb/mongo-ruby-driver", branch: '2.18-stable'
 
-gem 'actionpack'
+gem 'actionpack', '~> 5.2'
+gem 'activemodel', '~> 5.2'
+
 # https://github.com/jruby/jruby/issues/6573
 gem 'i18n', '~> 1.0', '< 1.8.8'
 

--- a/gemfiles/driver_stable.gemfile
+++ b/gemfiles/driver_stable.gemfile
@@ -2,7 +2,8 @@ source "https://rubygems.org"
 
 gem 'mongo', git: "https://github.com/mongodb/mongo-ruby-driver", branch: '2.18-stable'
 
-gem 'actionpack'
+gem 'actionpack', '~> 5.2'
+gem 'activemodel', '~> 5.2'
 
 gemspec path: '..'
 

--- a/gemfiles/driver_stable.gemfile
+++ b/gemfiles/driver_stable.gemfile
@@ -2,8 +2,8 @@ source "https://rubygems.org"
 
 gem 'mongo', git: "https://github.com/mongodb/mongo-ruby-driver", branch: '2.18-stable'
 
-gem 'actionpack', '~> 5.2'
-gem 'activemodel', '~> 5.2'
+gem 'actionpack', '>= 5.1'
+gem 'activemodel', '>= 5.1'
 
 gemspec path: '..'
 

--- a/gemfiles/driver_stable_jruby.gemfile
+++ b/gemfiles/driver_stable_jruby.gemfile
@@ -5,8 +5,8 @@ source "https://rubygems.org"
 # bson with JRuby, just test the driver then
 gem 'mongo', git: "https://github.com/mongodb/mongo-ruby-driver", branch: '2.18-stable'
 
-gem 'actionpack', '~> 5.2'
-gem 'activemodel', '~> 5.2'
+gem 'actionpack', '>= 5.1'
+gem 'activemodel', '>= 5.1'
 
 # https://github.com/jruby/jruby/issues/6573
 gem 'i18n', '~> 1.0', '< 1.8.8'

--- a/gemfiles/driver_stable_jruby.gemfile
+++ b/gemfiles/driver_stable_jruby.gemfile
@@ -5,7 +5,9 @@ source "https://rubygems.org"
 # bson with JRuby, just test the driver then
 gem 'mongo', git: "https://github.com/mongodb/mongo-ruby-driver", branch: '2.18-stable'
 
-gem 'actionpack'
+gem 'actionpack', '~> 5.2'
+gem 'activemodel', '~> 5.2'
+
 # https://github.com/jruby/jruby/issues/6573
 gem 'i18n', '~> 1.0', '< 1.8.8'
 

--- a/gemfiles/i18n-1.0.gemfile
+++ b/gemfiles/i18n-1.0.gemfile
@@ -1,6 +1,8 @@
 source "https://rubygems.org"
 
-gem 'actionpack'
+gem 'actionpack', '~> 5.1'
+gem 'activemodel', '~> 5.1'
+
 # https://jira.mongodb.org/browse/MONGOID-4614
 gem 'i18n', '~> 1.0.0'
 


### PR DESCRIPTION
This PR reverts the changes of https://github.com/mongodb/mongoid/pull/5555 and adds a proper fix. As @comandeo noted, the issue was than an old ActionPack version is installed, so the fix is:
- Use latest Bundler & Rubygems
- Correctly constrain the Gemfiles with `gem 'actionpack', '>= 5.1'`

Let's keep Github Actions in sync with Evergreen, so that community contributor PRs will be tested visibly against all supported Ruby versions. Remember, community members cannot see Evergreen run details, and Evergreen does not run automatically [because it insecure](EVG-16785).

If you run into trouble and would like me to help fix Github CI if it breaks in the future, please just ask before removing test coverage.
