### PR TITLE
MONGOID-5622 Reset the atomic operation state on reload (backport of #5656 to 8.1-stable)

### DIFF
--- a/lib/mongoid/atomic.rb
+++ b/lib/mongoid/atomic.rb
@@ -311,6 +311,13 @@ module Mongoid
 
     private
 
+    # Clears all pending atomic updates.
+    def reset_atomic_updates!
+      Atomic::UPDATES.each do |update|
+        send(update).clear
+      end
+    end
+
     # Generates the atomic updates in the correct order.
     #
     # @example Generate the updates.

--- a/lib/mongoid/changeable.rb
+++ b/lib/mongoid/changeable.rb
@@ -72,9 +72,7 @@ module Mongoid
       @previous_changes = changes
       @attributes_before_last_save = @previous_attributes
       @previous_attributes = attributes.dup
-      Atomic::UPDATES.each do |update|
-        send(update).clear
-      end
+      reset_atomic_updates!
       changed_attributes.clear
     end
 

--- a/lib/mongoid/reloadable.rb
+++ b/lib/mongoid/reloadable.rb
@@ -16,16 +16,14 @@ module Mongoid
     #
     # @return [ Document ] The document, reloaded.
     def reload
-      if @atomic_selector
-        # Clear atomic_selector cache for sharded clusters. MONGOID-5076
-        remove_instance_variable('@atomic_selector')
-      end
-
       reloaded = _reload
       if Mongoid.raise_not_found_error && (reloaded.nil? || reloaded.empty?)
         shard_keys = atomic_selector.with_indifferent_access.slice(*shard_key_fields, :_id)
         raise Errors::DocumentNotFound.new(self.class, _id, shard_keys)
       end
+
+      reset_atomic_updates!
+
       @attributes = reloaded
       @attributes_before_type_cast = @attributes.dup
       @changed_attributes = {}

--- a/spec/mongoid/reloadable_spec.rb
+++ b/spec/mongoid/reloadable_spec.rb
@@ -390,6 +390,30 @@ describe Mongoid::Reloadable do
       end
     end
 
+    context 'when embeds_many is modified' do
+      let(:contractor1) { Contractor.new(name: 'b') }
+      let(:contractor2) { Contractor.new(name: 'c') }
+
+      let(:building) do
+        Building.create!(name: 'a', contractors: [ contractor1 ])
+      end
+
+      let(:more_contractors) { building.contractors + [ contractor2 ] }
+
+      let(:modified_building) do
+        building.tap do
+          building.assign_attributes contractors: more_contractors
+        end
+      end
+
+      let(:reloaded_building) { modified_building.reload }
+
+      it 'resets delayed_atomic_sets' do
+        expect(modified_building.delayed_atomic_sets).not_to be_empty
+        expect(reloaded_building.delayed_atomic_sets).to be_empty
+      end
+    end
+
     context "when embedded document is nil" do
 
       let(:palette) do


### PR DESCRIPTION
This backports #5656 from master to 8.1-stable.

> Reloading a document was not resetting the atomic operation state, which meant the reloaded might object might still believe there were changes to persist. This makes sure that state is reset on reload.

> ref: https://jira.mongodb.org/browse/MONGOID-5622