### PR TITLE
MONGOID-5637 backport MONGOID-5632 to 8.1-stable (update_all does not map :as option of the field properly)

### DIFF
--- a/lib/mongoid/extensions/hash.rb
+++ b/lib/mongoid/extensions/hash.rb
@@ -38,8 +38,12 @@ module Mongoid
         consolidated = {}
         each_pair do |key, value|
           if key =~ /\$/
-            value.each_pair do |_key, _value|
-              value[_key] = (key == "$rename") ? _value.to_s : mongoize_for(key, klass, _key, _value)
+            value.keys.each do |key2|
+              value2 = value[key2]
+              real_key = klass.database_field_name(key2)
+
+              value.delete(key2) if real_key != key2
+              value[real_key] = (key == "$rename") ? value2.to_s : mongoize_for(key, klass, real_key, value2)
             end
             consolidated[key] ||= {}
             consolidated[key].update(value)

--- a/spec/mongoid/contextual/mongo_spec.rb
+++ b/spec/mongoid/contextual/mongo_spec.rb
@@ -3703,6 +3703,20 @@ describe Mongoid::Contextual::Mongo do
           end
         end
 
+        context 'when using aliased field names' do
+          before do
+            context.update_all('$set' => { years: 100 })
+          end
+
+          it "updates the first matching document" do
+            expect(depeche_mode.reload.years).to eq(100)
+          end
+
+          it "updates the last matching document" do
+            expect(new_order.reload.years).to eq(100)
+          end
+        end
+
         context "when the attributes must be mongoized" do
 
           before do

--- a/spec/mongoid/extensions/hash_spec.rb
+++ b/spec/mongoid/extensions/hash_spec.rb
@@ -178,7 +178,7 @@ describe Mongoid::Extensions::Hash do
 
         it "moves the non hash values under the provided key" do
           expect(consolidated).to eq({
-            "$set" => { name: "Tool", likes: 10 }, "$inc" => { plays: 1 }
+            "$set" => { 'name' => "Tool", likes: 10 }, "$inc" => { 'plays' => 1 }
           })
         end
       end
@@ -195,7 +195,7 @@ describe Mongoid::Extensions::Hash do
 
         it "moves the non hash values under the provided key" do
           expect(consolidated).to eq({
-            "$set" => { likes: 10, name: "Tool" }, "$inc" => { plays: 1 }
+            "$set" => { likes: 10, 'name' => "Tool" }, "$inc" => { 'plays' => 1 }
           })
         end
       end
@@ -213,7 +213,7 @@ describe Mongoid::Extensions::Hash do
 
       it "moves the non hash values under the provided key" do
         expect(consolidated).to eq({
-          "$set" => { likes: 10, name: "Tool" }, "$inc" => { plays: 1 }
+          "$set" => { likes: 10, name: "Tool" }, "$inc" => { 'plays' => 1 }
         })
       end
     end


### PR DESCRIPTION
Backports MONGOID-5632 (update_all does not map :as option of the field properly) to 8.1-stable.