### PR TITLE
MONGOID-5632 update_all with atomic operations and aliased fields

### DIFF
--- a/lib/mongoid/association/proxy.rb
+++ b/lib/mongoid/association/proxy.rb
@@ -26,7 +26,7 @@ module Mongoid
 
       # We undefine most methods to get them sent through to the target.
       instance_methods.each do |method|
-        undef_method(method) unless method.start_with?('__') || KEEPER_METHODS.include?(method)
+        undef_method(method) unless method.to_s.start_with?('__') || KEEPER_METHODS.include?(method)
       end
 
       include Threaded::Lifecycle

--- a/lib/mongoid/extensions/hash.rb
+++ b/lib/mongoid/extensions/hash.rb
@@ -39,8 +39,12 @@ module Mongoid
         consolidated = {}
         each_pair do |key, value|
           if key =~ /\$/
-            value.each_pair do |_key, _value|
-              value[_key] = (key == "$rename") ? _value.to_s : mongoize_for(key, klass, _key, _value)
+            value.keys.each do |key2|
+              value2 = value[key2]
+              real_key = klass.database_field_name(key2)
+
+              value.delete(key2) if real_key != key2
+              value[real_key] = (key == "$rename") ? value2.to_s : mongoize_for(key, klass, real_key, value2)
             end
             consolidated[key] ||= {}
             consolidated[key].update(value)

--- a/spec/mongoid/contextual/mongo_spec.rb
+++ b/spec/mongoid/contextual/mongo_spec.rb
@@ -3611,6 +3611,20 @@ describe Mongoid::Contextual::Mongo do
           end
         end
 
+        context 'when using aliased field names' do
+          before do
+            context.update_all('$set' => { years: 100 })
+          end
+
+          it "updates the first matching document" do
+            expect(depeche_mode.reload.years).to eq(100)
+          end
+
+          it "updates the last matching document" do
+            expect(new_order.reload.years).to eq(100)
+          end
+        end
+
         context "when the attributes must be mongoized" do
 
           before do

--- a/spec/mongoid/extensions/hash_spec.rb
+++ b/spec/mongoid/extensions/hash_spec.rb
@@ -179,7 +179,7 @@ describe Mongoid::Extensions::Hash do
 
         it "moves the non hash values under the provided key" do
           expect(consolidated).to eq({
-            "$set" => { name: "Tool", likes: 10 }, "$inc" => { plays: 1 }
+            "$set" => { 'name' => "Tool", likes: 10 }, "$inc" => { 'plays' => 1 }
           })
         end
       end
@@ -196,7 +196,7 @@ describe Mongoid::Extensions::Hash do
 
         it "moves the non hash values under the provided key" do
           expect(consolidated).to eq({
-            "$set" => { likes: 10, name: "Tool" }, "$inc" => { plays: 1 }
+            "$set" => { likes: 10, 'name' => "Tool" }, "$inc" => { 'plays' => 1 }
           })
         end
       end
@@ -214,7 +214,7 @@ describe Mongoid::Extensions::Hash do
 
       it "moves the non hash values under the provided key" do
         expect(consolidated).to eq({
-          "$set" => { likes: 10, name: "Tool" }, "$inc" => { plays: 1 }
+          "$set" => { likes: 10, name: "Tool" }, "$inc" => { 'plays' => 1 }
         })
       end
     end

--- a/spec/mongoid/tasks/database_rake_spec.rb
+++ b/spec/mongoid/tasks/database_rake_spec.rb
@@ -353,7 +353,7 @@ describe "db:mongoid:encryption:create_data_key" do
 
     expect_any_instance_of(Mongo::ClientEncryption)
       .to receive(:create_data_key)
-      .with('local')
+      .with('local', {})
       .and_call_original
   end
 


### PR DESCRIPTION
When `update_all` is invoked and atomic operations are given, it does not currently inspect the nested arguments for aliases. This results in broken behavior (and potentially corrupted data) when these atomic operations reference aliased fields.

This PR updates the `Hash#__consolidate__` method so that it looks for aliased fields, in addition to building the atomic set operation before an update.