### PR TITLE
MONGOID-5647 #for_js with #count (backport to 8.1-stable)

### DIFF
--- a/spec/mongoid/contextual/mongo_spec.rb
+++ b/spec/mongoid/contextual/mongo_spec.rb
@@ -158,6 +158,16 @@ describe Mongoid::Contextual::Mongo do
         end
       end
     end
+
+    context 'when for_js is present' do
+      let(:context) do
+        Band.for_js('this.name == "Depeche Mode"')
+      end
+
+      it 'counts the expected records' do
+        expect(context.count).to eq(1)
+      end
+    end
   end
 
   describe "#estimated_count" do


### PR DESCRIPTION
Backport of #5693.