### PR TITLE
MONGOID-5577: Redux of the `#readonly` changes on Mongoid 8.1 branch

### DIFF
--- a/docs/reference/crud.txt
+++ b/docs/reference/crud.txt
@@ -1013,65 +1013,98 @@ back to the model as follows:
 
 .. _readonly-documents:
 
-Readonly Documents
-==================
+Read-only Documents
+===================
 
-Documents can be marked read-only in two ways, depending on the value of the
-``Mongoid.legacy_readonly`` feature flag:
-
-If this flag is turned off, a document is marked read-only when the ``#readonly!``
-method is called on that documnet. A read-only document, with this flag turned off,
-will raise a ReadonlyDocument error on attempting to perform any persistence
-operation, including (but not limited to) saving, updating, deleting and
-destroying. Note that reloading does not reset the read-only state.
+You may mark documents as read-only by calling ``#readonly!`` on the document.
+This will prohibit saving, destroying, and atomically modifying the document.
 
 .. code:: ruby
 
   band = Band.first
   band.readonly? # => false
+
   band.readonly!
   band.readonly? # => true
+
   band.name = "The Rolling Stones"
   band.save # => raises ReadonlyDocument error
+  band.destroy # => raises ReadonlyDocument error
+  band.set(name: "Fleet Foxes") # => raises ReadonlyDocument error
   band.reload.readonly? # => true
 
