### PR TITLE
MONGOID-5472 Save models using the overridden storage options used for their loading

### DIFF
--- a/docs/reference/configuration.txt
+++ b/docs/reference/configuration.txt
@@ -320,6 +320,30 @@ for details on driver options.
       # to parent contexts by default.
       # join_contexts: false
 
+      # When this flag is false (the default as of Mongoid 9.0), a document that
+      # is created or loaded will remember the persistence context in which it
+      # was loaded, and will use that same context by default when saving or
+      # reloading itself.
+      #
+      # When this flag is true you'll get pre-9.0 behavior, where a document will
+      # not remember the persistence context in which it was loaded/created, and
+      # subsequent updates will need to explicitly set up that context each time.
+      #
+      # For example:
+      #
+      #    record = Model.with(collection: 'other_collection') { Model.first }
+      #
+      # This will try to load the first document from 'other_collection' and
+      # instantiate it as a Model instance. Pre-9.0, the record object would
+      # not remember that it came from 'other_collection', and attempts to
+      # update it or reload it would fail unless you first remembered to set
+      # up that persistence context each time.
+      #
+      # As of Mongoid 9.0, the record will remember that it came from
+      # 'other_collection', and updates and reloads will automatically default
+      # to that collection, for that record object.
+      # legacy_persistence_context_behavior: false
+
       # When this flag is false, a document will become read-only only once the
       # #readonly! method is called, and an error will be raised on attempting
       # to save or update such documents, instead of just on delete. When this

--- a/docs/reference/configuration.txt
+++ b/docs/reference/configuration.txt
@@ -321,13 +321,13 @@ for details on driver options.
       # join_contexts: false
 
       # When this flag is false (the default as of Mongoid 9.0), a document that
-      # is created or loaded will remember the persistence context in which it
-      # was loaded, and will use that same context by default when saving or
-      # reloading itself.
+      # is created or loaded will remember the storage options that were active
+      # when it was loaded, and will use those same options by default when
+      # saving or reloading itself.
       #
       # When this flag is true you'll get pre-9.0 behavior, where a document will
-      # not remember the persistence context in which it was loaded/created, and
-      # subsequent updates will need to explicitly set up that context each time.
+      # not remember the storage options from when it was loaded/created, and
+      # subsequent updates will need to explicitly set up those options each time.
       #
       # For example:
       #
@@ -336,8 +336,8 @@ for details on driver options.
       # This will try to load the first document from 'other_collection' and
       # instantiate it as a Model instance. Pre-9.0, the record object would
       # not remember that it came from 'other_collection', and attempts to
-      # update it or reload it would fail unless you first remembered to set
-      # up that persistence context each time.
+      # update it or reload it would fail unless you first remembered to
+      # explicitly specify the collection every time.
       #
       # As of Mongoid 9.0, the record will remember that it came from
       # 'other_collection', and updates and reloads will automatically default

--- a/docs/release-notes/mongoid-9.0.txt
+++ b/docs/release-notes/mongoid-9.0.txt
@@ -454,15 +454,16 @@ Consider the following code:
   record.update(field: 'value')
 
 Prior to Mongoid 9.0, this could would silently fail to execute the update,
