### PR TITLE
MONGOID-5611 - Fix ActiveJob::SerializationError for BSON::ObjectId

### DIFF
--- a/docs/release-notes/mongoid-9.0.txt
+++ b/docs/release-notes/mongoid-9.0.txt
@@ -311,3 +311,5 @@ This section will be for smaller bug fixes and improvements:
   a non-numeric, non-string value that implements ``:to_d`` will return a string
   rather than a ``BigDecimal``
   `MONGOID-5507 <https://jira.mongodb.org/browse/MONGOID-5507>`_.
+- ActiveJob now correctly serializes and deserializes BSON::ObjectId
+  `MONGOID-5611 <https://jira.mongodb.org/browse/MONGOID-5611>`_.

--- a/lib/mongoid/railtie.rb
+++ b/lib/mongoid/railtie.rb
@@ -118,6 +118,15 @@ module Rails
             ::Mongoid::Railties::ControllerRuntime::Collector.new
       end
 
+      # Adds custom serializers to ActiveJob.
+      initializer "mongoid.active_job.custom_serializers" do
+        require "mongoid/railties/active_job_serializers/bson_object_id_serializer"
+
+        config.after_initialize do
+          serializers = ::Mongoid::Railties::ActiveJobSerializers::BsonObjectIdSerializer
+          ActiveJob::Serializers.add_serializers serializers
+        end
+      end
     end
   end
 end

--- a/lib/mongoid/railties/active_job_serializers/bson_object_id_serializer.rb
+++ b/lib/mongoid/railties/active_job_serializers/bson_object_id_serializer.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+# rubocop:todo all
+
+module Mongoid
+  module Railties
+    module ActiveJobSerializers
+
+      # This extension mimics the Rails' internal method to
+      # measure ActiveRecord runtime during request processing.
+      # It appends MongoDB runtime value (`mongoid_runtime`) into payload
+      # of instrumentation event `process_action.action_controller`.
+      #
+      # @api private
+      class BsonObjectIdSerializer < ::ActiveJob::Serializers::ObjectSerializer
+
+        # Serializer BSON::ObjectId into String.
+        #
+        # @param [ BSON::ObjectId ] argument The deserialized object id.
+        #
+        # @return [ String ] The serialized object id.
+        def serialize(argument)
+          super('value' => argument.to_s)
+        end
+
+        # Deserialize String into BSON::ObjectId.
+        #
+        # @param [ String ] argument The serialized object id.
+        #
+        # @return [ BSON::ObjectId ] The deserialized object id.
+        def deserialize(argument)
+          ::BSON::ObjectId(argument['value'])
+        end
+
+        private
+
+        def klass
+          ::BSON::ObjectId
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
TODO:
- [ ] Add tests

Currently, if you provide a BSON::ObjectId as an argument to an ActiveJob job, Rails will raise a ActiveJob::SerializationError (Unsupported argument type: BSON::ObjectId).

This PR fixes this, so that BSON::ObjectId is serialized as a string and deserialized back into BSON::ObjectId.