### PR TITLE
MONGOID-5663 [Monkey Patch Removal] Remove Object#__sortable__

### DIFF
--- a/lib/mongoid/contextual/memory.rb
+++ b/lib/mongoid/contextual/memory.rb
@@ -647,25 +647,6 @@ module Mongoid
         compare_operand(a) <=> compare_operand(b)
       end
 
-      # Get the operand value to be used in comparison.
-      # Adds capability to sort boolean values.
-      #
-      # @api private
-      #
-      # @example Get the comparison operand.
-      #   compare_operand(true) #=> 1
-      #
-      # @param [ Object ] value The value to be used in comparison.
-      #
-      # @return [ Integer | Object ] The comparison operand.
-      def compare_operand(value)
-        case value
-        when TrueClass then 1
-        when FalseClass then 0
-        else value
-        end
-      end
-
       # Sort the documents in place.
       #
       # @example Sort the documents.
@@ -700,6 +681,23 @@ module Mongoid
 
       def _session
         @criteria.send(:_session)
+      end
+
+      # Get the operand value to be used in comparison.
+      # Adds capability to sort boolean values.
+      #
+      # @example Get the comparison operand.
+      #   compare_operand(true) #=> 1
+      #
+      # @param [ Object ] value The value to be used in comparison.
+      #
+      # @return [ Integer | Object ] The comparison operand.
+      def compare_operand(value)
+        case value
+        when TrueClass then 1
+        when FalseClass then 0
+        else value
+        end
       end
 
       # Retrieve the value for the current document at the given field path.

--- a/lib/mongoid/contextual/memory.rb
+++ b/lib/mongoid/contextual/memory.rb
@@ -627,7 +627,8 @@ module Mongoid
         end
       end
 
-      # Compare two values, checking for nil.
+      # Compare two values, handling the cases when
+      # either value is nil.
       #
       # @api private
       #
@@ -635,14 +636,33 @@ module Mongoid
       #   context.compare(a, b)
       #
       # @param [ Object ] a The first object.
-      # @param [ Object ] b The first object.
+      # @param [ Object ] b The second object.
       #
       # @return [ Integer ] The comparison value.
       def compare(a, b)
-        case
-        when a.nil? then b.nil? ? 0 : 1
-        when b.nil? then -1
-        else a <=> b
+        return 0 if a.nil? && b.nil?
+        return 1 if a.nil?
+        return -1 if b.nil?
+
+        compare_operand(a) <=> compare_operand(b)
+      end
+
+      # Get the operand value to be used in comparison.
+      # Adds capability to sort boolean values.
+      #
+      # @api private
+      #
+      # @example Get the comparison operand.
+      #   compare_operand(true) #=> 1
+      #
+      # @param [ Object ] value The value to be used in comparison.
+      #
+      # @return [ Integer | Object ] The comparison operand.
+      def compare_operand(value)
+        case value
+        when TrueClass then 1
+        when FalseClass then 0
+        else value
         end
       end
 
@@ -655,9 +675,8 @@ module Mongoid
       def in_place_sort(values)
         documents.sort! do |a, b|
           values.map do |field, direction|
-            a_value, b_value = a[field], b[field]
-            direction * compare(a_value.__sortable__, b_value.__sortable__)
-          end.find { |value| !value.zero? } || 0
+            direction * compare(a[field], b[field])
+          end.detect { |value| !value.zero? } || 0
         end
       end
 

--- a/lib/mongoid/extensions/false_class.rb
+++ b/lib/mongoid/extensions/false_class.rb
@@ -3,9 +3,19 @@
 
 module Mongoid
   module Extensions
-
     # Adds type-casting behavior to FalseClass.
     module FalseClass
+      # Get the value of the object as a mongo friendly sort value.
+      #
+      # @example Get the object as sort criteria.
+      #   object.__sortable__
+      #
+      # @return [ Integer ] 0.
+      # @deprecated
+      def __sortable__
+        0
+      end
+      Mongoid.deprecate(self, :__sortable__)
 
       # Is the passed value a boolean?
       #
@@ -25,4 +35,4 @@ module Mongoid
   end
 end
 
-::FalseClass.__send__(:include, Mongoid::Extensions::FalseClass)
+FalseClass.include Mongoid::Extensions::FalseClass

--- a/lib/mongoid/extensions/false_class.rb
+++ b/lib/mongoid/extensions/false_class.rb
@@ -7,16 +7,6 @@ module Mongoid
     # Adds type-casting behavior to FalseClass.
     module FalseClass
 
