### PR TITLE
MONGOID-5642 Queryable::Selector#merge! does not properly handle :$in/:$nin keys

### DIFF
--- a/lib/mongoid/criteria/queryable/selector.rb
+++ b/lib/mongoid/criteria/queryable/selector.rb
@@ -21,10 +21,10 @@ module Mongoid
           other.each_pair do |key, value|
             if value.is_a?(Hash) && self[key.to_s].is_a?(Hash)
               value = self[key.to_s].merge(value) do |_key, old_val, new_val|
-                case _key
-                when  /\$in/
+                case _key.to_s
+                when  '$in'
                   new_val & old_val
-                when  /\$nin/
+                when  '$nin'
                   (old_val + new_val).uniq
                 else
                   new_val

--- a/lib/mongoid/criteria/queryable/selector.rb
+++ b/lib/mongoid/criteria/queryable/selector.rb
@@ -22,9 +22,9 @@ module Mongoid
             if value.is_a?(Hash) && self[key.to_s].is_a?(Hash)
               value = self[key.to_s].merge(value) do |_key, old_val, new_val|
                 case _key
-                when '$in'
+                when  /\$in/
                   new_val & old_val
-                when '$nin'
+                when  /\$nin/
                   (old_val + new_val).uniq
                 else
                   new_val

--- a/lib/mongoid/criteria/queryable/selector.rb
+++ b/lib/mongoid/criteria/queryable/selector.rb
@@ -22,9 +22,9 @@ module Mongoid
             if value.is_a?(Hash) && self[key.to_s].is_a?(Hash)
               value = self[key.to_s].merge(value) do |_key, old_val, new_val|
                 case _key.to_s
-                when  '$in'
+                when '$in'
                   new_val & old_val
-                when  '$nin'
+                when '$nin'
                   (old_val + new_val).uniq
                 else
                   new_val

--- a/spec/mongoid/criteria/queryable/selector_spec.rb
+++ b/spec/mongoid/criteria/queryable/selector_spec.rb
@@ -45,7 +45,7 @@ describe Mongoid::Criteria::Queryable::Selector do
       end
     end
 
-    context "when selector contains a $nin" do
+    context "when selector contains a $nin string" do
 
       let(:initial) do
         { "$nin" => ["foo"] }
@@ -73,7 +73,35 @@ describe Mongoid::Criteria::Queryable::Selector do
       end
     end
 
-    context "when selector contains a $in" do
+    context "when selector contains a $nin symbol" do
+
+      let(:initial) do
+        { :$nin => ["foo"] }
+      end
+
+      before do
+        selector["field"] = initial
+      end
+
+      context "when merging in a new $nin" do
+
+        let(:other) do
+          { "field" => { :$nin => ["bar"] } }
+        end
+
+        before do
+          selector.merge!(other)
+        end
+
+        it "combines the two $nin queries into one" do
+          expect(selector).to eq({
+            "field" => { :$nin => ["foo", "bar"] }
+          })
+        end
+      end
+    end
+
+    context "when selector contains a $in string" do
 
       let(:initial) do
         { "$in" => [1, 2] }
@@ -113,6 +141,51 @@ describe Mongoid::Criteria::Queryable::Selector do
         it "intersects the $in values" do
           expect(selector).to eq({
                                      "field" => { "$in" => [] }
+                                 })
+        end
+      end
+    end
+
+    context "when selector contains a $in symbol" do
+
+      let(:initial) do
+        { :$in => [1, 2] }
+      end
+
+      before do
+        selector["field"] = initial
+      end
+
+      context "when merging in a new $in with an intersecting value" do
+
+        let(:other) do
+          { "field" => { :$in => [1] } }
+        end
+
+        before do
+          selector.merge!(other)
+        end
+
+        it "intersects the $in values" do
+          expect(selector).to eq({
+                                     "field" => { :$in => [1] }
+                                 })
+        end
+      end
+
+      context "when merging in a new $in with no intersecting values" do
+
+        let(:other) do
+          { "field" => { :$in => [3] } }
+        end
+
+        before do
+          selector.merge!(other)
+        end
+
+        it "intersects the $in values" do
+          expect(selector).to eq({
+                                     "field" => { :$in => [] }
                                  })
         end
       end


### PR DESCRIPTION
…ge $in and $nin when provided as a symbol as well as a string.

Issue was introduced with [PR-4645](https://github.com/mongodb/mongoid/pull/4645)
Behaviour before allowed $in and $nin to be provided as symbols or strings and would match correctly.
After [PR-4645](https://github.com/mongodb/mongoid/pull/4645) only $in or $nin strings would be merged.

This was breaking behaviour for our application during our upgrade from Mongoid 6.4 to 7.0 and is not mentioned anywhere as breaking in changelogs.

I have updated tests and new tests are passing with this change.