### PR TITLE
MONGOID-5656 Rails specs ought to enable FLE

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -681,6 +681,7 @@ buildvariants:
     topology: "standalone"
     rails: ['7.0']
     os: debian11
+    fle: helper
   display_name: "${rails}, ${driver}, ${mongodb-version}"
   tasks:
     - name: "test"
@@ -716,6 +717,7 @@ buildvariants:
     topology: "standalone"
     rails: ['6.0', '6.1']
     os: rhel80
+    fle: helper
   display_name: "${rails}, ${driver}, ${mongodb-version}"
   tasks:
      - name: "test"
@@ -728,6 +730,7 @@ buildvariants:
     topology: "standalone"
     rails: ['5.2']
     os: rhel80
+    fle: helper
   display_name: "${rails}, ${driver}, ${mongodb-version}"
   tasks:
      - name: "test"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -680,7 +680,7 @@ buildvariants:
     mongodb-version: "6.0"
     topology: "standalone"
     rails: ['7.0']
-    os: debian11
+    os: ubuntu-22.04
     fle: helper
   display_name: "${rails}, ${driver}, ${mongodb-version}"
   tasks:
@@ -717,7 +717,6 @@ buildvariants:
     topology: "standalone"
     rails: ['6.0', '6.1']
     os: rhel80
-    fle: helper
   display_name: "${rails}, ${driver}, ${mongodb-version}"
   tasks:
      - name: "test"
@@ -730,7 +729,6 @@ buildvariants:
     topology: "standalone"
     rails: ['5.2']
     os: rhel80
-    fle: helper
   display_name: "${rails}, ${driver}, ${mongodb-version}"
   tasks:
      - name: "test"

--- a/.evergreen/config/variants.yml.erb
+++ b/.evergreen/config/variants.yml.erb
@@ -116,9 +116,9 @@ buildvariants:
     mongodb-version: "6.0"
     topology: "standalone"
     rails: ['7.0']
-    os: debian11
+    os: ubuntu-22.04
     fle: helper
-  display_name: "${rails}, ${driver}, ${mongodb-version}"
+  display_name: "${rails}, ${driver}, ${mongodb-version} (FLE ${fle})"
   tasks:
     - name: "test"
 
@@ -153,7 +153,6 @@ buildvariants:
     topology: "standalone"
     rails: ['6.0', '6.1']
     os: rhel80
-    fle: helper
   display_name: "${rails}, ${driver}, ${mongodb-version}"
   tasks:
      - name: "test"
@@ -166,7 +165,6 @@ buildvariants:
     topology: "standalone"
     rails: ['5.2']
     os: rhel80
-    fle: helper
   display_name: "${rails}, ${driver}, ${mongodb-version}"
   tasks:
      - name: "test"

--- a/.evergreen/config/variants.yml.erb
+++ b/.evergreen/config/variants.yml.erb
@@ -117,6 +117,7 @@ buildvariants:
     topology: "standalone"
     rails: ['7.0']
     os: debian11
+    fle: helper
   display_name: "${rails}, ${driver}, ${mongodb-version}"
   tasks:
     - name: "test"
@@ -152,6 +153,7 @@ buildvariants:
     topology: "standalone"
     rails: ['6.0', '6.1']
     os: rhel80
+    fle: helper
   display_name: "${rails}, ${driver}, ${mongodb-version}"
   tasks:
      - name: "test"
@@ -164,6 +166,7 @@ buildvariants:
     topology: "standalone"
     rails: ['5.2']
     os: rhel80
+    fle: helper
   display_name: "${rails}, ${driver}, ${mongodb-version}"
   tasks:
      - name: "test"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -213,7 +213,7 @@ jobs:
     - name: test
       timeout-minutes: 60
       continue-on-error: "${{matrix.experimental}}"
-      run: bundle exec rake spec
+      run: bundle exec rake ci
       env:
         BUNDLE_GEMFILE: "${{matrix.gemfile}}"
         FLE: "${{matrix.fle}}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,8 +7,8 @@ name: Run Mongoid Tests
 - pull_request
 jobs:
   build:
-    name: "${{matrix.ruby}} driver-${{matrix.driver}} mongodb-${{matrix.mongodb}}
-      ${{matrix.topology}}"
+    name: "${{matrix.ruby}} drv:${{matrix.driver}} db:${{matrix.mongodb}}
+      rails:${{matrix.rails}} fle:${{matrix.fle}} ${{matrix.topology}}"
     env:
       CI: true
       TESTOPTS: "-v"
@@ -24,8 +24,6 @@ jobs:
           os: ubuntu-20.04
           task: test
           driver: current
-          rails:
-          i18n:
           gemfile: Gemfile
           experimental: false
         - mongodb: '6.0'
@@ -34,8 +32,6 @@ jobs:
           os: ubuntu-20.04
           task: test
           driver: current
-          rails:
-          i18n:
           gemfile: Gemfile
           experimental: false
         - mongodb: '6.0'
@@ -44,8 +40,6 @@ jobs:
           os: ubuntu-20.04
           task: test
           driver: current
