### PR TITLE
MONGOID-5590 Update sharding docs re: keys with "." characters in them

### DIFF
--- a/docs/reference/sharding.txt
+++ b/docs/reference/sharding.txt
@@ -83,6 +83,21 @@ configured in the association as the field name:
     index country: 1
   end
 
+The shard key may also reference a field in an embedded document, by using
+the "." character to delimit the field names:
+
+.. code-block:: ruby
+
+  shard_key "location.x" => 1, "location.y" => 1
+
+  shard_key "location.x", "location.y"
+
+.. note::
+
+  Because the "." character is used to delimit fields in embedded documents,
+  Mongoid does not currently support shard key fields that themselves
+  literally contain the "." character.
+
 .. note::
 
   If a model declares a shard key, Mongoid expects the respective collection


### PR DESCRIPTION
MONGOID-5582 updated Mongoid so that shard keys with "." in them are treated as delimited fields identifying attributes of embedded subdocuments. This precludes the possibility of using shard keys that literally contain the "." character. Since we've decided this design decision is acceptable, this PR updates the sharding documentation for Mongoid to mention this caveat.

Once accepted, I'll backport this PR to 7.5-stable, 8.0-stable, and 8.1-stable (which were also updated for MONGOID-5582).

ref: https://jira.mongodb.org/browse/MONGOID-5590