### PR TITLE
MONGOID-5600 Backport to 8.1-stable

### DIFF
--- a/lib/mongoid/document.rb
+++ b/lib/mongoid/document.rb
@@ -101,13 +101,7 @@ module Mongoid
     #
     # @return [ Document ] A new document.
     def initialize(attrs = nil, &block)
-      # A bug in Ruby 2.x (including 2.7.7) causes the attrs hash to be
-      # interpreted as keyword arguments, because construct_document accepts
-      # a keyword argument. Forcing an empty set of keyword arguments works
-      # around the bug. Once Ruby 2.x support is dropped, this hack can be
-      # removed.
-      # See https://bugs.ruby-lang.org/issues/15753
-      construct_document(attrs, **(;{}), &block)
+      construct_document(attrs, &block)
     end
 
     # Return the model name of the document.
@@ -214,13 +208,22 @@ module Mongoid
     # Does the construction of a document.
     #
     # @param [ Hash ] attrs The attributes to set up the document with.
-    # @param [ true | false ] execute_callbacks Flag specifies whether callbacks
-    #   should be run.
+    # @param [ Hash ] options The options to use.
+    #
+    # @option options [ true | false ] :execute_callbacks Flag specifies
+    #   whether callbacks should be run.
     #
     # @return [ Document ] A new document.
     #
+    # @note A Ruby 2.x bug prevents the options hash from being keyword
+    #   arguments. Once we drop support for Ruby 2.x, we can reimplement
+    #   the options hash as keyword arguments.
+    #   See https://bugs.ruby-lang.org/issues/15753
+    #
     # @api private
-    def construct_document(attrs = nil, execute_callbacks: Threaded.execute_callbacks?)
+    def construct_document(attrs = nil, options = {})
+      execute_callbacks = options.fetch(:execute_callbacks, Threaded.execute_callbacks?)
+
       @__parent = nil
       _building do
         @new_record = true
@@ -323,13 +326,20 @@ module Mongoid
       # @param [ Hash ] attrs The hash of attributes to instantiate with.
       # @param [ Integer ] selected_fields The selected fields from the
       #   criteria.
-      # @param [ true | false ] execute_callbacks Flag specifies whether callbacks
-      #   should be run.
+      # @param [ Hash ] options The options to use.
+      #
+      # @option options [ true | false ] :execute_callbacks Flag specifies
+      #   whether callbacks should be run.
       #
       # @return [ Document ] A new document.
       #
+      # @note A Ruby 2.x bug prevents the options hash from being keyword
+      #   arguments. Once we drop support for Ruby 2.x, we can reimplement
+      #   the options hash as keyword arguments.
+      #
       # @api private
-      def instantiate_document(attrs = nil, selected_fields = nil, execute_callbacks: Threaded.execute_callbacks?)
+      def instantiate_document(attrs = nil, selected_fields = nil, options = {})
+        execute_callbacks = options.fetch(:execute_callbacks, Threaded.execute_callbacks?)
         attributes = if Mongoid.legacy_attributes
           attrs
         else
@@ -360,13 +370,21 @@ module Mongoid
       # Allocates and constructs a document.
       #
       # @param [ Hash ] attrs The attributes to set up the document with.
-      # @param [ true | false ] execute_callbacks Flag specifies whether callbacks
-      #   should be run.
+      # @param [ Hash ] options The options to use.
+      #
+      # @option options [ true | false ] :execute_callbacks Flag specifies
+      #   whether callbacks should be run.
+      #
+      # @note A Ruby 2.x bug prevents the options hash from being keyword
+      #   arguments. Once we drop support for Ruby 2.x, we can reimplement
+      #   the options hash as keyword arguments.
+      #   See https://bugs.ruby-lang.org/issues/15753
       #
       # @return [ Document ] A new document.
       #
       # @api private
-      def construct_document(attrs = nil, execute_callbacks: Threaded.execute_callbacks?)
+      def construct_document(attrs = nil, options = {})
+        execute_callbacks = options.fetch(:execute_callbacks, Threaded.execute_callbacks?)
         with_callbacks(execute_callbacks) { new(attrs) }
       end
 

--- a/lib/mongoid/factory.rb
+++ b/lib/mongoid/factory.rb
@@ -25,7 +25,13 @@ module Mongoid
     #
     # @return [ Document ] The instantiated document.
     def build(klass, attributes = nil)
-      execute_build(klass, attributes, execute_callbacks: true)
+      # A bug in Ruby 2.x (including 2.7.7) causes the attributes hash to be
+      # interpreted as keyword arguments, because execute_build accepts
+      # a keyword argument. Forcing an empty set of keyword arguments works
+      # around the bug. Once Ruby 2.x support is dropped, this hack can be
+      # removed.
+      # See https://bugs.ruby-lang.org/issues/15753
+      execute_build(klass, attributes, **(;{}))
     end
 
     # Execute the build.
@@ -38,7 +44,7 @@ module Mongoid
     # @return [ Document ] The instantiated document.
     #
     # @api private
-    def execute_build(klass, attributes = nil, execute_callbacks: true)
+    def execute_build(klass, attributes = nil, execute_callbacks: Threaded.execute_callbacks?)
       attributes ||= {}
       dvalue = attributes[klass.discriminator_key] || attributes[klass.discriminator_key.to_sym]
       type = klass.get_discriminator_mapping(dvalue)
@@ -76,7 +82,7 @@ module Mongoid
     #
     # @return [ Document ] The instantiated document.
     def from_db(klass, attributes = nil, criteria = nil, selected_fields = nil)
