### PR TITLE
MONGOID-5599 - Fix broken tests for sharded clusters

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
           experimental: false
         - mongodb: '6.0'
           ruby: ruby-3.1
-          topology: replica_set
+          topology: sharded_cluster
           os: ubuntu-20.04
           task: test
           driver: current
@@ -50,7 +50,7 @@ jobs:
           experimental: false
         - mongodb: '6.0'
           ruby: ruby-3.1
-          topology: replica_set
+          topology: sharded_cluster
           os: ubuntu-20.04
           task: test
           driver: master
@@ -90,7 +90,7 @@ jobs:
           experimental: false
         - mongodb: '6.0'
           ruby: ruby-3.0
-          topology: server
+          topology: sharded_cluster
           os: ubuntu-20.04
           task: test
           driver: current
@@ -110,7 +110,7 @@ jobs:
           experimental: false
         - mongodb: '6.0'
           ruby: ruby-3.0
-          topology: server
+          topology: sharded_cluster
           os: ubuntu-20.04
           task: test
           driver: current
@@ -130,7 +130,7 @@ jobs:
           experimental: false
         - mongodb: '6.0'
           ruby: jruby-9.3
-          topology: server
+          topology: sharded_cluster
           os: ubuntu-20.04
           task: test
           driver: current

--- a/spec/mongoid/association/referenced/belongs_to/eager_spec.rb
+++ b/spec/mongoid/association/referenced/belongs_to/eager_spec.rb
@@ -309,7 +309,7 @@ describe Mongoid::Association::Referenced::BelongsTo::Eager do
         end
 
         it 'loads all associations eagerly' do
-          loaded = expect_query(4) do
+          expect_query(4, skip_if_sharded: true) do
             eager
           end
 

--- a/spec/mongoid/contextual/mongo_spec.rb
+++ b/spec/mongoid/contextual/mongo_spec.rb
@@ -194,7 +194,7 @@ describe Mongoid::Contextual::Mongo do
       end
 
       it "the results are not cached" do
-        expect_query(2) do
+        expect_query(2, skip_if_sharded: true) do
           2.times do
             context.estimated_count
           end

--- a/spec/mongoid/criteria/includable_spec.rb
+++ b/spec/mongoid/criteria/includable_spec.rb
@@ -1421,7 +1421,7 @@ describe Mongoid::Criteria::Includable do
     end
 
     it "executes a query for the non-retrieved elements" do
-      expect_query(3) do
+      expect_query(3, skip_if_sharded: true) do
         result.posts.each do |post|
           post.author
         end
@@ -1455,7 +1455,7 @@ describe Mongoid::Criteria::Includable do
     end
 
     it "executes a query for the non-retrieved elements" do
-      expect_query(3) do
+      expect_query(3, skip_if_sharded: true) do
         result.posts.each do |post|
           post.author
         end
@@ -1470,7 +1470,7 @@ describe Mongoid::Criteria::Includable do
         p = IncPerson.create!(name: "name")
         4.times { IncPost.create!(person: p)}
         criteria
-        expect_query(2) do
+        expect_query(2, skip_if_sharded: true) do
           criteria.each(&:person)
         end
       end
@@ -1483,7 +1483,7 @@ describe Mongoid::Criteria::Includable do
       # MONGOID-3942 reported that after iterating the criteria a second time,
       # the posts would not get the eager loaded person.
       it "eager loads the criteria" do
-        expect_query(2) do
+        expect_query(2, skip_if_sharded: true) do
           criteria.each(&:person)
         end
       end

--- a/spec/mongoid/query_cache_spec.rb
+++ b/spec/mongoid/query_cache_spec.rb
@@ -4,6 +4,7 @@ require "spec_helper"
 require 'mongoid/association/referenced/has_many_models'
 
 describe Mongoid::QueryCache do
+  require_no_multi_shard
 
   around do |spec|
     Mongoid::QueryCache.clear_cache

--- a/spec/support/expectations.rb
+++ b/spec/support/expectations.rb
@@ -4,15 +4,14 @@ module Mongoid
   module Expectations
 
     def connection_class
-      if defined?(Mongo::Server::ConnectionBase)
-        Mongo::Server::ConnectionBase
-      else
-        # Pre-2.8 drivers
-        Mongo::Server::Connection
-      end
+      Mongo::Server::ConnectionBase
     end
 
-    def expect_query(number)
+    def expect_query(number, skip_if_sharded: false)
+      if skip_if_sharded && number > 0 && ClusterConfig.instance.topology == :sharded
+        skip 'MONGOID-5599: Sharded clusters do extra read queries, causing expect_query to fail.'
+      end
+
       rv = nil
       RSpec::Mocks.with_temporary_scope do
         if number > 0


### PR DESCRIPTION
This PR fixes specs for sharded clusters. The gist is that the "expect_queries" test macro doesn't work with shards, or tends to fail sporadically in some cases.

Strangely, these specs seem to pass on Evergreen. I have no visibility as to what's going on there, but I am skeptical that they would pass with a proper multi-shard cluster setup. You may want to check if Evergreen is actually configured properly.
