### PR TITLE
[READY FOR REVIEW] MONGOID-5542 - Fix Github Actions unsupported Ubuntu version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -138,7 +138,6 @@ jobs:
           i18n:
           gemfile: gemfiles/rails-6.0.gemfile
           experimental: false
-
         - mongodb: '5.0'
           ruby: ruby-3.1
           topology: replica_set
@@ -162,7 +161,7 @@ jobs:
         - mongodb: '4.0'
           ruby: ruby-2.7
           topology: replica_set
-          os: ubuntu-18.04
+          os: ubuntu-20.04
           task: test
           driver: current
           rails:
@@ -172,14 +171,13 @@ jobs:
         - mongodb: '3.6'
           ruby: ruby-2.7
           topology: replica_set
-          os: ubuntu-18.04
+          os: ubuntu-20.04
           task: test
           driver: current
           rails:
           i18n:
           gemfile: Gemfile
           experimental: false
-
 
     steps:
     - name: repo checkout


### PR DESCRIPTION
This fixes the following failure in Github Actions CI by using `ubuntu-20.04` OS everywhere.

The failure happened suddenly as it looks like either the `setup_ruby/v1` task or the CI itself dropped support for `ubuntu-18.04`

```
Error: Unsupported platform ubuntu-18.04
    at Module.getAvailableVersions (/home/runner/work/_actions/ruby/setup-ruby/v1/dist/index.js:67995:[11](https://github.com/mongodb/mongoid/actions/runs/4297541531/jobs/7490639287#step:4:12))
    at setupRuby (/home/runner/work/_actions/ruby/setup-ruby/v1/dist/index.js:68802:36)
    at run (/home/runner/work/_actions/ruby/setup-ruby/v1/dist/index.js:68771:11)
    at /home/runner/work/_actions/ruby/setup-ruby/v1/dist/index.js:68936:40
    at /home/runner/work/_actions/ruby/setup-ruby/v1/dist/index.js:68938:3
    at Object.<anonymous> (/home/runner/work/_actions/ruby/setup-ruby/v1/dist/index.js:68941:[12](https://github.com/mongodb/mongoid/actions/runs/4297541531/jobs/7490639287#step:4:13))
    at Module._compile (node:internal/modules/cjs/loader:1105:[14](https://github.com/mongodb/mongoid/actions/runs/4297541531/jobs/7490639287#step:4:15))
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1[15](https://github.com/mongodb/mongoid/actions/runs/4297541531/jobs/7490639287#step:4:16)9:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
```