### PR TITLE
RUBY-2807 - Add "compressors" option to Mongoid.yml

### DIFF
--- a/docs/reference/configuration.txt
+++ b/docs/reference/configuration.txt
@@ -755,7 +755,7 @@ the Ruby driver, which implements the three algorithms that are supported by Mon
   requires the `zstd-ruby <https://rubygems.org/gems/zstd-ruby>`_ library to
   be installed.
 
-To use wire protocol compression, configure the Ruby driver options within the ``mongoid.yml``:
+To use wire protocol compression, configure the Ruby driver options within ``mongoid.yml``:
 
 .. code-block:: yaml
 

--- a/docs/reference/configuration.txt
+++ b/docs/reference/configuration.txt
@@ -239,6 +239,9 @@ for details on driver options.
           # not belong to this replica set will be ignored.
           replica_set: my_replica_set
 
+          # Compressors to use for wire protocol compression. (default is to not use compression)
+          compressors: ["zstd", "snappy", "zlib"]
+
           # Whether to connect to the servers via ssl. (default: false)
           ssl: true
 
@@ -259,9 +262,6 @@ for details on driver options.
           # The file containing a set of concatenated certification authority certifications
           # used to validate certs passed from the other end of the connection.
           ssl_ca_cert: /path/to/ca.cert
-
-          # Compressors to use for wire protocol compression. (default is to not use compression)
-          compressors: ["zstd", "snappy", "zlib"]
 
     # Configure Mongoid-specific options. (optional)
     options:

--- a/docs/reference/configuration.txt
+++ b/docs/reference/configuration.txt
@@ -260,8 +260,8 @@ for details on driver options.
           # used to validate certs passed from the other end of the connection.
           ssl_ca_cert: /path/to/ca.cert
 
-          # Compressors to use. (default is to not use compression)
-          compressors: [zlib]
+          # Compressors to use for wire protocol compression. (default is to not use compression)
+          compressors: ["zstd", "snappy", "zlib"]
 
     # Configure Mongoid-specific options. (optional)
     options:
@@ -755,9 +755,7 @@ the Ruby driver, which implements the three algorithms that are supported by Mon
   requires the `zstd-ruby <https://rubygems.org/gems/zstd-ruby>`_ library to
   be installed.
 
-To use wire protocol compression, at least one compressor must be explicitly requested
-using either the `compressors URI option <https://www.mongodb.com/docs/manual/reference/connection-string/#mongodb-urioption-urioption.compressors>`_,
-or directly within the  ``mongoid.yml``:
+To use wire protocol compression, configure the Ruby driver options within the ``mongoid.yml``:
 
 .. code-block:: yaml
 

--- a/lib/rails/generators/mongoid/config/templates/mongoid.yml
+++ b/lib/rails/generators/mongoid/config/templates/mongoid.yml
@@ -93,6 +93,11 @@ development:
         # not belong to this replica set will be ignored.
         # replica_set: name
 
+        # Compressors to use for wire protocol compression. (default is to not use compression)
+        # "zstd" requires zstd-ruby gem. "snappy" requires snappy gem.
+        # Refer to: https://www.mongodb.com/docs/ruby-driver/current/reference/create-client/#compression
+        # compressors: ["zstd", "snappy", "zlib"]
+
         # Whether to connect to the servers via ssl. (default: false)
         # ssl: true
 


### PR DESCRIPTION
This PR adds the "compressors" option to the auto-generated `mongoid.yml` template. Note that since it is a driver option, it is not covered by the Introspection feature. This is important, because I think many users look at the generated `mongoid.yml` as their primary reference for config options.

In addition, I've removed a line from the docs about setting compressors via connection string. Although this is *technically possible*, it is not something that should be recommended to users. (Virtually _all options_ can be set via connection string, and the Mongoid docs never recommend to use it, so it feels out-of-place in this specific instance.)