### PR TITLE
5508 touch on custom field

### DIFF
--- a/spec/mongoid/touchable_spec.rb
+++ b/spec/mongoid/touchable_spec.rb
@@ -733,6 +733,44 @@ describe Mongoid::Touchable do
       end
     end
 
+    context 'when a custom field is specified' do
+      let!(:start_time) { Timecop.freeze(Time.at(Time.now.to_i)) }
+      let(:update_time) { Timecop.freeze(Time.at(Time.now.to_i) + 2) }
+
+      after do 
+        Timecop.return 
+      end
+
+      let!(:label) do 
+        TouchableSpec::Referenced::Label.create!
+      end 
+    
+      let!(:band) do
+        TouchableSpec::Referenced::Band.create!(label: label)
+      end
+
+      before do
+        update_time
+        band.touch 
+      end
+
+      it "updates the specified field in the parent document" do
+        expect(label.bands_updated_at).to eq(update_time)
+        expect(label.reload.bands_updated_at).to eq(update_time)
+      end
+
+      it "updates the parent's timestamp" do
+        expect(label.updated_at).to eq(update_time)
+        expect(label.reload.updated_at).to eq(update_time)
+      end 
+
+      it "updates the child's timestamp" do
+        expect(band.updated_at).to eq(update_time)
+        expect(band.reload.updated_at).to eq(update_time)
+      end 
+
+    end
+
     context 'multi-level' do
 
       let!(:start_time) { Timecop.freeze(Time.at(Time.now.to_i)) }

--- a/spec/mongoid/touchable_spec.rb
+++ b/spec/mongoid/touchable_spec.rb
@@ -754,14 +754,13 @@ describe Mongoid::Touchable do
         end
 
         before do
-          band
           update_time
           band.send(meth)
         end
 
         it "updates the child's timestamp" do
-          # expect(band.updated_at).to eq(update_time.utc)
-          expect(band.reload.updated_at).to eq(update_time.utc)
+          expect(band.updated_at).to eq(update_time)
+          expect(band.reload.updated_at).to eq(update_time)
         end
       end
 

--- a/spec/mongoid/touchable_spec_models.rb
+++ b/spec/mongoid/touchable_spec_models.rb
@@ -153,9 +153,16 @@ module TouchableSpec
 
     class Label
       include Mongoid::Document 
-      field :band_updated_at, type: DateTime 
+      field :bands_updated_at, type: DateTime 
       field :name, type: String 
       has_many :bands 
-    end 
+    end
+    
+    class Band
+      include Mongoid::Document 
+      field :name, type: String 
+      belongs_to :label, touch :bands_updated_at
+    end
+    
   end
 end

--- a/spec/mongoid/touchable_spec_models.rb
+++ b/spec/mongoid/touchable_spec_models.rb
@@ -150,5 +150,12 @@ module TouchableSpec
 
       embedded_in :floor, touch: true, class_name: "TouchableSpec::Referenced::Floor"
     end
+
+    class Label
+      include Mongoid::Document 
+      field :band_updated_at, type: DateTime 
+      field :name, type: String 
+      has_many :bands 
+    end 
   end
 end

--- a/spec/mongoid/touchable_spec_models.rb
+++ b/spec/mongoid/touchable_spec_models.rb
@@ -152,16 +152,18 @@ module TouchableSpec
     end
 
     class Label
-      include Mongoid::Document 
-      field :bands_updated_at, type: DateTime 
-      field :name, type: String 
-      has_many :bands 
+      include Mongoid::Document
+      include Mongoid::Timestamps
+
+      field :bands_updated_at, type: DateTime
+      has_many :bands, class_name: "TouchableSpec::Referenced::Band"
     end
     
     class Band
-      include Mongoid::Document 
-      field :name, type: String 
-      belongs_to :label, touch :bands_updated_at
+      include Mongoid::Document
+      include Mongoid::Timestamps
+
+      belongs_to :label, touch: :bands_updated_at, class_name: "TouchableSpec::Referenced::Label"
     end
     
   end


### PR DESCRIPTION
This branch adds a spec to touchable_spec.rb to test whether the symbol representing the field to touch provided to the touch option is indeed touched. Two extra models - Band and Label - were also added to touchable_spec_model.rb for this. See https://jira.mongodb.org/browse/MONGOID-5508 for more. 
