### PR TITLE
MONGOID-5762 Prep for 9.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ Compatibility
 
 Mongoid supports and is tested against:
 
-- MRI 2.7 - 3.1
+- MRI 2.7 - 3.2
 - JRuby 9.4
-- MongoDB server 3.6 - 6.0
+- MongoDB server 3.6 - 7.0
 
 Issues
 ------

--- a/lib/mongoid/version.rb
+++ b/lib/mongoid/version.rb
@@ -2,5 +2,5 @@
 # rubocop:todo all
 
 module Mongoid
-  VERSION = "9.0.0.alpha"
+  VERSION = "9.0.0"
 end


### PR DESCRIPTION
# Mongoid 9.0

Mongoid 9.0 is a new major update to the Mongoid ODM. It includes many bug fixes, updates, improvements, and new features.

Significant new features include the following:

* You can now create and manage Atlas search indexes directly from Mongoid, by specifying your search index definitions directly on the relevant models. (MONGOID-5601)
* You can now declare a transaction with a block, using syntax that should be familiar to Rails programmers. (You must still be using a MongoDB topology that supports transactions, like a replica-set or sharded topology.) Along with this new syntax, support has also been added for `after_commit` and `after_rollback` callbacks. (MONGOID-5530, MONGOID-5531 and MONGOID-5708)
* Around callbacks on embedded documents are now disabled by default, for performance reasons. If a parent document has a large number (hundreds) of embedded documents, it is possible for the stack to be exhausted while processing "around" callbacks for those embedded documents. If you need around callbacks for your embedded documents, and you are confident that you will not have large numbers of embedded documents in a single parent, you can enable around callbacks with the `Mongoid.around_embedded_document_callbacks` configuration option. (MONGOID-5658)
* A new serializer has been added to allow `BSON::ObjectId` instances to be serialized and deserialized by ActiveJob. (MONGOID-5611)
* If you specify custom storage options when loading a model (e.g. overriding its collection name, database name, or the named client), you will not need to explicitly specify those same options when saving the model. The model will remember the storage options that were active when it was loaded. (MONGOID-5472)
* Support for "sandbox mode" in the Rails console has been added. As long as you are using a supported topology (replica-set or sharded, for example), when you specify `--sandbox` when starting the Rails console, your console session will be wrapped in a transaction. (MONGOID-4901)
* You can now enjoy [Client-Side Field Level Encryption](https://www.mongodb.com/docs/manual/core/csfle/) (CSFLE) in Mongoid with supported database server versions. Declare your CSFLE schemas in your documents, configure your encryption in `mongoid.yml` or `config.rb`, and generate new data keys via `rake`. (MONGOID-5585, MONGOID-5587, MONGOID-5589, MONGOID-5592, MONGOID-5613, MONGOID-5615.)

Many other changes are included as well, including the following:

* Support for Rails 2.6 and Rails 5 have been dropped. (MONGOID-5574)
* Support has been added for JRuby 9.4, and BSON 5. (MONGOID-5575, MONGOID-5739, RUBY-2846)
* Added `Mongoid.reconnect_clients` in conjunction with improving documentation about working with forking webservers. (MONGOID-5758)
* Saving a model in a session other than the one that loaded it will now result in a warning message (as this is generally considered a bug.) (MONGOID-5552)
* Eager loading now works with embedded associations. These associations cannot actually be eager loaded, but this allows you to chain eager loading through embedded associations, for example with has-and-belongs-to-many associations. (MONGOID-5052)
* For embedded associations, the default is now `touch: true`. This means that when you update an embedded document, its parent is automatically touched (or saved, with the timestamps updated) as well. (MONGOID-5016)
* You can now prevent Mongoid from type-casting a given value in a query by wrapping it with `Mongoid::RawValue`. This makes it easier to deal with legacy data that does not conform to an expected type. (MONGOID-5408)
* The Rails generator for Mongoid (`rails g mongoid:config`) now additionally generates a default `config/initializers/mongoid.rb`. (MONGOID-5439)
* When calling `#touch` on a model, Mongoid now clears the 'changed' state of the model. Previously, `#touch` left the model in a 'changed' state, even though it had been persisted by the touch operation. (MONGOID-5504)
* Mongoid's `db:mongoid:create_indexes` rake task was not always loading all models before creating the indexes, resulting in some missing indexes. This is now fixed. (MONGOID-5547)
* Added support for `$min`, `$max`, and `$mul` operators (via `set_min`, `set_max`, and `mul`), as well as `$setOnInsert` when doing an upsert (via a new `:set_on_insert` option to `#upsert`). (MONGOID-5442)
* A timezone configured in your app (via `Time.zone=`) will now be used when typecasting dates for time-valued fields. (MONGOID-5488)
* Typecasting strings for numeric fields now correctly converts the strings into `BigDecimal` values. (MONGOID-5484)
* Field aliases are now honored in index specifications. (MONGOID-5314)
* Fixed an issue where an empty list in a HABTM association needed special handling (instead of blindly using an empty list with `$in`). (MONGOID-5164)
* Attempting to call `estimated_count` when a default scope is active on a collection now raises a dedicated exception (`Mongoid::Errors::InvalidEstimatedCountScoping`) (MONGOID-4960)
* Mongoid now raises `Mongoid::Errors:AttributeNotLoaded` when a program attempts to access a field that is defined on the model, but which was excluded by the query's projection. Previously, `ActiveModel::MissingAttributeError` was raised in this situation. (MONGOID-5467)
* When assigning an array of Hashes to a field, the hashes are always converted to a `BSON::Document`. This makes the behavior consistent with how those fields are loaded from the database. (MONGOID-5410)

Additionally, a number of methods that were monkey-patched onto core modules have been deprecated, including the following:
* `Array#multi_arged?` (MONGOID-5669)
* `BigDecimal#__to_inc__` (MONGOID-5662)
* `Hash#__consolidate__` (MONGOID-5654)
* `Hash#__mongoid_unsatisfiable_criteria?` (MONGOID-5671)
* `Hash#__nested__` (MONGOID-5653)
* `Hash#delete_id` (MONGOID-5670)
* `Hash#extract_id` (MONGOID-5670)
* `Hash#to_criteria` (MONGOID-5677)
* `Integer#unconvertable_to_bson?`
* `Object#__find_args__` (MONGOID-5665)
* `Object#__mongoize_fk__` (MONGOID-5675)
* `Object#__setter__` (MONGOID-5664)
* `Object#__sortable__` (MONGOID-5663)
* `Object#__to_inc__` (MONGOID-5662)
* `Object#blank_criteria?` (MONGOID-5671)
* `Object#do_or_do_not` (MONGOID-5673)
* `Object#regexp?` (MONGOID-5674)
* `Object#you_must` (MONGOID-5673)
* `String#mongoid_id?` (MONGOID-5668)
* `String#unconvertable_to_bson?` (MONGOID-5667)
* `Symbol#mongoid_id?` (MONGOID-5668)
* `Time#configured` (MONGOID-5676)

Also, `Criteria#for_js` has been deprecated (MONGOID-5651), and `Mongoid::QueryCache` (which was previously deprecated) has been removed (MONGOID-5625).
