### PR TITLE
MONGOID-5662 [Monkey Patch Removal] Remove Object#__to_inc__

### DIFF
--- a/lib/mongoid/extensions/big_decimal.rb
+++ b/lib/mongoid/extensions/big_decimal.rb
@@ -7,16 +7,6 @@ module Mongoid
     # Adds type-casting behavior to BigDecimal class.
     module BigDecimal
 
-      # Convert the big decimal to an $inc-able value.
-      #
-      # @example Convert the big decimal.
-      #   bd.__to_inc__
-      #
-      # @return [ Float ] The big decimal as a float.
-      def __to_inc__
-        to_f
-      end
-
       # Turn the object from the ruby type we deal with to a Mongo friendly
       # type.
       #

--- a/lib/mongoid/extensions/object.rb
+++ b/lib/mongoid/extensions/object.rb
@@ -64,16 +64,6 @@ module Mongoid
         self
       end
 
-      # Conversion of an object to an $inc-able value.
-      #
-      # @example Convert the object.
-      #   1.__to_inc__
-      #
-      # @return [ Object ] The object.
-      def __to_inc__
-        self
-      end
-
       # Checks whether conditions given in this object are known to be
       # unsatisfiable, i.e., querying with this object will always return no
       # documents.

--- a/lib/mongoid/persistable/incrementable.rb
+++ b/lib/mongoid/persistable/incrementable.rb
@@ -21,10 +21,10 @@ module Mongoid
       def inc(increments)
         prepare_atomic_operation do |ops|
           process_atomic_operations(increments) do |field, value|
-            increment = value.__to_inc__
+            increment = value.is_a?(BigDecimal) ? value.to_f : value
             current = attributes[field]
             new_value = (current || 0) + increment
-            process_attribute field, new_value if executing_atomically?
+            process_attribute(field, new_value) if executing_atomically?
             attributes[field] = new_value
             ops[atomic_attribute_name(field)] = increment
           end

--- a/lib/mongoid/persistable/multipliable.rb
+++ b/lib/mongoid/persistable/multipliable.rb
@@ -21,10 +21,10 @@ module Mongoid
       def mul(factors)
         prepare_atomic_operation do |ops|
           process_atomic_operations(factors) do |field, value|
-            factor = value.__to_inc__
+            factor = value.is_a?(BigDecimal) ? value.to_f : value
             current = attributes[field]
             new_value = (current || 0) * factor
-            process_attribute field, new_value if executing_atomically?
+            process_attribute(field, new_value) if executing_atomically?
             attributes[field] = new_value
             ops[atomic_attribute_name(field)] = factor
           end


### PR DESCRIPTION
Fixes MONGOID-5662

`Object#__to_inc__` is a kernel monkey patch used only in the #inc and #mul atomic methods.

This PR removes the monkey patch and inlines its code to the two places it is used. The logic is covered by existing specs, so no new specs needed.

Overall progress is tracked here: http://tinyurl.com/mongoid-monkey. Refer to [MONGOID-5660](https://jira.mongodb.org/browse/MONGOID-5660) for context.