### PR TITLE
MONGOID-5620 backport MONGOID-5560 to 8.1-stable

### DIFF
--- a/lib/mongoid/association/embedded/embeds_many/proxy.rb
+++ b/lib/mongoid/association/embedded/embeds_many/proxy.rb
@@ -154,6 +154,23 @@ module Mongoid
             end
           end
 
+          # Mongoid::Extensions::Array defines Array#delete_one, so we need
+          # to make sure that method behaves reasonably on proxies, too.
+          alias delete_one delete
+
+          # Removes a single document from the collection *in memory only*.
+          # It will *not* persist the change.
+          #
+          # @param [ Document ] document The document to delete.
+          #
+          # @api private
+          def _remove(document)
+            _target.delete_one(document)
+            _unscoped.delete_one(document)
+            update_attributes_hash
+            reindex
+          end
+
           # Delete all the documents in the association without running callbacks.
           #
           # @example Delete all documents from the association.
@@ -395,21 +412,6 @@ module Mongoid
           # @return [ Criteria ] A new criteria.
           def criteria
             _association.criteria(_base, _target)
-          end
-
-          # Deletes one document from the target and unscoped.
-          #
-          # @api private
-          #
-          # @example Delete one document.
-          #   relation.delete_one(doc)
-          #
-          # @param [ Document ] document The document to delete.
-          def delete_one(document)
-            _target.delete_one(document)
-            _unscoped.delete_one(document)
-            update_attributes_hash
-            reindex
           end
 
           # Integrate the document into the association. will set its metadata and

--- a/lib/mongoid/association/referenced/has_and_belongs_to_many/proxy.rb
+++ b/lib/mongoid/association/referenced/has_and_belongs_to_many/proxy.rb
@@ -137,6 +137,10 @@ module Mongoid
             doc
           end
 
+          # Mongoid::Extensions::Array defines Array#delete_one, so we need
+          # to make sure that method behaves reasonably on proxies, too.
+          alias delete_one delete
+
           # Removes all associations between the base document and the target
           # documents by deleting the foreign keys and the references, orphaning
           # the target documents in the process.

--- a/lib/mongoid/association/referenced/has_many/proxy.rb
+++ b/lib/mongoid/association/referenced/has_many/proxy.rb
@@ -105,6 +105,10 @@ module Mongoid
             end
           end
 
+          # Mongoid::Extensions::Array defines Array#delete_one, so we need
+          # to make sure that method behaves reasonably on proxies, too.
+          alias delete_one delete
+
           # Deletes all related documents from the database given the supplied
           # conditions.
           #

--- a/lib/mongoid/threaded.rb
+++ b/lib/mongoid/threaded.rb
@@ -28,7 +28,7 @@ module Mongoid
 
     # The key storing the default value for whether or not callbacks are
     # executed on documents.
-    EXECUTE_CALLBACKS = "[mongoid]:execute-callbacks"
+    EXECUTE_CALLBACKS = '[mongoid]:execute-callbacks'
 
     extend self
 

--- a/lib/mongoid/traversable.rb
+++ b/lib/mongoid/traversable.rb
@@ -237,7 +237,7 @@ module Mongoid
         remove_ivar(name)
       else
         relation = send(name)
-        relation.send(:delete_one, child)
+        relation._remove(child)
       end
     end
 

--- a/spec/mongoid/association/embedded/embeds_many/proxy_spec.rb
+++ b/spec/mongoid/association/embedded/embeds_many/proxy_spec.rb
@@ -1862,51 +1862,56 @@ describe Mongoid::Association::Embedded::EmbedsMany::Proxy do
     end
   end
 
-  describe "#delete" do
+  %i[ delete delete_one ].each do |method|
+    describe "\##{method}" do
+      let(:address_one) { Address.new(street: "first") }
+      let(:address_two) { Address.new(street: "second") }
 
-    let(:person) do
-      Person.new
-    end
-
-    let(:address_one) do
-      Address.new(street: "first")
-    end
-
-    let(:address_two) do
-      Address.new(street: "second")
-    end
-
-    before do
-      person.addresses << [ address_one, address_two ]
-    end
-
-    context "when the document exists in the relation" do
-
-      let!(:deleted) do
-        person.addresses.delete(address_one)
+      before do
+        person.addresses << [ address_one, address_two ]
       end
 
