### PR TITLE
Memoize Database Field Names For Faster Fields Access

### DIFF
--- a/lib/mongoid/fields.rb
+++ b/lib/mongoid/fields.rb
@@ -456,7 +456,8 @@ module Mongoid
       #
       # @return [ String ] The name of the field as it's stored in the db.
       def database_field_name(name)
-        Fields.database_field_name(name, relations, aliased_fields, aliased_associations)
+        @database_field_names ||= {}
+        @database_field_names[name] ||= Fields.database_field_name(name, relations, aliased_fields, aliased_associations)
       end
 
       # Defines all the fields that are accessible on the Document
@@ -561,6 +562,7 @@ module Mongoid
       #
       # @api private
       def add_field(name, options = {})
+        @database_field_names[name] = nil if @database_field_names
         aliased = options[:as]
         aliased_fields[aliased.to_s] = name if aliased
         field = field_for(name, options)


### PR DESCRIPTION
Background: 
While working on improving performance on our app, I've noticed that the `database_field_name` is consistently taking long than expected when calling the same field repeatedly(very common when iterating over tens of thousands of objects or in inner loops)
While debugging I've noticed that `Mongoid::Fields#database_field_name` is taking a significant time to perform.

Comparison(very naive):
```
1000000.times do
  product.price
end
```
Before this change takes roughly 1.55 seconds, after it would take 0.99 seconds.
In more realistic cases such as validations of large number of objects as part of factories I've seen 15-20% differences 


This code should be able to accept aliases and non-aliases and preserve the mapping, and save time on repeated access.
It is very possible I've missed some cache busters, please help me identify cases like that, as well as confirm my performance estimations, or if you can help with an even faster solution.