### PR TITLE
MONGOID-5489 note explicit default values for legacy_readonly

### DIFF
--- a/docs/release-notes/mongoid-8.1.txt
+++ b/docs/release-notes/mongoid-8.1.txt
@@ -260,7 +260,7 @@ Added ``readonly!`` method and ``legacy_readonly`` feature flag
 ---------------------------------------------------------------
 
 Mongoid 8.1 changes the meaning of read-only documents. In Mongoid 8.1 with
-this feature flag turned off, a document becomes read-only when calling the
+this feature flag turned off (``false``), a document becomes read-only when calling the
 ``readonly!`` method:
 
 .. code:: ruby
@@ -276,7 +276,7 @@ With this feature flag turned off, a ``ReadonlyDocument`` error will be
 raised when destroying or deleting, as well as when saving or updating.
 
 Prior to Mongoid 8.1 and in 8.1 with the ``legacy_readonly`` feature flag
-turned on, documents become read-only when they are projected (i.e. using
+turned on (``true``), documents become read-only when they are projected (i.e. using
 ``#only`` or ``#without``).
 
 .. code:: ruby


### PR DESCRIPTION
The release notes for 8.1 say only that the feature should be `on` or `off`, which can be assumed to mean `true` or `false`, but we should be more explicit about that.

(Note: this needs to be backported to 8.1-stable.)