### PR TITLE
MONGOID-5514: Improve forking guidance

### DIFF
--- a/docs/reference/configuration.txt
+++ b/docs/reference/configuration.txt
@@ -822,7 +822,7 @@ the ``before_fork`` hook to close clients in the parent process
         client.reconnect
       end
     else
-      raise "Mongoid is not loaded. You might forget to enable app preloading."
+      raise "Mongoid is not loaded. You may have forgotten to enable app preloading."
     end
   end
 
@@ -848,7 +848,7 @@ the ``before_fork`` hook to close clients in the parent process
         client.reconnect
       end
     else
-      raise "Mongoid is not loaded. You might forget to enable app preloading."
+      raise "Mongoid is not loaded. You may have forgotten to enable app preloading."
     end
   end
 

--- a/docs/reference/configuration.txt
+++ b/docs/reference/configuration.txt
@@ -816,14 +816,18 @@ the ``before_fork`` hook to close clients in the parent process
 .. code-block:: ruby
 
   on_worker_boot do
-    Mongoid::Clients.clients.each do |name, client|
-      client.close
-      client.reconnect
+    if defined?(Mongoid)
+      Mongoid::Clients.clients.each do |name, client|
+        client.close
+        client.reconnect
+      end
     end
   end
 
   before_fork do
-    Mongoid.disconnect_clients
+    if defined?(Mongoid)
+      Mongoid.disconnect_clients
+    end
   end
 
 Unicorn
@@ -836,14 +840,18 @@ the ``before_fork`` hook to close clients in the parent process
 .. code-block:: ruby
 
   after_fork do |server, worker|
-    Mongoid::Clients.clients.each do |name, client|
-      client.close
-      client.reconnect
+    if defined?(Mongoid)
+      Mongoid::Clients.clients.each do |name, client|
+        client.close
+        client.reconnect
+      end
     end
   end
 
   before_fork do |server, worker|
-    Mongoid.disconnect_clients
+    if defined?(Mongoid)
+      Mongoid.disconnect_clients
+    end
   end
 
 Passenger
@@ -859,9 +867,11 @@ before the workers are forked.
 
   if defined?(PhusionPassenger)
     PhusionPassenger.on_event(:starting_worker_process) do |forked|
-      Mongoid::Clients.clients.each do |name, client|
-        client.close
-        client.reconnect
+      if defined?(Mongoid)
+        Mongoid::Clients.clients.each do |name, client|
+          client.close
+          client.reconnect
+        end
       end
     end
   end

--- a/docs/reference/configuration.txt
+++ b/docs/reference/configuration.txt
@@ -821,6 +821,8 @@ the ``before_fork`` hook to close clients in the parent process
         client.close
         client.reconnect
       end
+    else
+      raise "Mongoid is not loaded. You might forget to enable app preloading."
     end
   end
 
@@ -845,6 +847,8 @@ the ``before_fork`` hook to close clients in the parent process
         client.close
         client.reconnect
       end
+    else
+      raise "Mongoid is not loaded. You might forget to enable app preloading."
     end
   end
 
@@ -867,7 +871,7 @@ before the workers are forked.
 
   if defined?(PhusionPassenger)
     PhusionPassenger.on_event(:starting_worker_process) do |forked|
-      if defined?(Mongoid)
+      if forked
         Mongoid::Clients.clients.each do |name, client|
           client.close
           client.reconnect


### PR DESCRIPTION
Update forking guidance examples to test if `Mongoid` is `defined?` to ensure these examples don't fail when run in environments where Mongoid may not have been preloaded (ex: development environments)