-      execute_from_db(klass, attributes, criteria, selected_fields, execute_callbacks: true)
+      execute_from_db(klass, attributes, criteria, selected_fields)
     end
 
     # Execute from_db.
@@ -97,7 +103,7 @@ module Mongoid
     # @return [ Document ] The instantiated document.
     #
     # @api private
-    def execute_from_db(klass, attributes = nil, criteria = nil, selected_fields = nil, execute_callbacks: true)
+    def execute_from_db(klass, attributes = nil, criteria = nil, selected_fields = nil, execute_callbacks: Threaded.execute_callbacks?)
       if criteria
         selected_fields ||= criteria.options[:fields]
       end

--- a/lib/mongoid/factory.rb
+++ b/lib/mongoid/factory.rb
@@ -31,27 +31,34 @@ module Mongoid
       # around the bug. Once Ruby 2.x support is dropped, this hack can be
       # removed.
       # See https://bugs.ruby-lang.org/issues/15753
-      execute_build(klass, attributes, **(;{}))
+      execute_build(klass, attributes)
     end
 
     # Execute the build.
     #
     # @param [ Class ] klass The class to instantiate from if _type is not present.
     # @param [ Hash ] attributes The document attributes.
-    # @param [ true | false ] execute_callbacks Flag specifies whether callbacks
-    #   should be run.
+    # @param [ Hash ] options The options to use.
+    #
+    # @option options [ true | false ] :execute_callbacks Flag specifies
+    #   whether callbacks should be run.
+    #
+    # @note A Ruby 2.x bug prevents the options hash from being keyword
+    #   arguments. Once we drop support for Ruby 2.x, we can reimplement
+    #   the options hash as keyword arguments.
+    #   See https://bugs.ruby-lang.org/issues/15753
     #
     # @return [ Document ] The instantiated document.
     #
     # @api private
-    def execute_build(klass, attributes = nil, execute_callbacks: Threaded.execute_callbacks?)
+    def execute_build(klass, attributes = nil, options = {})
       attributes ||= {}
       dvalue = attributes[klass.discriminator_key] || attributes[klass.discriminator_key.to_sym]
       type = klass.get_discriminator_mapping(dvalue)
       if type
-        type.construct_document(attributes, execute_callbacks: execute_callbacks)
+        type.construct_document(attributes, options)
       else
-        klass.construct_document(attributes, execute_callbacks: execute_callbacks)
+        klass.construct_document(attributes, options)
       end
     end
 

--- a/lib/mongoid/threaded.rb
+++ b/lib/mongoid/threaded.rb
@@ -26,6 +26,10 @@ module Mongoid
       hash[key] = "[mongoid]:#{key}-stack"
     end
 
+    # The key storing the default value for whether or not callbacks are
+    # executed on documents.
+    EXECUTE_CALLBACKS = "[mongoid]:execute-callbacks"
+
     extend self
 
     # Begin entry into a named thread local stack.
@@ -345,6 +349,32 @@ module Mongoid
       session = get_session
       session.end_session if session
       Thread.current["[mongoid]:session"] = nil
+    end
+
+    # Queries whether document callbacks should be executed by default for the
+    # current thread.
+    #
+    # Unless otherwise indicated (by #execute_callbacks=), this will return
+    # true.
+    #
+    # @return [ true | false ] Whether or not document callbacks should be
+    #   executed by default.
+    def execute_callbacks?
+      if Thread.current.key?(EXECUTE_CALLBACKS)
+        Thread.current[EXECUTE_CALLBACKS]
+      else
+        true
+      end
+    end
+
+    # Indicates whether document callbacks should be invoked by default for
+    # the current thread. Individual documents may further override the
+    # callback behavior, but this will be used for the default behavior.
+    #
+    # @param flag [ true | false ] Whether or not document callbacks should be
+    #   executed by default.
+    def execute_callbacks=(flag)
+      Thread.current[EXECUTE_CALLBACKS] = flag
     end
   end
 end

--- a/spec/mongoid/association/referenced/has_many/proxy_spec.rb
+++ b/spec/mongoid/association/referenced/has_many/proxy_spec.rb
@@ -2,6 +2,26 @@
 
 require "spec_helper"
 
+module RefHasManySpec
+  module OverrideInitialize
+    class Parent
+      include Mongoid::Document
+      has_many :children, inverse_of: :parent
+    end
+
+    class Child
+      include Mongoid::Document
+      belongs_to :parent
+      field :name, type: String
+
+      def initialize(*args)
+        super
+        self.name ||= "default"
+      end
+    end
+  end
+end
+
 describe Mongoid::Association::Referenced::HasMany::Proxy do
   config_override :raise_not_found_error, true
 
@@ -876,6 +896,14 @@ describe Mongoid::Association::Referenced::HasMany::Proxy do
   [ :build, :new ].each do |method|
 
     describe "##{method}" do
+      context 'when model has #initialize' do
+        let(:parent) { RefHasManySpec::OverrideInitialize::Parent.create }
+        let(:child)  { parent.children.send(method) }
+
+        it 'should call #initialize' do
+          expect(child.name).to be == "default"
+        end
+      end
 
       context "when the association is not polymorphic" do
 


### PR DESCRIPTION
[MONGOID-5600](https://jira.mongodb.org/browse/MONGOID-5600) fixes the initialize method not being called when creating records via foo.bars.build. This PR backports those changes to the 8.1-stable branch.