### PR TITLE
MONGOID-5673 [Monkey Patch Removal] Remove Object#do_or_do_not and Object#you_must

### DIFF
--- a/lib/mongoid/association/bindable.rb
+++ b/lib/mongoid/association/bindable.rb
@@ -120,7 +120,7 @@ module Mongoid
       # @param [ Object ] id The id of the bound document.
       def bind_foreign_key(keyed, id)
         unless keyed.frozen?
-          keyed.you_must(_association.foreign_key_setter, id)
+          try_method(keyed, _association.foreign_key_setter, id)
         end
       end
 
@@ -135,8 +135,8 @@ module Mongoid
       # @param [ Document ] typed The document that stores the type field.
       # @param [ String ] name The name of the model.
       def bind_polymorphic_type(typed, name)
-        if _association.type
-          typed.you_must(_association.type_setter, name)
+        if _association.type && !typed.frozen?
+          try_method(typed, _association.type_setter, name)
         end
       end
 
@@ -151,8 +151,8 @@ module Mongoid
       # @param [ Document ] typed The document that stores the type field.
       # @param [ String ] name The name of the model.
       def bind_polymorphic_inverse_type(typed, name)
-        if _association.inverse_type
-          typed.you_must(_association.inverse_type_setter, name)
+        if _association.inverse_type && !typed.frozen?
+          try_method(typed, _association.inverse_type_setter, name)
         end
       end
 
@@ -167,8 +167,8 @@ module Mongoid
       # @param [ Document ] doc The base document.
       # @param [ Document ] inverse The inverse document.
       def bind_inverse(doc, inverse)
-        if doc.respond_to?(_association.inverse_setter)
-          doc.you_must(_association.inverse_setter, inverse)
+        if doc.respond_to?(_association.inverse_setter) && !doc.frozen?
+          try_method(doc, _association.inverse_setter, inverse)
         end
       end
 
@@ -222,6 +222,24 @@ module Mongoid
         bind_foreign_key(doc, nil)
         bind_polymorphic_type(doc, nil)
         bind_inverse(doc, nil)
+      end
+
+      # Convenience method to perform +#try+ but return
+      # nil if the method argument is nil.
+      #
+      # @example Call method if it exists.
+      #   object.try_method(:use, "The Force")
+      #
+      # @example Return nil if method argument is nil.
+      #   object.try_method(nil, "The Force") #=> nil
+      #
+      # @param [ String | Symbol ] method_name The method name.
+      # @param [ Object... ] *args The arguments.
+      #
+      # @return [ Object | nil ] The result of the try or nil if the
+      #   method does not exist.
+      def try_method(object, method_name, *args)
+        object.try(method_name, *args) if method_name
       end
     end
   end

--- a/lib/mongoid/association/embedded/embedded_in/binding.rb
+++ b/lib/mongoid/association/embedded/embedded_in/binding.rb
@@ -25,10 +25,10 @@ module Mongoid
               _base._association = _association.inverse_association(_target) unless _base._association
               _base.parentize(_target)
               if _base.embedded_many?
-                _target.do_or_do_not(_association.inverse(_target)).push(_base)
+                _target.send(_association.inverse(_target)).push(_base)
               else
                 remove_associated(_target)
-                _target.do_or_do_not(_association.inverse_setter(_target), _base)
+                try_method(_target, _association.inverse_setter(_target), _base)
               end
             end
           end
@@ -42,9 +42,9 @@ module Mongoid
           def unbind_one
             binding do
               if _base.embedded_many?
-                _target.do_or_do_not(_association.inverse(_target)).delete(_base)
+                _target.send(_association.inverse(_target)).delete(_base)
               else
-                _target.do_or_do_not(_association.inverse_setter(_target), nil)
+                try_method(_target, _association.inverse_setter(_target), nil)
               end
             end
           end

--- a/lib/mongoid/association/embedded/embeds_many/binding.rb
+++ b/lib/mongoid/association/embedded/embeds_many/binding.rb
@@ -21,7 +21,7 @@ module Mongoid
             doc.parentize(_base)
             binding do
               remove_associated(doc)
-              doc.do_or_do_not(_association.inverse_setter(_target), _base)
+              try_method(doc, _association.inverse_setter(_target), _base)
             end
           end
 
@@ -33,7 +33,7 @@ module Mongoid
           # @param [ Document ] doc The single document to unbind.
           def unbind_one(doc)
             binding do
-              doc.do_or_do_not(_association.inverse_setter(_target), nil)
+              try_method(doc, _association.inverse_setter(_target), nil)
             end
           end
         end

--- a/lib/mongoid/association/embedded/embeds_one/binding.rb
+++ b/lib/mongoid/association/embedded/embeds_one/binding.rb
@@ -22,7 +22,7 @@ module Mongoid
           def bind_one
             _target.parentize(_base)
             binding do
