### PR TITLE
DOCSP-37326: fix formatting

### DIFF
--- a/docs/reference/queries.txt
+++ b/docs/reference/queries.txt
@@ -1151,7 +1151,7 @@ examples.
 If any of the ``_id`` values are not found in the database, the behavior of
 ``find`` depends on the value of the ``raise_not_found_error`` configuration
 option. If the option is set to ``true``, ``find`` raises
-``Mongoid::Errors::DocumentNotFound`` if any of the ``_id``s are not found.
+``Mongoid::Errors::DocumentNotFound`` if any of the ``_id``\s are not found.
 If the option is set to ``false`` and ``find`` is given a single ``_id`` to
 find and there is no matching document, ``find`` returns ``nil``. If the
 option is set to ``false`` and ``find`` is given an array of ids to find


### PR DESCRIPTION
https://jira.mongodb.org/browse/DOCSP-37326

We're working with a third-party vendor to localize our documentation. One of their linguists reported the following formatting error on one of the Mongoid docs pages:
[live site](https://www.mongodb.com/docs/mongoid/current/reference/queries/#:~:text=Mongoid%3A%3AErrors%3A%3ADocumentNotFound%20if%20any%20of%20the)

Minor change to correct formatting, as shown here:
[staged changes](https://docs-mongodbcom-staging.corp.mongodb.com/mongoid/docsworker-xlarge/DOCSP-37326/reference/queries/#:~:text=Mongoid%3A%3AErrors%3A%3ADocumentNotFound)

[build log](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65e64de111db7b04277925c7)