### PR TITLE
MONGOID-5691 Ensure that all Mongoid config options are mentioned in the documentation

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -67,6 +67,20 @@ namespace :eg do
   end
 end
 
+namespace :generate do
+  desc 'Generates a mongoid.yml from the template'
+  task :config do
+    require 'mongoid'
+    require 'erb'
+
+    template_path = 'lib/rails/generators/mongoid/config/templates/mongoid.yml'
+    database_name = ENV['DATABASE_NAME'] || 'my_db'
+
+    config = ERB.new(File.read(template_path), trim_mode: '-').result(binding)
+    File.write('mongoid.yml', config)
+  end
+end
+
 CLASSIFIERS = [
   [%r,^mongoid/attribute,, :attributes],
   [%r,^mongoid/association/[or],, :associations_referenced],

--- a/docs/reference/configuration.txt
+++ b/docs/reference/configuration.txt
@@ -174,7 +174,7 @@ for details on driver options.
           # Change the default authentication mechanism. Valid options are: :scram,
           # :mongodb_cr, :mongodb_x509, and :plain. Note that all authentication
           # mechanisms require username and password, with the exception of :mongodb_x509.
-          # Default on mongoDB 3.0 is :scram, default on 2.4 and 2.6 is :plain.
+          # Default is :scram since MongoDB 3.0; earlier versions defaulted to :plain.
           # auth_mech: :scram
 
           # The database or source to authenticate the user against.

--- a/docs/reference/configuration.txt
+++ b/docs/reference/configuration.txt
@@ -131,100 +131,84 @@ for details on driver options.
   development:
     # Configure available database clients. (required)
     clients:
-      # Define the default client. (required)
+      # Defines the default client. (required)
       default:
-        # A uri may be defined for a client:
-        # uri: 'mongodb://user:password@myhost1.mydomain.com:27017/my_db'
-        # Please see driver documentation for details. Alternatively, you can
-        # define the following:
-        #
-        # Define the name of the default database that Mongoid can connect to.
+        # Mongoid can connect to a URI accepted by the driver:
+        # uri: mongodb://user:password@mongodb.domain.com:27017/my_db_development
+
+        # Otherwise define the parameters separately.
+        # This defines the name of the default database that Mongoid can connect to.
         # (required).
-        database: my_db
-        # Provide the hosts the default client can connect to. Must be an array
+        database: my_db_development
+        # Provides the hosts the default client can connect to. Must be an array
         # of host:port pairs. (required)
         hosts:
-          - myhost1.mydomain.com:27017
-          - myhost2.mydomain.com:27017
-          - myhost3.mydomain.com:27017
+          - localhost:27017
         options:
-          # These options are Ruby driver options, documented in
-          # https://mongodb.com/docs/ruby-driver/current/reference/create-client/
-
+          # Note that all options listed below are Ruby driver client options (the mongo gem).
+          # Please refer to the driver documentation of the version of the mongo gem you are using
+          # for the most up-to-date list of options.
+          #
           # Change the default write concern. (default = { w: 1 })
-          write:
-            w: 1
+          # write:
+          #   w: 1
 
           # Change the default read preference. Valid options for mode are: :secondary,
           # :secondary_preferred, :primary, :primary_preferred, :nearest
           # (default: primary)
-          read:
-            mode: :secondary_preferred
-            tag_sets:
-              - use: web
+          # read:
+          #   mode: :secondary_preferred
+          #   tag_sets:
+          #     - use: web
 
           # The name of the user for authentication.
-          user: 'user'
+          # user: 'user'
 
           # The password of the user for authentication.
-          password: 'password'
+          # password: 'password'
 
           # The user's database roles.
-          roles:
-            - 'dbOwner'
+          # roles:
+          #   - 'dbOwner'
 
-          # Change the default authentication mechanism. Please see the
-          # driver documentation linked above for details on how to configure
-          # authentication. Valid options are :aws, :gssapi, :mongodb_cr,
-          # :mongodb_x509, :plain, :scram and :scram256 (default on 3.0
-          # and higher servers is :scram, default on 2.6 servers is :plain)
-          auth_mech: :scram
+          # Change the default authentication mechanism. Valid options are: :scram,
+          # :mongodb_cr, :mongodb_x509, and :plain. Note that all authentication
+          # mechanisms require username and password, with the exception of :mongodb_x509.
+          # Default on mongoDB 3.0 is :scram, default on 2.4 and 2.6 is :plain.
+          # auth_mech: :scram
 
-          # Specify the auth source, i.e. the database or other source which
-          # contains the user's login credentials. Allowed values for auth source
-          # depend on the authentication mechanism, as explained in the server documentation:
-          # https://mongodb.com/docs/manual/reference/connection-string/#mongodb-urioption-urioption.authSource
-          # If no auth source is specified, the default auth source as
-          # determined by the driver will be used. Please refer to:
-          # https://mongodb.com/docs/ruby-driver/current/reference/authentication/#auth-source
-          auth_source: admin
+          # The database or source to authenticate the user against.
+          # (default: the database specified above or admin)
+          # auth_source: admin
 
-          # Connect directly to and perform all operations on the specified
-          # server, bypassing replica set node discovery and monitoring.
-          # Exactly one host address must be specified. (default: false)
-          #direct_connection: true
+          # Force a the driver cluster to behave in a certain manner instead of auto-
+          # discovering. Can be one of: :direct, :replica_set, :sharded. Set to :direct
+          # when connecting to hidden members of a replica set.
+          # connect: :direct
 
-          # Deprecated. Force the driver to connect in a specific way instead
-          # of automatically discovering the deployment type and connecting
-          # accordingly. To connect directly to a replica set node bypassing
-          # node discovery and monitoring, use direct_connection: true instead
-          # of this option. Possible values: :direct, :replica_set, :sharded.
-          # (default: none)
-          #connect: :direct
-
-          # Change the default time in seconds the server monitors refresh their status
+          # Changes the default time in seconds the server monitors refresh their status
           # via hello commands. (default: 10)
-          heartbeat_frequency: 10
+          # heartbeat_frequency: 10
 
           # The time in seconds for selecting servers for a near read preference. (default: 0.015)
-          local_threshold: 0.015
+          # local_threshold: 0.015
 
           # The timeout in seconds for selecting a server for an operation. (default: 30)
-          server_selection_timeout: 30
+          # server_selection_timeout: 30
 
           # The maximum number of connections in the connection pool. (default: 5)
-          max_pool_size: 5
+          # max_pool_size: 5
 
           # The minimum number of connections in the connection pool. (default: 1)
-          min_pool_size: 1
+          # min_pool_size: 1
 
           # The time to wait, in seconds, in the connection pool for a connection
-          # to be checked in before timing out. (default: 1)
-          wait_queue_timeout: 1
+          # to be checked in before timing out. (default: 5)
+          # wait_queue_timeout: 5
 
           # The time to wait to establish a connection before timing out, in seconds.
           # (default: 10)
-          connect_timeout: 10
+          # connect_timeout: 10
 
           # How long to wait for a response for each operation sent to the
           # server. This timeout should be set to a value larger than the
@@ -233,140 +217,169 @@ for details on driver options.
           # the server may continue executing an operation after the client
           # aborts it with the SocketTimeout exception.
           # (default: nil, meaning no timeout)
-          socket_timeout: 5
+          # socket_timeout: 5
 
           # The name of the replica set to connect to. Servers provided as seeds that do
           # not belong to this replica set will be ignored.
-          replica_set: my_replica_set
+          # replica_set: name
 
           # Compressors to use for wire protocol compression. (default is to not use compression)
-          compressors: ["zstd", "snappy", "zlib"]
+          # "zstd" requires zstd-ruby gem. "snappy" requires snappy gem.
+          # Refer to: https://www.mongodb.com/docs/ruby-driver/current/reference/create-client/#compression
+          # compressors: ["zstd", "snappy", "zlib"]
 
           # Whether to connect to the servers via ssl. (default: false)
-          ssl: true
+          # ssl: true
 
           # The certificate file used to identify the connection against MongoDB.
-          ssl_cert: /path/to/my.cert
+          # ssl_cert: /path/to/my.cert
 
           # The private keyfile used to identify the connection against MongoDB.
           # Note that even if the key is stored in the same file as the certificate,
           # both need to be explicitly specified.
-          ssl_key: /path/to/my.key
+          # ssl_key: /path/to/my.key
 
           # A passphrase for the private key.
-          ssl_key_pass_phrase: password
+          # ssl_key_pass_phrase: password
 
-          # Whether or not to do peer certification validation. (default: true)
-          ssl_verify: true
+          # Whether to do peer certification validation. (default: true)
+          # ssl_verify: true
 
-          # The file containing a set of concatenated certification authority certifications
+          # The file containing concatenated certificate authority certificates
           # used to validate certs passed from the other end of the connection.
-          ssl_ca_cert: /path/to/ca.cert
+          # ssl_ca_cert: /path/to/ca.cert
+
+          # Whether to truncate long log lines. (default: true)
+          # truncate_logs: true
 
     # Configure Mongoid-specific options. (optional)
     options:
-      # Application name that is printed to the MongoDB logs upon establishing
-      # a connection in server versions 3.4 or greater. Note that the name
-      # cannot exceed 128 bytes in length. It is also used as the database name
-      # if the database name is not explicitly defined. (default: nil)
-      app_name: MyApplicationName
+      # Allow BSON::Decimal128 to be parsed and returned directly in
+      # field values. When BSON 5 is present and the this option is set to false
+      # (the default), BSON::Decimal128 values in the database will be returned
+      # as BigDecimal.
+      #
+      # @note this option only has effect when BSON 5+ is present. Otherwise,
+      #   the setting is ignored.
+      # allow_bson5_decimal128: false
 
-      # Type of executor for queries scheduled using ``load_async`` method.
+      # Application name that is printed to the mongodb logs upon establishing
+      # a connection in server versions >= 3.4. Note that the name cannot
+      # exceed 128 bytes. It is also used as the database name if the
+      # database name is not explicitly defined.
+      # app_name: nil
+
+      # When this flag is false, callbacks for embedded documents will not be
+      # called. This is the default in 9.0.
       #
-      # There are two possible values for this option:
+      # Setting this flag to true restores the pre-9.0 behavior, where callbacks
+      # for embedded documents are called. This may lead to stack overflow errors
+      # if there are more than cicrca 1000 embedded documents in the root
+      # document's dependencies graph.
+      # See https://jira.mongodb.org/browse/MONGOID-5658 for more details.
+      # around_callbacks_for_embeds: false
+
+      # Sets the async_query_executor for the application. By default the thread pool executor
+      #   is set to `:immediate. Options are:
       #
-      #   - :immediate - Queries will be immediately executed on a current thread.
-      #       This is the default option.
-      #   - :global_thread_pool - Queries will be executed asynchronously in
-      #       background using a thread pool.
-      #async_query_executor: :immediate
+      #   - :immediate - Initializes a single +Concurrent::ImmediateExecutor+
+      #   - :global_thread_pool - Initializes a single +Concurrent::ThreadPoolExecutor+
+      #      that uses the +async_query_concurrency+ for the +max_threads+ value.
+      # async_query_executor: :immediate
 
       # Mark belongs_to associations as required by default, so that saving a
       # model with a missing belongs_to association will trigger a validation
-      # error. (default: true)
-      belongs_to_required_by_default: true
+      # error.
+      # belongs_to_required_by_default: true
 
-      # Set the global discriminator key. (default: "_type")
-      discriminator_key: "_type"
+      # Set the global discriminator key.
+      # discriminator_key: "_type"
 
-      # Raise an exception when a field is redefined. (default: false)
-      duplicate_fields_exception: false
+      # Raise an exception when a field is redefined.
+      # duplicate_fields_exception: false
 
       # Defines how many asynchronous queries can be executed concurrently.
-      # This option should be set only if `async_query_executor` option is set
+      # This option should be set only if `async_query_executor` is set
       # to `:global_thread_pool`.
-      #global_executor_concurrency: nil
+      # global_executor_concurrency: nil
 
-      # Include the root model name in json serialization. (default: false)
-      include_root_in_json: false
+      # When this flag is true, any attempt to change the _id of a persisted
+      # document will raise an exception (`Errors::ImmutableAttribute`).
+      # This is the default in 9.0. Setting this flag to false restores the
+      # pre-9.0 behavior, where changing the _id of a persisted
+      # document might be ignored, or it might work, depending on the situation.
+      # immutable_ids: true
 
-      # Include the _type field in serialization. (default: false)
-      include_type_for_serialization: false
+      # Include the root model name in json serialization.
+      # include_root_in_json: false
+
+      # # Include the _type field in serialization.
+      # include_type_for_serialization: false
 
       # Whether to join nested persistence contexts for atomic operations
-      # to parent contexts by default. (default: false)
-      join_contexts: false
+      # to parent contexts by default.
+      # join_contexts: false
 
       # When this flag is false, a document will become read-only only once the
       # #readonly! method is called, and an error will be raised on attempting
       # to save or update such documents, instead of just on delete. When this
       # flag is true, a document is only read-only if it has been projected
       # using #only or #without, and read-only documents will not be
-      # deletable/destroyable, but will be savable/updatable.
+      # deletable/destroyable, but they will be savable/updatable.
       # When this feature flag is turned on, the read-only state will be reset on
       # reload, but when it is turned off, it won't be.
-      # (default: false)
-      #legacy_readonly: true
+      # legacy_readonly: false
 
-      # Set the Mongoid and Ruby driver log levels when Mongoid is not using
-      # Ruby on Rails logger instance. (default: :info)
-      log_level: :info
+      # The log level.
+      #
+      # It must be set prior to referencing clients or Mongo.logger,
+      # changes to this option are not be propagated to any clients and
+      # loggers that already exist.
+      #
+      # Additionally, only when the clients are configured via the
+      # configuration file is the log level given by this option honored.
+      # log_level: :info
 
-      # When using the BigDecimal field type, store the value in the database
-      # as a BSON::Decimal128 instead of a string. (default: true)
-      #map_big_decimal_to_decimal128: true
+      # Store BigDecimals as Decimal128s instead of strings in the db.
+      # map_big_decimal_to_decimal128: true
 
-      # Preload all models in development, needed when models use
-      # inheritance. (default: false)
-      preload_models: false
+      # Preload all models in development, needed when models use inheritance.
+      # preload_models: false
+
+      # When this flag is true, callbacks for every embedded document will be
+      # called only once, even if the embedded document is embedded in multiple
+      # documents in the root document's dependencies graph.
+      # This is the default in 9.0. Setting this flag to false restores the
+      # pre-9.0 behavior, where callbacks are called for every occurrence of an
+      # embedded document. The pre-9.0 behavior leads to a problem that for multi
+      # level nested documents callbacks are called multiple times.
+      # See https://jira.mongodb.org/browse/MONGOID-5542
+      # prevent_multiple_calls_of_embedded_callbacks: true
 
       # Raise an error when performing a #find and the document is not found.
-      # (default: true)
-      raise_not_found_error: true
+      # raise_not_found_error: true
 
       # Raise an error when defining a scope with the same name as an
-      # existing method. (default: false)
-      scope_overwrite_exception: false
+      # existing method.
+      # scope_overwrite_exception: false
 
-      # Return stored times as UTC. See the time zone section below for
-      # further information. Most applications should not use this option.
-      # (default: false)
-      use_utc: false
+      # Return stored times as UTC.
+      # use_utc: false
 
-      # (Deprecated) In MongoDB 4.0 and earlier, set whether to create
-      # indexes in the background by default. (default: false)
-      background_indexing: false
-
-    # Configure driver-specific options. (optional)
+    # Configure Driver-specific options. (optional)
     driver_options:
-      # When this flag is turned off, inline options will be correctly
-      # propagated to Mongoid and Driver finder methods. When this flag is turned
-      # on those options will be ignored. For example, with this flag turned
-      # off, Band.all.limit(1).count will take the limit into account, while
-      # when this flag is turned on, that limit is ignored. The affected driver
-      # methods are: aggregate, count, count_documents, distinct, and
-      # estimated_document_count. The corresponding Mongoid methods are also
-      # affected. (default: false, driver version: 2.18.0+)
-      #broken_view_options: false
+      # When this flag is off, an aggregation done on a view will be executed over
+      # the documents included in that view, instead of all documents in the
+      # collection. When this flag is on, the view fiter is ignored.
+      # broken_view_aggregate: true
 
-      # Validates that there are no atomic operators (those that start with $)
-      # in the root of a replacement document, and that there are only atomic
-      # operators at the root of an update document. If this feature flag is on,
-      # an error will be raised on an invalid update or replacement document,
-      # if not, a warning will be output to the logs. This flag does not affect
-      # Mongoid as of 8.0, but will affect calls to driver update/replace
-      # methods. (default: false, driver version: 2.18.0+)
-      #validate_update_replace: false
+      # When this flag is set to false, the view options will be correctly
+      # propagated to readable methods.
+      # broken_view_options: true
+
+      # When this flag is set to true, the update and replace methods will
+      # validate the paramters and raise an error if they are invalid.
+      # validate_update_replace: false
 
 
 .. _load-defaults:

--- a/docs/reference/configuration.txt
+++ b/docs/reference/configuration.txt
@@ -148,7 +148,7 @@ for details on driver options.
           # Note that all options listed below are Ruby driver client options (the mongo gem).
           # Please refer to the driver documentation of the version of the mongo gem you are using
           # for the most up-to-date list of options.
-          #
+
           # Change the default write concern. (default = { w: 1 })
           # write:
           #   w: 1

--- a/lib/rails/generators/mongoid/config/templates/mongoid.yml
+++ b/lib/rails/generators/mongoid/config/templates/mongoid.yml
@@ -118,17 +118,32 @@ development:
         # The file containing concatenated certificate authority certificates
         # used to validate certs passed from the other end of the connection.
         # ssl_ca_cert: /path/to/ca.cert
-        
+
         # Whether to truncate long log lines. (default: true)
         # truncate_logs: true
 
-  # Configure Mongoid specific options. (optional)
+  # Configure Mongoid-specific options. (optional)
   options:
 <%- Mongoid::Config::Introspection.options.each do |opt| -%>
     <%= opt.indented_comment(indent: 4) %>
     # <%= opt.name %>: <%= opt.default %>
 
 <%- end -%>
+  # Configure Driver-specific options. (optional)
+  driver_options:
+    # When this flag is off, an aggregation done on a view will be executed over
+    # the documents included in that view, instead of all documents in the
+    # collection. When this flag is on, the view fiter is ignored.
+    # broken_view_aggregate: true
+
+    # When this flag is set to false, the view options will be correctly
+    # propagated to readable methods.
+    # broken_view_options: true
+
+    # When this flag is set to true, the update and replace methods will
+    # validate the paramters and raise an error if they are invalid.
+    # validate_update_replace: false
+
 
 test:
   clients:

--- a/lib/rails/generators/mongoid/config/templates/mongoid.yml
+++ b/lib/rails/generators/mongoid/config/templates/mongoid.yml
@@ -18,7 +18,7 @@ development:
         # Note that all options listed below are Ruby driver client options (the mongo gem).
         # Please refer to the driver documentation of the version of the mongo gem you are using
         # for the most up-to-date list of options.
-        #
+
         # Change the default write concern. (default = { w: 1 })
         # write:
         #   w: 1

--- a/lib/rails/generators/mongoid/config/templates/mongoid.yml
+++ b/lib/rails/generators/mongoid/config/templates/mongoid.yml
@@ -44,7 +44,7 @@ development:
         # Change the default authentication mechanism. Valid options are: :scram,
         # :mongodb_cr, :mongodb_x509, and :plain. Note that all authentication
         # mechanisms require username and password, with the exception of :mongodb_x509.
-        # Default on mongoDB 3.0 is :scram, default on 2.4 and 2.6 is :plain.
+        # Default is :scram since MongoDB 3.0; earlier versions defaulted to :plain.
         # auth_mech: :scram
 
         # The database or source to authenticate the user against.


### PR DESCRIPTION
Refreshes the documentation for the configuration options so it mirrors the current mongoid.yml template.