### PR TITLE
[Monkey Patch Removal] Remove Object#regexp?

### DIFF
--- a/lib/mongoid/criteria/queryable/extensions/object.rb
+++ b/lib/mongoid/criteria/queryable/extensions/object.rb
@@ -122,16 +122,6 @@ module Mongoid
             self
           end
 
-          # Is the object a regex.
-          #
-          # @example Is the object a regex?
-          #   obj.regexp?
-          #
-          # @return [ false ] Always false.
-          def regexp?
-            false
-          end
-
           module ClassMethods
 
             # Evolve the object.

--- a/lib/mongoid/criteria/queryable/extensions/regexp.rb
+++ b/lib/mongoid/criteria/queryable/extensions/regexp.rb
@@ -9,14 +9,6 @@ module Mongoid
         # Adds query type-casting behavior to Regexp class.
         module Regexp
 
-          # Is the object a regexp?
-          #
-          # @example Is the object a regex?
-          #   /\A[123]/.regexp?
-          #
-          # @return [ true ] Always true.
-          def regexp?; true; end
-
           module ClassMethods
 
             # Evolve the object into a regex.
@@ -36,14 +28,6 @@ module Mongoid
 
           # Adds query type-casting behavior to BSON::Regexp::Raw class.
           module Raw_
-
-            # Is the object a regexp?
-            #
-            # @example Is the object a regex?
-            #   bson_raw_regexp.regexp?
-            #
-            # @return [ true ] Always true.
-            def regexp?; true; end
 
             module ClassMethods
 

--- a/lib/mongoid/criteria/queryable/extensions/string.rb
+++ b/lib/mongoid/criteria/queryable/extensions/string.rb
@@ -82,7 +82,7 @@ module Mongoid
             # @return [ Hash ] The selection.
             def __expr_part__(key, value, negating = false)
               if negating
-                { key => { "$#{value.regexp? ? "not" : "ne"}" => value }}
+                { key => { "$#{__regexp?(value) ? "not" : "ne"}" => value }}
               else
                 { key => value }
               end
@@ -99,8 +99,19 @@ module Mongoid
             # @return [ String ] The value as a string.
             def evolve(object)
               __evolve__(object) do |obj|
-                obj.regexp? ? obj : obj.to_s
+                __regexp?(obj) ? obj : obj.to_s
               end
+            end
+
+            private
+
+            # Returns whether the object is Regexp-like.
+            #
+            # @param [ Object ] object The object to evaluate.
+            #
+            # @return [ Boolean ] Whether the object is Regexp-like.
+            def __regexp?(object)
+              object.is_a?(Regexp) || object.is_a?(BSON::Regexp::Raw)
             end
           end
         end

--- a/spec/mongoid/criteria/queryable/extensions/regexp_raw_spec.rb
+++ b/spec/mongoid/criteria/queryable/extensions/regexp_raw_spec.rb
@@ -78,15 +78,4 @@ describe Mongoid::Criteria::Queryable::Extensions::Regexp::Raw_ do
       end
     end
   end
-
-  describe "#regexp?" do
-
-    let(:regexp) do
-      BSON::Regexp::Raw.new('^[123]')
-    end
-
-    it "returns true" do
-      expect(regexp).to be_regexp
-    end
-  end
 end

--- a/spec/mongoid/criteria/queryable/extensions/regexp_spec.rb
+++ b/spec/mongoid/criteria/queryable/extensions/regexp_spec.rb
@@ -79,15 +79,4 @@ describe Mongoid::Criteria::Queryable::Extensions::Regexp do
       end
     end
   end
-
-  describe "#regexp?" do
-
-    let(:regexp) do
-      /\A[123]/
-    end
-
-    it "returns true" do
-      expect(regexp).to be_regexp
-    end
-  end
 end

--- a/spec/mongoid/criteria/queryable/extensions/string_spec.rb
+++ b/spec/mongoid/criteria/queryable/extensions/string_spec.rb
@@ -181,84 +181,83 @@ describe String do
     end
   end
 
