### PR TITLE
Wrap ActiveJob custom Serializers handling with on_load(:active_job) hook

### DIFF
--- a/lib/mongoid/railtie.rb
+++ b/lib/mongoid/railtie.rb
@@ -123,11 +123,9 @@ module Rails
         ActiveSupport.on_load :active_job do
           require 'mongoid/railties/bson_object_id_serializer'
 
-          config.after_initialize do
-            ActiveJob::Serializers.add_serializers(
-              [::Mongoid::Railties::ActiveJobSerializers::BsonObjectIdSerializer]
-            )
-          end
+          ActiveJob::Serializers.add_serializers(
+            [::Mongoid::Railties::ActiveJobSerializers::BsonObjectIdSerializer]
+          )
         end
       end
 

--- a/lib/mongoid/railtie.rb
+++ b/lib/mongoid/railtie.rb
@@ -120,12 +120,14 @@ module Rails
 
       # Add custom serializers for BSON::ObjectId
       initializer 'mongoid.active_job.custom_serializers' do
-        require 'mongoid/railties/bson_object_id_serializer'
+        ActiveSupport.on_load :active_job do
+          require 'mongoid/railties/bson_object_id_serializer'
 
-        config.after_initialize do
-          ActiveJob::Serializers.add_serializers(
-            [::Mongoid::Railties::ActiveJobSerializers::BsonObjectIdSerializer]
-          )
+          config.after_initialize do
+            ActiveJob::Serializers.add_serializers(
+              [::Mongoid::Railties::ActiveJobSerializers::BsonObjectIdSerializer]
+            )
+          end
         end
       end
 


### PR DESCRIPTION
Because directly referencing `ActiveJob` constant would cause `NameError` on Rails apps that do not bundle AJ.

This follows up #5676.