### PR TITLE
MONGOID-5654 [Monkey Patch Removal] Move Hash#__consolidate__ into Mongoid::Contextual

### DIFF
--- a/lib/mongoid/contextual/mongo.rb
+++ b/lib/mongoid/contextual/mongo.rb
@@ -811,7 +811,6 @@ module Mongoid
       def update_documents(attributes, method = :update_one, opts = {})
         return false unless attributes
 
-        attributes = Hash[attributes.map { |k, v| [klass.database_field_name(k.to_s), v] }]
         view.send(method, prepare_atomic_updates(klass, attributes), opts)
       end
 
@@ -1076,6 +1075,7 @@ module Mongoid
       # @return [ Hash ] The prepared atomic updates.
       def prepare_atomic_updates(klass, attributes)
         attributes.each_pair.with_object({}) do |(key, value), atomic_updates|
+          key = klass.database_field_name(key)
           if key.to_s.start_with?('$')
             value = value.each_with_object({}) do |(key2, value2), hash|
               key2 = klass.database_field_name(key2)

--- a/lib/mongoid/contextual/mongo.rb
+++ b/lib/mongoid/contextual/mongo.rb
@@ -810,6 +810,7 @@ module Mongoid
       # @return [ true | false ] If the update succeeded.
       def update_documents(attributes, method = :update_one, opts = {})
         return false unless attributes
+
         attributes = Hash[attributes.map { |k, v| [klass.database_field_name(k.to_s), v] }]
         view.send(method, prepare_atomic_updates(klass, attributes), opts)
       end

--- a/lib/mongoid/contextual/mongo.rb
+++ b/lib/mongoid/contextual/mongo.rb
@@ -811,7 +811,7 @@ module Mongoid
       def update_documents(attributes, method = :update_one, opts = {})
         return false unless attributes
         attributes = Hash[attributes.map { |k, v| [klass.database_field_name(k.to_s), v] }]
-        view.send(method, attributes.__consolidate__(klass), opts)
+        view.send(method, prepare_atomic_updates(klass, attributes), opts)
       end
 
       # Apply the field limitations.
@@ -1064,6 +1064,48 @@ module Mongoid
         v = v.skip(n) if n > 0
         raw_docs = v.to_a.reverse
         process_raw_docs(raw_docs, limit)
+      end
+
+      # Convert the key/values in the attributes into a hash of atomic updates.
+      # Non-operator keys are assumed to use $set operation.
+      #
+      # @param [ Class ] klass The model class.
+      # @param [ Hash ] The attributes to convert.
+      #
+      # @return [ Hash ] The prepared atomic updates.
+      def prepare_atomic_updates(klass, attributes)
+        attributes.each_pair.with_object({}) do |(key, value), atomic_updates|
+          if key.to_s.start_with?('$')
+            value = value.each_with_object({}) do |(key2, value2), hash|
+              key2 = klass.database_field_name(key2)
+              hash[key2] = key == '$rename' ? value2.to_s : mongoize_for_atomic_update(klass, key, key2, value2)
+            end
+            atomic_updates[key] ||= {}
+            atomic_updates[key].update(value)
+          else
+            atomic_updates['$set'] ||= {}
+            atomic_updates['$set'][key] = mongoize_for_atomic_update(klass, key, key, value)
+          end
+        end
+      end
+
+      # Mongoize a value for an atomic update for the given klass, operator, and field.
+      #
+      # @param [ Class ] klass The model class.
+      # @param [ String ] operator The operator.
+      # @param [ String | Symbol ] field_name The field key.
+      # @param [ Object ] value The value to mongoize.
+      #
+      # @return [ Object ] The mongoized value.
+      def mongoize_for_atomic_update(klass, operator, field_name, value)
+        field = klass.fields[field_name.to_s]
+        return value unless field
+
+        value = field.mongoize(value)
+        if Mongoid::Persistable::LIST_OPERATIONS.include?(operator) && field.resizable? && !value.is_a?(Array)
+          value = value.first
+        end
+        value
       end
     end
   end

--- a/lib/mongoid/contextual/mongo.rb
+++ b/lib/mongoid/contextual/mongo.rb
@@ -1070,7 +1070,7 @@ module Mongoid
       # Non-operator keys are assumed to use $set operation.
       #
       # @param [ Class ] klass The model class.
