### PR TITLE
MONGOID-5658 Fix callbacks for embedded

### DIFF
--- a/docs/release-notes/mongoid-9.0.txt
+++ b/docs/release-notes/mongoid-9.0.txt
@@ -18,6 +18,23 @@ please consult GitHub releases for detailed release notes and JIRA for
 the complete list of issues fixed in each release, including bug fixes.
 
 
+``around_*`` callbacks for embedded documents are now ignored
+-------------------------------------------------------------
+
+Mongoid 8.x and older allows user to define ``around_*`` callbacks for embedded
+documents. Starting from 9.0 these callbacks are ignored and will not be executed.
+A warning will be printed to the console if such callbacks are defined.
+
+If you want to restore the old behavior, you can set
+``Mongoid.around_embedded_document_callbacks`` to true in your application.
+
+.. note::
+  Enabling ``around_*`` callbacks for embedded documents is not recommended
+  as it may cause ``SystemStackError`` exceptions when a document has many
+  embedded documents. See `MONGOID-5658 <https://jira.mongodb.org/browse/MONGOID-5658>`_
+  for more details.
+
+
 ``for_js`` method is deprecated
 -------------------------------
 

--- a/lib/mongoid/config.rb
+++ b/lib/mongoid/config.rb
@@ -137,6 +137,14 @@ module Mongoid
     # See https://jira.mongodb.org/browse/MONGOID-5542
     option :prevent_multiple_calls_of_embedded_callbacks, default: true
 
+    # When this flag is true, callbacks for embedded documents will not be
+    # called. This is the default in 9.0.
+    #
+    # Setting this flag to false restores the pre-9.0 behavior, where callbacks
+    # for embedded documents are called. This may lead to stack overflow errors
+    # if there are more than cicrca 1000 embedded documents in the root
+    # document's dependencies graph.
+    # See https://jira.mongodb.org/browse/MONGOID-5658 for more details.
     option :around_callbacks_for_embeds, default: false
 
     # Returns the Config singleton, for use in the configure DSL.

--- a/lib/mongoid/config.rb
+++ b/lib/mongoid/config.rb
@@ -137,10 +137,10 @@ module Mongoid
     # See https://jira.mongodb.org/browse/MONGOID-5542
     option :prevent_multiple_calls_of_embedded_callbacks, default: true
 
-    # When this flag is true, callbacks for embedded documents will not be
+    # When this flag is false, callbacks for embedded documents will not be
     # called. This is the default in 9.0.
     #
-    # Setting this flag to false restores the pre-9.0 behavior, where callbacks
+    # Setting this flag to true restores the pre-9.0 behavior, where callbacks
     # for embedded documents are called. This may lead to stack overflow errors
     # if there are more than cicrca 1000 embedded documents in the root
     # document's dependencies graph.

--- a/lib/mongoid/config.rb
+++ b/lib/mongoid/config.rb
@@ -137,6 +137,8 @@ module Mongoid
     # See https://jira.mongodb.org/browse/MONGOID-5542
     option :prevent_multiple_calls_of_embedded_callbacks, default: true
 
+    option :around_callbacks_for_embeds, default: false
+
     # Returns the Config singleton, for use in the configure DSL.
     #
     # @return [ self ] The Config singleton.

--- a/lib/mongoid/interceptable.rb
+++ b/lib/mongoid/interceptable.rb
@@ -175,6 +175,10 @@ module Mongoid
         callbacks = child.__callbacks[child_callback_type(kind, child)]
         env = ActiveSupport::Callbacks::Filters::Environment.new(child, false, nil)
         next_sequence = callbacks.compile
+        unless next_sequence.final?
+          Mongoid.logger.warn("Around callbacks are disabled for embedded documents. Skipping around callbacks for #{child.class.name}.")
+          Mongoid.logger.warn("To enable around callbacks for embedded documents, set Mongoid::Config.around_callbacks_for_embeds to true.")
+        end
         next_sequence.invoke_before(env)
         return false if env.halted
         env.value = !env.halted

--- a/spec/integration/callbacks_spec.rb
+++ b/spec/integration/callbacks_spec.rb
@@ -585,6 +585,8 @@ describe 'callbacks integration tests' do
   end
 
   context 'cascade callbacks' do
