### PR TITLE
MONGOID-5554 Expand arrays in queries

### DIFF
--- a/docs/release-notes/mongoid-9.0.txt
+++ b/docs/release-notes/mongoid-9.0.txt
@@ -17,6 +17,31 @@ The complete list of releases is available `on GitHub
 please consult GitHub releases for detailed release notes and JIRA for
 the complete list of issues fixed in each release, including bug fixes.
 
+Arrays containing a single element are now expanded in queries
+--------------------------------------------------------------
+
+**Breaking change** In Mongoid 8.1 and older if a query includes an array as
+a value, it is used in the criteria without changes:
+
+.. code-block:: ruby
+
+  # Mongoid 8.x behaviour
+  Person.where(name: ['Kate']).selector # { 'name' => [ 'Kate' ] }
+  Person.where(name: ['Kate', 'Anna']).selector # { 'name' => [ 'Kate', 'Anna' ] }
+
+In Mongoid 9.0 we change this behavior to bring it in accordance with
+ActiveRecord:
+
+.. code-block:: ruby
+
+  # Mongoid 9.x behaviour
+  Person.where(name: ['Kate']).selector # { 'name' => 'Kate' }
+  Person.where(name: ['Kate', 'Anna']).selector # { 'name' => [ 'Kate', 'Anna' ] }
+
+You can return to the old behavior by setting
+``expand_single_element_arrays_in_query`` to ``false`` in your
+``config/mongoid.yml`` file.
+
 Deprecated options removed
 --------------------------
 

--- a/lib/mongoid/config.rb
+++ b/lib/mongoid/config.rb
@@ -109,6 +109,14 @@ module Mongoid
     # document might be ignored, or it might work, depending on the situation.
     option :immutable_ids, default: true
 
+    # When this flag is true, database queries that contain a single element
+    # array will be expanded to a query with a single element.
+    # For example, the query `Band.where(name: ['The Beatles'])` will
+    # produce the criteria `{"name" => "The Beatles"}`.
+    # This is the default in 9.0. Setting this flag to false restores the
+    # pre-9.0 behavior, where the query will be sent as is.
+    option :expand_single_element_arrays_in_query, default: true
+
     # Returns the Config singleton, for use in the configure DSL.
     #
     # @return [ self ] The Config singleton.

--- a/lib/mongoid/config/defaults.rb
+++ b/lib/mongoid/config/defaults.rb
@@ -32,6 +32,7 @@ module Mongoid
           load_defaults "8.1"
         when "8.1"
           self.immutable_ids = false
+          self.expand_single_element_arrays_in_query = false
 
           load_defaults "9.0"
         when "9.0"

--- a/lib/mongoid/criteria/queryable/selectable.rb
+++ b/lib/mongoid/criteria/queryable/selectable.rb
@@ -864,8 +864,8 @@ module Mongoid
                 # Query expression-level operator, like $and or $where
                 query.add_operator_expression(field_s, value)
               else
-                if value.is_a?(Array) && value.size == 1
-                  query.add_field_expression(field, value.first)
+                if value.is_a?(Array) && value.size == 1 && !value.first.is_a?(Hash)
+                  query.add_field_expression(field, value)
                 else
                   query.add_field_expression(field, value)
                 end

--- a/lib/mongoid/criteria/queryable/selectable.rb
+++ b/lib/mongoid/criteria/queryable/selectable.rb
@@ -864,7 +864,11 @@ module Mongoid
                 # Query expression-level operator, like $and or $where
                 query.add_operator_expression(field_s, value)
               else
-                query.add_field_expression(field, value)
+                if value.is_a?(Array) && value.size == 1
+                  query.add_field_expression(field, value.first)
+                else
+                  query.add_field_expression(field, value)
+                end
               end
             end
             query.reset_strategies!

--- a/lib/mongoid/criteria/queryable/selectable.rb
+++ b/lib/mongoid/criteria/queryable/selectable.rb
@@ -864,14 +864,28 @@ module Mongoid
                 # Query expression-level operator, like $and or $where
                 query.add_operator_expression(field_s, value)
               else
-                if value.is_a?(Array) && value.size == 1 && !value.first.is_a?(Hash)
-                  query.add_field_expression(field, value.first)
-                else
-                  query.add_field_expression(field, value)
-                end
+                query.add_field_expression(field, maybe_convert_field_value(value))
               end
             end
             query.reset_strategies!
+          end
+        end
+
+        # Converts a value provided by the user to a value that should be added
+        # to the query.
+        #
+        # @param [ Object ] value The value as provided by the user when
+        #   constructing the query.
+        #
+        # @return [ Object ] The value to be added.
+        def maybe_convert_field_value(value)
+          return value unless value.is_a?(Array)
+          return value unless value.size == 1
+
+          if Mongoid.expand_single_element_arrays_in_query
+            value.first
+          else
+            value
           end
         end
 

--- a/lib/mongoid/criteria/queryable/selectable.rb
+++ b/lib/mongoid/criteria/queryable/selectable.rb
@@ -881,6 +881,7 @@ module Mongoid
         def maybe_convert_field_value(value)
           return value unless value.is_a?(Array)
           return value unless value.size == 1
+          return value if value.first.is_a?(Hash)
 
           if Mongoid.expand_single_element_arrays_in_query
             value.first

--- a/lib/mongoid/criteria/queryable/selectable.rb
+++ b/lib/mongoid/criteria/queryable/selectable.rb
@@ -865,7 +865,7 @@ module Mongoid
                 query.add_operator_expression(field_s, value)
               else
                 if value.is_a?(Array) && value.size == 1 && !value.first.is_a?(Hash)
-                  query.add_field_expression(field, value)
+                  query.add_field_expression(field, value.first)
                 else
                   query.add_field_expression(field, value)
                 end

--- a/spec/integration/matcher_operator_data/implicit.yml
+++ b/spec/integration/matcher_operator_data/implicit.yml
@@ -134,13 +134,6 @@
     airports: [SFO, EWR]
   matches: false
 
-# - name: array query with subset of elements
-#   document:
-#     airports: [EWR, SFO]
-#   query:
-#     airports: [EWR]
-#   matches: true
-
 - name: exact array match with empty array
   document:
     airports: []

--- a/spec/integration/matcher_operator_data/implicit.yml
+++ b/spec/integration/matcher_operator_data/implicit.yml
@@ -134,12 +134,12 @@
     airports: [SFO, EWR]
   matches: false
 
-- name: array query with subset of elements
-  document:
-    airports: [EWR, SFO]
-  query:
-    airports: [EWR]
-  matches: true # Because array of a single scalar element is expanded
+# - name: array query with subset of elements
+#   document:
+#     airports: [EWR, SFO]
+#   query:
+#     airports: [EWR]
+#   matches: true
 
 - name: exact array match with empty array
   document:

--- a/spec/integration/matcher_operator_data/implicit.yml
+++ b/spec/integration/matcher_operator_data/implicit.yml
@@ -139,7 +139,7 @@
     airports: [EWR, SFO]
   query:
     airports: [EWR]
-  matches: false
+  matches: true # Because array of a single scalar element is expanded
 
 - name: exact array match with empty array
   document:

--- a/spec/integration/to_key_spec.rb
+++ b/spec/integration/to_key_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Using to_key in queries" do
+  config_override :expand_single_element_arrays_in_query, true
+
+  let(:person) do
+    Person.create!(title: "Sir", aliases: ["John", "Jack"])
+  end
+
+  context 'using where' do
+    it "returns the document" do
+      expect(Person.where(id: person.to_key).first).to eq(person)
+    end
+  end
+
+  context 'using find' do
+    it "returns the document" do
+      expect(Person.find(person.to_key).first).to eq(person)
+    end
+  end
+
+  context 'using find_by' do
+    it "returns the document" do
+      expect(Person.find_by(id: person.to_key)).to eq(person)
+    end
+  end
+end

--- a/spec/mongoid/criteria/queryable/selectable_where_spec.rb
+++ b/spec/mongoid/criteria/queryable/selectable_where_spec.rb
@@ -202,6 +202,28 @@ describe Mongoid::Criteria::Queryable::Selectable do
           end
         end
       end
+
+      context 'when the values is an array' do
+        context 'when the array contains only one element' do
+          let(:selection) do
+            query.where(name: ['Syd'])
+          end
+
+          it 'uses the value of the array' do
+            expect(selection.selector).to eq({ "name" => "Syd" })
+          end
+        end
+
+        context 'when the array contains more than one element' do
+          let(:selection) do
+            query.where(name: ['Syd', 'Mick'])
+          end
+
+          it 'uses the array' do
+            expect(selection.selector).to eq({ "name" => ["Syd", "Mick"] })
+          end
+        end
+      end
     end
 
     context "when provided complex criterion" do

--- a/spec/mongoid/criteria/queryable/selectable_where_spec.rb
+++ b/spec/mongoid/criteria/queryable/selectable_where_spec.rb
@@ -209,8 +209,20 @@ describe Mongoid::Criteria::Queryable::Selectable do
             query.where(name: ['Syd'])
           end
 
-          it 'uses the value of the array' do
-            expect(selection.selector).to eq({ "name" => "Syd" })
+          context 'when expand_single_element_arrays_in_query is true' do
+            config_override :expand_single_element_arrays_in_query, true
+
+            it 'uses the value of the array' do
+              expect(selection.selector).to eq({ "name" => "Syd" })
+            end
+          end
+
+          context 'when expand_single_element_arrays_in_query is false' do
+            config_override :expand_single_element_arrays_in_query, false
+
+            it 'uses the value of the array' do
+              expect(selection.selector).to eq({ "name" => ["Syd"] })
+            end
           end
         end
 


### PR DESCRIPTION
Even though [the ticket](https://jira.mongodb.org/browse/MONGOID-5554) that initiates this PR describes a particular issue, the solution turned out to be global.

ActiveRecord expands arrays containing one element in queries:
```ruby
Person.where(id: [1])
#  Person Load (0.3ms)  SELECT "people".* FROM "people" WHERE "people"."id" = ?  [["id", 1]]
Person.where(id: [1, 2])
#  Person Load (0.5ms)  SELECT "people".* FROM "people" WHERE "people"."id" IN (?, ?)  [["id", 1], ["id", 2]]
```

Even though it seems to be a performance optimisation, It turned out that some Rails functionality depends on this behaviour. For example, `to_key` method returns an array of a single element (in case of a simple primary key). Therefore, the following find the document in ActiveRecord, but not in Mongoid:
```ruby
Person.where(id: person.to_key)
```

Even though this performance optimisation is not necessary in Mongoid (server expands arrays of one element automatically), we decided to copy the Rails behaviour. It ensures that third party gems that relies on this functionality of ActiveRecord work in Mongoid, too.