-              _target.do_or_do_not(_association.inverse_setter(_target), _base)
+              try_method(_target, _association.inverse_setter(_target), _base)
             end
           end
 
@@ -34,7 +34,7 @@ module Mongoid
           #   person.name = nil
           def unbind_one
             binding do
-              _target.do_or_do_not(_association.inverse_setter(_target), nil)
+              try_method(_target, _association.inverse_setter(_target), nil)
             end
           end
         end

--- a/lib/mongoid/association/referenced/has_and_belongs_to_many/binding.rb
+++ b/lib/mongoid/association/referenced/has_and_belongs_to_many/binding.rb
@@ -19,15 +19,13 @@ module Mongoid
           # @param [ Document ] doc The single document to bind.
           def bind_one(doc)
             binding do
-              unless doc.frozen?
-                inverse_keys = try_method(doc, _association.inverse_foreign_key)
-                if inverse_keys
-                  record_id = inverse_record_id(doc)
-                  unless inverse_keys.include?(record_id)
-                    try_method(doc, _association.inverse_foreign_key_setter, inverse_keys.push(record_id))
-                  end
-                  doc.reset_relation_criteria(_association.inverse)
+              inverse_keys = try_method(doc, _association.inverse_foreign_key) unless doc.frozen?
+              if inverse_keys
+                record_id = inverse_record_id(doc)
+                unless inverse_keys.include?(record_id)
+                  try_method(doc, _association.inverse_foreign_key_setter, inverse_keys.push(record_id))
                 end
+                doc.reset_relation_criteria(_association.inverse)
               end
               _base._synced[_association.foreign_key] = true
               doc._synced[_association.inverse_foreign_key] = true
@@ -41,12 +39,10 @@ module Mongoid
           def unbind_one(doc)
             binding do
               _base.send(_association.foreign_key).delete_one(record_id(doc))
-              unless doc.frozen?
-                inverse_keys = try_method(doc, _association.inverse_foreign_key)
-                if inverse_keys
-                  inverse_keys.delete_one(inverse_record_id(doc))
-                  doc.reset_relation_criteria(_association.inverse)
-                end
+              inverse_keys = try_method(doc, _association.inverse_foreign_key) unless doc.frozen?
+              if inverse_keys
+                inverse_keys.delete_one(inverse_record_id(doc))
+                doc.reset_relation_criteria(_association.inverse)
               end
               _base._synced[_association.foreign_key] = true
               doc._synced[_association.inverse_foreign_key] = true

--- a/lib/mongoid/cacheable.rb
+++ b/lib/mongoid/cacheable.rb
@@ -27,7 +27,7 @@ module Mongoid
     # @return [ String ] the string with or without updated_at
     def cache_key
       return "#{model_key}/new" if new_record?
-      return "#{model_key}/#{_id}-#{updated_at.utc.to_formatted_s(cache_timestamp_format)}" if do_or_do_not(:updated_at)
+      return "#{model_key}/#{_id}-#{updated_at.utc.to_formatted_s(cache_timestamp_format)}" if try(:updated_at)
       "#{model_key}/#{_id}"
     end
   end

--- a/lib/mongoid/extensions/object.rb
+++ b/lib/mongoid/extensions/object.rb
@@ -88,6 +88,23 @@ module Mongoid
         false
       end
 
+
+      # Do or do not, there is no try. -- Yoda.
+      #
+      # @example Do or do not.
+      #   object.do_or_do_not(:use, "The Force")
+      #
+      # @param [ String | Symbol ] name The method name.
+      # @param [ Object... ] *args The arguments.
+      #
+      # @return [ Object | nil ] The result of the method call or nil if the
+      #   method does not exist.
+      # @deprecated
+      def do_or_do_not(name, *args)
+        send(name, *args) if name && respond_to?(name)
+      end
+      Mongoid.deprecate(self, :do_or_do_not)
+
       # Get the value for an instance variable or false if it doesn't exist.
       #
       # @example Get the value for an instance var.
@@ -172,6 +189,22 @@ module Mongoid
       def substitutable
         self
       end
+
+      # You must unlearn what you have learned. -- Yoda
+      #
+      # @example You must perform this execution.
+      #   object.you_must(:use, "The Force")
+      #
+      # @param [ String | Symbol ] name The method name.
+      # @param [ Object... ] *args The arguments.
+      #
+      # @return [ Object | nil ] The result of the method call or nil if the
+      #   method does not exist. Nil if the object is frozen.
+      # @deprecated
+      def you_must(name, *args)
+        frozen? ? nil : do_or_do_not(name, *args)
+      end
+      Mongoid.deprecate(self, :you_must)
 
       module ClassMethods
 