-      # Get the value of the object as a mongo friendly sort value.
-      #
-      # @example Get the object as sort criteria.
-      #   object.__sortable__
-      #
-      # @return [ Integer ] 0.
-      def __sortable__
-        0
-      end
-
       # Is the passed value a boolean?
       #
       # @example Is the value a boolean type?

--- a/lib/mongoid/extensions/object.rb
+++ b/lib/mongoid/extensions/object.rb
@@ -54,16 +54,6 @@ module Mongoid
         "#{self}="
       end
 
-      # Get the value of the object as a mongo friendly sort value.
-      #
-      # @example Get the object as sort criteria.
-      #   object.__sortable__
-      #
-      # @return [ Object ] self.
-      def __sortable__
-        self
-      end
-
       # Conversion of an object to an $inc-able value.
       #
       # @example Convert the object.

--- a/lib/mongoid/extensions/object.rb
+++ b/lib/mongoid/extensions/object.rb
@@ -54,6 +54,18 @@ module Mongoid
         "#{self}="
       end
 
+      # Get the value of the object as a mongo friendly sort value.
+      #
+      # @example Get the object as sort criteria.
+      #   object.__sortable__
+      #
+      # @return [ Object ] self.
+      # @deprecated
+      def __sortable__
+        self
+      end
+      Mongoid.deprecate(self, :__sortable__)
+
       # Conversion of an object to an $inc-able value.
       #
       # @example Convert the object.

--- a/lib/mongoid/extensions/true_class.rb
+++ b/lib/mongoid/extensions/true_class.rb
@@ -7,16 +7,6 @@ module Mongoid
     # Adds type-casting behavior to TrueClass
     module TrueClass
 
-      # Get the value of the object as a mongo friendly sort value.
-      #
-      # @example Get the object as sort criteria.
-      #   object.__sortable__
-      #
-      # @return [ Integer ] 1.
-      def __sortable__
-        1
-      end
-
       # Is the passed value a boolean?
       #
       # @example Is the value a boolean type?

--- a/lib/mongoid/extensions/true_class.rb
+++ b/lib/mongoid/extensions/true_class.rb
@@ -3,9 +3,19 @@
 
 module Mongoid
   module Extensions
-
     # Adds type-casting behavior to TrueClass
     module TrueClass
+      # Get the value of the object as a mongo friendly sort value.
+      #
+      # @example Get the object as sort criteria.
+      #   object.__sortable__
+      #
+      # @return [ Integer ] 1.
+      # @deprecated
+      def __sortable__
+        1
+      end
+      Mongoid.deprecate(self, :__sortable__)
 
       # Is the passed value a boolean?
       #
@@ -25,4 +35,4 @@ module Mongoid
   end
 end
 
-::TrueClass.__send__(:include, Mongoid::Extensions::TrueClass)
+TrueClass.include Mongoid::Extensions::TrueClass

--- a/spec/mongoid/extensions/false_class_spec.rb
+++ b/spec/mongoid/extensions/false_class_spec.rb
@@ -5,13 +5,6 @@ require "spec_helper"
 
 describe Mongoid::Extensions::FalseClass do
 
-  describe "#__sortable__" do
-
-    it "returns 0" do
-      expect(false.__sortable__).to eq(0)
-    end
-  end
-
   describe "#is_a?" do
 
     context "when provided a Boolean" do

--- a/spec/mongoid/extensions/object_spec.rb
+++ b/spec/mongoid/extensions/object_spec.rb
@@ -128,13 +128,6 @@ describe Mongoid::Extensions::Object do
     end
   end
 
-  describe "#__sortable__" do
-
-    it "returns self" do
-      expect(object.__sortable__).to eq(object)
-    end
-  end
-
   describe ".demongoize" do
 
     let(:object) do

--- a/spec/mongoid/extensions/true_class_spec.rb
+++ b/spec/mongoid/extensions/true_class_spec.rb
@@ -5,13 +5,6 @@ require "spec_helper"
 
 describe Mongoid::Extensions::TrueClass do
 
-  describe "#__sortable__" do
-
-    it "returns 1" do
-      expect(true.__sortable__).to eq(1)
-    end
-  end
-
   describe "#is_a?" do
 
     context "when provided a Boolean" do


### PR DESCRIPTION
Fixes MONGOID-5663

`Object#__sortable__` is a kernel monkey patch which is only used in `Contextual::Memory`.

This PR moves it to a private method in `Contextual::Memory` with a minor amount of refactoring. Existing tests already cover all the functionality.

Overall progress is tracked here: http://tinyurl.com/mongoid-monkey. Refer to [MONGOID-5660](https://jira.mongodb.org/browse/MONGOID-5660) for context.