### PR TITLE
MONGOID-5704 Fix performance regression on belongs_to validation

### DIFF
--- a/lib/mongoid/validatable.rb
+++ b/lib/mongoid/validatable.rb
@@ -38,6 +38,14 @@ module Mongoid
       Threaded.exit_validate(self)
     end
 
+    # Perform a validation within the associated block.
+    def validating
+      begin_validate
+      yield
+    ensure
+      exit_validate
+    end
+
     # Given the provided options, are we performing validations?
     #
     # @example Are we performing validations?

--- a/lib/mongoid/validatable/associated.rb
+++ b/lib/mongoid/validatable/associated.rb
@@ -17,19 +17,6 @@ module Mongoid
     #     validates_associated :name, :addresses
     #   end
     class AssociatedValidator < ActiveModel::Validator
-      attr_reader :attributes
-
-      # Create a new validator with the given options.
-      #
-      # @params [ Hash ] options the options to use to
-      #   initialize the validator.
-      #
-      # @option options [ Array<Symbol> ] :attributes the list of
-      #   attributes to be validated by this validator.
-      def initialize(options)
-        @attributes = options[:attributes]
-      end
-
       # Checks that the named associations of the given record
       # (`attributes`) are valid. This does NOT load the associations
       # from memory, and will only validate records that are dirty
@@ -41,7 +28,7 @@ module Mongoid
       # @param [ Mongoid::Document ] document the document with the
       #   associations to validate.
       def validate(document)
-        attributes.each do |attr_name|
+        options[:attributes].each do |attr_name|
           validate_association(document, attr_name)
         end
       end

--- a/lib/mongoid/validatable/associated.rb
+++ b/lib/mongoid/validatable/associated.rb
@@ -50,7 +50,7 @@ module Mongoid
       def validate_association(document, attribute)
         valid = document.validating do
           Array(document.ivar(attribute)).all? do |value|
-            if value && (!value.persisted? || value.changed?)
+            if value && !value.flagged_for_destroy? && (!value.persisted? || value.changed?)
               value.validated? ? true : value.valid?
             else
               true

--- a/lib/mongoid/validatable/associated.rb
+++ b/lib/mongoid/validatable/associated.rb
@@ -19,6 +19,13 @@ module Mongoid
     class AssociatedValidator < ActiveModel::Validator
       attr_reader :attributes
 
+      # Create a new validator with the given options.
+      #
+      # @params [ Hash ] options the options to use to
+      #   initialize the validator.
+      #
+      # @option options [ Array<Symbol> ] :attributes the list of
+      #   attributes to be validated by this validator.
       def initialize(options)
         @attributes = options[:attributes]
       end
@@ -84,6 +91,13 @@ module Mongoid
 
       private
 
+      # Examine the given target object and return an array of
+      # documents (possibly empty) that the target represents.
+      #
+      # @param [ Array | Mongoid::Document | Mongoid::Association::Proxy | HasMany::Enumerable ] target
+      #   the target object to examine.
+      #
+      # @return [ Array<Mongoid::Document> ] the list of documents
       def get_target_documents(target)
         if target.respond_to?(:_loaded?)
           get_target_documents_for_has_many(target)
@@ -92,10 +106,25 @@ module Mongoid
         end
       end
 
+      # Returns the list of all currently in-memory values held by
+      # the target. The target will not be loaded.
+      #
+      # @param [ HasMany::Enumerable ] target the target that will
+      #   be examined for in-memory documents.
+      #
+      # @return [ Array<Mongoid::Document> ] the in-memory documents
+      #   held by the target.
       def get_target_documents_for_has_many(target)
         [ *target._loaded.values, *target._added.values ]
       end
 
+      # Returns the target as an array. If the target represents a single
+      # value, it is wrapped in an array.
+      #
+      # @param [ Array | Mongoid::Document | Mongoid::Association::Proxy ] target
+      #   the target to return.
+      #
+      # @return [ Array<Mongoid::Document> ] the target, as an array.
       def get_target_documents_for_other(target)
         Array.wrap(target)
       end

