### PR TITLE
[READY FOR REVIEW] MONGOID-5715 - [Ruby 2.6 Removal] Remove note about range in Ruby 2.6

### DIFF
--- a/lib/mongoid/extensions/range.rb
+++ b/lib/mongoid/extensions/range.rb
@@ -51,8 +51,6 @@ module Mongoid
         # @param [ Hash ] object The object to demongoize.
         #
         # @return [ Range | nil ] The range, or nil if object cannot be represented as range.
-        #
-        # @note Ruby 2.6 and lower do not support endless ranges that Ruby 2.7+ support.
         def demongoize(object)
           return if object.nil?
           if object.is_a?(Hash)
@@ -62,7 +60,7 @@ module Mongoid
                 ::Range.new(hash["min"] || hash[:min],
                             hash["max"] || hash[:max],
                             hash["exclude_end"] || hash[:exclude_end])
-              rescue ArgumentError # can be removed when Ruby version >= 2.7
+              rescue ArgumentError
                 nil
               end
             end


### PR DESCRIPTION
This PR removes a note which is relevant to Ruby 2.6.

I think we should still catch ArgumentError here as it is still possible to occur, e.g. if min and max are both blank, or if they aren't range compatible, etc.