-  describe "#__expr_part__" do
+  describe '#__expr_part__' do
+    subject(:specified) { 'field'.__expr_part__(value) }
+    let(:value) { 10 }
 
-    let(:specified) do
-      "field".__expr_part__(10)
+    it 'returns the expression with the value' do
+      expect(specified).to eq({ 'field' => 10 })
     end
 
-    it "returns the string with the value" do
-      expect(specified).to eq({ "field" => 10 })
+    context 'with a Regexp' do
+      let(:value) { /test/ }
+
+      it 'returns the expression with the value' do
+        expect(specified).to eq({ 'field' => /test/ })
+      end
     end
 
-    context "with a regexp" do
+    context 'with a BSON::Regexp::Raw' do
+      let(:value) { BSON::Regexp::Raw.new('^[123]') }
 
-      let(:specified) do
-        "field".__expr_part__(/test/)
+      it 'returns the expression with the value' do
+        expect(specified).to eq({ 'field' => BSON::Regexp::Raw.new('^[123]') })
       end
-
-      it "returns the symbol with the value" do
-        expect(specified).to eq({ "field" => /test/ })
-      end
-
     end
 
-    context "when negated" do
+    context 'when negated' do
+      subject(:specified) { 'field'.__expr_part__(value, true) }
 
-      context "with a regexp" do
+      context 'with a Regexp' do
+        let(:value) { /test/ }
 
-        let(:specified) do
-          "field".__expr_part__(/test/, true)
+        it 'returns the expression with the value negated' do
+          expect(specified).to eq({ 'field' => { '$not' => /test/ } })
         end
-
-        it "returns the string with the value negated" do
-          expect(specified).to eq({ "field" => { "$not" => /test/ } })
-        end
-
       end
 
-      context "with anything else" do
+      context 'with a BSON::Regexp::Raw' do
+        let(:value) { BSON::Regexp::Raw.new('^[123]') }
 
-        let(:specified) do
-          "field".__expr_part__('test', true)
+        it 'returns the expression with the value' do
+          expect(specified).to eq({ 'field' => { '$not' => BSON::Regexp::Raw.new('^[123]') } })
         end
+      end
 
-        it "returns the string with the value negated" do
-          expect(specified).to eq({ "field" => { "$ne" => "test" }})
+      context 'with anything else' do
+        let(:value) { 'test' }
+
+        it 'returns the expression with the value negated' do
+          expect(specified).to eq({ 'field' => { '$ne' => 'test' }})
         end
       end
     end
   end
 
-  describe ".evolve" do
+  describe '.evolve' do
+    subject(:evolved) { described_class.evolve(object) }
 
-    context "when provided a regex" do
+    context 'when provided a Regexp' do
+      let(:object) { /\A[123]/.freeze }
 
-      let(:regex) do
-        /\A[123]/.freeze
-      end
-
-      let(:evolved) do
-        described_class.evolve(regex)
-      end
-
-      it "returns the regex" do
-        expect(evolved).to eq(regex)
+      it 'returns the regexp' do
+        expect(evolved).to eq(/\A[123]/)
       end
     end
 
-    context "when provided an object" do
+    context 'when provided a BSON::Regexp::Raw' do
+      let(:object) { BSON::Regexp::Raw.new('^[123]') }
 
-      let(:object) do
-        1234
+      it 'returns the BSON::Regexp::Raw' do
+        expect(evolved).to eq(BSON::Regexp::Raw.new('^[123]'))
       end
+    end
 
-      let(:evolved) do
-        described_class.evolve(object)
-      end
+    context 'when provided an object' do
+      let(:object) { 1234 }
 
-      it "returns the object as a string" do
-        expect(evolved).to eq("1234")
+      it 'returns the object as a string' do
+        expect(evolved).to eq('1234')
       end
     end
   end


### PR DESCRIPTION
Object#regexp? is a trivial kernel monkey patch which returns true for Regexp and BSON::Regexp::Raw, and false for all else, including BSON::Regexp.

