### PR TITLE
MONGOID-5670 [Monkey Patch Removal] Remove Hash#delete_id and Hash#extract_id

### DIFF
--- a/lib/mongoid/association/nested/many.rb
+++ b/lib/mongoid/association/nested/many.rb
@@ -101,7 +101,8 @@ module Mongoid
         # @param [ Hash ] attrs The single document attributes to process.
         def process_attributes(parent, attrs)
           return if reject?(parent, attrs)
-          if id = attrs.extract_id
+
+          if (id = extract_id(attrs))
             update_nested_relation(parent, id, attrs)
           else
             existing.push(Factory.build(@class_name, attrs)) unless destroyable?(attrs)
@@ -153,7 +154,7 @@ module Mongoid
         # @param [ Document ] doc The document to update.
         # @param [ Hash ] attrs The attributes.
         def update_document(doc, attrs)
-          attrs.delete_id
+          delete_id(attrs)
           if association.embedded?
             doc.assign_attributes(attrs)
           else

--- a/lib/mongoid/association/nested/nested_buildable.rb
+++ b/lib/mongoid/association/nested/nested_buildable.rb
@@ -65,6 +65,33 @@ module Mongoid
         def convert_id(klass, id)
           klass.using_object_ids? ? BSON::ObjectId.mongoize(id) : id
         end
+
+        private
+
+        # Get the id attribute from the given hash, whether it's
+        # prefixed with an underscore or is a symbol.
+        #
+        # @example Get the id.
+        #   extract_id({ _id: 1 })
+        #
+        # @param [ Hash ] hash The hash from which to extract.
+        #
+        # @return [ Object ] The value of the id.
+        def extract_id(hash)
+          hash['_id'] || hash[:_id] || hash['id'] || hash[:id]
+        end
+
+        # Deletes the id key from the given hash.
+        #
+        # @example Delete an id value.
+        #   delete_id({ "_id" => 1 })
+        #
+        # @param [ Hash ] hash The hash from which to delete.
+        #
+        # @return [ Object ] The deleted value, or nil.
+        def delete_id(hash)
+          hash.delete('_id') || hash.delete(:_id) || hash.delete('id') || hash.delete(:id)
+        end
       end
     end
   end

--- a/lib/mongoid/association/nested/one.rb
+++ b/lib/mongoid/association/nested/one.rb
@@ -29,7 +29,7 @@ module Mongoid
           return if reject?(parent, attributes)
           @existing = parent.send(association.name)
           if update?
-            attributes.delete_id
+            delete_id(attributes)
             existing.assign_attributes(attributes)
           elsif replace?
             parent.send(association.setter, Factory.build(@class_name, attributes))

--- a/lib/mongoid/criteria.rb
+++ b/lib/mongoid/criteria.rb
@@ -160,7 +160,7 @@ module Mongoid
     #
     # @return [ Object ] The id.
     def extract_id
-      selector.extract_id
+      selector['_id'] || selector[:_id] || selector['id'] || selector[:id]
     end
 
     # Adds a criterion to the +Criteria+ that specifies additional options
@@ -223,7 +223,7 @@ module Mongoid
     # may be desired.
     #
     # @example Merge the criteria with another criteria.
-    #   criteri.merge(other_criteria)
+    #   criteria.merge(other_criteria)
     #
     # @example Merge the criteria with a hash. The hash must contain a klass
     #   key and the key/value pairs correspond to method names/args.

--- a/lib/mongoid/extensions/hash.rb
+++ b/lib/mongoid/extensions/hash.rb
@@ -106,6 +106,31 @@ module Mongoid
       # @deprecated
       alias :blank_criteria? :_mongoid_unsatisfiable_criteria?
 
+      # Deletes an id value from the hash.
+      #
+      # @example Delete an id value.
+      #   {}.delete_id
+      #
+      # @return [ Object ] The deleted value, or nil.
+      # @deprecated
+      def delete_id
+        delete("_id") || delete(:_id) || delete("id") || delete(:id)
+      end
+      Mongoid.deprecate(self, :delete_id)
+
+      # Get the id attribute from this hash, whether it's prefixed with an
+      # underscore or is a symbol.
+      #
+      # @example Extract the id.
+      #   { :_id => 1 }.extract_id
+      #
+      # @return [ Object ] The value of the id.
+      # @deprecated
+      def extract_id
+        self["_id"] || self[:_id] || self["id"] || self[:id]
+      end
+      Mongoid.deprecate(self, :extract_id)
+
       # Turn the object from the ruby type we deal with to a Mongo friendly
       # type.
       #

--- a/lib/mongoid/extensions/hash.rb
+++ b/lib/mongoid/extensions/hash.rb
@@ -106,27 +106,6 @@ module Mongoid
       # @deprecated
       alias :blank_criteria? :_mongoid_unsatisfiable_criteria?
 
-      # Deletes an id value from the hash.
-      #
-      # @example Delete an id value.
-      #   {}.delete_id
-      #
-      # @return [ Object ] The deleted value, or nil.
-      def delete_id
-        delete("_id") || delete(:_id) || delete("id") || delete(:id)
-      end
-
-      # Get the id attribute from this hash, whether it's prefixed with an
-      # underscore or is a symbol.
-      #
-      # @example Extract the id.
-      #   { :_id => 1 }.extract_id
-      #
-      # @return [ Object ] The value of the id.
-      def extract_id
-        self["_id"] || self[:_id] || self["id"] || self[:id]
-      end
-
       # Turn the object from the ruby type we deal with to a Mongo friendly
       # type.
       #


### PR DESCRIPTION
Fixes MONGOID-5670

Moved to Nested::NestedBuildable

These should first be marked deprecated, so I will raise a PR to 8.1 branch.

Also it seems there are no specs for these. Since they are private, it will stay that way.

Overall progress is tracked here: http://tinyurl.com/mongoid-monkey. Refer to [MONGOID-5660](https://jira.mongodb.org/browse/MONGOID-5660) for context.