### PR TITLE
MONGOID-5586 Make sure nested `with_scope` calls restore the previous scope

### DIFF
--- a/lib/mongoid/scopable.rb
+++ b/lib/mongoid/scopable.rb
@@ -226,11 +226,12 @@ module Mongoid
       #
       # @since 1.0.0
       def with_scope(criteria)
+        previous = Threaded.current_scope(self)
         Threaded.set_current_scope(criteria, self)
         begin
           yield criteria
         ensure
-          Threaded.set_current_scope(nil, self)
+          Threaded.set_current_scope(previous, self)
         end
       end
 

--- a/spec/mongoid/scopable_spec.rb
+++ b/spec/mongoid/scopable_spec.rb
@@ -1063,6 +1063,22 @@ describe Mongoid::Scopable do
         end
       end
     end
+
+    context "when chained with a scope that has no conditions" do
+      class ThingWithDefaultScopeAndProjectionScope
+        include Mongoid::Document
+
+        default_scope -> { where(foo: 1) }
+        scope :no_condition, -> { without(:bar) }
+      end
+
+      let(:criteria) { ThingWithDefaultScopeAndProjectionScope.unscoped.no_condition }
+
+      it "removes all scoping" do
+        puts "querying selector"
+        expect(criteria.selector).to be_empty
+      end
+    end
   end
 
   describe ".with_default_scope" do


### PR DESCRIPTION
It looks like this issue was indeed introduced in 7.3, as a result of refactoring `Mongoid::Fields::IDS` to `Mongoid::Fields#id_fields`. This refactoring relied on `Criteria#method_missing` to delegate the call to the `klass`, but that delegation involved wrapping the invocation in `with_scope`. The problem here is that from 7.3 until 8.0, there was a bug in `with_scope` that caused nested `with_scope` calls to misbehave, resetting the scope when the innermost invocation exited.

The fix is straightforward: essentially to port the basics of the bugfix from [MONGOID-5186](https://jira.mongodb.org/browse/MONGOID-5186) to 7.3-stable, 7.4-stable, and 7.5-stable.

This PR handles the fix for the 7.3-stable branch.

ref: https://jira.mongodb.org/browse/MONGOID-5586