--- a/lib/mongoid/validatable/associated.rb
+++ b/lib/mongoid/validatable/associated.rb
@@ -35,8 +35,7 @@ module Mongoid
       #   associations to validate.
       def validate(document)
         attributes.each do |attr_name|
-          relation = document.class.relations[attr_name]
-          validate_association(document, relation)
+          validate_association(document, attr_name)
         end
       end
 
@@ -48,9 +47,9 @@ module Mongoid
       #
       # @param [ Document ] document The document to validate.
       # @param [ Symbol ] attribute The association to validate.
-      def validate_association(document, relation)
+      def validate_association(document, attribute)
         valid = document.validating do
-          Array(document.ivar(relation.name)).all? do |value|
+          Array(document.ivar(attribute)).all? do |value|
             if value && (!value.persisted? || value.changed?)
               value.validated? ? true : value.valid?
             else

--- a/lib/mongoid/validatable/associated.rb
+++ b/lib/mongoid/validatable/associated.rb
@@ -25,7 +25,7 @@ module Mongoid
 
       # Checks that the named associations of the given record
       # (`attributes`) are valid. This does NOT load the associations
-      # from memory, and will only validate records that are dirty
+      # from the database, and will only validate records that are dirty
       # or unpersisted.
       #
       # If anything is not valid, appropriate errors will be added to

--- a/lib/mongoid/validatable/associated.rb
+++ b/lib/mongoid/validatable/associated.rb
@@ -49,7 +49,23 @@ module Mongoid
       # @param [ Symbol ] attribute The association to validate.
       def validate_association(document, attribute)
         valid = document.validating do
-          Array(document.ivar(attribute)).all? do |value|
+          # grab the proxy from the instance variable directly; we don't want
+          # any loading logic to run; we just want to see if it's already
+          # been loaded.
+          proxy = document.ivar(attribute)
+          next true unless proxy
+
+          # if the variable exists, now we see if it is a proxy, or an actual
+          # document. It might be a literal document instead of a proxy if this
+          # document was created with a Document instance as a provided attribute,
+          # e.g. "Post.new(message: Message.new)".
+          target = proxy.respond_to?(:_target) ? proxy._target : proxy
+          next true if target.respond_to?(:_loaded?) && !target._loaded?
+
+          # Now, treating the target as an array, look at each element
+          # and see if it is valid, but only if it has already been
+          # persisted, or changed, and hasn't been flagged for destroy.
+          Array.wrap(target).all? do |value|
             if value && !value.flagged_for_destroy? && (!value.persisted? || value.changed?)
               value.validated? ? true : value.valid?
             else

--- a/lib/mongoid/validatable/associated.rb
+++ b/lib/mongoid/validatable/associated.rb
@@ -17,6 +17,12 @@ module Mongoid
     #     validates_associated :name, :addresses
     #   end
     class AssociatedValidator < ActiveModel::Validator
+      # Required by `validates_with` so that the validator
+      # gets added to the correct attributes.
+      def attributes
+        options[:attributes]
+      end
+
       # Checks that the named associations of the given record
       # (`attributes`) are valid. This does NOT load the associations
       # from memory, and will only validate records that are dirty

--- a/spec/support/models/name.rb
+++ b/spec/support/models/name.rb
@@ -5,6 +5,8 @@ class Name
   include Mongoid::Document
   include Mongoid::Attributes::Dynamic
 
+  validate :is_not_jamis
+
   field :_id, type: String, overwrite: true, default: ->{
     "#{first_name}-#{last_name}"
   }
@@ -23,5 +25,13 @@ class Name
 
   def set_parent=(set = false)
     self.parent_title = namable.title if set
+  end
+
+  private
+
+  def is_not_jamis
+    if first_name == 'Jamis' && last_name == 'Buck'
+      errors.add(:base, :invalid)
+    end
   end
 end


### PR DESCRIPTION
When validating a belongs_to association, Mongoid was loading the associated record and validating it, which could result in a recursive chain of records being loaded and validated, even though they had been persisted and had not changed.

This PR fixes the regression by only validating the associated record if it is (1) already loaded, and (2) either new (unpersisted), or changed.