### PR TITLE
MONGOID-5667 [Monkey Patch Removal] Remove String/Integer#unconvertable_to_bson?

### DIFF
--- a/lib/mongoid/extensions/integer.rb
+++ b/lib/mongoid/extensions/integer.rb
@@ -27,16 +27,6 @@ module Mongoid
         true
       end
 
-      # Is the object not to be converted to bson on criteria creation?
-      #
-      # @example Is the object unconvertable?
-      #   object.unconvertable_to_bson?
-      #
-      # @return [ true ] If the object is unconvertable.
-      def unconvertable_to_bson?
-        true
-      end
-
       module ClassMethods
 
         # Turn the object from the ruby type we deal with to a Mongo friendly

--- a/lib/mongoid/extensions/integer.rb
+++ b/lib/mongoid/extensions/integer.rb
@@ -27,6 +27,18 @@ module Mongoid
         true
       end
 
+      # Is the object not to be converted to bson on criteria creation?
+      #
+      # @example Is the object unconvertable?
+      #   object.unconvertable_to_bson?
+      #
+      # @return [ true ] If the object is unconvertable.
+      # @deprecated
+      def unconvertable_to_bson?
+        true
+      end
+      Mongoid.deprecate(self, :unconvertable_to_bson?)
+
       module ClassMethods
 
         # Turn the object from the ruby type we deal with to a Mongo friendly

--- a/lib/mongoid/extensions/string.rb
+++ b/lib/mongoid/extensions/string.rb
@@ -7,6 +7,11 @@ module Mongoid
     # Adds type-casting behavior to String class.
     module String
 
+      # @attribute [rw] unconvertable_to_bson If the document is unconvertable.
+      # @deprecated
+      attr_accessor :unconvertable_to_bson
+      Mongoid.deprecate(self, :unconvertable_to_bson, :unconvertable_to_bson=)
+
       # Evolve the string into an object id if possible.
       #
       # @example Evolve the string.
@@ -122,6 +127,19 @@ module Mongoid
       def before_type_cast?
         ends_with?("_before_type_cast")
       end
+
+
+      # Is the object not to be converted to bson on criteria creation?
+      #
+      # @example Is the object unconvertable?
+      #   object.unconvertable_to_bson?
+      #
+      # @return [ true | false ] If the object is unconvertable.
+      # @deprecated
+      def unconvertable_to_bson?
+        @unconvertable_to_bson ||= false
+      end
+      Mongoid.deprecate(self, :unconvertable_to_bson?)
 
       private
 

--- a/lib/mongoid/extensions/string.rb
+++ b/lib/mongoid/extensions/string.rb
@@ -7,9 +7,6 @@ module Mongoid
     # Adds type-casting behavior to String class.
     module String
 
-      # @attribute [rw] unconvertable_to_bson If the document is unconvertable.
-      attr_accessor :unconvertable_to_bson
-
       # Evolve the string into an object id if possible.
       #
       # @example Evolve the string.

--- a/lib/mongoid/extensions/string.rb
+++ b/lib/mongoid/extensions/string.rb
@@ -126,16 +126,6 @@ module Mongoid
         ends_with?("_before_type_cast")
       end
 
-      # Is the object not to be converted to bson on criteria creation?
-      #
-      # @example Is the object unconvertable?
-      #   object.unconvertable_to_bson?
-      #
-      # @return [ true | false ] If the object is unconvertable.
-      def unconvertable_to_bson?
-        @unconvertable_to_bson ||= false
-      end
-
       private
 
       # If the string is a legal object id, convert it.


### PR DESCRIPTION
Fixes MONGOID-5667

These methods currently serve no purpose and are not called anywhere. They are probably relics of the past.

Overall progress is tracked here: http://tinyurl.com/mongoid-monkey. Refer to [MONGOID-5660](https://jira.mongodb.org/browse/MONGOID-5660) for context.