### PR TITLE
MONGOID-5662 Deprecate Object#__to_inc__ and BigDecimal#__to_inc__

### DIFF
--- a/lib/mongoid/extensions/big_decimal.rb
+++ b/lib/mongoid/extensions/big_decimal.rb
@@ -3,9 +3,16 @@
 
 module Mongoid
   module Extensions
-
     # Adds type-casting behavior to BigDecimal class.
     module BigDecimal
+      # Behavior to be invoked when the module is included.
+      #
+      # @param [ Module ] base the class or module doing the including
+      #
+      # @api private
+      def self.included(base)
+        base.extend(ClassMethods)
+      end
 
       # Convert the big decimal to an $inc-able value.
       #
@@ -13,9 +20,11 @@ module Mongoid
       #   bd.__to_inc__
       #
       # @return [ Float ] The big decimal as a float.
+      # @deprecated
       def __to_inc__
         to_f
       end
+      Mongoid.deprecate(self, :__to_inc__)
 
       # Turn the object from the ruby type we deal with to a Mongo friendly
       # type.
@@ -39,7 +48,6 @@ module Mongoid
       end
 
       module ClassMethods
-
         # Convert the object from its mongo friendly ruby type to this type.
         #
         # @param [ Object ] object The object to demongoize.
@@ -89,5 +97,4 @@ module Mongoid
   end
 end
 
-::BigDecimal.__send__(:include, Mongoid::Extensions::BigDecimal)
-::BigDecimal.extend(Mongoid::Extensions::BigDecimal::ClassMethods)
+BigDecimal.include Mongoid::Extensions::BigDecimal

--- a/lib/mongoid/extensions/object.rb
+++ b/lib/mongoid/extensions/object.rb
@@ -3,9 +3,11 @@
 
 module Mongoid
   module Extensions
-
     # Adds type-casting behavior to Object class.
     module Object
+      def self.included(base)
+        base.extend(ClassMethods)
+      end
 
       # Evolve a plain object into an object id.
       #
@@ -70,9 +72,11 @@ module Mongoid
       #   1.__to_inc__
       #
       # @return [ Object ] The object.
+      # @deprecated
       def __to_inc__
         self
       end
+      Mongoid.deprecate(self, :__to_inc__)
 
       # Checks whether conditions given in this object are known to be
       # unsatisfiable, i.e., querying with this object will always return no
@@ -87,6 +91,7 @@ module Mongoid
       def blank_criteria?
         false
       end
+      Mongoid.deprecate(self, :blank_criteria?)
 
       # Do or do not, there is no try. -- Yoda.
       #
@@ -202,7 +207,6 @@ module Mongoid
       end
 
       module ClassMethods
-
         # Convert the provided object to a foreign key, given the metadata key
         # contstraint.
         #
@@ -247,7 +251,4 @@ module Mongoid
   end
 end
 
-::Object.__send__(:include, Mongoid::Extensions::Object)
-::Object.extend(Mongoid::Extensions::Object::ClassMethods)
-
-::Mongoid.deprecate(Object, :blank_criteria)
+Object.include Mongoid::Extensions::Object

--- a/lib/mongoid/persistable/incrementable.rb
+++ b/lib/mongoid/persistable/incrementable.rb
@@ -21,7 +21,7 @@ module Mongoid
       def inc(increments)
         prepare_atomic_operation do |ops|
           process_atomic_operations(increments) do |field, value|
-            increment = value.__to_inc__
+            increment = value.is_a?(BigDecimal) ? value.to_f : value
             current = attributes[field]
             new_value = (current || 0) + increment
             process_attribute field, new_value if executing_atomically?

--- a/lib/mongoid/persistable/multipliable.rb
+++ b/lib/mongoid/persistable/multipliable.rb
@@ -21,7 +21,7 @@ module Mongoid
       def mul(factors)
         prepare_atomic_operation do |ops|
           process_atomic_operations(factors) do |field, value|
-            factor = value.__to_inc__
+            factor = value.is_a?(BigDecimal) ? value.to_f : value
             current = attributes[field]
             new_value = (current || 0) * factor
             process_attribute field, new_value if executing_atomically?


### PR DESCRIPTION
This extends @johnnyshields work in https://github.com/mongodb/mongoid/pull/5709 and deprecates `Object#__to_inc__` and `BigDecimal#__to_inc__`.

Though these are implicitly private API methods, they were never explicitly declared as such, and so we're opting to deprecate them for now and remove them in a later major release.