### PR TITLE
Fix autosave for accepts_nested_attributes_for

### DIFF
--- a/spec/mongoid/attributes/nested_spec.rb
+++ b/spec/mongoid/attributes/nested_spec.rb
@@ -66,6 +66,36 @@ describe Mongoid::Attributes::Nested do
         expect(association).to_not be_autosave
       end
     end
+
+    context "when autosave is explicitly false in association" do
+      context "when autosave is true as nested attributes" do
+
+        let(:post) do
+          NestedPost.new
+        end
+
+        before do
+          NestedPost.accepts_nested_attributes_for :likes, autosave: true
+        end
+
+        after do
+          NestedPost.send(:undef_method, :likes_attributes=)
+          NestedPost.nested_attributes.clear
+        end
+
+        let(:association) do
+          NestedPost.reflect_on_association(:likes)
+        end
+
+        it "sets autosave to true" do
+          expect(association).to be_autosave
+        end
+
+        it "autosaves if the association is not embedded" do
+          expect(post).to respond_to(:autosave_documents_for_likes)
+        end
+      end
+    end
   end
 
   describe "#initialize" do

--- a/spec/mongoid/attributes/nested_spec.rb
+++ b/spec/mongoid/attributes/nested_spec.rb
@@ -91,8 +91,14 @@ describe Mongoid::Attributes::Nested do
           expect(association).to be_autosave
         end
 
-        it "autosaves if the association is not embedded" do
+        it "defines autosave_documents_for_likes" do
           expect(post).to respond_to(:autosave_documents_for_likes)
+        end
+
+        it "saves associated NestedLike documents" do
+          like = NestedLike.new
+          post = NestedPost.new(likes: [like])
+          expect { post.save }.to change(NestedLike, :count).by(1)
         end
       end
     end

--- a/spec/mongoid/attributes/nested_spec_models.rb
+++ b/spec/mongoid/attributes/nested_spec_models.rb
@@ -16,6 +16,12 @@ class NestedComment
   belongs_to :post, class_name: "NestedPost"
 end
 
+class NestedLike
+  include Mongoid::Document
+
+  belongs_to :post, class_name: "NestedPost"
+end
+
 class NestedPost
   include Mongoid::Document
 
@@ -23,6 +29,8 @@ class NestedPost
   belongs_to :author, class_name: "NestedAuthor"
   has_many :comments, class_name: "NestedComment"
   accepts_nested_attributes_for :comments
+  has_many :likes, class_name: "NestedLike", autosave: false
+  accepts_nested_attributes_for :likes, autosave: true
 end
 
 class NestedBook


### PR DESCRIPTION
#### Summary
This PR attempts to [automatically save](https://www.mongodb.com/docs/mongoid/master/reference/associations/#autosaving) associated documents for referenced (i.e., non-embedded) associations when the parent is saved even if `autosave` option set to `false` as long as associated documents are declared as nested attributes via `accepts_nested_attributes_for` and `autosave` is set to `true`.

```ruby
class Foo
  include Mongoid::Document
 
  has_many :bars, autosave: false

  accepts_nested_attributes_for :bars, autosave: true # This should autosave :bars association
                                                      # even if autosave is set to false in has_many
end
 
class Bar
  include Mongoid::Document
 
  belongs_to :foo
end
 
foo = Foo.new(bars: [Bar.new])
foo.save # must save associated bars documents


```