+    ruby_version_gte '3.0'
+
     let(:book) do
       Book.new
     end
@@ -597,7 +599,7 @@ describe 'callbacks integration tests' do
 
     # https://jira.mongodb.org/browse/MONGOID-5658
     it 'does not raise SystemStackError' do
-      expect { book.save! }.not_to raise_error
+      expect { book.save! }.not_to raise_error(SystemStackError)
     end
   end
 end

--- a/spec/integration/callbacks_spec.rb
+++ b/spec/integration/callbacks_spec.rb
@@ -583,4 +583,21 @@ describe 'callbacks integration tests' do
       expect(logger).to eq(%i[embedded_twice embedded_once root])
     end
   end
+
+  context 'cascade callbacks' do
+    let(:book) do
+      Book.new
+    end
+
+    before do
+      1500.times do
+        book.pages.build
+      end
+    end
+
+    # https://jira.mongodb.org/browse/MONGOID-5658
+    it 'does not raise SystemStackError' do
+      expect { book.save! }.not_to raise_error
+    end
+  end
 end

--- a/spec/integration/callbacks_spec.rb
+++ b/spec/integration/callbacks_spec.rb
@@ -558,6 +558,7 @@ describe 'callbacks integration tests' do
 
   context 'nested embedded documents' do
     config_override :prevent_multiple_calls_of_embedded_callbacks, true
+    config_override :around_callbacks_for_embeds, true
 
     let(:logger) { Array.new }
 

--- a/spec/mongoid/interceptable_spec.rb
+++ b/spec/mongoid/interceptable_spec.rb
@@ -583,6 +583,7 @@ describe Mongoid::Interceptable do
         context "when saving the root" do
           context 'with prevent_multiple_calls_of_embedded_callbacks enabled' do
             config_override :prevent_multiple_calls_of_embedded_callbacks, true
+            config_override :around_callbacks_for_embeds, true
 
             it "executes the callbacks only once for each document" do
               expect(note).to receive(:update_saved).once

--- a/spec/mongoid/interceptable_spec.rb
+++ b/spec/mongoid/interceptable_spec.rb
@@ -2176,7 +2176,7 @@ describe Mongoid::Interceptable do
       end
 
       context "with around callbacks" do
-        config_override:around_callbacks_for_embeds, true
+        config_override :around_callbacks_for_embeds, true
 
         let(:expected) do
           [
@@ -2235,7 +2235,7 @@ describe Mongoid::Interceptable do
       end
 
       context "without around callbacks" do
-        config_override:around_callbacks_for_embeds, false
+        config_override :around_callbacks_for_embeds, false
 
         let(:expected) do
           [
@@ -2569,6 +2569,29 @@ describe Mongoid::Interceptable do
       expect do
         user.save!
       end.to_not raise_error(Mongoid::Errors::AttributeNotLoaded)
+    end
+  end
+
+  context "when around callbacks for embedded are disabled" do
+    config_override :around_callbacks_for_embeds, false
+
+    context "when around callback is defined" do
+      let(:registry) { InterceptableSpec::CallbackRegistry.new }
+
+      let(:parent) do
+        InterceptableSpec::CbEmbedsOneParent.new(registry).tap do |parent|
+          parent.child = InterceptableSpec::CbEmbedsOneChild.new(registry)
+        end
+      end
+
+      before do
+        expect(Mongoid.logger).to receive(:warn).with(/Around callbacks are disabled for embedded documents/).twice.and_call_original
+        expect(Mongoid.logger).to receive(:warn).with(/To enable around callbacks for embedded documents/).twice.and_call_original
+      end
+
+      it "logs a warning" do
+        parent.save!
+      end
     end
   end
 end


### PR DESCRIPTION
This is a band-aid for [MONGOID-5658](https://jira.mongodb.org/browse/MONGOID-5658)

The existing implementation of callbacks guarantees a sane order of execution; however, it causes stack overflow if there are many embeddeds (even in a flat structure). To fix this issue we suggest ignoring around callbacks for embedded documents. This allows us to patch the existing implementation of the callbacks and keep the proper order of callbacks.

If something still needs to be done around a database operation for an embedded document, it can be done in corresponding callback of the parent document.

We should discuss a necessity of callbacks for embedded documents in general. If we still feel that we should keep this functionality, the callbacks implementation in general should be revised. 