### PR TITLE
MONGOID-5701: Rubocop: Disable empty line cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -58,9 +58,7 @@ Gemspec/OrderedDependencies:
   Enabled: false
 
 Layout/EmptyLinesAroundBlockBody:
-  Exclude:
-    - '**/*.rake'
-    - 'spec/**/*'
+  Enabled: false
 
 Layout/EmptyLinesAroundClassBody:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -57,6 +57,17 @@ Bundler/OrderedGems:
 Gemspec/OrderedDependencies:
   Enabled: false
 
+Layout/EmptyLinesAroundBlockBody:
+  Exclude:
+    - '**/*.rake'
+    - 'spec/**/*'
+
+Layout/EmptyLinesAroundClassBody:
+  Enabled: false
+
+Layout/EmptyLinesAroundModuleBody:
+  Enabled: false
+
 Layout/SpaceInsideArrayLiteralBrackets:
   EnforcedStyle: space
 


### PR DESCRIPTION
This disables several rubocop cops which most of Mongoid's existing codebase intentionally doesn't follow:

- Layout/EmptyLinesAroundBlockBody
- Layout/EmptyLinesAroundClassBody
- Layout/EmptyLinesAroundModuleBody

Here is an example of what most Mongoid code does today:

```ruby
module Mongoid

  # Some comment
  class SomeClass

    # Some comment
    def my_method
    end
  end
end
```

I think this is aesthetically pleasing, however, the two empty lines will trigger Rubocop. Rather than updating all the existing code, I think we should just disable the cops.

Notes:
- The BlockBody one is used for `class_methods do` etc. on certain blocks that look like module definitions. Also in RSpecs
- For Class/ModuleBody, there is a `EnforcedStyle: beginning_only` option which we could consider, however, I think it is better to just keep this one flexible.