### PR TITLE
Fix broken mongoid/tasks/database_rake_spec

### DIFF
--- a/lib/mongoid/tasks/encryption.rake
+++ b/lib/mongoid/tasks/encryption.rake
@@ -20,9 +20,8 @@ namespace :db do
             options[:key_alt_name] = v
           end
         end
-        # rubocop:disable Lint/EmptyBlock
-        parser.parse!(parser.order!(ARGV) {})
-        # rubocop:enable Lint/EmptyBlock
+        parser.parse!(parser.order!(ARGV) {}) # rubocop:disable Lint/EmptyBlock
+
         result = Mongoid::Tasks::Encryption.create_data_key(
           client_name: options[:client_name],
           kms_provider_name: options[:kms_provider_name],

--- a/spec/mongoid/tasks/database_rake_spec.rb
+++ b/spec/mongoid/tasks/database_rake_spec.rb
@@ -334,7 +334,8 @@ describe "db:mongoid:encryption:create_data_key" do
 
   let(:config) do
     {
-      default: {
+      default: { hosts: SpecConfig.instance.addresses, database: database_id },
+      encrypted: {
         hosts: SpecConfig.instance.addresses,
         database: database_id,
         options: {
@@ -355,6 +356,9 @@ describe "db:mongoid:encryption:create_data_key" do
       .to receive(:create_data_key)
       .with('local', {})
       .and_call_original
+
+    # OptionParser incorrectly handles RSpec's options such as --pattern
+    allow_any_instance_of(OptionParser).to receive(:order!).and_return({})
   end
 
   it "creates the key" do


### PR DESCRIPTION
I am pretty sure this spec is broken and Mongoid is not running to correctly.

You can see the failure here: https://github.com/tablecheck/mongoid-ultra/actions/runs/5989956616/job/16246745994

There are two problems:
1. The DB client for `encrypted` is not configured correctly.
2. `OptionParser#order!` is choking on RSpec's default `--pattern` option. This might be somewhat environment specific, but AFAIK RSpec injects this automatically.
