### PR TITLE
MONGOID-5560 delete_one on embeds_many is callable and is not consistent with delete

### DIFF
--- a/lib/mongoid/association/embedded/embeds_many/proxy.rb
+++ b/lib/mongoid/association/embedded/embeds_many/proxy.rb
@@ -437,6 +437,7 @@ module Mongoid
           #
           # @return [ Criteria | Object ] A Criteria or return value from the target.
           ruby2_keywords def method_missing(name, *args, &block)
+            enforce_forwarding_list!(name)
             return super if _target.respond_to?(name)
             klass.send(:with_scope, criteria) do
               criteria.public_send(name, *args, &block)

--- a/lib/mongoid/association/many.rb
+++ b/lib/mongoid/association/many.rb
@@ -10,6 +10,10 @@ module Mongoid
       extend Forwardable
       include ::Enumerable
 
+      # `delete_one` is added to Array by Mongoid, but does not make sense
+      # for associations.
+      forbid_forwarding :delete_one
+
       def_delegators :criteria, :avg, :max, :min, :sum
       def_delegators :_target, :length, :size, :any?
 
@@ -134,9 +138,9 @@ module Mongoid
       # @param [ true | false ] include_private Whether to include private methods.
       #
       # @return [ true | false ] If the proxy responds to the method.
-      def respond_to?(name, include_private = false)
-        [].respond_to?(name, include_private) ||
-          klass.respond_to?(name, include_private) || super
+      def respond_to_missing?(name, include_private = false)
+        return false unless self.__class__.allow_forward?(name)
+        klass.respond_to?(name, include_private) || super
       end
 
       # This is public access to the association's criteria.

--- a/lib/mongoid/association/one.rb
+++ b/lib/mongoid/association/one.rb
@@ -28,18 +28,6 @@ module Mongoid
         [ _target ]
       end
 
-      # Since method_missing is overridden we should override this as well.
-      #
-      # @example Does the proxy respond to the method?
-      #   relation.respond_to?(:name)
-      #
-      # @param [ Symbol ] name The method name.
-      #
-      # @return [ true | false ] If the proxy responds to the method.
-      def respond_to?(name, include_private = false)
-        _target.respond_to?(name, include_private) || super
-      end
-
       # Evolve the proxy document into an object id.
       #
       # @example Evolve the proxy document.

--- a/lib/mongoid/association/proxy.rb
+++ b/lib/mongoid/association/proxy.rb
@@ -12,11 +12,27 @@ module Mongoid
       extend Forwardable
 
       class <<self
+        # Adds the given methods to an internal "do not forward" list. Any
+        # attempt to forward one of these methods (via `method_missing`) will
+        # fail with a `NoMethodError`.
+        #
+        # @param [ Array<String | Symbol> ] method_names the method names to
+        #   forbid
+        #
+        # @api private
         def forbid_forwarding(*method_names)
           @do_not_forward ||= []
           @do_not_forward.concat(method_names.map(&:to_sym))
         end
 
+        # Queries whether the given method name can be forwarded (via
+        # method_missing) or not.
+        #
+        # @param [ String | Symbol ] method_name the name of the method to
+        #   query
+        #
+        # @return [ true | false ] if the method can be forwarded or not.
+        # @api private
         def allow_forward?(method_name)
           return false if (@do_not_forward || []).include?(method_name.to_sym)
           return superclass.allow_forward?(method_name) if superclass.respond_to?(:allow_forward?)

--- a/lib/mongoid/association/referenced/has_many/proxy.rb
+++ b/lib/mongoid/association/referenced/has_many/proxy.rb
@@ -421,6 +421,8 @@ module Mongoid
           #
           # @return [ Criteria | Object ] A Criteria or return value from the target.
           ruby2_keywords def method_missing(name, *args, &block)
+            enforce_forwarding_list!(name)
+
             if _target.respond_to?(name)
               _target.send(name, *args, &block)
             else

--- a/lib/mongoid/threaded.rb
+++ b/lib/mongoid/threaded.rb
@@ -34,10 +34,6 @@ module Mongoid
     # executed on documents.
     EXECUTE_CALLBACKS = '[mongoid]:execute-callbacks'
 