-          rails:
-          i18n:
           gemfile: Gemfile
           experimental: false
         - mongodb: '6.0'
@@ -54,8 +48,6 @@ jobs:
           os: ubuntu-20.04
           task: test
           driver: master
-          rails:
-          i18n:
           gemfile: gemfiles/driver_master.gemfile
           experimental: true
         - mongodb: '6.0'
@@ -64,8 +56,6 @@ jobs:
           os: ubuntu-20.04
           task: test
           driver: stable
-          rails:
-          i18n:
           gemfile: gemfiles/driver_stable.gemfile
           experimental: false
         - mongodb: '6.0'
@@ -76,7 +66,6 @@ jobs:
           driver: current
           rails: '7.0'
           fle: helper
-          i18n:
           gemfile: gemfiles/rails-7.0.gemfile
           experimental: false
         - mongodb: '6.0'
@@ -87,7 +76,6 @@ jobs:
           driver: current
           rails: '6.1'
           fle: helper
-          i18n:
           gemfile: gemfiles/rails-6.1.gemfile
           experimental: false
         - mongodb: '6.0'
@@ -98,7 +86,6 @@ jobs:
           driver: current
           rails: '7.0'
           fle: helper
-          i18n:
           gemfile: gemfiles/rails-7.0.gemfile
           experimental: false
         - mongodb: '6.0'
@@ -109,7 +96,6 @@ jobs:
           driver: current
           rails: '6.1'
           fle: helper
-          i18n:
           gemfile: gemfiles/rails-6.1.gemfile
           experimental: false
         - mongodb: '6.0'
@@ -120,7 +106,6 @@ jobs:
           driver: current
           rails: '6.0'
           fle: helper
-          i18n:
           gemfile: gemfiles/rails-6.0.gemfile
           experimental: false
         - mongodb: '6.0'
@@ -131,7 +116,6 @@ jobs:
           driver: current
           rails: '5.2'
           fle: helper
-          i18n:
           gemfile: gemfiles/rails-5.2.gemfile
           experimental: false
         - mongodb: '6.0'
@@ -142,7 +126,6 @@ jobs:
           driver: current
           rails: '6.0'
           fle: helper
-          i18n:
           gemfile: gemfiles/rails-6.0.gemfile
           experimental: false
         - mongodb: '5.0'
@@ -151,8 +134,6 @@ jobs:
           os: ubuntu-20.04
           task: test
           driver: current
-          rails:
-          i18n:
           gemfile: Gemfile
           experimental: false
         - mongodb: '4.4'
@@ -161,8 +142,6 @@ jobs:
           os: ubuntu-20.04
           task: test
           driver: current
-          rails:
-          i18n:
           gemfile: Gemfile
           experimental: false
         - mongodb: '4.0'
@@ -171,8 +150,6 @@ jobs:
           os: ubuntu-20.04
           task: test
           driver: current
-          rails:
-          i18n:
           gemfile: Gemfile
           experimental: false
         - mongodb: '3.6'
@@ -181,8 +158,6 @@ jobs:
           os: ubuntu-20.04
           task: test
           driver: current
-          rails:
-          i18n:
           gemfile: Gemfile
           experimental: false
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,6 +75,7 @@ jobs:
           task: test
           driver: current
           rails: '7.0'
+          fle: helper
           i18n:
           gemfile: gemfiles/rails-7.0.gemfile
           experimental: false
@@ -85,6 +86,7 @@ jobs:
           task: test
           driver: current
           rails: '6.1'
+          fle: helper
           i18n:
           gemfile: gemfiles/rails-6.1.gemfile
           experimental: false
@@ -95,6 +97,7 @@ jobs:
           task: test
           driver: current
           rails: '7.0'
+          fle: helper
           i18n:
           gemfile: gemfiles/rails-7.0.gemfile
           experimental: false
@@ -105,6 +108,7 @@ jobs:
           task: test
           driver: current
           rails: '6.1'
+          fle: helper
           i18n:
           gemfile: gemfiles/rails-6.1.gemfile
           experimental: false
@@ -115,6 +119,7 @@ jobs:
           task: test
           driver: current
           rails: '6.0'
+          fle: helper
           i18n:
           gemfile: gemfiles/rails-6.0.gemfile
           experimental: false
@@ -125,6 +130,7 @@ jobs:
           task: test
           driver: current
           rails: '5.2'
+          fle: helper
           i18n:
           gemfile: gemfiles/rails-5.2.gemfile
           experimental: false
@@ -135,6 +141,7 @@ jobs:
           task: test
           driver: current
           rails: '6.0'
+          fle: helper
           i18n:
           gemfile: gemfiles/rails-6.0.gemfile
           experimental: false
@@ -193,6 +200,7 @@ jobs:
     - name: load ruby
       uses: ruby/setup-ruby@v1
       env:
+        FLE: "${{matrix.fle}}"
         BUNDLE_GEMFILE: "${{matrix.gemfile}}"
       with:
         ruby-version: "${{matrix.ruby}}"
@@ -200,6 +208,7 @@ jobs:
     - name: bundle
       run: bundle install --jobs 4 --retry 3
       env:
