### PR TITLE
Object monkey patch removal

### DIFF
--- a/docs/release-notes/mongoid-9.0.txt
+++ b/docs/release-notes/mongoid-9.0.txt
@@ -51,6 +51,11 @@ Deprecated functionality removed
   The method ``Mongoid::QueryCache#clear_cache`` should be replaced with ``Mongo::QueryCache#clear``.
   All other methods and submodules are identically named. Refer to the `driver query cache documentation
   <https://mongodb.com/docs/ruby-driver/current/reference/query-cache/>`_ for more details.
+- Removed various monkey-patch methods:
+  - ``Object#__find_args__`` (not used)
+  - ``Object#__setter__`` (not used)
+  - ``Object#__sortable__`` (not used)
+  - ``Object#__to_inc__`` (not used)
 
 
 ``touch`` method now clears changed state

--- a/docs/release-notes/mongoid-9.0.txt
+++ b/docs/release-notes/mongoid-9.0.txt
@@ -51,7 +51,7 @@ Deprecated functionality removed
   The method ``Mongoid::QueryCache#clear_cache`` should be replaced with ``Mongo::QueryCache#clear``.
   All other methods and submodules are identically named. Refer to the `driver query cache documentation
   <https://mongodb.com/docs/ruby-driver/current/reference/query-cache/>`_ for more details.
-- Removed various monkey-patch methods:
+- Removed various monkey-patch methods from kernel classes:
   - ``Object#__find_args__`` (not used)
   - ``Object#__setter__`` (not used)
   - ``Object#__sortable__`` (not used)

--- a/lib/mongoid/extensions/array.rb
+++ b/lib/mongoid/extensions/array.rb
@@ -18,16 +18,6 @@ module Mongoid
         self
       end
 
-      # Get the array of args as arguments for a find query.
-      #
-      # @example Get the array as find args.
-      #   [ 1, 2, 3 ].__find_args__
-      #
-      # @return [ Array ] The array of args.
-      def __find_args__
-        flat_map{ |a| a.__find_args__ }.uniq{ |a| a.to_s }
-      end
-
       # Mongoize the array into an array of object ids.
       #
       # @example Evolve the array to object ids.

--- a/lib/mongoid/extensions/big_decimal.rb
+++ b/lib/mongoid/extensions/big_decimal.rb
@@ -7,16 +7,6 @@ module Mongoid
     # Adds type-casting behavior to BigDecimal class.
     module BigDecimal
 
-      # Convert the big decimal to an $inc-able value.
-      #
-      # @example Convert the big decimal.
-      #   bd.__to_inc__
-      #
-      # @return [ Float ] The big decimal as a float.
-      def __to_inc__
-        to_f
-      end
-
       # Turn the object from the ruby type we deal with to a Mongo friendly
       # type.
       #

--- a/lib/mongoid/extensions/false_class.rb
+++ b/lib/mongoid/extensions/false_class.rb
@@ -7,16 +7,6 @@ module Mongoid
     # Adds type-casting behavior to FalseClass.
     module FalseClass
 
-      # Get the value of the object as a mongo friendly sort value.
-      #
-      # @example Get the object as sort criteria.
-      #   object.__sortable__
-      #
-      # @return [ Integer ] 0.
-      def __sortable__
-        0
-      end
-
       # Is the passed value a boolean?
       #
       # @example Is the value a boolean type?

--- a/lib/mongoid/extensions/nil_class.rb
+++ b/lib/mongoid/extensions/nil_class.rb
@@ -7,16 +7,6 @@ module Mongoid
     # Adds type-casting behavior to NilClass.
     module NilClass
 
-      # Try to form a setter from this object.
-      #
-      # @example Try to form a setter.
-      #   object.__setter__
-      #
-      # @return [ nil ] Always nil.
-      def __setter__
-        self
-      end
-
       # Get the name of a nil collection.
       #
       # @example Get the nil name.

--- a/lib/mongoid/extensions/object.rb
+++ b/lib/mongoid/extensions/object.rb
@@ -18,16 +18,6 @@ module Mongoid
       end
       alias :__mongoize_object_id__ :__evolve_object_id__
 
-      # Convert the object to args for a find query.
-      #
-      # @example Convert the object to args.
-      #   object.__find_args__
-      #
-      # @return [ Object ] self.
-      def __find_args__
-        self
-      end
-
       # Mongoize a plain object into a time.
       #
       # @note This method should not be used, because it does not
@@ -41,36 +31,6 @@ module Mongoid
       # @return [ Object ] self.
       # @deprecated
       def __mongoize_time__
-        self
-      end
-
-      # Try to form a setter from this object.
-      #
-      # @example Try to form a setter.
-      #   object.__setter__
-      #
-      # @return [ String ] The object as a string plus =.
-      def __setter__
-        "#{self}="
-      end
-
-      # Get the value of the object as a mongo friendly sort value.
-      #
-      # @example Get the object as sort criteria.
-      #   object.__sortable__
-      #
-      # @return [ Object ] self.
-      def __sortable__
-        self
-      end
-
-      # Conversion of an object to an $inc-able value.
-      #
-      # @example Convert the object.
-      #   1.__to_inc__
-      #
-      # @return [ Object ] The object.
-      def __to_inc__
         self
       end
 

--- a/lib/mongoid/extensions/range.rb
+++ b/lib/mongoid/extensions/range.rb
@@ -7,16 +7,6 @@ module Mongoid
     # Adds type-casting behavior to Range class.
     module Range
 
-      # Get the range as arguments for a find.
-      #
-      # @example Get the range as find args.
-      #   range.__find_args__
-      #
-      # @return [ Array ] The range as an array.
-      def __find_args__
-        to_a
-      end
-
       # Turn the object from the ruby type we deal with to a Mongo friendly
       # type.
       #

--- a/lib/mongoid/extensions/true_class.rb
+++ b/lib/mongoid/extensions/true_class.rb
@@ -7,16 +7,6 @@ module Mongoid
     # Adds type-casting behavior to TrueClass
     module TrueClass
 
-      # Get the value of the object as a mongo friendly sort value.
-      #
-      # @example Get the object as sort criteria.
-      #   object.__sortable__
-      #
-      # @return [ Integer ] 1.
-      def __sortable__
-        1
-      end
-
       # Is the passed value a boolean?
       #
       # @example Is the value a boolean type?


### PR DESCRIPTION
Remove the following double-underscore monkey-patches:
- Object#__find_args__ (also defined in Array, Range)
- Object#__setter__ (also defined in NilClass)
- Object#__sortable__ (also defined in TrueClass, FalseClass)
- Object#__to_inc__ (also defined in BigDecimal)

These methods are not used anywhere in the codebase (nor do they have any tests.) Since their names have double-underscore we can assume they are safe to remove. I will explicitly mark them as deprecated in 8.1 for good measure.