### PR TITLE
MONGOID-5585 Declare FLE schema in Mongoid document

### DIFF
--- a/lib/mongoid/composable.rb
+++ b/lib/mongoid/composable.rb
@@ -2,6 +2,7 @@
 
 require "mongoid/changeable"
 require "mongoid/collection_configurable"
+require "mongoid/encryptable"
 require "mongoid/findable"
 require "mongoid/indexable"
 require "mongoid/inspectable"
@@ -59,6 +60,7 @@ module Mongoid
     include Interceptable
     include Copyable
     include Equality
+    include Encryptable
 
     MODULES = [
       Atomic,

--- a/lib/mongoid/config.rb
+++ b/lib/mongoid/config.rb
@@ -5,6 +5,7 @@ require "mongoid/config/environment"
 require "mongoid/config/options"
 require "mongoid/config/validators"
 require "mongoid/config/introspection"
+require "mongoid/config/encryption"
 
 module Mongoid
 
@@ -14,6 +15,7 @@ module Mongoid
     extend Forwardable
     extend Options
     extend Defaults
+    extend Encryption
     extend self
 
     def_delegators ::Mongoid, :logger, :logger=

--- a/lib/mongoid/config/encryption.rb
+++ b/lib/mongoid/config/encryption.rb
@@ -1,0 +1,159 @@
+# frozen_string_literal: true
+
+require 'mongoid/extensions/boolean'
+require 'mongoid/stringified_symbol'
+
+module Mongoid
+  module Config
+    # This module contains the logic for configuring Client Side
+    # Field Level automatic encryption.
+    #
+    # @api private
+    module Encryption
+      extend self
+
+      # Generate the encryption schema map for the provided models.
+      #
+      # @param [ Array<Mongoid::Document> ] models The models to generate the schema map for.
+      #   Defaults to all models in the application.
+      # @return [ Hash ] The encryption schema map.
+      def encryption_schema_map(models = ::Mongoid.models)
+        models.each_with_object({}) do |model, map|
+          next if model.embedded?
+
+          key = "#{model.persistence_context.database_name}.#{model.persistence_context.collection_name}"
+          props = metadata_for(model).merge(properties_for(model))
+          map[key] = props unless props.empty?
+        end
+      end
+
+      private
+
+      # The algorithm to use for the deterministic encryption.
+      DETERMINISTIC_ALGORITHM = 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic'
+
+      # The algorithm to use for the non-deterministic encryption.
+      RANDOM_ALGORITHM = 'AEAD_AES_256_CBC_HMAC_SHA_512-Random'
+
+      # The mapping of Mongoid field types to BSON type identifiers.
+      TYPE_MAPPINGS = {
+        Hash => 'object',
+        Integer => 'int',
+        BSON::Int32 => 'int',
+        BSON::Int64 => 'long',
+        BSON::ObjectId => 'objectId',
+        Time => 'date',
+        Date => 'date',
+        DateTime => 'date',
+        Float => 'double',
+        String => 'string',
+        BSON::Binary => 'binData',
+        Array => 'array',
+        Mongoid::Boolean => 'bool',
+        BigDecimal => 'decimal',
+        Range => 'object',
+        Regexp => 'regex',
+        Set => 'array',
+        Mongoid::StringifiedSymbol => 'string',
+        ActiveSupport::TimeWithZone => 'date'
+      }.freeze
+
+      # Generate the encryptMetadata object for the provided model.
+      #
+      # @param [ Mongoid::Document ] model The model to generate the metadata for.
+      # @return [ Hash ] The encryptMetadata object.
+      def metadata_for(model)
+        metadata = {}.tap do |metadata|
+          if (key_id = key_id_for(model.encrypt_metadata[:key_id]))
+            metadata['keyId'] = key_id
+          end
+          if model.encrypt_metadata.key?(:deterministic)
+            metadata['algorithm'] = if model.encrypt_metadata[:deterministic]
+                                      DETERMINISTIC_ALGORITHM
+                                    else
+                                      RANDOM_ALGORITHM
+                                    end
+          end
+        end
+        if metadata.empty?
+          {}
+        else
+          {
+            'bsonType' => 'object',
+            'encryptMetadata' => metadata
+          }
+        end
+      end
+
+      # Generate encryption properties for the provided model.
+      #
+      # This method generates the properties for the fields and relations that
+      # are marked as encrypted.
+      #
+      # @param [ Mongoid::Document ] model The model to generate the properties for.
+      # @return [ Hash ] The encryption properties.
+      def properties_for(model)
+        result = properties_for_fields(model).merge(properties_for_relations(model))
+        if result.empty?
+          {}
+        else
+          { 'properties' => result }
+        end
+      end
+
+      def properties_for_fields(model)
+        model.fields.each_with_object({}) do |(name, field), props|
+          next unless field.is_a?(Mongoid::Fields::Encrypted)
+
+          props[name] = {
+            'encrypt' => {
+              'bsonType' => bson_type_for(field)
+            }
+          }
+          if (algorithm = algorithm_for(field))
+            props[name]['encrypt']['algorithm'] = algorithm
+          end
+          if (key_id = key_id_for(field.key_id))
+            props[name]['encrypt']['keyId'] = key_id
+          end
+        end
+      end
+
+      def properties_for_relations(model)
+        model.relations.each_with_object({}) do |(name, relation), props|
+          next unless relation.is_a?(Association::Embedded::EmbedsMany) ||
+                      relation.is_a?(Association::Embedded::EmbedsOne)
+
+          metadata_for(
+            relation.relation_class
+          ).merge(
+            properties_for(relation.relation_class)
+          ).tap do |properties|
+            props[name] = { 'bsonType' => 'object' }.merge(properties) unless properties.empty?
+          end
+        end
+      end
+
+      def bson_type_for(field)
+        TYPE_MAPPINGS[field.type]
+      end
+
+      def algorithm_for(field)
+        case field.deterministic?
+        when true
+          DETERMINISTIC_ALGORITHM
+        when false
+          RANDOM_ALGORITHM
+        else
+          nil
+        end
+      end
+
+      def key_id_for(key_id_base64)
+        return nil unless key_id_base64
+
+        [ BSON::Binary.new(Base64.decode64(key_id_base64), :uuid) ]
+      end
+    end
+  end
+end

--- a/lib/mongoid/encryptable.rb
+++ b/lib/mongoid/encryptable.rb
@@ -1,0 +1,28 @@
+module Mongoid
+  # This module is used to extend Mongoid::Document
+  # to add encryption functionality.
+  module Encryptable
+    extend ActiveSupport::Concern
+
+    included do
+      # @return [Hash] The encryption metadata for the model.
+      class_attribute :encrypt_metadata
+      self.encrypt_metadata = {}
+    end
+
+    module ClassMethods
+      # Set the encryption metadata for the model. Parameters set here will be
+      # used to encrypt the fields of the model, unless overridden on the
+      # field itself.
+      #
+      # @param [ Hash ] options The encryption metadata.
+      # @option options [ String ] :key_id The base64-encoded UUID of the key
+      #   used to encrypt fields.
+      # @option options [ true | false ] :deterministic Whether the encryption
+      # is deterministic or not.
+      def encrypt_with(options = {})
+        self.encrypt_metadata = options
+      end
+    end
+  end
+end

--- a/lib/mongoid/fields.rb
+++ b/lib/mongoid/fields.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "mongoid/fields/standard"
+require "mongoid/fields/encrypted"
 require "mongoid/fields/foreign_key"
 require "mongoid/fields/localized"
 require "mongoid/fields/validators"
@@ -796,6 +797,7 @@ module Mongoid
         opts[:type] = retrieve_and_validate_type(name, options[:type])
         return Fields::Localized.new(name, opts) if options[:localize]
         return Fields::ForeignKey.new(name, opts) if options[:identity]
+        return Fields::Encrypted.new(name, opts) if options[:encrypt]
         Fields::Standard.new(name, opts)
       end
 

--- a/lib/mongoid/fields/encrypted.rb
+++ b/lib/mongoid/fields/encrypted.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Mongoid
+  module Fields
+    # Represents a field that should be encrypted.
+    class Encrypted < Standard
+      def initialize(name, options = {})
+        @encryption_options = if options[:encrypt].is_a?(Hash)
+                                options[:encrypt]
+                              else
+                                {}
+                              end
+        super
+      end
+
+      # @return [ true | false | nil ] Whether the field should be encrypted using a
+      #   deterministic encryption algorithm; if not specified, nil is returned.
+      def deterministic?
+        @encryption_options[:deterministic]
+      end
+
+      # @return [ String | nil ] The key id to use for encryption; if not specified,
+      #   nil is returned.
+      def key_id
+        @encryption_options[:key_id]
+      end
+    end
+  end
+end

--- a/lib/mongoid/fields/validators/macro.rb
+++ b/lib/mongoid/fields/validators/macro.rb
@@ -19,7 +19,8 @@ module Mongoid
           :pre_processed,
           :subtype,
           :type,
-          :overwrite
+          :overwrite,
+          :encrypt
         ]
 
         # Validate the field definition.

