### PR TITLE
MONGOID-5647 Allow #count to be used with #for_js

### DIFF
--- a/spec/mongoid/contextual/mongo_spec.rb
+++ b/spec/mongoid/contextual/mongo_spec.rb
@@ -159,6 +159,16 @@ describe Mongoid::Contextual::Mongo do
         end
       end
     end
+
+    context 'when for_js is present' do
+      let(:context) do
+        Band.for_js('this.name == "Depeche Mode"')
+      end
+
+      it 'counts the expected records' do
+        expect(context.count).to eq(1)
+      end
+    end
   end
 
   describe "#estimated_count" do


### PR DESCRIPTION
Currently, trying to invoke `#count` after calling `#for_js` results in an error, because `#count` calls `view.count_documents` under the covers, and that method does not support the `$where` command. This PR puts a bandaid on this scenario by making `#count` call `view.count` if the filter contains a `$where` command.