### PR TITLE
MONGOID-5600 make sure build calls initialize

### DIFF
--- a/lib/mongoid/document.rb
+++ b/lib/mongoid/document.rb
@@ -288,8 +288,15 @@ module Mongoid
 
     module ClassMethods
 
-      def suppress_callbacks
-        saved, Threaded.execute_callbacks = Threaded.execute_callbacks?, false
+      # Suppress callbacks (by default) for documents within the associated
+      # block. Callbacks may still be explicitly invoked by passing
+      # `execute_callbacks: true` where available.
+      #
+      # @params execute_callbacks [ true | false ] Whether callbacks should be
+      #   suppressed or not.
+      def suppress_callbacks(execute_callbacks = false)
+        saved, Threaded.execute_callbacks =
+          Threaded.execute_callbacks?, execute_callbacks
         yield
       ensure
         Threaded.execute_callbacks = saved
@@ -354,11 +361,7 @@ module Mongoid
       #
       # @api private
       def construct_document(attrs = nil, execute_callbacks: Threaded.execute_callbacks?)
-        if !execute_callbacks
-          suppress_callbacks { new(attrs) }
-        else
-          new(attrs)
-        end
+        suppress_callbacks(execute_callbacks) { new(attrs) }
       end
 
       # Returns all types to query for when using this class as the base.

--- a/lib/mongoid/document.rb
+++ b/lib/mongoid/document.rb
@@ -102,7 +102,13 @@ module Mongoid
     #
     # @return [ Document ] A new document.
     def initialize(attrs = nil, &block)
-      construct_document(attrs, &block)
+      # A bug in Ruby 2.x (including 2.7.7) causes the attrs hash to be
+      # interpreted as keyword arguments, because construct_document accepts
+      # a keyword argument. Forcing an empty set of keyword arguments works
+      # around the bug. Once Ruby 2.x support is dropped, this hack can be
+      # removed.
+      # See https://bugs.ruby-lang.org/issues/15753
+      construct_document(attrs, **{}, &block)
     end
 
     # Return the model name of the document.

--- a/lib/mongoid/document.rb
+++ b/lib/mongoid/document.rb
@@ -102,7 +102,7 @@ module Mongoid
     #
     # @return [ Document ] A new document.
     def initialize(attrs = nil, &block)
-      construct_document(attrs, execute_callbacks: Threaded.execute_callbacks?, &block)
+      construct_document(attrs, &block)
     end
 
     # Return the model name of the document.
@@ -303,8 +303,7 @@ module Mongoid
       #
       # @return [ Document ] A new document.
       def instantiate(attrs = nil, selected_fields = nil, &block)
-        instantiate_document(attrs, selected_fields,
-          execute_callbacks: Threaded.execute_callbacks?, &block)
+        instantiate_document(attrs, selected_fields, &block)
       end
 
       # Instantiate the document.

--- a/lib/mongoid/document.rb
+++ b/lib/mongoid/document.rb
@@ -288,13 +288,13 @@ module Mongoid
 
     module ClassMethods
 
-      # Suppress callbacks (by default) for documents within the associated
-      # block. Callbacks may still be explicitly invoked by passing
+      # Indicate whether callbacks should be invoked by default or not,
+      # within the block. Callbacks may always be explicitly invoked by passing
       # `execute_callbacks: true` where available.
       #
       # @params execute_callbacks [ true | false ] Whether callbacks should be
       #   suppressed or not.
-      def suppress_callbacks(execute_callbacks = false)
+      def with_callbacks(execute_callbacks)
         saved, Threaded.execute_callbacks =
           Threaded.execute_callbacks?, execute_callbacks
         yield
@@ -361,7 +361,7 @@ module Mongoid
       #
       # @api private
       def construct_document(attrs = nil, execute_callbacks: Threaded.execute_callbacks?)
-        suppress_callbacks(execute_callbacks) { new(attrs) }
+        with_callbacks(execute_callbacks) { new(attrs) }
       end
 
       # Returns all types to query for when using this class as the base.

--- a/lib/mongoid/document.rb
+++ b/lib/mongoid/document.rb
@@ -108,7 +108,7 @@ module Mongoid
       # around the bug. Once Ruby 2.x support is dropped, this hack can be
       # removed.
       # See https://bugs.ruby-lang.org/issues/15753
-      construct_document(attrs, **{}, &block)
+      construct_document(attrs, **(;{}), &block)
     end
 
     # Return the model name of the document.

--- a/lib/mongoid/factory.rb
+++ b/lib/mongoid/factory.rb
@@ -26,7 +26,13 @@ module Mongoid
     #
     # @return [ Document ] The instantiated document.
     def build(klass, attributes = nil)
