### PR TITLE
Bug Fix: Fix using exists? with args on relations.

### DIFF
--- a/lib/mongoid/association/embedded/embeds_many/proxy.rb
+++ b/lib/mongoid/association/embedded/embeds_many/proxy.rb
@@ -211,9 +211,25 @@ module Mongoid
           # @example Are there persisted documents?
           #   person.posts.exists?
           #
+          # @example Is a document with the given id persisted?
+          #   context.exists?(BSON::ObjectId(...))
+          #
+          # @example Are there persisted documents with the given title?
+          #   person.posts.exists?({ title: "50 Ways to Leave Your Lover" })
+          #
+          # @example Always return false.
+          #   person.posts.exists?(false)
+          #
+          # @param [ :none | Hash | BSON::ObjectId | nil | false ] id_or_conditions
+          #   May optionally supply search conditions as a hash or an object id.
+          #   Will always return false when given nil or false. The symbol :none is
+          #   the default when argument is not supplied.
+          #
           # @return [ true | false ] True is persisted documents exist, false if not.
-          def exists?
-            _target.any? { |doc| doc.persisted? }
+          def exists?(id_or_conditions = :none)
+            return _target.any?(&:persisted?) if id_or_conditions == :none
+
+            criteria.exists?(id_or_conditions)
           end
 
           # Finds a document in this association through several different

--- a/lib/mongoid/association/referenced/has_many/proxy.rb
+++ b/lib/mongoid/association/referenced/has_many/proxy.rb
@@ -169,9 +169,12 @@ module Mongoid
           # @example Are there persisted documents?
           #   person.posts.exists?
           #
+          # @param [ Hash | Object | false ] id_or_conditions an _id to
+          #   search for, a hash of conditions, nil or false.
+          #
           # @return [ true | false ] True is persisted documents exist, false if not.
-          def exists?
-            criteria.exists?
+          def exists?(id_or_conditions = :none)
+            criteria.exists?(id_or_conditions)
           end
 
           # Find the matching document on the association, either based on id or

--- a/lib/mongoid/association/referenced/has_many/proxy.rb
+++ b/lib/mongoid/association/referenced/has_many/proxy.rb
@@ -11,7 +11,7 @@ module Mongoid
         class Proxy < Association::Many
           extend Forwardable
 
-          def_delegator :criteria, :count
+          def_delegators :criteria, :count, :exists?
           def_delegators :_target, :first, :in_memory, :last, :reset, :uniq
 
           # Appends a document or array of documents to the association. Will set
@@ -155,26 +155,6 @@ module Mongoid
             else
               to_enum
             end
-          end
-
-          # Determine if any documents in this association exist in the database.
-          #
-          # If the association contains documents but all of the documents
-          # exist only in the application, i.e. have not been persisted to the
-          # database, this method returns false.
-          #
-          # This method queries the database on each invocation even if the
-          # association is already loaded into memory.
-          #
-          # @example Are there persisted documents?
-          #   person.posts.exists?
-          #
-          # @param [ Hash | Object | false ] id_or_conditions an _id to
-          #   search for, a hash of conditions, nil or false.
-          #
-          # @return [ true | false ] True is persisted documents exist, false if not.
-          def exists?(id_or_conditions = :none)
-            criteria.exists?(id_or_conditions)
           end
 
           # Find the matching document on the association, either based on id or

--- a/lib/mongoid/contextual/memory.rb
+++ b/lib/mongoid/contextual/memory.rb
@@ -113,8 +113,13 @@ module Mongoid
       # @example Do any documents exist for given conditions.
       #   context.exists?(name: "...")
       #
-      # @param [ Hash | Object | false ] id_or_conditions an _id to
-      #   search for, a hash of conditions, nil or false.
+      # @example Always return false.
+      #   context.exists?(false)
+      #
+      # @param [ :none | Hash | BSON::ObjectId | nil | false ] id_or_conditions
+      #   May optionally supply search conditions as a hash or an object id.
+      #   Will always return false when given nil or false. The symbol :none is
+      #   the default when argument is not supplied.
       #
       # @return [ true | false ] If the count is more than zero.
       #   Always false if passed nil or false.

--- a/lib/mongoid/contextual/mongo.rb
+++ b/lib/mongoid/contextual/mongo.rb
@@ -170,11 +170,16 @@ module Mongoid
       # @example Do any documents exist for given conditions.
       #   context.exists?(name: "...")
       #
+      # @example Always return false.
+      #   context.exists?(false)
+      #
       # @note We don't use count here since Mongo does not use counted
       #   b-tree indexes.
       #
-      # @param [ Hash | Object | false ] id_or_conditions an _id to
-      #   search for, a hash of conditions, nil or false.
+      # @param [ :none | Hash | BSON::ObjectId | nil | false ] id_or_conditions
+      #   May optionally supply search conditions as a hash or an object id.
+      #   Will always return false when given nil or false. The symbol :none is
+      #   the default when argument is not supplied.
       #
       # @return [ true | false ] If the count is more than zero.
       #   Always false if passed nil or false.

--- a/lib/mongoid/contextual/none.rb
+++ b/lib/mongoid/contextual/none.rb
@@ -54,7 +54,7 @@ module Mongoid
         end
       end
 
-      # Do any documents exist for the context.
+      # Do any documents exist for the null context.
       #
       # @example Do any documents exist in the null context.
       #   context.exists?
@@ -65,11 +65,14 @@ module Mongoid
       # @example Do any documents exist for given conditions.
       #   context.exists?(name: "...")
       #
-      # @param [ Hash | Object | false ] id_or_conditions an _id to
-      #   search for, a hash of conditions, nil or false.
+      # @example Always return false.
+      #   context.exists?(false)
+      #
+      # @param [ :none | Hash | BSON::ObjectId | nil | false ] _id_or_conditions
+      #   Not used in null context.
       #
       # @return [ false ] Always false.
-      def exists?(id_or_conditions = :none); false; end
+      def exists?(_id_or_conditions = :none); false; end
 
       # Pluck the field values in null context.
       #

--- a/lib/mongoid/findable.rb
+++ b/lib/mongoid/findable.rb
@@ -108,8 +108,13 @@ module Mongoid
     # @example Do any documents exist for given conditions.
     #   Person.exists?(name: "...")
     #
-    # @param [ Hash | Object | false ] id_or_conditions an _id to
-    #   search for, a hash of conditions, nil or false.
+    # @example Always return false.
+    #   context.exists?(false)
+    #
+    # @param [ :none | Hash | BSON::ObjectId | nil | false ] id_or_conditions
+    #   May optionally supply search conditions as a hash or an object id.
+    #   Will always return false when given nil or false. The symbol :none is
+    #   the default when argument is not supplied.
     #
     # @return [ true | false ] If any documents exist for the conditions.
     #   Always false if passed nil or false.


### PR DESCRIPTION
Fix using `exists?` with args on relations. For example:

```
person.posts.exists?({ title: "50 Ways to Leave Your Lover" })
```

This was missed in the original implementation [MONGOID-5100](https://jira.mongodb.org/browse/MONGOID-5100)

Also cleans up method docs which were not accurate.