-      # @param [ Hash ] The attributes to convert.
+      # @param [ Hash ] attributes The attributes to convert.
       #
       # @return [ Hash ] The prepared atomic updates.
       def prepare_atomic_updates(klass, attributes)

--- a/lib/mongoid/contextual/mongo.rb
+++ b/lib/mongoid/contextual/mongo.rb
@@ -1102,11 +1102,11 @@ module Mongoid
         field = klass.fields[field_name.to_s]
         return value unless field
 
-        value = field.mongoize(value)
+        mongoized = field.mongoize(value)
         if Mongoid::Persistable::LIST_OPERATIONS.include?(operator) && field.resizable? && !value.is_a?(Array)
-          value = value.first
+          mongoized = mongoized.first
         end
-        value
+        mongoized
       end
     end
   end

--- a/lib/mongoid/extensions/hash.rb
+++ b/lib/mongoid/extensions/hash.rb
@@ -31,33 +31,6 @@ module Mongoid
         end
       end
 
-      # Consolidate the key/values in the hash under an atomic $set.
-      #
-      # @example Consolidate the hash.
-      #   { name: "Placebo" }.__consolidate__
-      #
-      # @return [ Hash ] A new consolidated hash.
-      def __consolidate__(klass)
-        consolidated = {}
-        each_pair do |key, value|
-          if key =~ /\$/
-            value.keys.each do |key2|
-              value2 = value[key2]
-              real_key = klass.database_field_name(key2)
-
-              value.delete(key2) if real_key != key2
-              value[real_key] = (key == "$rename") ? value2.to_s : mongoize_for(key, klass, real_key, value2)
-            end
-            consolidated[key] ||= {}
-            consolidated[key].update(value)
-          else
-            consolidated["$set"] ||= {}
-            consolidated["$set"].update(key => mongoize_for(key, klass, key, value))
-          end
-        end
-        consolidated
-      end
-
       # Checks whether conditions given in this hash are known to be
       # unsatisfiable, i.e., querying with this hash will always return no
       # documents.
@@ -184,34 +157,6 @@ module Mongoid
           criteria = criteria.__send__(method, args)
         end
         criteria
-      end
-
-      private
-
-      # Mongoize for the klass, key and value.
-      #
-      # @api private
-      #
-      # @example Mongoize for the klass, field and value.
-      #   {}.mongoize_for("$push", Band, "name", "test")
-      #
-      # @param [ String ] operator The operator.
-      # @param [ Class ] klass The model class.
-      # @param [ String | Symbol ] key The field key.
-      # @param [ Object ] value The value to mongoize.
-      #
-      # @return [ Object ] The mongoized value.
-      def mongoize_for(operator, klass, key, value)
-        field = klass.fields[key.to_s]
-        if field
-          val = field.mongoize(value)
-          if Mongoid::Persistable::LIST_OPERATIONS.include?(operator) && field.resizable?
-            val = val.first if !value.is_a?(Array)
-          end
-          val
-        else
-          value
-        end
       end
 
       module ClassMethods

--- a/spec/mongoid/contextual/mongo_spec.rb
+++ b/spec/mongoid/contextual/mongo_spec.rb
@@ -4573,9 +4573,9 @@ describe Mongoid::Contextual::Mongo do
   end
 
   describe '#prepare_atomic_updates' do
-    let(:instance) { described_class.new(Band.where(name: 'Depeche Mode')) }
+    subject(:updates) { instance.send(:prepare_atomic_updates, Band, hash) }
 
-    subject { instance.send(:prepare_atomic_updates, Band, hash) }
+    let(:instance) { described_class.new(Band.where(name: 'Depeche Mode')) }
 
     context 'when the hash already contains the key' do
 
@@ -4585,10 +4585,10 @@ describe Mongoid::Contextual::Mongo do
         end
 
         it 'moves the non hash values under the provided key' do
-          expect(subject).to eq({
-                                  '$set' => { 'name' => 'Tool', likes: 10 },
-                                  '$inc' => { 'plays' => 1 }
-                                })
+          expect(updates).to eq({
+            '$set' => { 'name' => 'Tool', 'likes' => 10 },
+            '$inc' => { 'plays' => 1 }
+          })
         end
       end
 
