### PR TITLE
MONGOID-5643 Storable#add_field_expression add values with same operator keys using $and when value is a hash with symbol operator key

### DIFF
--- a/lib/mongoid/criteria/queryable/storable.rb
+++ b/lib/mongoid/criteria/queryable/storable.rb
@@ -48,7 +48,7 @@ module Mongoid
             if value.is_a?(Hash) && selector[field].is_a?(Hash) &&
               value.keys.all? { |key|
                 key_s = key.to_s
-                key_s.start_with?('$') && !selector[field].key?(key_s)
+                key_s.start_with?('$') && !selector[field].keys.map(&:to_s).include?(key_s)
               }
             then
               # Multiple operators can be combined on the same field by

--- a/spec/mongoid/criteria/queryable/storable_spec.rb
+++ b/spec/mongoid/criteria/queryable/storable_spec.rb
@@ -188,7 +188,79 @@ describe Mongoid::Criteria::Queryable::Storable do
         }
       end
     end
+
+    context 'when value is a hash combine values with different operator keys' do
+      let(:base) do
+        query.add_field_expression('foo', {'$in' => ['bar']})
+      end
+
+      let(:modified) do
+        base.add_field_expression('foo', {'$nin' => ['zoom']})
+      end
+
+      it 'combines the conditions using $and' do
+        modified.selector.should == {
+          'foo' => {
+            '$in' => ['bar'],
+            '$nin' => ['zoom']
+          }
+        }
+      end
+    end
+
+    context 'when value is a hash with symbol operator key combine values with different operator keys' do
+      let(:base) do
+        query.add_field_expression('foo', {:$in => ['bar']})
+      end
+
+      let(:modified) do
+        base.add_field_expression('foo', {:$nin => ['zoom']})
+      end
+
+      it 'combines the conditions using $and' do
+        modified.selector.should == {
+          'foo' => {
+            :$in => ['bar'],
+            :$nin => ['zoom']
+          }
+        }
+      end
+    end
+
+    context 'when value is a hash add values with same operator keys using $and' do
+      let(:base) do
+        query.add_field_expression('foo', {'$in' => ['bar']})
+      end
+
+      let(:modified) do
+        base.add_field_expression('foo', {'$in' => ['zoom']})
+      end
+
+      it 'adds the new condition using $and' do
+        modified.selector.should == {
+          'foo' => {'$in' => ['bar']},
+          '$and' => ['foo' => {'$in' => ['zoom']}]
+        }
+      end
+    end
+
+  context 'when value is a hash with symbol operator key add values with same operator keys using $and' do
+    let(:base) do
+      query.add_field_expression('foo', {:$in => ['bar']})
+    end
+
+    let(:modified) do
+      base.add_field_expression('foo', {:$in => ['zoom']})
+    end
+
+    it 'adds the new condition using $and' do
+      modified.selector.should == {
+        'foo' => {:$in => ['bar']},
+        '$and' => ['foo' => {:$in => ['zoom']}]
+      }
+    end
   end
+end
 
   describe '#add_operator_expression' do
     let(:query_method) { :add_operator_expression }


### PR DESCRIPTION
Mongoid::Criteria::Queryable::Storable#add_field_expression when value is a hash with symbol operator key add values with same operator keys using $and

The keys of the hash being added are converted to a string but they keys of the corresponding hash in the selector are not converted to a string so they do not match and wrong result is given from `Mongoid::Criteria::Queryable::Storable#add_field_expression`
because `'$in' != :$in`

Currently using a symbol rather than a string will result in a different output e.g.
```
#Strings
Band.where("foo"=>{'$in' =>["bar"]}).where('foo' => {'$in' => ['zoom']})
=>  {"foo"=>{'$in'=>["bar"]}, "$and"=>[{"foo"=>{'$in'=>["zoom"]}}]}

#Symbols
Band.where("foo"=>{:$in=>["bar"]}).where('foo' => {:$in => ['zoom']})
=> {"foo"=>{:$in=>["zoom"]}}
```

With this fix we will see the correct output
```
#Symbols
Band.where("foo"=>{:$in=>["bar"]}).where('foo' => {:$in => ['zoom']})
=>  {"foo"=>{:$in=>["bar"]}, "$and"=>[{"foo"=>{:$in=>["zoom"]}}]}
```