### PR TITLE
MONGOID-5664 [Monkey Patch Removal] Remove Object#__setter__ monkey-patch

### DIFF
--- a/lib/mongoid/association/relatable.rb
+++ b/lib/mongoid/association/relatable.rb
@@ -81,7 +81,7 @@ module Mongoid
       #
       # @return [ String ] The type setter method.
       def type_setter
-        @type_setter ||= type.__setter__
+        @type_setter ||= "#{type}=" if type
       end
 
       # Whether trying to bind an object using this association should raise
@@ -233,7 +233,7 @@ module Mongoid
       #
       # @return [ String ] The name of the setter.
       def inverse_type_setter
-        @inverse_type_setter ||= inverse_type.__setter__
+        @inverse_type_setter ||= "#{inverse_type}=" if inverse_type
       end
 
       # Get the name of the method to check if the foreign key has changed.

--- a/lib/mongoid/extensions/nil_class.rb
+++ b/lib/mongoid/extensions/nil_class.rb
@@ -7,16 +7,6 @@ module Mongoid
     # Adds type-casting behavior to NilClass.
     module NilClass
 
-      # Try to form a setter from this object.
-      #
-      # @example Try to form a setter.
-      #   object.__setter__
-      #
-      # @return [ nil ] Always nil.
-      def __setter__
-        self
-      end
-
       # Get the name of a nil collection.
       #
       # @example Get the nil name.

--- a/lib/mongoid/extensions/nil_class.rb
+++ b/lib/mongoid/extensions/nil_class.rb
@@ -3,9 +3,19 @@
 
 module Mongoid
   module Extensions
-
     # Adds type-casting behavior to NilClass.
     module NilClass
+      # Try to form a setter from this object.
+      #
+      # @example Try to form a setter.
+      #   object.__setter__
+      #
+      # @return [ nil ] Always nil.
+      # @deprecated
+      def __setter__
+        self
+      end
+      Mongoid.deprecate(self, :__setter__)
 
       # Get the name of a nil collection.
       #
@@ -20,4 +30,4 @@ module Mongoid
   end
 end
 
-::NilClass.__send__(:include, Mongoid::Extensions::NilClass)
+NilClass.include Mongoid::Extensions::NilClass

--- a/lib/mongoid/extensions/object.rb
+++ b/lib/mongoid/extensions/object.rb
@@ -44,16 +44,6 @@ module Mongoid
         self
       end
 
-      # Try to form a setter from this object.
-      #
-      # @example Try to form a setter.
-      #   object.__setter__
-      #
-      # @return [ String ] The object as a string plus =.
-      def __setter__
-        "#{self}="
-      end
-
       # Get the value of the object as a mongo friendly sort value.
       #
       # @example Get the object as sort criteria.

--- a/lib/mongoid/extensions/object.rb
+++ b/lib/mongoid/extensions/object.rb
@@ -44,6 +44,18 @@ module Mongoid
         self
       end
 
+      # Try to form a setter from this object.
+      #
+      # @example Try to form a setter.
+      #   object.__setter__
+      #
+      # @return [ String ] The object as a string plus =.
+      # @deprecated
+      def __setter__
+        "#{self}="
+      end
+      Mongoid.deprecate(self, :__setter__)
+
       # Get the value of the object as a mongo friendly sort value.
       #
       # @example Get the object as sort criteria.


### PR DESCRIPTION
Fixes [MONGOID-5664](https://jira.mongodb.org/browse/MONGOID-5664)

`Object#__setter__` is a kernel monkey-patch used only in `Mongoid::Association::Relatable`. This is a trivial method so I've just inlined it. (The same logic is already inlined in several other places.)

Overall progress is tracked here: http://tinyurl.com/mongoid-monkey. Refer to [MONGOID-5660](https://jira.mongodb.org/browse/MONGOID-5660) for context.
