### PR TITLE
[Docs] Cleanup version compatibility tables

### DIFF
--- a/docs/reference/compatibility.txt
+++ b/docs/reference/compatibility.txt
@@ -34,47 +34,17 @@ specified Mongoid versions.
      - Driver 2.17-2.10
      - Driver 2.9-2.7
 
-   * - 8.1
+   * - 8.0 thru 8.1
      - |checkmark|
      -
      -
 
-   * - 8.0
-     - |checkmark|
-     -
-     -
-
-   * - 7.5
+   * - 7.2 thru 7.5
      - |checkmark|
      - |checkmark|
      -
 
-   * - 7.4
-     - |checkmark|
-     - |checkmark|
-     -
-
-   * - 7.3
-     - |checkmark|
-     - |checkmark|
-     -
-
-   * - 7.2
-     - |checkmark|
-     - |checkmark|
-     -
-
-   * - 7.1
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-
-   * - 7.0
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-
-   * - 6.4
+   * - 7.0 thru 7.1
      - |checkmark|
      - |checkmark|
      - |checkmark|
@@ -102,8 +72,8 @@ is deprecated.
      - Ruby 2.4
      - Ruby 2.3
      - Ruby 2.2
-     - JRuby 9.2
      - JRuby 9.3
+     - JRuby 9.2
 
    * - 8.1
      - |checkmark|
@@ -115,8 +85,8 @@ is deprecated.
      -
      -
      -
-     -
      - |checkmark|
+     -
 
 
    * - 8.0
@@ -129,8 +99,8 @@ is deprecated.
      -
      -
      -
-     -
      - |checkmark|
+     -
 
    * - 7.5
      -
@@ -142,8 +112,8 @@ is deprecated.
      -
      -
      -
-     - D
      - |checkmark|
+     - D
 
    * - 7.4
      -
@@ -155,10 +125,10 @@ is deprecated.
      -
      -
      -
-     - |checkmark|
      -
+     - |checkmark|
 
-   * - 7.3
+   * - 7.2 thru 7.3
      -
      - |checkmark| [#mongoid-7.3-ruby-3.0]_
      - |checkmark| [#mongoid-7.3-ruby-3.0]_
@@ -168,8 +138,8 @@ is deprecated.
      - D
      - D
      -
-     - |checkmark|
      -
+     - |checkmark|
 
    * - 7.2
      -
@@ -181,8 +151,8 @@ is deprecated.
      - D
      - D
      -
-     - |checkmark|
      -
+     - |checkmark|
 
    * - 7.1
      -
@@ -194,8 +164,8 @@ is deprecated.
      - |checkmark| [#ruby-2.4]_
      - |checkmark|
      -
-     - |checkmark|
      -
+     - |checkmark|
 
    * - 7.0
      -
@@ -207,21 +177,8 @@ is deprecated.
      - |checkmark| [#ruby-2.4]_
      - |checkmark|
      - |checkmark| [#ruby-2.2]_
-     - |checkmark|
-     -
-
-   * - 6.4
-     -
-     -
-     -
      -
      - |checkmark|
-     - |checkmark|
-     - |checkmark| [#ruby-2.4]_
-     - |checkmark|
-     - |checkmark| [#ruby-2.2]_
-     - |checkmark|
-     -
 
 .. [#mongoid-7.3-ruby-3.0] Mongoid version 7.3.2 or higher is required.
 
@@ -267,7 +224,7 @@ and will be removed in a next version.
      - MongoDB 3.0
      - MongoDB 2.6
 
-   * - 8.1
+   * - 8.0 thru 8.1
      - |checkmark|
      - |checkmark|
      - |checkmark|
@@ -280,20 +237,7 @@ and will be removed in a next version.
      -
      -
 
-   * - 8.0
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     -
-     -
-     -
-     -
-
-   * - 7.5
+   * - 7.4 thru 7.5
      - |checkmark|
      - |checkmark|
      - |checkmark|
@@ -306,72 +250,7 @@ and will be removed in a next version.
      - D
      - D
 
-   * - 7.4
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - D
-     - D
-     - D
-     - D
-
-   * - 7.3
-     -
-     -
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - D
-     - D
-     - D
-     - D
-
-   * - 7.2
-     -
-     -
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - D
-     - D
-     - D
-     - D
-
-   * - 7.1
-     -
-     -
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - D
-     - D
-     - D
-     - D
-
-   * - 7.0
-     -
-     -
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - D
-     - D
-     - D
-     - D
-
-   * - 6.4
+   * - 7.0 thru 7.3
      -
      -
      - |checkmark|
@@ -406,15 +285,7 @@ are supported by Mongoid.
      - Rails 5.2
      - Rails 5.1
 
-   * - 8.1
-     - |checkmark| [#rails-7.1]_
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - |checkmark| [#rails-5-ruby-3.0]_
-     -
-
-   * - 8.0
+   * - 8.0 thru 8.1
      - |checkmark| [#rails-7.1]_
      - |checkmark|
      - |checkmark|
@@ -467,14 +338,6 @@ are supported by Mongoid.
      -
      - |checkmark| [#rails-6.1]_
      - |checkmark| [#rails-6]_
-     - |checkmark|
-     - |checkmark|
-
-   * - 6.4
-     -
-     -
-     -
-     -
      - |checkmark|
      - |checkmark|
 


### PR DESCRIPTION
Cleanup version compatibility tables in documentation:
- Combine columns which have same values, e.g. with header "7.2 thru 7.5"
- Remove mention of version 6.4 which is very old at this point
- In Ruby Compatibility table, flip-flop JRuby 9.3 and 9.2 cols so that higher comes first, to keep ordering consistent