-      it "deletes the document" do
-        expect(person.addresses).to eq([ address_two ])
+      shared_examples_for 'deleting from the collection' do
+        context 'when the document exists in the relation' do
+          let!(:deleted) do
+            person.addresses.send(method, address_one)
+          end
+
+          it 'deletes the document' do
+            expect(person.addresses).to eq([ address_two ])
+            expect(person.reload.addresses).to eq([ address_two ]) if person.persisted?
+          end
+
+          it 'deletes the document from the unscoped' do
+            expect(person.addresses.send(:_unscoped)).to eq([ address_two ])
+          end
+
+          it 'reindexes the relation' do
+            expect(address_two._index).to eq(0)
+          end
+
+          it 'returns the document' do
+            expect(deleted).to eq(address_one)
+          end
+        end
+
+        context 'when the document does not exist' do
+          it 'returns nil' do
+            expect(person.addresses.send(method, Address.new)).to be_nil
+          end
+        end
       end
 
-      it "deletes the document from the unscoped" do
-        expect(person.addresses.send(:_unscoped)).to eq([ address_two ])
+      context 'when the root document is unpersisted' do
+        let(:person) { Person.new }
+
+        it_behaves_like 'deleting from the collection'
       end
 
-      it "reindexes the relation" do
-        expect(address_two._index).to eq(0)
-      end
+      context 'when the root document is persisted' do
+        let(:person) { Person.create }
 
-      it "returns the document" do
-        expect(deleted).to eq(address_one)
-      end
-    end
-
-    context "when the document does not exist" do
-
-      it "returns nil" do
-        expect(person.addresses.delete(Address.new)).to be_nil
+        it_behaves_like 'deleting from the collection'
       end
     end
   end

--- a/spec/mongoid/association/referenced/has_and_belongs_to_many/proxy_spec.rb
+++ b/spec/mongoid/association/referenced/has_and_belongs_to_many/proxy_spec.rb
@@ -2085,283 +2085,229 @@ describe Mongoid::Association::Referenced::HasAndBelongsToMany::Proxy do
     end
   end
 
-  describe "#delete" do
+  %i[ delete delete_one ].each do |method|
+    describe "\##{method}" do
+      let(:person) { Person.create! }
+      let(:preference_one) { Preference.create!(name: "Testing") }
+      let(:preference_two) { Preference.create!(name: "Test") }
 
-    let(:person) do
-      Person.create!
-    end
-
-    let(:preference_one) do
-      Preference.create!(name: "Testing")
-    end
-
-    let(:preference_two) do
-      Preference.create!(name: "Test")
-    end
-
-    before do
-      person.preferences << [ preference_one, preference_two ]
-    end
-
-    context "when the document exists" do
-
-      let!(:deleted) do
-        person.preferences.delete(preference_one)
+      before do
+        person.preferences << [ preference_one, preference_two ]
       end
 
-      it "removes the document from the relation" do
-        expect(person.preferences).to eq([ preference_two ])
-      end
-
-      it "returns the document" do
-        expect(deleted).to eq(preference_one)
-      end
-
-      it "removes the document key from the foreign key" do
-        expect(person.preference_ids).to eq([ preference_two.id ])
-      end
-
-      it "removes the inverse reference" do
-        expect(deleted.reload.people).to be_empty
-      end
-
-      it "removes the base id from the inverse keys" do
-        expect(deleted.reload.person_ids).to be_empty
-      end
-
-      context "and person and preferences are reloaded" do
-
-        before do
-          person.reload
-          preference_one.reload
-          preference_two.reload
+      context 'when the document exists' do
+        let!(:deleted) do
+          person.preferences.send(method, preference_one)
         end
 
-        it "nullifies the deleted preference" do
+        it 'removes the document from the relation' do
           expect(person.preferences).to eq([ preference_two ])
         end
 
-        it "retains the ids for one preference" do
+        it 'returns the document' do
+          expect(deleted).to eq(preference_one)
+        end
+
+        it 'removes the document key from the foreign key' do
           expect(person.preference_ids).to eq([ preference_two.id ])
         end
-      end
-    end
 
-    context "when the document does not exist" do
-
-      let!(:deleted) do
-        person.preferences.delete(Preference.new)
-      end
-
-      it "returns nil" do
-        expect(deleted).to be_nil
-      end
-
-      it "does not modify the relation" do
-        expect(person.preferences).to eq([ preference_one, preference_two ])
-      end
-
-      it "does not modify the keys" do
-        expect(person.preference_ids).to eq([ preference_one.id, preference_two.id ])
-      end
-    end
-
-    context "when :dependent => :nullify is set" do
-
-      context "when :inverse_of is set" do
-
-        let(:event) do
-          Event.create!
+        it 'removes the inverse reference' do
+          expect(deleted.reload.people).to be_empty
         end
