### PR TITLE
MONGOID-5668 [Monkey Patch Removal] Remove String/Symbol#mongoid_id?

### DIFF
--- a/lib/mongoid/extensions/string.rb
+++ b/lib/mongoid/extensions/string.rb
@@ -63,6 +63,18 @@ module Mongoid
         tableize.gsub("/", "_")
       end
 
+      # Is the string a valid value for a Mongoid id?
+      #
+      # @example Is the string an id value?
+      #   "_id".mongoid_id?
+      #
+      # @return [ true | false ] If the string is id or _id.
+      # @deprecated
+      def mongoid_id?
+        self =~ /\A(|_)id\z/
+      end
+      Mongoid.deprecate(self, :mongoid_id?)
+
       # Is the string a number? The literals "NaN", "Infinity", and "-Infinity"
       # are counted as numbers.
       #

--- a/lib/mongoid/extensions/string.rb
+++ b/lib/mongoid/extensions/string.rb
@@ -63,16 +63,6 @@ module Mongoid
         tableize.gsub("/", "_")
       end
 
-      # Is the string a valid value for a Mongoid id?
-      #
-      # @example Is the string an id value?
-      #   "_id".mongoid_id?
-      #
-      # @return [ true | false ] If the string is id or _id.
-      def mongoid_id?
-        self =~ /\A(|_)id\z/
-      end
-
       # Is the string a number? The literals "NaN", "Infinity", and "-Infinity"
       # are counted as numbers.
       #

--- a/lib/mongoid/extensions/symbol.rb
+++ b/lib/mongoid/extensions/symbol.rb
@@ -7,6 +7,18 @@ module Mongoid
     # Adds type-casting behavior to Symbol class.
     module Symbol
 
+      # Is the symbol a valid value for a Mongoid id?
+      #
+      # @example Is the string an id value?
+      #   :_id.mongoid_id?
+      #
+      # @return [ true | false ] If the symbol is :id or :_id.
+      # @deprecated
+      def mongoid_id?
+        to_s.mongoid_id?
+      end
+      Mongoid.deprecate(self, :mongoid_id?)
+
       module ClassMethods
 
         # Turn the object from the ruby type we deal with to a Mongo friendly

--- a/lib/mongoid/extensions/symbol.rb
+++ b/lib/mongoid/extensions/symbol.rb
@@ -7,16 +7,6 @@ module Mongoid
     # Adds type-casting behavior to Symbol class.
     module Symbol
 
-      # Is the symbol a valid value for a Mongoid id?
-      #
-      # @example Is the string an id value?
-      #   :_id.mongoid_id?
-      #
-      # @return [ true | false ] If the symbol is :id or :_id.
-      def mongoid_id?
-        to_s.mongoid_id?
-      end
-
       module ClassMethods
 
         # Turn the object from the ruby type we deal with to a Mongo friendly

--- a/spec/mongoid/extensions/string_spec.rb
+++ b/spec/mongoid/extensions/string_spec.rb
@@ -172,37 +172,6 @@ describe Mongoid::Extensions::String do
     end
   end
 
-  describe "#mongoid_id?" do
-
-    context "when the string is id" do
-
-      it "returns true" do
-        expect("id").to be_mongoid_id
-      end
-    end
-
-    context "when the string is _id" do
-
-      it "returns true" do
-        expect("_id").to be_mongoid_id
-      end
-    end
-
-    context "when the string contains id" do
-
-      it "returns false" do
-        expect("identity").to_not be_mongoid_id
-      end
-    end
-
-    context "when the string contains _id" do
-
-      it "returns false" do
-        expect("something_id").to_not be_mongoid_id
-      end
-    end
-  end
-
   [ :mongoize, :demongoize ].each do |method|
 
     describe ".#{method}" do

--- a/spec/mongoid/extensions/symbol_spec.rb
+++ b/spec/mongoid/extensions/symbol_spec.rb
@@ -5,37 +5,6 @@ require "spec_helper"
 
 describe Mongoid::Extensions::Symbol do
 
-  describe "#mongoid_id?" do
-
-    context "when the string is id" do
-
-      it "returns true" do
-        expect(:id).to be_mongoid_id
-      end
-    end
-
-    context "when the string is _id" do
-
-      it "returns true" do
-        expect(:_id).to be_mongoid_id
-      end
-    end
-
-    context "when the string contains id" do
-
-      it "returns false" do
-        expect(:identity).to_not be_mongoid_id
-      end
-    end
-
-    context "when the string contains _id" do
-
-      it "returns false" do
-        expect(:something_id).to_not be_mongoid_id
-      end
-    end
-  end
-
   [ :mongoize, :demongoize ].each do |method|
 
     describe ".mongoize" do


### PR DESCRIPTION
Fixes MONGOID-5668

These methods are not called anywhere in the code, and they do not serve any clear purpose. They are unlikely to be in use by actual users.

They need to be deprecated before removal.

Overall progress is tracked here: http://tinyurl.com/mongoid-monkey. Refer to [MONGOID-5660](https://jira.mongodb.org/browse/MONGOID-5660) for context.