### PR TITLE
MONGOID-5786: Fix some compatibility issues with Enumerable API

### DIFF
--- a/lib/mongoid/contextual/aggregable/memory.rb
+++ b/lib/mongoid/contextual/aggregable/memory.rb
@@ -94,7 +94,7 @@ module Mongoid
         #
         # @return [ Numeric ] The sum value.
         def sum(field = nil)
-          return super() if block_given?
+          return super(field || 0) if block_given?
 
           aggregate_by(field, :sum) || 0
         end

--- a/lib/mongoid/contextual/aggregable/memory.rb
+++ b/lib/mongoid/contextual/aggregable/memory.rb
@@ -90,7 +90,8 @@ module Mongoid
         # @example Get the sum for the provided block.
         #   aggregable.sum(&:likes)
         #
-        # @param [ Symbol ] field The field to sum.
+        # @param [ Symbol | Numeric ] field The field to sum, or the intial
+        #   value of the sum when a block is given.
         #
         # @return [ Numeric ] The sum value.
         def sum(field = nil)

--- a/lib/mongoid/contextual/aggregable/mongo.rb
+++ b/lib/mongoid/contextual/aggregable/mongo.rb
@@ -100,7 +100,9 @@ module Mongoid
         #
         # @return [ Float ] The sum value.
         def sum(field = nil)
-          block_given? ? super() : aggregates(field)["sum"] || 0
+          return super(field || 0) if block_given?
+
+          aggregates(field)["sum"] || 0
         end
 
         private

--- a/lib/mongoid/contextual/aggregable/mongo.rb
+++ b/lib/mongoid/contextual/aggregable/mongo.rb
@@ -96,7 +96,8 @@ module Mongoid
         # @example Get the sum for the provided block.
         #   aggregable.sum(&:likes)
         #
-        # @param [ Symbol ] field The field to sum.
+        # @param [ Symbol | Numeric ] field The field to sum, or the initial
+        #    value of the sum when a block is given.
         #
         # @return [ Float ] The sum value.
         def sum(field = nil)

--- a/spec/mongoid/contextual/aggregable/memory_spec.rb
+++ b/spec/mongoid/contextual/aggregable/memory_spec.rb
@@ -570,5 +570,16 @@ describe Mongoid::Contextual::Aggregable::Memory do
         expect(sum).to eq(1500)
       end
     end
+
+    context "when provided a block with initial value" do
+
+      let(:sum) do
+        context.sum(500, &:likes)
+      end
+
+      it "returns the sum for the provided block starting from initial value" do
+        expect(sum).to eq(2000)
+      end
+    end
   end
 end

--- a/spec/mongoid/contextual/aggregable/mongo_spec.rb
+++ b/spec/mongoid/contextual/aggregable/mongo_spec.rb
@@ -515,6 +515,17 @@ describe Mongoid::Contextual::Aggregable::Mongo do
           expect(sum).to eq(1500)
         end
       end
+
+      context "when provided a block with initial value" do
+
+        let(:sum) do
+          context.sum(500, &:likes)
+        end
+
+        it "returns the sum for the provided block starting from initial value" do
+          expect(sum).to eq(2000)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Hi, in accordance with Ruby's enumerable API, I've added support for initial value when a block is given to `Enumerable#sum`.

Tell me if the provided changes are ok and I could replicate the same changes to `min` and `max` methods.

Cheers!