### PR TITLE
MONGOID-5607: Rescue StandardError instead of Exception

### DIFF
--- a/lib/mongoid/persistable.rb
+++ b/lib/mongoid/persistable.rb
@@ -109,7 +109,7 @@ module Mongoid
       end
 
       true
-    rescue Exception => e
+    rescue StandardError => e
       _mongoid_reset_atomic_context_changes! if has_own_context
       raise e
     ensure


### PR DESCRIPTION
Should never rescue Exception because its used for things like sigkill.