-      execute_build(klass, attributes)
+      # A bug in Ruby 2.x (including 2.7.7) causes the attributes hash to be
+      # interpreted as keyword arguments, because execute_build accepts
+      # a keyword argument. Forcing an empty set of keyword arguments works
+      # around the bug. Once Ruby 2.x support is dropped, this hack can be
+      # removed.
+      # See https://bugs.ruby-lang.org/issues/15753
+      execute_build(klass, attributes, **{})
     end
 
     # Execute the build.

--- a/lib/mongoid/factory.rb
+++ b/lib/mongoid/factory.rb
@@ -32,7 +32,7 @@ module Mongoid
       # around the bug. Once Ruby 2.x support is dropped, this hack can be
       # removed.
       # See https://bugs.ruby-lang.org/issues/15753
-      execute_build(klass, attributes, **{})
+      execute_build(klass, attributes, **(;{}))
     end
 
     # Execute the build.

--- a/lib/mongoid/factory.rb
+++ b/lib/mongoid/factory.rb
@@ -26,7 +26,7 @@ module Mongoid
     #
     # @return [ Document ] The instantiated document.
     def build(klass, attributes = nil)
-      execute_build(klass, attributes, execute_callbacks: true)
+      execute_build(klass, attributes)
     end
 
     # Execute the build.
@@ -39,7 +39,7 @@ module Mongoid
     # @return [ Document ] The instantiated document.
     #
     # @api private
-    def execute_build(klass, attributes = nil, execute_callbacks: true)
+    def execute_build(klass, attributes = nil, execute_callbacks: Threaded.execute_callbacks?)
       attributes ||= {}
       dvalue = attributes[klass.discriminator_key] || attributes[klass.discriminator_key.to_sym]
       type = klass.get_discriminator_mapping(dvalue)
@@ -77,7 +77,7 @@ module Mongoid
     #
     # @return [ Document ] The instantiated document.
     def from_db(klass, attributes = nil, criteria = nil, selected_fields = nil)
-      execute_from_db(klass, attributes, criteria, selected_fields, execute_callbacks: true)
+      execute_from_db(klass, attributes, criteria, selected_fields)
     end
 
     # Execute from_db.
@@ -98,7 +98,7 @@ module Mongoid
     # @return [ Document ] The instantiated document.
     #
     # @api private
-    def execute_from_db(klass, attributes = nil, criteria = nil, selected_fields = nil, execute_callbacks: true)
+    def execute_from_db(klass, attributes = nil, criteria = nil, selected_fields = nil, execute_callbacks: Threaded.execute_callbacks?)
       if criteria
         selected_fields ||= criteria.options[:fields]
       end

--- a/lib/mongoid/threaded.rb
+++ b/lib/mongoid/threaded.rb
@@ -33,6 +33,10 @@ module Mongoid
     # The key for storing documents modified inside transactions.
     MODIFIED_DOCUMENTS_KEY="[mongoid]:modified-documents"
 
+    # The key storing the default value for whether or not callbacks are
+    # executed on documents.
+    EXECUTE_CALLBACKS = "[mongoid]:execute-callbacks"
+
     extend self
 
     # Begin entry into a named thread local stack.
@@ -380,6 +384,32 @@ module Mongoid
       modified_documents[session].dup
     ensure
       modified_documents[session].clear
+    end
+
+    # Queries whether document callbacks should be executed by default for the
+    # current thread.
+    #
+    # Unless otherwise indicated (by #execute_callbacks=), this will return
+    # true.
+    #
+    # @return [ true | false ] Whether or not document callbacks should be
+    #   executed by default.
+    def execute_callbacks?
+      if Thread.current.key?(EXECUTE_CALLBACKS)
+        Thread.current[EXECUTE_CALLBACKS]
+      else
+        true
+      end
+    end
+
+    # Indicates whether document callbacks should be invoked by default for
+    # the current thread. Individual documents may further override the
+    # callback behavior, but this will be used for the default behavior.
+    #
+    # @param flag [ true | false ] Whether or not document callbacks should be
+    #   executed by default.
+    def execute_callbacks=(flag)
+      Thread.current[EXECUTE_CALLBACKS] = flag
     end
 
     # @api private

--- a/spec/mongoid/association/referenced/has_many/proxy_spec.rb
+++ b/spec/mongoid/association/referenced/has_many/proxy_spec.rb
@@ -15,7 +15,7 @@ module RefHasManySpec
       belongs_to :parent
       field :name, type: String
 
-      def initialize(...)
+      def initialize(*args)
         super
         self.name ||= "default"
       end


### PR DESCRIPTION
When MONGOID-2586 landed, it made it so that a model's `initialize` method would not be called in certain circumstances, including when calling `build` on a child collection. This PR corrects that specific case (though there are other circumstances where `initialize` is still not called, typically via the `Factory` methods).

ref https://jira.mongodb.org/browse/MONGOID-5600