--- a/spec/mongoid/config/config_spec_models.rb
+++ b/spec/mongoid/config/config_spec_models.rb
@@ -1,0 +1,42 @@
+module Config
+  class Patient
+    include Mongoid::Document
+
+    encrypt_with key_id: "grolrnFVSSW9Gq04Q87R9Q=="
+
+    field :medical_records, type: Array, encrypt: { deterministic: false}
+    field :blood_type, type: String, encrypt: { deterministic: false }
+    field :ssn, type: Integer, encrypt: { deterministic: true }
+
+    embeds_one :insurance, class_name: "Config::Insurance"
+  end
+
+  class Insurance
+    include Mongoid::Document
+
+    field :policy_number, type: Integer, encrypt: { deterministic: true }
+    embedded_in :patient, class_name: "Config::Patient"
+  end
+
+  class User
+    include Mongoid::Document
+
+    field :name, type: String, encrypt: {
+      key_id: "grolrnFVSSW9Gq04Q87R9Q==",
+      deterministic: false
+    }
+    field :email, type: String, encrypt: {
+      key_id: "S34mE/HhSFSym3yErpER6Q==",
+      deterministic: true
+    }
+  end
+
+  class Car
+    include Mongoid::Document
+
+    encrypt_with key_id: "grolrnFVSSW9Gq04Q87R9Q==", deterministic: true
+
+    field :vin, type: String, encrypt: true
+    field :make, type: String
+  end
+end