-    # The key storing the default value for whether or not callbacks are
-    # executed on documents.
-    EXECUTE_CALLBACKS = '[mongoid]:execute-callbacks'
-
     extend self
 
     # Begin entry into a named thread local stack.

--- a/spec/mongoid/association/embedded/embeds_many/proxy_spec.rb
+++ b/spec/mongoid/association/embedded/embeds_many/proxy_spec.rb
@@ -3121,22 +3121,14 @@ describe Mongoid::Association::Embedded::EmbedsMany::Proxy do
       person.addresses
     end
 
-    Array.public_instance_methods.each do |method|
+    [ Array, described_class ].each do |klass|
+      klass.public_instance_methods.each do |method|
+        context "when checking #{klass}##{method}" do
+          allowed = described_class.allow_forward?(method)
 
-      context "when checking #{method}" do
-
-        it "returns true" do
-          expect(addresses.respond_to?(method)).to be true
-        end
-      end
-    end
-
-    Mongoid::Association::Embedded::EmbedsMany::Proxy.public_instance_methods.each do |method|
-
-      context "when checking #{method}" do
-
-        it "returns true" do
-          expect(addresses.respond_to?(method)).to be true
+          it "returns #{allowed}" do
+            expect(addresses.respond_to?(method)).to be allowed
+          end
         end
       end
     end

--- a/spec/mongoid/association/referenced/has_and_belongs_to_many/proxy_spec.rb
+++ b/spec/mongoid/association/referenced/has_and_belongs_to_many/proxy_spec.rb
@@ -3008,15 +3008,11 @@ describe Mongoid::Association::Referenced::HasAndBelongsToMany::Proxy do
     end
 
     Array.public_instance_methods.sort.each do |method|
-
       context "when checking Array##{method}" do
+        allowed = described_class.allow_forward?(method)
 
-        before do
-          expect([].respond_to?(method)).to be true
-        end
-
-        it "returns true" do
-          expect(preferences.respond_to?(method)).to be true
+        it "returns #{allowed}" do
+          expect(preferences.respond_to?(method)).to be allowed
         end
       end
     end

--- a/spec/mongoid/association/referenced/has_many/proxy_spec.rb
+++ b/spec/mongoid/association/referenced/has_many/proxy_spec.rb
@@ -2699,18 +2699,14 @@ describe Mongoid::Association::Referenced::HasMany::Proxy do
     let(:person) { Person.new }
     let(:posts) { person.posts }
 
-    Array.public_instance_methods.each do |method|
-      context "when checking #{method}" do
-        it 'returns true' do
-          expect(posts.respond_to?(method)).to be true
-        end
-      end
-    end
+    [ Array, described_class ].each do |klass|
+      klass.public_instance_methods.each do |method|
+        context "when checking #{klass}##{method}" do
+          allowed = described_class.allow_forward?(method)
 
-    described_class.public_instance_methods.each do |method|
-      context "when checking #{method}" do
-        it 'returns true' do
-          expect(posts.respond_to?(method)).to be true
+          it "returns #{allowed}" do
+            expect(posts.respond_to?(method)).to be allowed
+          end
         end
       end
     end


### PR DESCRIPTION
This PR updates the method delegation for the `has_many`, `has_and_belongs_to_many`, and `embeds_many` proxies to prevent them from responding to the `delete_one` method.

Mongoid defines an Array extension method, `delete_one`, which is intended to remove only the first matching element. (Contrast this with `Array#delete`, which removes all matching elements, and the proxy `#delete` methods, which remove the given element _and persist the change_.) The problem is that this method is exposed on the association proxies via method delegation, and has been confusing to users. The method only removes the element from the in-memory collection; it does not persist changes to the database, and in virtually every case the caller _probably_ intends to call `delete` instead of `delete_one`.

I believe it is safe to remove access to this method without putting the change behind a feature flag. The `delete_one` 
method was never explicitly intended to be exposed on the proxies, but most importantly, it's not part of the public API. Anyone who has been using `delete_one` via an association proxy has been relying on a private API.