### PR TITLE
MONGOID-5465: remove deprecation from docs regarding single-value $in

### DIFF
--- a/docs/reference/queries.txt
+++ b/docs/reference/queries.txt
@@ -685,9 +685,6 @@ as the following example demonstrates:
     class:    Band
     embedded: false>
 
-This wrapping behavior is deprecated and should not be relied on. It may be
-removed in a future release of Mongoid.
-
 
 Query Methods
 =============


### PR DESCRIPTION
The server will optimize a single-value `$in` to an `$eq` so there's no harm in leaving the functionality in Mongoid but just removing the deprecation not.