### PR TITLE
Fix typo/leftover in mongoid.yml file generator template

### DIFF
--- a/lib/rails/generators/mongoid/config/templates/mongoid.yml
+++ b/lib/rails/generators/mongoid/config/templates/mongoid.yml
@@ -51,8 +51,8 @@ development:
         # (default: the database specified above or admin)
         # auth_source: admin
 
-        # Force a the driver cluster to behave in a certain manner instead of auto-
-        # discovering. Can be one of: :direct, :replica_set, :sharded. Set to :direct
+        # Force the driver cluster to behave in a certain manner instead of auto-discovering.
+        # Can be one of: :direct, :replica_set, :sharded. Set to :direct
         # when connecting to hidden members of a replica set.
         # connect: :direct
 


### PR DESCRIPTION
If my English is not failing me, this seems like a typo/leftover.