### PR TITLE
Mongoize is not called on update_all, when $set operator is used

### DIFF
--- a/lib/mongoid/atomic_update_preparer.rb
+++ b/lib/mongoid/atomic_update_preparer.rb
@@ -53,6 +53,7 @@ module Mongoid
       #
       # @param [ String ] operator The operator.
       # @param [ Class ] klass The model class.
+      # @param [ String | Symbol ] key The field key.
       # @param [ Object ] value The original value.
       #
       # @return [ Object ] Value prepared for the provided operator.

--- a/lib/mongoid/atomic_update_preparer.rb
+++ b/lib/mongoid/atomic_update_preparer.rb
@@ -25,7 +25,7 @@ module Mongoid
           if key.to_s.start_with?('$')
             (atomic_updates[key] ||= {}).update(prepare_operation(klass, key, value))
           else
-            (atomic_updates['$set'] ||= {})[key] = mongoize_for(key, klass, key, value)
+            (atomic_updates['$set'] ||= {})[key] = mongoize_for('$set', klass, key, value)
           end
         end
       end

--- a/lib/mongoid/atomic_update_preparer.rb
+++ b/lib/mongoid/atomic_update_preparer.rb
@@ -43,7 +43,7 @@ module Mongoid
       def prepare_operation(klass, key, value)
         value.each_with_object({}) do |(key2, value2), hash|
           key2 = klass.database_field_name(key2)
-          hash[key2] = value_for(key, klass, value2)
+          hash[key2] = value_for(key, klass, key2, value2)
         end
       end
 
@@ -56,11 +56,11 @@ module Mongoid
       # @param [ Object ] value The original value.
       #
       # @return [ Object ] Value prepared for the provided operator.
-      def value_for(operator, klass, value)
+      def value_for(operator, klass, key, value)
         case operator
         when '$rename' then value.to_s
         when '$addToSet', '$push' then value.mongoize
-        else mongoize_for(operator, klass, operator, value)
+        else mongoize_for(operator, klass, key, value)
         end
       end
 

--- a/spec/mongoid/contextual/mongo_spec.rb
+++ b/spec/mongoid/contextual/mongo_spec.rb
@@ -3659,15 +3659,15 @@ describe Mongoid::Contextual::Mongo do
         context "when the attributes must be mongoized" do
 
           before do
-            context.update_all("$set" => { member_count: "1" })
+            context.update_all("$set" => { location: LatLng.new(52.30, 13.25) })
           end
 
           it "updates the first matching document" do
-            expect(depeche_mode.reload.member_count).to eq(1)
+            expect(depeche_mode.reload.location).to eq(LatLng.new(52.30, 13.25))
           end
 
           it "updates the last matching document" do
-            expect(new_order.reload.member_count).to eq(1)
+            expect(new_order.reload.location).to eq(LatLng.new(52.30, 13.25))
           end
         end
       end

--- a/spec/support/models/band.rb
+++ b/spec/support/models/band.rb
@@ -26,6 +26,7 @@ class Band
   field :mojo, type: Object
   field :tags, type: Hash
   field :fans
+  field :location, type: LatLng
 
   alias_attribute :d, :deleted
 

--- a/spec/support/models/lat_lng.rb
+++ b/spec/support/models/lat_lng.rb
@@ -5,6 +5,8 @@ class LatLng
   attr_accessor :lat, :lng
 
   def self.demongoize(object)
+    return if object.nil?
+
     LatLng.new(object[1], object[0])
   end
 

--- a/spec/support/models/lat_lng.rb
+++ b/spec/support/models/lat_lng.rb
@@ -15,4 +15,8 @@ class LatLng
   def mongoize
     [ lng, lat ]
   end
+
+  def ==(other)
+    lat == other.lat && lng == other.lng
+  end
 end


### PR DESCRIPTION
During our upgrade of mongoid to 8.x version hit into issue that that custom type field classes stops working in update_all, when
$set operator is used:
```
class LatLng
  attr_accessor :lat, :lng

  def self.demongoize(object)
    LatLng.new(object[1], object[0])
  end

  def initialize(lat, lng)
    @lat, @lng = lat, lng
  end

  def mongoize
    [ lng, lat ]
  end
end

class Bar
  include Mongoid::Document
  field :lat_lng, type: LatLng
end

Bar.create!

Bar.update_all('$set' => { lat_lng: LatLng.new(52.30, 13.25) })

BSON::Error::UnserializableClass: Value does not define its BSON serialized type: #<LatLng:0x000057678d11ddb0>
```

This problem is not highlighted by the tests due to mongoize does not work, but BSON still able serialize strings and send it to database:
```
context.update_all("$set" => { member_count: "1" })
```

And in test case reloaded results from database -  string value transformed to Integer by demongoize. Tests always stays green, however problem exists:
```
          it "updates the first matching document" do
            expect(depeche_mode.reload.member_count).to eq(1)
          end
```

It is easy to find with couple of lines console output:
```
          it "updates the first matching document" do
            depeche_mode.reload
            pp depeche_mode.member_count
            pp depeche_mode.member_count.class
            pp depeche_mode.as_document[:member_count]
            pp depeche_mode.as_document[:member_count].class
            expect(depeche_mode.reload.member_count).to eq(1)
          end
```
Output of rspec test will be
```
bundle exec rspec ./spec/mongoid/contextual/mongo_spec.rb:3665
[mongoid] Warning: No private key present, creating unsigned gem.
Run options: include {:locations=>{"./spec/mongoid/contextual/mongo_spec.rb"=>[3665]}}                                                                                                               
W, [2024-05-10T13:16:15.670196 #31184]  WARN -- : Using BSON::Decimal128 as the field type is not supported. In BSON <= 4, the BSON::Decimal128 type will work as expected for both storing and querying, but will return a BigDecimal on query in BSON 5+. To use literal BSON::Decimal128 fields with BSON 5, set Mongoid.allow_bson5_decimal128 to true.
1
Integer
"1"
String
 1/1 |==================================================================================== 100 ====================================================================================>| Time: 00:00:00 

Finished in 0.18469 seconds (files took 0.65765 seconds to load)
1 example, 0 failures
```

Issue happens due to misuse of the mongoize_for third param. It should be key (i.e. field key), not operator
```
mongoize_for(operator, klass, operator, value)
```
In this case in mongoize_for field will be nil and it return original value without demongoization:
```
field = klass.fields[key.to_s]
return value unless field
```

This issue exists at least at `8.1-stable` branch, but code is different there. I will provide separate PR to fix this issue in `8.1-stable` branch.

`8.1-stable` fix is actually important for us (https://www.onepagecrm.com), we are aiming to make upgrade to 8.1.x, but do not go further for a minute.

This PR also fix a problem describer by [midnight-wonderer](https://github.com/midnight-wonderer) in discussion https://github.com/mongodb/mongoid/discussions/5812
He also right about line with misuse of first attribute:
```
(atomic_updates['$set'] ||= {})[key] = mongoize_for(key, klass, key, value)
```
I've included this small suggested fix in this PR.