-because the "persistence context" (here, the specification of an alternate
+because the storage options (here, the specification of an alternate
 collection for the model) would not be remembered by the record. Thus, the
 record would be loaded from "other_collection", but when updated, would attempt
 to look for and update the document in the default collection for Model. To
-make this work, you would have had to specify the persistence context for
+make this work, you would have had to specify the collection explicitly for
 every update.
 
-As of Mongoid 9.0, records that are created or loaded under a custom persistence
-context, will remember that context.
+As of Mongoid 9.0, records that are created or loaded under explicit storage
+options, will remember those options (including a named client,
+a different database, or a different collection).
 
 If you need the legacy (pre-9.0) behavior, you can enable it with the following
 flag:

--- a/docs/release-notes/mongoid-9.0.txt
+++ b/docs/release-notes/mongoid-9.0.txt
@@ -439,8 +439,39 @@ by running the following command:
 
 ... code-block:: bash
 
-$ ruby -ractive_support/values/time_zone \
-  -e 'puts ActiveSupport::TimeZone::MAPPING.keys'
+  $ ruby -ractive_support/values/time_zone \
+    -e 'puts ActiveSupport::TimeZone::MAPPING.keys'
+
+
+Records now remember the persistence context in which they were loaded/created
+------------------------------------------------------------------------------
+
+Consider the following code:
+
+... code-block:: ruby
+
+  record = Model.with(collection: 'other_collection') { Model.first }
+  record.update(field: 'value')
+
+Prior to Mongoid 9.0, this could would silently fail to execute the update,
+because the "persistence context" (here, the specification of an alternate
+collection for the model) would not be remembered by the record. Thus, the
+record would be loaded from "other_collection", but when updated, would attempt
+to look for and update the document in the default collection for Model. To
+make this work, you would have had to specify the persistence context for
+every update.
+
+As of Mongoid 9.0, records that are created or loaded under a custom persistence
+context, will remember that context.
+
+If you need the legacy (pre-9.0) behavior, you can enable it with the following
+flag:
+
+... code-block:: ruby
+
+  Mongoid.legacy_persistence_context_behavior = true
+
+This flag defaults to false in Mongoid 9.
 
 
 Bug Fixes and Improvements

--- a/lib/mongoid/association/referenced/auto_save.rb
+++ b/lib/mongoid/association/referenced/auto_save.rb
@@ -60,7 +60,7 @@ module Mongoid
                 __autosaving__ do
                   if assoc_value = ivar(association.name)
                     Array(assoc_value).each do |doc|
-                      pc = doc.persistence_context? ? doc.persistence_context : persistence_context
+                      pc = doc.persistence_context? ? doc.persistence_context : persistence_context.for_child(doc)
                       doc.with(pc) do |d|
                         d.save
                       end

--- a/lib/mongoid/association/referenced/counter_cache.rb
+++ b/lib/mongoid/association/referenced/counter_cache.rb
@@ -108,7 +108,7 @@ module Mongoid
                 original, current = send("#{foreign_key}_previous_change")
 
                 unless original.nil?
-                  association.klass.with(persistence_context) do |_class|
+                  association.klass.with(persistence_context.for_child(association.klass)) do |_class|
                     _class.decrement_counter(cache_column, original)
                   end
                 end

--- a/lib/mongoid/clients/options.rb
+++ b/lib/mongoid/clients/options.rb
@@ -104,7 +104,7 @@ module Mongoid
         if embedded? && !_root?
           _root.persistence_context?
         else
-          remembered_storage_options.any? ||
+          remembered_storage_options&.any? ||
             PersistenceContext.get(self).present? ||
             PersistenceContext.get(self.class).present?
         end

--- a/lib/mongoid/clients/options.rb
+++ b/lib/mongoid/clients/options.rb
@@ -12,7 +12,7 @@ module Mongoid
     module Options
       extend ActiveSupport::Concern
 
-      # Returns the default persistence context that was used either when
+      # Returns the default persistence context that was used when
       # this document was first instantiated (created, or queried).
       #
       # @note This shouldn't be stored using PersistenceContext.set, because
@@ -29,6 +29,16 @@ module Mongoid
       #
       # @api private
       attr_accessor :default_persistence_context
+
+      # Implements the Mongoid.legacy_legacy_persistence_context_behavior
+      # flag, by always setting the default persistence context to nil
+      # if the flag is true. Once the flag is retired (when Mongoid 8.x
+      # is no longer supported), we can remove this method.
+      #
+      # @api private
+      def default_persistence_context=(context)
+        @default_persistence_context = Mongoid.legacy_persistence_context_behavior ? nil : context
+      end
 
       # Change the persistence context for this object during the block.
       #

--- a/lib/mongoid/clients/storage_options.rb
+++ b/lib/mongoid/clients/storage_options.rb
@@ -11,7 +11,30 @@ module Mongoid
       extend ActiveSupport::Concern
 
       included do
-        class_attribute :storage_options, instance_writer: false, default: storage_options_defaults
+        class_attribute :storage_options, instance_accessor: false, default: storage_options_defaults
+      end
+
+      attr_accessor :remembered_storage_options
+
+      # The storage options that apply to this record, consisting of both
+      # the class-level declared storage options (e.g. store_in) merged with
+      # any remembered storage options.
+      #
+      # @return [ Hash ] the storage options for the record
+      #
+      # @api private
+      def storage_options
+        self.class.storage_options.merge(remembered_storage_options || {})
+      end
+
+      # Saves the storage options from the current persistence context.
+      #
+      # @api private
+      def remember_storage_options!
+        return if Mongoid.legacy_persistence_context_behavior
+
+        opts = persistence_context.requested_storage_options
+        self.remembered_storage_options = opts if opts
       end
 
       module ClassMethods

--- a/lib/mongoid/clients/storage_options.rb
+++ b/lib/mongoid/clients/storage_options.rb
@@ -14,6 +14,14 @@ module Mongoid
         class_attribute :storage_options, instance_accessor: false, default: storage_options_defaults
       end
 
+      # Remembers the storage options that were active when the current object
+      # was instantiated/created.
+      #
+      # @return [ Hash | nil ] the storage options that have been cached for
+      #   this object instance (or nil if no storage options have been
+      #   cached).
+      #
+      # @api private
       attr_accessor :remembered_storage_options
 
       # The storage options that apply to this record, consisting of both

--- a/lib/mongoid/config.rb
+++ b/lib/mongoid/config.rb
@@ -121,13 +121,13 @@ module Mongoid
     option :legacy_readonly, default: false
 
     # When this flag is false (the default as of Mongoid 9.0), a document that
-    # is created or loaded will remember the persistence context in which it
-    # was loaded, and will use that same context by default when saving or
-    # reloading itself.
+    # is created or loaded will remember the storage options that were active
+    # when it was loaded, and will use those same options by default when
+    # saving or reloading itself.
     #
     # When this flag is true you'll get pre-9.0 behavior, where a document will
-    # not remember the persistence context in which it was loaded/created, and
-    # subsequent updates will need to explicitly set up that context each time.
+    # not remember the storage options from when it was loaded/created, and
+    # subsequent updates will need to explicitly set up those options each time.
     #
     # For example:
     #
@@ -136,8 +136,8 @@ module Mongoid
     # This will try to load the first document from 'other_collection' and
     # instantiate it as a Model instance. Pre-9.0, the record object would
     # not remember that it came from 'other_collection', and attempts to
-    # update it or reload it would fail unless you first remembered to set
-    # up that persistence context each time.
+    # update it or reload it would fail unless you first remembered to
+    # explicitly specify the collection every time.
     #
     # As of Mongoid 9.0, the record will remember that it came from
     # 'other_collection', and updates and reloads will automatically default

--- a/lib/mongoid/config.rb
+++ b/lib/mongoid/config.rb
@@ -120,6 +120,30 @@ module Mongoid
     # reload, but when it is turned off, it won't be.
     option :legacy_readonly, default: false
 
+    # When this flag is false (the default as of Mongoid 9.0), a document that
+    # is created or loaded will remember the persistence context in which it
+    # was loaded, and will use that same context by default when saving or
+    # reloading itself.
+    #
+    # When this flag is true you'll get pre-9.0 behavior, where a document will
+    # not remember the persistence context in which it was loaded/created, and
+    # subsequent updates will need to explicitly set up that context each time.
+    #
+    # For example:
+    #
+    #    record = Model.with(collection: 'other_collection') { Model.first }
+    #
+    # This will try to load the first document from 'other_collection' and
+    # instantiate it as a Model instance. Pre-9.0, the record object would
+    # not remember that it came from 'other_collection', and attempts to
+    # update it or reload it would fail unless you first remembered to set
+    # up that persistence context each time.
+    #
+    # As of Mongoid 9.0, the record will remember that it came from
+    # 'other_collection', and updates and reloads will automatically default
+    # to that collection, for that record object.
+    option :legacy_persistence_context_behavior, default: false
+
     # When this flag is true, any attempt to change the _id of a persisted
     # document will raise an exception (`Errors::ImmutableAttribute`).
     # This is the default in 9.0. Setting this flag to false restores the

--- a/lib/mongoid/config/defaults.rb
+++ b/lib/mongoid/config/defaults.rb
@@ -15,17 +15,8 @@ module Mongoid
       #
       # raises [ ArgumentError ] if an invalid version is given.
       def load_defaults(version)
-        # Note that for 7.x, since all of the feature flag defaults have been
-        # flipped to the new functionality, all of the settings for those
-        # versions are to give old functionality. Because of this, it is
-        # possible to recurse to later version to get all of the options to
-        # turn off. Note that this won't be true when adding feature flags to
-        # 9.x, since the default will be the old functionality until the next
-        # major version is released. More likely, the recursion will have to go
-        # in the other direction (towards earlier versions).
-
         case version.to_s
-        when "7.3", "7.4", "7.5"
+        when /^[0-7]\./
           raise ArgumentError, "Version no longer supported: #{version}"
         when "8.0"
           self.legacy_readonly = true
@@ -33,6 +24,7 @@ module Mongoid
           load_defaults "8.1"
         when "8.1"
           self.immutable_ids = false
+          self.legacy_persistence_context_behavior = true
 
           load_defaults "9.0"
         when "9.0"

--- a/lib/mongoid/document.rb
+++ b/lib/mongoid/document.rb
@@ -443,6 +443,7 @@ module Mongoid
 
         doc._handle_callbacks_after_instantiation(execute_callbacks, &block)
 
+        doc.default_persistence_context = doc.persistence_context
         doc
       end
 

--- a/lib/mongoid/document.rb
+++ b/lib/mongoid/document.rb
@@ -443,7 +443,7 @@ module Mongoid
 
         doc._handle_callbacks_after_instantiation(execute_callbacks, &block)
 
-        doc.default_persistence_context = doc.persistence_context
+        doc.remember_storage_options!
         doc
       end
 

--- a/lib/mongoid/persistable/creatable.rb
+++ b/lib/mongoid/persistable/creatable.rb
@@ -84,7 +84,7 @@ module Mongoid
       # @return [ true ] true.
       def post_process_insert
         self.new_record = false
-        self.default_persistence_context = persistence_context
+        remember_storage_options!
         flag_descendants_persisted
         true
       end

--- a/lib/mongoid/persistable/creatable.rb
+++ b/lib/mongoid/persistable/creatable.rb
@@ -84,6 +84,7 @@ module Mongoid
       # @return [ true ] true.
       def post_process_insert
         self.new_record = false
+        self.default_persistence_context = persistence_context
         flag_descendants_persisted
         true
       end

--- a/lib/mongoid/persistence_context.rb
+++ b/lib/mongoid/persistence_context.rb
@@ -66,10 +66,9 @@ module Mongoid
     #
     # @api private
     def for_child(document)
-      case document
-      when Class
+      if document.is_a?(Class)
         return self if document == (@object.is_a?(Class) ? @object : @object.class)
-      when Mongoid::Document
+      elsif document.is_a?(Mongoid::Document)
         return self if document.class == (@object.is_a?(Class) ? @object : @object.class)
       else
         raise ArgumentError, 'must specify a class or a document instance'

--- a/lib/mongoid/persistence_context.rb
+++ b/lib/mongoid/persistence_context.rb
@@ -60,13 +60,21 @@ module Mongoid
     # Returns a new persistence context that is consistent with the given
     # child document, inheriting most appropriate settings.
     #
-    # @param [ Mongoid::Document ] document the child document
+    # @param [ Mongoid::Document | Class ] document the child document
     #
     # @return [ PersistenceContext ] the new persistence context
     #
     # @api private
     def for_child(document)
-      return self if document.class == @object.class
+      case document
+      when Class
+        return self if document == (@object.is_a?(Class) ? @object : @object.class)
+      when Mongoid::Document
+        return self if document.class == (@object.is_a?(Class) ? @object : @object.class)
+      else
+        raise ArgumentError, 'must specify a class or a document instance'
+      end
+
       PersistenceContext.new(document, options.merge(document.storage_options))
     end
 

--- a/lib/mongoid/persistence_context.rb
+++ b/lib/mongoid/persistence_context.rb
@@ -47,16 +47,6 @@ module Mongoid
       set_options!(opts)
     end
 
-    # Returns a new persistence context that merges the given options
-    # with the current context.
-    #
-    # @param [ Hash ] opts the options hash to merge
-    #
-    # @return [ PersistenceContext ] the new context
-    def merge(opts)
-      PersistenceContext.new(@object, options.merge(opts))
-    end
-
     # Returns a new persistence context that is consistent with the given
     # child document, inheriting most appropriate settings.
     #

--- a/lib/mongoid/persistence_context.rb
+++ b/lib/mongoid/persistence_context.rb
@@ -57,6 +57,19 @@ module Mongoid
       PersistenceContext.new(@object, options.merge(opts))
     end
 
+    # Returns a new persistence context that is consistent with the given
+    # child document, inheriting most appropriate settings.
+    #
+    # @param [ Mongoid::Document ] document the child document
+    #
+    # @return [ PersistenceContext ] the new persistence context
+    #
+    # @api private
+    def for_child(document)
+      return self if document.class == @object.class
+      PersistenceContext.new(document, options.merge(document.storage_options))
+    end
+
     # Get the collection for this persistence context.
     #
     # @example Get the collection for this persistence context.

--- a/spec/mongoid/clients/options_spec.rb
+++ b/spec/mongoid/clients/options_spec.rb
@@ -343,7 +343,7 @@ describe Mongoid::Clients::Options, retry: 3 do
 
         it 'clears the persistence context' do
           begin; persistence_context; rescue Mongoid::Errors::InvalidPersistenceOption; end
-          expect(test_model.persistence_context).to eq(Mongoid::PersistenceContext.new(test_model))
+          expect(test_model.persistence_context).to eq(Mongoid::PersistenceContext.new(test_model, test_model.storage_options))
         end
       end
 

--- a/spec/mongoid/config/defaults_spec.rb
+++ b/spec/mongoid/config/defaults_spec.rb
@@ -26,12 +26,14 @@ describe Mongoid::Config::Defaults do
     shared_examples "uses settings for 8.1" do
       it "uses settings for 8.1" do
         expect(Mongoid.immutable_ids).to be false
+        expect(Mongoid.legacy_persistence_context_behavior).to be true
       end
     end
 
     shared_examples "does not use settings for 8.1" do
       it "does not use settings for 8.1" do
         expect(Mongoid.immutable_ids).to be true
+        expect(Mongoid.legacy_persistence_context_behavior).to be false
       end
     end
 
@@ -81,12 +83,12 @@ describe Mongoid::Config::Defaults do
     end
 
     context "when given version an invalid version" do
-      let(:version) { 4.2 }
+      let(:version) { '4,2' }
 
       it "raises an error" do
         expect do
           config.load_defaults(version)
-        end.to raise_error(ArgumentError, 'Unknown version: 4.2')
+        end.to raise_error(ArgumentError, 'Unknown version: 4,2')
       end
     end
   end

--- a/spec/mongoid/config_spec.rb
+++ b/spec/mongoid/config_spec.rb
@@ -352,6 +352,13 @@ describe Mongoid::Config do
     it_behaves_like "a config option"
   end
 
+  context 'when setting the legacy_persistence_context_behavior option in the config' do
+    let(:option) { :legacy_persistence_context_behavior }
+    let(:default) { false }
+
+    it_behaves_like "a config option"
+  end
+
   describe "#load!" do
 
     let(:file) do

--- a/spec/mongoid/document_persistence_context_spec.rb
+++ b/spec/mongoid/document_persistence_context_spec.rb
@@ -34,30 +34,64 @@ describe Mongoid::Document do
   context 'when loaded with an overridden persistence context' do
     let(:options) { { collection: 'extra_people' } }
     let(:person) { Person.with(options) { Person.create username: 'zyg14' } }
-    let(:context) { Mongoid::PersistenceContext.get(person) }
 
-    it 'remembers its persistence context' do
-      expect(person.collection_name).to be == :extra_people
+    # Mongoid 9+ default persistence behavior
+    context 'when Mongoid.legacy_persistence_context_behavior is false' do
+      config_override :legacy_persistence_context_behavior, false
+
+      it 'remembers its persistence context when created' do
+        expect(person.collection_name).to be == :extra_people
+      end
+
+      it 'remembers its context when queried specifically' do
+        person_by_id = Person.with(options) { Person.find(_id: person._id) }
+        expect(person_by_id.collection_name).to be == :extra_people
+      end
+
+      it 'remembers its context when queried generally' do
+        person # force the person to be created
+        person_generally = Person.with(options) { Person.all[0] }
+        expect(person_generally.collection_name).to be == :extra_people
+      end
+
+      it 'can be reloaded without specifying the context' do
+        expect { person.reload }.not_to raise_error
+        expect(person.collection_name).to be == :extra_people
+      end
+
+      it 'can be updated without specifying the context' do
+        person.update username: 'zyg15'
+        expect(Person.with(options) { Person.first.username }).to be == 'zyg15'
+      end
     end
 
-    it 'can be reloaded without specifying the context' do
-      expect { person.reload }.not_to raise_error
-    end
+    # pre-9.0 default persistence behavior
+    context 'when Mongoid.legacy_persistence_context_behavior is true' do
+      config_override :legacy_persistence_context_behavior, true
 
-    it 'remembers its context when queried specifically' do
-      person_by_id = Person.with(options) { Person.find(_id: person._id) }
-      expect(person_by_id.collection_name).to be == :extra_people
-    end
+      it 'does not remember its persistence context when created' do
+        expect(person.collection_name).to be == :people
+      end
 
-    it 'remembers its context when queried generally' do
-      person # force the person to be created
-      person_generally = Person.with(options) { Person.all[0] }
-      expect(person_generally.collection_name).to be == :extra_people
-    end
+      it 'does not remember its context when queried specifically' do
+        person_by_id = Person.with(options) { Person.find(_id: person._id) }
+        expect(person_by_id.collection_name).to be == :people
+      end
 
-    it 'can be updated without specifying the context' do
-      person.update username: 'zyg15'
-      expect(Person.with(options) { Person.first.username }).to be == 'zyg15'
+      it 'does not remember its context when queried generally' do
+        person # force the person to be created
+        person_generally = Person.with(options) { Person.all[0] }
+        expect(person_generally.collection_name).to be == :people
+      end
+
+      it 'cannot be reloaded without specifying the context' do
+        expect { person.reload }.to raise_error
+      end
+
+      it 'cannot be updated without specifying the context' do
+        person.update username: 'zyg15'
+        expect(Person.with(options) { Person.first.username }).to be == 'zyg14'
+      end
     end
   end
 end

--- a/spec/mongoid/document_persistence_context_spec.rb
+++ b/spec/mongoid/document_persistence_context_spec.rb
@@ -63,6 +63,18 @@ describe Mongoid::Document do
         person.update username: 'zyg15'
         expect(Person.with(options) { Person.first.username }).to be == 'zyg15'
       end
+
+      it 'an explicit context takes precedence over a remembered context when persisting' do
+        person.username = 'bob'
+        # should not actually save -- the person does not exist in the
+        # `other` collection and so cannot be updated.
+        Person.with(collection: 'other') { person.save! }
+        expect(person.reload.username).to eq 'zyg14'
+      end
+
+      it 'an explicit context takes precedence over a remembered context when reloading' do
+        expect { Person.with(collection: 'other') { person.reload } }.to raise_error(Mongoid::Errors::DocumentNotFound)
+      end
     end
 
     # pre-9.0 default persistence behavior


### PR DESCRIPTION
Makes the storage options writable for individual records, and incorporates those individualized storage options into the persistence context so that subsequent operations on that document object will then fall back to those storage options, if others are not overriding them.

See MONGOID-5472.