### PR TITLE
MONGOID-5600 Use options hash instead of surprising syntax to work around Ruby 2.x kwarg bug

### DIFF
--- a/lib/mongoid/document.rb
+++ b/lib/mongoid/document.rb
@@ -102,13 +102,7 @@ module Mongoid
     #
     # @return [ Document ] A new document.
     def initialize(attrs = nil, &block)
-      # A bug in Ruby 2.x (including 2.7.7) causes the attrs hash to be
-      # interpreted as keyword arguments, because construct_document accepts
-      # a keyword argument. Forcing an empty set of keyword arguments works
-      # around the bug. Once Ruby 2.x support is dropped, this hack can be
-      # removed.
-      # See https://bugs.ruby-lang.org/issues/15753
-      construct_document(attrs, **(;{}), &block)
+      construct_document(attrs, &block)
     end
 
     # Return the model name of the document.
@@ -215,13 +209,22 @@ module Mongoid
     # Does the construction of a document.
     #
     # @param [ Hash ] attrs The attributes to set up the document with.
-    # @param [ true | false ] execute_callbacks Flag specifies whether callbacks
-    #   should be run.
+    # @param [ Hash ] options The options to use.
+    #
+    # @option options [ true | false ] :execute_callbacks Flag specifies
+    #   whether callbacks should be run.
     #
     # @return [ Document ] A new document.
     #
+    # @note A Ruby 2.x bug prevents the options hash from being keyword
+    #   arguments. Once we drop support for Ruby 2.x, we can reimplement
+    #   the options hash as keyword arguments.
+    #   See https://bugs.ruby-lang.org/issues/15753
+    #
     # @api private
-    def construct_document(attrs = nil, execute_callbacks: Threaded.execute_callbacks?)
+    def construct_document(attrs = nil, options = {})
+      execute_callbacks = options.fetch(:execute_callbacks, Threaded.execute_callbacks?)
+
       @__parent = nil
       _building do
         @new_record = true
@@ -324,13 +327,20 @@ module Mongoid
       # @param [ Hash ] attrs The hash of attributes to instantiate with.
       # @param [ Integer ] selected_fields The selected fields from the
       #   criteria.
-      # @param [ true | false ] execute_callbacks Flag specifies whether callbacks
-      #   should be run.
+      # @param [ Hash ] options The options to use.
+      #
+      # @option options [ true | false ] :execute_callbacks Flag specifies
+      #   whether callbacks should be run.
       #
       # @return [ Document ] A new document.
       #
+      # @note A Ruby 2.x bug prevents the options hash from being keyword
+      #   arguments. Once we drop support for Ruby 2.x, we can reimplement
+      #   the options hash as keyword arguments.
+      #
       # @api private
-      def instantiate_document(attrs = nil, selected_fields = nil, execute_callbacks: Threaded.execute_callbacks?)
+      def instantiate_document(attrs = nil, selected_fields = nil, options = {})
+        execute_callbacks = options.fetch(:execute_callbacks, Threaded.execute_callbacks?)
         attributes = attrs&.to_h || {}
 
         doc = allocate
@@ -354,13 +364,21 @@ module Mongoid
       # Allocates and constructs a document.
       #
       # @param [ Hash ] attrs The attributes to set up the document with.
-      # @param [ true | false ] execute_callbacks Flag specifies whether callbacks
-      #   should be run.
+      # @param [ Hash ] options The options to use.
+      #
+      # @option options [ true | false ] :execute_callbacks Flag specifies
+      #   whether callbacks should be run.
+      #
+      # @note A Ruby 2.x bug prevents the options hash from being keyword
+      #   arguments. Once we drop support for Ruby 2.x, we can reimplement
+      #   the options hash as keyword arguments.
+      #   See https://bugs.ruby-lang.org/issues/15753
       #
       # @return [ Document ] A new document.
       #
       # @api private
-      def construct_document(attrs = nil, execute_callbacks: Threaded.execute_callbacks?)
+      def construct_document(attrs = nil, options = {})
+        execute_callbacks = options.fetch(:execute_callbacks, Threaded.execute_callbacks?)
         with_callbacks(execute_callbacks) { new(attrs) }
       end
 

--- a/lib/mongoid/factory.rb
+++ b/lib/mongoid/factory.rb
@@ -32,27 +32,34 @@ module Mongoid
       # around the bug. Once Ruby 2.x support is dropped, this hack can be
       # removed.
       # See https://bugs.ruby-lang.org/issues/15753
-      execute_build(klass, attributes, **(;{}))
+      execute_build(klass, attributes)
     end
 
     # Execute the build.
     #
     # @param [ Class ] klass The class to instantiate from if _type is not present.
     # @param [ Hash ] attributes The document attributes.
-    # @param [ true | false ] execute_callbacks Flag specifies whether callbacks
-    #   should be run.
+    # @param [ Hash ] options The options to use.
+    #
+    # @option options [ true | false ] :execute_callbacks Flag specifies
+    #   whether callbacks should be run.
+    #
+    # @note A Ruby 2.x bug prevents the options hash from being keyword
+    #   arguments. Once we drop support for Ruby 2.x, we can reimplement
+    #   the options hash as keyword arguments.
+    #   See https://bugs.ruby-lang.org/issues/15753
     #
     # @return [ Document ] The instantiated document.
     #
     # @api private
-    def execute_build(klass, attributes = nil, execute_callbacks: Threaded.execute_callbacks?)
+    def execute_build(klass, attributes = nil, options = {})
       attributes ||= {}
       dvalue = attributes[klass.discriminator_key] || attributes[klass.discriminator_key.to_sym]
       type = klass.get_discriminator_mapping(dvalue)
       if type
-        type.construct_document(attributes, execute_callbacks: execute_callbacks)
+        type.construct_document(attributes, options)
       else
-        klass.construct_document(attributes, execute_callbacks: execute_callbacks)
+        klass.construct_document(attributes, options)
       end
     end
 


### PR DESCRIPTION
There is a Ruby 2.x issue (https://bugs.ruby-lang.org/issues/15753) that makes it so that hash arguments which are immediately followed by keyword arguments, are treated as keyword arguments, and which causes runtime errors. That linked ticket also suggests a clever (and obscure) syntax trick that can be used to work around the issue on MRI, but it doesn't work on JRuby.

Thus, this PR replaces the problematic keyword arguments with options hashes, which are not as self-documenting, but which will hopefully play nicely on both Ruby 2.x and JRuby 9.2/9.3.