-If this flag is turned on, a document is marked read-only when that document
-has been projected (i.e. using ``#only`` or ``#without``). A read-only document,
-with this flag turned on, will not be deletable or destroyable (a
-``ReadonlyDocument`` error will be raised), but will be saveable and updatable.
-The read-only status is reset on reloading the document.
+You may unmark read-only status by calling ``#write_safe!`` on the document.
+
+.. code:: ruby
+
+  band.write_safe!
+  band.readonly? # => false
+
+Read-only and queries
+---------------------
+
+Calling ``#readonly`` on a query criteria will cause all documents
+it loads to have the read-only flag set:
+
+.. code:: ruby
+
+  bands = Band.all.readonly.limit(3).to_a
+  bands.map(&:readonly?) # => [true, true, true]
+
+Queries which use field projection (i.e. ``#only`` or ``#without``) will
+return documents with read-only set automatically. This is safe-guard
+to prevent data corruption mishaps that could arise from working with
+incomplete set of state on documents. You may override this by calling
+``write_safe`` on your query criteria:
+
+.. code:: ruby
+
+  bands = Band.all.only(:name).limit(3).to_a
+  bands.map(&:readonly?) # => [true, true, true]
+
+  bands = Band.all.only(:name).write_safe.limit(3).to_a
+  bands.map(&:readonly?) # => [false, false, false]
+
+Making a model read-only by default
+-----------------------------------
+
+You may declare a model class to be read-only by default by
+calling the ``readonly`` macro inside the class definition.
+This can be useful when working with legacy data which you'd
+like to ensure is never modified.
 
 .. code:: ruby
 
   class Band
     include Mongoid::Document
+
+    readonly
+
     field :name, type: String
-    field :genre, type: String
-  end
-
-  band = Band.only(:name).first
-  band.readonly? # => true
-  band.destroy # => raises ReadonlyDocument error
-  band.reload.readonly? # => false
-
-
-Overriding ``readonly?``
-------------------------
-
-Another way to make a document read-only is by overriding the readonly? method:
-
-.. code:: ruby
-
-  class Band
-    include Mongoid::Document
-    field :name, type: String
-    field :genre, type: String
-
-    def readonly?
-      true
-    end
   end
 
   band = Band.first
   band.readonly? # => true
   band.destroy # => raises ReadonlyDocument error
+
+For such models, you may still call ``#write_safe!`` to unmark
+read-only status. Note this is required when creating new documents:
+
+.. code:: ruby
+  band = Band.new
+  band.name = "The Spirit of the Beehive"
+
+  band.readonly? # => true
+  band.save # => raises ReadonlyDocument error
+
+  band.write_safe!
+  band.readonly? # => false
+  band.save # => true
+
+Legacy read-only behavior
+-------------------------
+
+In the default configuration of Mongoid 8.1 and later, read-only status
+prevents both saving and destroying documents. In Mongoid 8.0 and prior,
+and when ``legacy_readonly`` feature flag is ``true``, read-only status only
+prevents destroying documents, but saving is still permitted.

--- a/docs/release-notes/mongoid-8.1.txt
+++ b/docs/release-notes/mongoid-8.1.txt
@@ -257,12 +257,54 @@ Previously, an error was raised if this was done. See the section on
 for more details.
 
 
-Added ``readonly!`` method and ``legacy_readonly`` feature flag
----------------------------------------------------------------
+Added ``readonly!``, etc. methods and ``legacy_readonly`` feature flag
+----------------------------------------------------------------------
 
-Mongoid 8.1 changes the meaning of read-only documents. In Mongoid 8.1 with
-this feature flag turned off, a document becomes read-only when calling the
-``readonly!`` method:
+Mongoid 8.1 overhauls read-only document functionality. This includes the
+capability to mark documents, queries, and model classes as read-only.
+The following are now possible:
+
+.. code:: ruby
+
+  band = Band.first
+  band.readonly? # => false
+
+  # Mark a document as read-only
+  band.readonly!
+  band.readonly? # => true
+  band.save # => raises ReadonlyDocument error
+
+  # Unmark a document's read-only status
+  band.write_safe!
+  band.readonly? # => false
+
+  # Load all documents in a query as read-only
+  bands = Band.all.readonly.limit(3).to_a
+  bands.map(&:readonly?) # => [true, true, true]
+
+  # Load all documents in a projected query without read-only
+  bands = Band.only(:name).write_safe.limit(3).to_a
+  bands.map(&:readonly?) # => [false, false, false]
+
+  # Declare a model class to be read-only by default
+  class Llama
+    include Mongoid::Document
+
+    readonly
+  end
+
+  llama = Llama.first
+  llama.readonly? # => true
+  llama.write_safe!
+  llama.readonly? # => false
+
+See the section on :ref:`Read-only Documents <read-only-documents>`
+for more details.
+
+Mongoid 8.1 introduces a ``legacy_readonly`` feature flag which affects
+which actions are prevented in read-only status. When this flag is false
+(new Mongoid 8.1 default), read-only status prevents both saving and
+destroying documents by raising a ``ReadonlyDocument`` error.
 
 .. code:: ruby
 
@@ -273,28 +315,15 @@ this feature flag turned off, a document becomes read-only when calling the
   band.name = "The Rolling Stones"
   band.save # => raises ReadonlyDocument error
 
-With this feature flag turned off, a ``ReadonlyDocument`` error will be
-raised when destroying or deleting, as well as when saving or updating.
-
-Prior to Mongoid 8.1 and in 8.1 with the ``legacy_readonly`` feature flag
-turned on, documents become read-only when they are projected (i.e. using
-``#only`` or ``#without``).
+In Mongoid 8.0 and prior, and when ``legacy_readonly`` feature flag is true,
+read-only status only prevents destroying documents, but saving is still permitted.
 
 .. code:: ruby
 
-  class Band
-    include Mongoid::Document
-    field :name, type: String
-    field :genre, type: String
-  end
-
-  band = Band.only(:name).first
+  band = Band.first
+  band.readonly!
   band.readonly? # => true
-  band.destroy # => raises ReadonlyDocument error
-
-Note that with this feature flag on, a ``ReadonlyDocument`` error will only be
-raised when destroying or deleting, and not on saving or updating. See the
-section on :ref:`Read-only Documents <readonly-documents>` for more details.
+  band.save # => true
 
 
 Added method parameters to ``#exists?``


### PR DESCRIPTION
As outlined in MONGOID-5577, I feel the readonly changes what were done on the 8.1 branch (not yet released to the wild) are missing the mark and potentially dangerous.

In this PR I've written a new readme and release notes of what I think should be done. Code example below. I feel this spec better addresses the user requirements in [MONGOID-3535](https://jira.mongodb.org/browse/MONGOID-3535) and is ultimately more flexible and intuitive.

With the MongoDB's blessing I'm happy to spend time to implement this.

```ruby

  band = Band.first
  band.readonly? # => false

  # Mark a document as read-only
  band.readonly!
  band.readonly? # => true
  band.save # => raises ReadonlyDocument error

  # Unmark a document's read-only status
  band.write_safe!
  band.readonly? # => false

  # Load all documents in a query as read-only
  bands = Band.all.readonly.limit(3).to_a
  bands.map(&:readonly?) # => [true, true, true]

  # Load all documents in a projected query without read-only
  bands = Band.only(:name).write_safe.limit(3).to_a
  bands.map(&:readonly?) # => [false, false, false]

  # Declare a model class to be read-only by default
  class Llama
    include Mongoid::Document

    readonly
  end

  llama = Llama.first
  llama.readonly? # => true
  llama.write_safe!
  llama.readonly? # => false
```