@@ -4598,10 +4598,10 @@ describe Mongoid::Contextual::Mongo do
         end
 
         it 'moves the non hash values under the provided key' do
-          expect(subject).to eq({
-                                  '$set' => { likes: 10, 'name' => 'Tool' },
-                                  '$inc' => { 'plays' => 1 }
-                                })
+          expect(updates).to eq({
+            '$set' => { 'likes' => 10, 'name' => 'Tool' },
+            '$inc' => { 'plays' => 1 }
+          })
         end
       end
     end
@@ -4612,10 +4612,10 @@ describe Mongoid::Contextual::Mongo do
       end
 
       it 'moves the non hash values under the provided key' do
-        expect(subject).to eq({
-                                '$set' => { likes: 10, name: 'Tool' },
-                                '$inc' => { 'plays' => 1 }
-                              })
+        expect(updates).to eq({
+          '$set' => { 'likes' => 10, 'name' => 'Tool' },
+          '$inc' => { 'plays' => 1 }
+        })
       end
     end
   end

--- a/spec/mongoid/contextual/mongo_spec.rb
+++ b/spec/mongoid/contextual/mongo_spec.rb
@@ -4598,7 +4598,7 @@ describe Mongoid::Contextual::Mongo do
         end
 
         it 'moves the non hash values under the provided key' do
-          expect(updates).to eq({
+          expect(subject).to eq({
                                   '$set' => { likes: 10, 'name' => 'Tool' },
                                   '$inc' => { 'plays' => 1 }
                                 })
@@ -4612,7 +4612,7 @@ describe Mongoid::Contextual::Mongo do
       end
 
       it 'moves the non hash values under the provided key' do
-        expect(updates).to eq({
+        expect(subject).to eq({
                                 '$set' => { likes: 10, name: 'Tool' },
                                 '$inc' => { 'plays' => 1 }
                               })

--- a/spec/mongoid/extensions/hash_spec.rb
+++ b/spec/mongoid/extensions/hash_spec.rb
@@ -163,63 +163,6 @@ describe Mongoid::Extensions::Hash do
     end
   end
 
-  describe "#__consolidate__" do
-
-    context "when the hash already contains the key" do
-
-      context "when the $set is first" do
-
-        let(:hash) do
-          { "$set" => { name: "Tool" }, likes: 10, "$inc" => { plays: 1 }}
-        end
-
-        let(:consolidated) do
-          hash.__consolidate__(Band)
-        end
-
-        it "moves the non hash values under the provided key" do
-          expect(consolidated).to eq({
-            "$set" => { 'name' => "Tool", likes: 10 }, "$inc" => { 'plays' => 1 }
-          })
-        end
-      end
-
-      context "when the $set is not first" do
-
-        let(:hash) do
-          { likes: 10, "$inc" => { plays: 1 }, "$set" => { name: "Tool" }}
-        end
-
-        let(:consolidated) do
-          hash.__consolidate__(Band)
-        end
-
-        it "moves the non hash values under the provided key" do
-          expect(consolidated).to eq({
-            "$set" => { likes: 10, 'name' => "Tool" }, "$inc" => { 'plays' => 1 }
-          })
-        end
-      end
-    end
-
-    context "when the hash does not contain the key" do
-
-      let(:hash) do
-        { likes: 10, "$inc" => { plays: 1 }, name: "Tool"}
-      end
-
-      let(:consolidated) do
-        hash.__consolidate__(Band)
-      end
-
-      it "moves the non hash values under the provided key" do
-        expect(consolidated).to eq({
-          "$set" => { likes: 10, name: "Tool" }, "$inc" => { 'plays' => 1 }
-        })
-      end
-    end
-  end
-
   context "when the hash key is a string" do
 
     let(:hash) do


### PR DESCRIPTION
Fixes MONGOID-5654

`Hash#__consolidate__` monkey-patch method is used only once in the entire Mongoid codebase, in a private capacity inside `Contextual::Mongo` class. There is no reason to monkey-patch the kernel Hash class for this.

This PR does the following:
- ~~Move the method into `Contextual::Mongo` as a private method.~~
- Move the associated `Hash#mongoize_for` private method, which is only called once inside `__consolidate__`
- Rename and refactor the methods.

* [ ] TODO: Move private method tests to cover a public method behavior.

The method name has `__` prefix so we can assume this is an internal only method that is safe to remove.