### PR TITLE
MONGOID-5489 backport to 8.1

### DIFF
--- a/docs/release-notes/mongoid-8.1.txt
+++ b/docs/release-notes/mongoid-8.1.txt
@@ -261,7 +261,7 @@ Added ``readonly!`` method and ``legacy_readonly`` feature flag
 ---------------------------------------------------------------
 
 Mongoid 8.1 changes the meaning of read-only documents. In Mongoid 8.1 with
-this feature flag turned off, a document becomes read-only when calling the
+this feature flag turned off (``false``), a document becomes read-only when calling the
 ``readonly!`` method:
 
 .. code:: ruby
@@ -277,7 +277,7 @@ With this feature flag turned off, a ``ReadonlyDocument`` error will be
 raised when destroying or deleting, as well as when saving or updating.
 
 Prior to Mongoid 8.1 and in 8.1 with the ``legacy_readonly`` feature flag
-turned on, documents become read-only when they are projected (i.e. using
+turned on (``true``), documents become read-only when they are projected (i.e. using
 ``#only`` or ``#without``).
 
 .. code:: ruby


### PR DESCRIPTION
This backports the wording change in the 8.1 release notes, relative to true/false values on the `legacy_readonly` setting.