### PR TITLE
Backport MONGOID-5352 to `7.5-stable`

### DIFF
--- a/lib/mongoid/atomic/paths/embedded/many.rb
+++ b/lib/mongoid/atomic/paths/embedded/many.rb
@@ -34,6 +34,25 @@ module Mongoid
             locator = document.new_record? ? "" : ".#{document._index}"
             "#{pos}#{"." unless pos.blank?}#{document._association.store_as}#{locator}"
           end
+
+          class << self
+
+            # Get the position of where the document would go for the given
+            # association. The use case for this function is when trying to
+            # persist an empty list for an embedded association. All of the
+            # existing functions for getting the position to store a document
+            # require passing in a document to store, which we don't have when
+            # trying to store the empty list.
+            #
+            # @param [ Document ] parent The parent document to store in.
+            # @param [ Association ] association The association.
+            #
+            # @return [ String ] The position string.
+            def position_without_document(parent, association)
+              pos = parent.atomic_position
+              "#{pos}#{"." unless pos.blank?}#{association.store_as}"
+            end
+          end
         end
       end
     end

--- a/spec/mongoid/association/embedded/embeds_many/proxy_spec.rb
+++ b/spec/mongoid/association/embedded/embeds_many/proxy_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+require_relative '../embeds_many_models.rb'
 
 describe Mongoid::Association::Embedded::EmbedsMany::Proxy do
 
@@ -4647,6 +4648,26 @@ describe Mongoid::Association::Embedded::EmbedsMany::Proxy do
           expect(zone.soa.delete).to be true
         end
       end
+    end
+  end
+
+  context "when using assign_attributes with an already populated array" do
+    let(:post) { EmmPost.create! }
+
+    before do
+      post.assign_attributes(company_tags: [{id: BSON::ObjectId.new, title: 'a'}],
+        user_tags: [{id: BSON::ObjectId.new, title: 'b'}])
+      post.save!
+      post.reload
+      post.assign_attributes(company_tags: [{id: BSON::ObjectId.new, title: 'c'}],
+        user_tags: [])
+      post.save!
+      post.reload
+    end
+
+    it "has the correct embedded documents" do
+      expect(post.company_tags.length).to eq(1)
+      expect(post.company_tags.first.title).to eq("c")
     end
   end
 end

--- a/spec/mongoid/association/embedded/embeds_many_models.rb
+++ b/spec/mongoid/association/embedded/embeds_many_models.rb
@@ -67,3 +67,124 @@ class EmmOuter
 
   field :level, :type => Integer
 end
+
+class EmmCustomerAddress
+  include Mongoid::Document
+
+  embedded_in :addressable, polymorphic: true, inverse_of: :work_address
+end
+
+class EmmFriend
+  include Mongoid::Document
+
+  embedded_in :befriendable, polymorphic: true
+end
+
+class EmmCustomer
+  include Mongoid::Document
+
+  embeds_one :home_address, class_name: 'EmmCustomerAddress', as: :addressable
+  embeds_one :work_address, class_name: 'EmmCustomerAddress', as: :addressable
+
+  embeds_many :close_friends, class_name: 'EmmFriend', as: :befriendable
+  embeds_many :acquaintances, class_name: 'EmmFriend', as: :befriendable
+end
+
+class EmmUser
+  include Mongoid::Document
+  include Mongoid::Timestamps
+
+  embeds_many :orders, class_name: 'EmmOrder'
+end
+
+class EmmOrder
+  include Mongoid::Document
+
+  field :amount, type: Integer
+
+  embedded_in :user, class_name: 'EmmUser'
+end
+
+module EmmSpec
+  # There is also a top-level Car class defined.
+  class Car
+    include Mongoid::Document
+
+    embeds_many :doors
+  end
+
+  class Door
+    include Mongoid::Document
+
+    embedded_in :car
+  end
+
+  class Tank
+    include Mongoid::Document
+
+    embeds_many :guns
+    embeds_many :emm_turrets
+    # This association references a model that is not in our module,
+    # and it does not define class_name hence Mongoid will not be able to
+    # figure out the inverse for this association.
+    embeds_many :emm_hatches
+
+    # class_name is intentionally unqualified, references a class in the
+    # same module. Rails permits class_name to be unqualified like this.
+    embeds_many :launchers, class_name: 'Launcher'
+  end
+
+  class Gun
+    include Mongoid::Document
+
+    embedded_in :tank
+  end
+
+  class Launcher
+    include Mongoid::Document
+
+    # class_name is intentionally unqualified.
+    embedded_in :tank, class_name: 'Tank'
+  end
+end
+
+# This is intentionally on top level.
+class EmmTurret
+  include Mongoid::Document
+
+  embedded_in :tank, class_name: 'EmmSpec::Tank'
+end
+
+# This is intentionally on top level.
+class EmmHatch
+  include Mongoid::Document
+
+  # No :class_name option on this association intentionally.
+  embedded_in :tank
+end
+
+class EmmPost
+  include Mongoid::Document
+
+  embeds_many :company_tags, class_name: "EmmCompanyTag"
+  embeds_many :user_tags, class_name: "EmmUserTag"
+end
+
+
+class EmmCompanyTag
+  include Mongoid::Document
+
+  field :title, type: String
+
+  embedded_in :post, class_name: "EmmPost"
+end
+
+
+class EmmUserTag
+  include Mongoid::Document
+
+  field :title, type: String
+
+  embedded_in :post, class_name: "EmmPost"
+end
+


### PR DESCRIPTION
https://github.com/mongodb/mongoid/pull/5274#discussion_r1239052891 was backported to 7.3 and 7.4, but not 7.5