+
+        it 'removes the base id from the inverse keys' do
+          expect(deleted.reload.person_ids).to be_empty
+        end
+
+        context 'and person and preferences are reloaded' do
+          before do
+            person.reload
+            preference_one.reload
+            preference_two.reload
+          end
+
+          it 'nullifies the deleted preference' do
+            expect(person.preferences).to eq([ preference_two ])
+          end
+
+          it 'retains the ids for one preference' do
+            expect(person.preference_ids).to eq([ preference_two.id ])
+          end
+        end
+      end
+
+      context 'when the document does not exist' do
+        let!(:deleted) do
+          person.preferences.send(method, Preference.new)
+        end
+
+        it 'returns nil' do
+          expect(deleted).to be_nil
+        end
+
+        it 'does not modify the relation' do
+          expect(person.preferences).to eq([ preference_one, preference_two ])
+        end
+
+        it 'does not modify the keys' do
+          expect(person.preference_ids).to eq([ preference_one.id, preference_two.id ])
+        end
+      end
+
+      context 'when :dependent => :nullify is set' do
+        context 'when :inverse_of is set' do
+          let(:event) { Event.create! }
+
+          before do
+            person.administrated_events << [ event ]
+          end
+
+          it 'deletes the document' do
+            expect(event.delete).to be true
+          end
+        end
+      end
+
+      context 'when the relationships are self referencing' do
+        let(:tag_one) { Tag.create!(text: "one") }
+        let(:tag_two) { Tag.create!(text: "two") }
 
         before do
-          person.administrated_events << [ event ]
+          tag_one.related << tag_two
         end
 
-        it "deletes the document" do
-          expect(event.delete).to be true
-        end
-      end
-    end
+        context 'when deleting without reloading' do
+          let!(:deleted) { tag_one.related.send(method, tag_two) }
 
-    context "when the relationships are self referencing" do
-
-      let(:tag_one) do
-        Tag.create!(text: "one")
-      end
-
-      let(:tag_two) do
-        Tag.create!(text: "two")
-      end
-
-      before do
-        tag_one.related << tag_two
-      end
-
-      context "when deleting without reloading" do
-
-        let!(:deleted) do
-          tag_one.related.delete(tag_two)
-        end
-
-        it "deletes the document from the relation" do
-          expect(tag_one.related).to be_empty
-        end
-
-        it "deletes the foreign key from the relation" do
-          expect(tag_one.related_ids).to be_empty
-        end
-
-        it "removes the reference from the inverse" do
-          expect(deleted.related).to be_empty
-        end
-
-        it "removes the foreign keys from the inverse" do
-          expect(deleted.related_ids).to be_empty
-        end
-      end
-
-      context "when deleting with reloading" do
-
-        context "when deleting from the front side" do
-
-          let(:reloaded) do
-            tag_one.reload
+          it 'deletes the document from the relation' do
+            expect(tag_one.related).to be_empty
           end
 
-          let!(:deleted) do
-            reloaded.related.delete(tag_two)
+          it 'deletes the foreign key from the relation' do
+            expect(tag_one.related_ids).to be_empty
           end
 
-          it "deletes the document from the relation" do
-            expect(reloaded.related).to be_empty
-          end
-
-          it "deletes the foreign key from the relation" do
-            expect(reloaded.related_ids).to be_empty
-          end
-
-          it "removes the reference from the inverse" do
+          it 'removes the reference from the inverse' do
             expect(deleted.related).to be_empty
           end
 
-          it "removes the foreign keys from the inverse" do
+          it 'removes the foreign keys from the inverse' do
             expect(deleted.related_ids).to be_empty
           end
         end
 
-        context "when deleting from the inverse side" do
+        context 'when deleting with reloading' do
+          context "when deleting from the front side" do
+            let(:reloaded) { tag_one.reload }
+            let!(:deleted) { reloaded.related.send(method, tag_two) }
 
-          let(:reloaded) do
-            tag_two.reload
+            it 'deletes the document from the relation' do
+              expect(reloaded.related).to be_empty
+            end
+
+            it 'deletes the foreign key from the relation' do
+              expect(reloaded.related_ids).to be_empty
+            end
+
+            it 'removes the reference from the inverse' do
+              expect(deleted.related).to be_empty
+            end
+
+            it 'removes the foreign keys from the inverse' do
+              expect(deleted.related_ids).to be_empty
+            end
           end
 
-          let!(:deleted) do
-            reloaded.related.delete(tag_one)
-          end
+          context 'when deleting from the inverse side' do
+            let(:reloaded) { tag_two.reload }
+            let!(:deleted) { reloaded.related.send(method, tag_one) }
 
-          it "deletes the document from the relation" do
-            expect(reloaded.related).to be_empty
-          end
+            it 'deletes the document from the relation' do
+              expect(reloaded.related).to be_empty
+            end
 
