### PR TITLE
[wip] Add newline to inspectable method

### DIFF
--- a/lib/mongoid/inspectable.rb
+++ b/lib/mongoid/inspectable.rb
@@ -15,6 +15,15 @@ module Mongoid
     def inspect
       inspection = []
       inspection.concat(inspect_fields).concat(inspect_dynamic_fields)
+
+      # move created_at and updated_at fields to the end.
+      [/^created_at: /, /^c_at: /, /^updated_at: /, /^u_at: /].each do |regexp|
+        next unless index = inspection.find_index {|s| s.match(regexp) }
+
+        s = inspection.delete_at(index)
+        inspection.push(s)
+      end
+
       "\n#<#{self.class.name}\n _id: #{_id},\n #{inspection * ",\n "}>"
     end
 

--- a/lib/mongoid/inspectable.rb
+++ b/lib/mongoid/inspectable.rb
@@ -15,7 +15,7 @@ module Mongoid
     def inspect
       inspection = []
       inspection.concat(inspect_fields).concat(inspect_dynamic_fields)
-      "#<#{self.class.name} _id: #{_id}, #{inspection * ', '}>"
+      "\n#<#{self.class.name}\n _id: #{_id},\n #{inspection * ",\n "}>"
     end
 
     private

--- a/spec/mongoid/inspectable_spec.rb
+++ b/spec/mongoid/inspectable_spec.rb
@@ -79,7 +79,7 @@ describe Mongoid::Inspectable do
       let(:shirt) { Shirt.new(id: 1, _id: 2) }
 
       it 'shows the correct _id and id values' do
-        shirt.inspect.should == "#<Shirt _id: 2, color: nil, id: \"1\">"
+        shirt.inspect.should == "\n#<Shirt\n _id: 2,\n color: nil,\n id: \"1\">"
       end
     end
   end


### PR DESCRIPTION
Mongoid prints data in one line in rails console like following. But I find it a little difficult to read.

```rb
[5] pry(main)> User.first
=> #<User _id: 64002124c849723d04d26d64, created_at: 2023-03-02 04:08:04.369 UTC, updated_at: 2023-03-07 07:05:15.893 UTC, n(name): "test_user", e(email): "test_user@example.com">
```

This PR adds a line break for each field like `ActiveRecord` to make the data easier to read.
Also, this PR move `created_at` and `updated_at` fields to the end like AR.
As a result, it will be displayed as follows.

```rb
[9] pry(main)> User.first
=>
#<User
 _id: 64002124c849723d04d26d64,
 n(name): "test001",
 e(email): "test@st.inc">
 created_at: 2023-03-02 04:08:04.369 UTC,
 updated_at: 2023-03-07 07:05:15.893 UTC>
```