--- a/lib/mongoid/extensions/object.rb
+++ b/lib/mongoid/extensions/object.rb
@@ -88,20 +88,6 @@ module Mongoid
         false
       end
 
-      # Do or do not, there is no try. -- Yoda.
-      #
-      # @example Do or do not.
-      #   object.do_or_do_not(:use, "The Force")
-      #
-      # @param [ String | Symbol ] name The method name.
-      # @param [ Object... ] *args The arguments.
-      #
-      # @return [ Object | nil ] The result of the method call or nil if the
-      #   method does not exist.
-      def do_or_do_not(name, *args)
-        send(name, *args) if name && respond_to?(name)
-      end
-
       # Get the value for an instance variable or false if it doesn't exist.
       #
       # @example Get the value for an instance var.
@@ -185,20 +171,6 @@ module Mongoid
       # @return [ Object ] self.
       def substitutable
         self
-      end
-
-      # You must unlearn what you have learned. -- Yoda
-      #
-      # @example You must perform this execution.
-      #   object.you_must(:use, "The Force")
-      #
-      # @param [ String | Symbol ] name The method name.
-      # @param [ Object... ] *args The arguments.
-      #
-      # @return [ Object | nil ] The result of the method call or nil if the
-      #   method does not exist. Nil if the object is frozen.
-      def you_must(name, *args)
-        frozen? ? nil : do_or_do_not(name, *args)
       end
 
       module ClassMethods

--- a/lib/mongoid/validatable.rb
+++ b/lib/mongoid/validatable.rb
@@ -68,7 +68,7 @@ module Mongoid
         begin_validate
         relation = without_autobuild { send(attr) }
         exit_validate
-        relation.do_or_do_not(:in_memory) || relation
+        relation.try(:in_memory) || relation
       elsif fields[attribute].try(:localized?)
         attributes[attribute]
       else

--- a/spec/mongoid/extensions/object_spec.rb
+++ b/spec/mongoid/extensions/object_spec.rb
@@ -146,45 +146,6 @@ describe Mongoid::Extensions::Object do
     end
   end
 
-  describe "#do_or_do_not" do
-
-    context "when the object is nil" do
-
-      let(:result) do
-        nil.do_or_do_not(:not_a_method, "The force is strong with you")
-      end
-
-      it "returns nil" do
-        expect(result).to be_nil
-      end
-    end
-
-    context "when the object is not nil" do
-
-      context "when the object responds to the method" do
-
-        let(:result) do
-          [ "Yoda", "Luke" ].do_or_do_not(:join, ",")
-        end
-
-        it "returns the result of the method" do
-          expect(result).to eq("Yoda,Luke")
-        end
-      end
-
-      context "when the object does not respond to the method" do
-
-        let(:result) do
-          "Yoda".do_or_do_not(:use, "The Force", 1000)
-        end
-
-        it "returns the result of the method" do
-          expect(result).to be_nil
-        end
-      end
-    end
-  end
-
   describe ".mongoize" do
 
     let(:object) do

--- a/spec/mongoid/extensions/object_spec.rb
+++ b/spec/mongoid/extensions/object_spec.rb
@@ -214,24 +214,6 @@ describe Mongoid::Extensions::Object do
     end
   end
 
-  describe "#you_must" do
-
-    context "when the object is frozen" do
-
-      let(:person) do
-        Person.new.tap { |peep| peep.freeze }
-      end
-
-      let(:result) do
-        person.you_must(:aliases=, [])
-      end
-
-      it "returns nil" do
-        expect(result).to be_nil
-      end
-    end
-  end
-
   describe "#remove_ivar" do
 
     context "when the instance variable is defined" do


### PR DESCRIPTION
Fixes MONGOID-5673

Object#do_or_do_not and Object#you_must are kernel monkey patches which are similar to #try. Someone got cute and added Star Wars Yoda references `#do_or_do_not, there is no #try`.

For `#do_or_do_not` usages which can obviously be replaced with `#try` or `#send` I've done so. The remaining usages are localized to the `Bindable` module, so I've added a convenience method there which I've named `#try_method`.

For `#you_must`, I've inlined the call the `if frozen?`

No tests added here because the method is private and trivial.

> Don't be too proud of this technological terror you've constructed.
> -- Darth Vader.

### Note about Future Refactoring

`#try` (and `#try_method` used here) are code smells. `#try_method` should be removed entirely in in the future, but at least for now it's localized to the `Bindable` module (far better than a monkey patch on `Object`.)

Overall progress is tracked here: http://tinyurl.com/mongoid-monkey. Refer to [MONGOID-5660](https://jira.mongodb.org/browse/MONGOID-5660) for context.