-          it "deletes the foreign key from the relation" do
-            expect(reloaded.related_ids).to be_empty
-          end
+            it 'deletes the foreign key from the relation' do
+              expect(reloaded.related_ids).to be_empty
+            end
 
-          it "removes the foreign keys from the inverse" do
-            expect(deleted.related_ids).to be_empty
-          end
-        end
-      end
-    end
-
-    context "when the association has callbacks" do
-
-      let(:post) do
-        Post.new
-      end
-
-      let(:tag) do
-        Tag.new
-      end
-
-      before do
-        post.tags << tag
-      end
-
-      context "when the callback is a before_remove" do
-
-        context "when there are no errors" do
-
-          before do
-            post.tags.delete tag
-          end
-
-          it "executes the callback" do
-            expect(post.before_remove_called).to be true
-          end
-
-          it "removes the document from the relation" do
-            expect(post.tags).to be_empty
-          end
-        end
-
-        context "when errors are raised" do
-
-          before do
-            expect(post).to receive(:before_remove_tag).and_raise
-            begin; post.tags.delete(tag); rescue; end
-          end
-
-          it "does not remove the document from the relation" do
-            expect(post.tags).to eq([ tag ])
+            it 'removes the foreign keys from the inverse' do
+              expect(deleted.related_ids).to be_empty
+            end
           end
         end
       end
 
-      context "when the callback is an after_remove" do
+      context 'when the association has callbacks' do
+        let(:post) { Post.new }
+        let(:tag) { Tag.new }
 
-        context "when no errors are raised" do
+        before do
+          post.tags << tag
+        end
 
-          before do
-            post.tags.delete(tag)
+        context 'when the callback is a before_remove' do
+          context 'when there are no errors' do
+            before do
+              post.tags.send(method, tag)
+            end
+
+            it 'executes the callback' do
+              expect(post.before_remove_called).to be true
+            end
+
+            it 'removes the document from the relation' do
+              expect(post.tags).to be_empty
+            end
           end
 
-          it "executes the callback" do
-            expect(post.after_remove_called).to be true
-          end
+          context "when errors are raised" do
+            before do
+              expect(post).to receive(:before_remove_tag).and_raise
+              begin; post.tags.send(method, tag); rescue; end
+            end
 
-          it "removes the document from the relation" do
-            expect(post.tags).to be_empty
+            it 'does not remove the document from the relation' do
+              expect(post.tags).to eq([ tag ])
+            end
           end
         end
 
-        context "when errors are raised" do
+        context 'when the callback is an after_remove' do
+          context 'when no errors are raised' do
+            before do
+              post.tags.send(method, tag)
+            end
 
-          before do
-            expect(post).to receive(:after_remove_tag).and_raise
-            begin; post.tags.delete(tag); rescue; end
+            it 'executes the callback' do
+              expect(post.after_remove_called).to be true
+            end
+
+            it 'removes the document from the relation' do
+              expect(post.tags).to be_empty
+            end
           end
 
-          it "removes the document from the relation" do
-            expect(post.tags).to be_empty
+          context 'when errors are raised' do
+            before do
+              expect(post).to receive(:after_remove_tag).and_raise
+              begin; post.tags.send(method, tag); rescue; end
+            end
+
+            it 'removes the document from the relation' do
+              expect(post.tags).to be_empty
+            end
           end
         end
       end
     end
   end
 
-  [ :delete_all, :destroy_all ].each do |method|
-
-    describe "##{method}" do
-
-      context "when the relation is not polymorphic" do
-
-        context "when conditions are provided" do
-
-          let(:person) do
-            Person.create!
-          end
+  %i[ delete_all destroy_all ].each do |method|
+    describe "\##{method}" do
+      context 'when the relation is not polymorphic' do
+        context 'when conditions are provided' do
+          let(:person) { Person.create! }
 
           let!(:preference_one) do
             person.preferences.create!(name: "Testing")

--- a/spec/mongoid/attributes_spec.rb
+++ b/spec/mongoid/attributes_spec.rb
@@ -2496,7 +2496,7 @@ describe Mongoid::Attributes do
         end
       end
 
-      context "when doing delete_one" do
+      context "when doing _remove" do
         let(:doc) { NestedBook.create! }
         let(:page) { NestedPage.new }
         before do
@@ -2504,7 +2504,7 @@ describe Mongoid::Attributes do
           doc.pages << NestedPage.new
           doc.pages << NestedPage.new
 
-          doc.pages.send(:delete_one, page)
+          doc.pages._remove(page)
         end
 
         it "updates the attributes" do


### PR DESCRIPTION
This backports the changes to `delete_one` in MONGOID-5560 to the 8.1-stable branch.