+        FLE: "${{matrix.fle}}"
         BUNDLE_GEMFILE: "${{matrix.gemfile}}"
     - name: test
       timeout-minutes: 60
@@ -207,4 +216,5 @@ jobs:
       run: bundle exec rake spec
       env:
         BUNDLE_GEMFILE: "${{matrix.gemfile}}"
+        FLE: "${{matrix.fle}}"
         MONGODB_URI: "${{ steps.start-mongodb.outputs.cluster-uri }}"

--- a/lib/mongoid/tasks/database.rb
+++ b/lib/mongoid/tasks/database.rb
@@ -27,7 +27,7 @@ module Mongoid
             logger.info("MONGOID: collection options ignored on: #{model}, please define in the root model.")
           end
         rescue Exception
-          puts "error while creating collection for #{model}"
+          logger.error "error while creating collection for #{model}"
           raise
         end
       end

--- a/lib/mongoid/tasks/database.rb
+++ b/lib/mongoid/tasks/database.rb
@@ -26,6 +26,9 @@ module Mongoid
           else
             logger.info("MONGOID: collection options ignored on: #{model}, please define in the root model.")
           end
+        rescue Mongoid::Error
+          puts "error while creating collection for #{model}"
+          raise
         end
       end
 

--- a/lib/mongoid/tasks/database.rb
+++ b/lib/mongoid/tasks/database.rb
@@ -26,7 +26,7 @@ module Mongoid
           else
             logger.info("MONGOID: collection options ignored on: #{model}, please define in the root model.")
           end
-        rescue Mongoid::Error
+        rescue Exception
           puts "error while creating collection for #{model}"
           raise
         end

--- a/lib/mongoid/tasks/encryption.rake
+++ b/lib/mongoid/tasks/encryption.rake
@@ -2,27 +2,45 @@
 
 require 'optparse'
 
-# rubocop:disable Metrics/BlockLength
+def parse_data_key_options(argv = ARGV)
+  # The only way to use OptionParser to parse custom options in rake is
+  # to pass an empty argument ("--") before specifying them, e.g.:
+  #
+  #    rake db:mongoid:encryption:create_data_key -- --client default
+  #
+  # Otherwise, rake complains about an unknown option. Thus, we can tell
+  # if the argument list is valid for us to parse by detecting this empty
+  # argument.
+  #
+  # (This works around an issue in the tests, where the specs are loading
+  # the tasks directly to test them, but the option parser is then picking
+  # up rspec command-line arguments and raising an exception).
+  return {} unless argv.include?('--')
+
+  {}.tap do |options|
+    parser = OptionParser.new do |opts|
+      opts.on('-c', '--client CLIENT', 'Name of the client to use') do |v|
+        options[:client_name] = v
+      end
+      opts.on('-p', '--provider PROVIDER', 'KMS provider to use') do |v|
+        options[:kms_provider_name] = v
+      end
+      opts.on('-n', '--key-alt-name KEY_ALT_NAME', 'Alternate name for the key') do |v|
+        options[:key_alt_name] = v
+      end
+    end
+    # rubocop:disable Lint/EmptyBlock
+    parser.parse!(parser.order!(argv) {})
+    # rubocop:enable Lint/EmptyBlock
+  end
+end
+
 namespace :db do
   namespace :mongoid do
     namespace :encryption do
       desc 'Create encryption key'
       task create_data_key: [ :environment ] do
-        options = {}
-        parser = OptionParser.new do |opts|
-          opts.on('-c', '--client CLIENT', 'Name of the client to use') do |v|
-            options[:client_name] = v
-          end
-          opts.on('-p', '--provider PROVIDER', 'KMS provider to use') do |v|
-            options[:kms_provider_name] = v
-          end
-          opts.on('-n', '--key-alt-name KEY_ALT_NAME', 'Alternate name for the key') do |v|
-            options[:key_alt_name] = v
-          end
-        end
-        # rubocop:disable Lint/EmptyBlock
-        parser.parse!(parser.order!(ARGV) {})
-        # rubocop:enable Lint/EmptyBlock
+        options = parse_data_key_options
         result = Mongoid::Tasks::Encryption.create_data_key(
           client_name: options[:client_name],
           kms_provider_name: options[:kms_provider_name],
@@ -39,4 +57,3 @@ namespace :db do
     end
   end
 end
-# rubocop:enable Metrics/BlockLength

--- a/spec/mongoid/tasks/database_rake_spec.rb
+++ b/spec/mongoid/tasks/database_rake_spec.rb
@@ -11,9 +11,7 @@ shared_context "rake task" do
   let(:task_file) { "mongoid/tasks/database" }
 
   let(:logger) do
-    double("logger").tap do |log|
-      allow(log).to receive(:info)
-    end
+    Logger.new(STDOUT, level: :error, formatter: ->(_sev, _dt, _prog, msg) { msg })
   end
 
   before do


### PR DESCRIPTION
The Rails specs in the Mongoid evergreen suite do not enable FLE for the database rake tasks, which means those specs are consistently being skipped.