--- a/spec/mongoid/config/encryption_spec.rb
+++ b/spec/mongoid/config/encryption_spec.rb
@@ -1,0 +1,149 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require_relative './config_spec_models'
+
+describe Mongoid::Config::Encryption do
+  describe ".encryption_schema_map" do
+
+    let(:encryption_schema_map) do
+      Mongoid.config.encryption_schema_map(models)
+    end
+
+    context "when a model has encrypted fields" do
+      context 'when model has encrypt_metadata' do
+        let(:expected_schema_map) do
+          {
+            "mongoid_test.config_patients" => {
+              "bsonType" => "object",
+              "encryptMetadata" => {
+                "keyId" => [BSON::Binary.new(Base64.decode64("grolrnFVSSW9Gq04Q87R9Q=="), :uuid)]
+              },
+              "properties" => {
+                "medical_records" => {
+                  "encrypt" => {
+                    "bsonType" => "array",
+                    "algorithm" => "AEAD_AES_256_CBC_HMAC_SHA_512-Random"
+                  }
+                },
+                "blood_type" => {
+                  "encrypt" => {
+                    "bsonType" => "string",
+                    "algorithm" => "AEAD_AES_256_CBC_HMAC_SHA_512-Random"
+                  }
+                },
+                "ssn" => {
+                  "encrypt" => {
+                    "bsonType" => "int",
+                    "algorithm" => "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+                  }
+                },
+                'insurance' => {
+                  'bsonType' => 'object',
+                  'properties' => {
+                    'policy_number' => {
+                      'encrypt' => {
+                        'bsonType' => 'int',
+                        'algorithm' => 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic'
+                      }
+                    }
+                  }
+                }
+              },
+            }
+          }
+        end
+
+        let(:models) do
+          [ Config::Patient ]
+        end
+
+        it "returns a map of encryption schemas" do
+          expect(encryption_schema_map).to eq(expected_schema_map)
+        end
+
+        context "when models are related" do
+          let(:models) do
+            [ Config::Patient, Config::Insurance ]
+          end
+
+          it "returns a map of encryption schemas" do
+            expect(encryption_schema_map).to eq(expected_schema_map)
+          end
+        end
+
+        context 'and fields do not have encryption options' do
+          let(:models) do
+            [ Config::Car ]
+          end
+
+          let(:expected_schema_map) do
+            {
+              "mongoid_test.config_cars" => {
+                "bsonType" => "object",
+                "encryptMetadata" => {
+                  "keyId" => [BSON::Binary.new(Base64.decode64("grolrnFVSSW9Gq04Q87R9Q=="), :uuid)],
+                  "algorithm" => "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+                },
+                "properties" => {
+                  "vin" => {
+                    "encrypt" => {
+                      "bsonType" => "string"
+                    }
+                  }
+                }
+              }
+            }
+          end
+
+          it "returns a map of encryption schemas" do
+            expect(encryption_schema_map).to eq(expected_schema_map)
+          end
+        end
+      end
+
+      context 'when model does not have encrypt_metadata' do
+        let(:expected_schema_map) do
+          {
+            "mongoid_test.config_users" => {
+              "properties" => {
+                "name" => {
+                  "encrypt" => {
+                    'keyId' => [BSON::Binary.new(Base64.decode64("grolrnFVSSW9Gq04Q87R9Q=="), :uuid)],
+                    "bsonType" => "string",
+                    "algorithm" => "AEAD_AES_256_CBC_HMAC_SHA_512-Random"
+                  }
+                },
+                "email" => {
+                  "encrypt" => {
+                    'keyId' => [BSON::Binary.new(Base64.decode64("S34mE/HhSFSym3yErpER6Q=="), :uuid)],
+                    "bsonType" => "string",
+                    "algorithm" => "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+                  }
+                }
+              }
+            }
+          }
+        end
+
+        let(:models) do
+          [ Config::User ]
+        end
+
+        it "returns a map of encryption schemas" do
+          expect(encryption_schema_map).to eq(expected_schema_map)
+        end
+      end
+    end
+
+    context 'when a model does not have encrypted fields' do
+      let(:models) do
+        [ Person ]
+      end
+
+      it 'returns an empty map' do
+        expect(encryption_schema_map).to eq({})
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is the first PR in the series that adds support of CSFLE to Mongoid.

In this PR we implement only CSFLE schema generation from Mongoid documents. For more information about the schema syntax see https://www.mongodb.com/docs/manual/core/csfle/reference/encryption-schemas/

Schemas generated in the tests are for now manually tested with the Ruby driver. In the upcoming PRs we will implement configuring client(s) with the schema; it will allow us to add proper testing.