### PR TITLE
MONGOID-5785 allow named scopes to remove a default scope

### DIFF
--- a/lib/mongoid/config.rb
+++ b/lib/mongoid/config.rb
@@ -171,6 +171,15 @@ module Mongoid
     # See https://jira.mongodb.org/browse/MONGOID-5658 for more details.
     option :around_callbacks_for_embeds, default: false
 
+    # When this flag is false, named scopes cannot unset a default scope.
+    # This is the traditional (and default) behavior in Mongoid 9 and earlier.
+    #
+    # Setting this flag to true will allow named scopes to unset the default
+    # scope. This will be the default in Mongoid 10.
+    #
+    # See https://jira.mongodb.org/browse/MONGOID-5785 for more details.
+    option :allow_scopes_to_unset_default_scope, default: false
+
     # Returns the Config singleton, for use in the configure DSL.
     #
     # @return [ self ] The Config singleton.

--- a/lib/mongoid/scopable.rb
+++ b/lib/mongoid/scopable.rb
@@ -294,7 +294,13 @@ module Mongoid
             scope = instance_exec(*args, **kwargs, &scoping[:scope])
             extension = scoping[:extension]
             to_merge = scope || queryable
-            criteria = to_merge.empty_and_chainable? ? to_merge : with_default_scope.merge(to_merge)
+
+            criteria = if Mongoid.allow_scopes_to_unset_default_scope
+                         to_merge
+                       else
+                         to_merge.empty_and_chainable? ? to_merge : with_default_scope.merge(to_merge)
+                       end
+
             criteria.extend(extension)
             criteria
           end

--- a/spec/mongoid/scopable_spec.rb
+++ b/spec/mongoid/scopable_spec.rb
@@ -3,6 +3,19 @@
 
 require "spec_helper"
 
+# Retrieve the singleton class for the given class.
+def singleton_class_for(klass)
+  class <<klass; self; end
+end
+
+# Helper method for removing a declared scope
+def remove_scope(klass, scope)
+  if klass._declared_scopes[scope]
+    singleton_class_for(klass).remove_method(scope)
+    klass._declared_scopes.delete(scope)
+  end
+end
+
 describe Mongoid::Scopable do
 
   describe ".default_scope" do
@@ -349,6 +362,10 @@ describe Mongoid::Scopable do
           Band.create!(name: 'testing')
         end
 
+        after do
+          remove_scope(Band, :tests)
+        end
+
         it 'applies the collation' do
           expect(Band.tests.first['name']).to eq('testing')
         end
@@ -365,10 +382,7 @@ describe Mongoid::Scopable do
         end
 
         after do
-          class << Band
-            undef_method :active
-          end
-          Band._declared_scopes.clear
+          remove_scope(Band, :active)
         end
 
         let(:scope) do
@@ -390,10 +404,7 @@ describe Mongoid::Scopable do
         end
 
         after do
-          class << Record
-            undef_method :tool
-          end
-          Record._declared_scopes.clear
+          remove_scope(Record, :tool)
         end
 
         context "when calling the scope" do
@@ -423,10 +434,7 @@ describe Mongoid::Scopable do
         end
 
         after do
-          class << Band
-            undef_method :active
-          end
-          Band._declared_scopes.clear
+          remove_scope(Band, :active)
         end
 
         it "adds a method for the scope" do
@@ -461,10 +469,7 @@ describe Mongoid::Scopable do
             end
 
             after do
-              class << Band
-                undef_method :english
-              end
-              Band._declared_scopes.clear
+              remove_scope(Band, :english)
             end
 
             let(:scope) do
@@ -527,10 +532,7 @@ describe Mongoid::Scopable do
           config_override :scope_overwrite_exception, true
 
           after do
-            class << Band
-              undef_method :active
-            end
-            Band._declared_scopes.clear
+            remove_scope(Band, :active)
           end
 
           it "raises an exception" do
@@ -545,10 +547,7 @@ describe Mongoid::Scopable do
           config_override :scope_overwrite_exception, false
 
           after do
-            class << Band
-              undef_method :active
-            end
-            Band._declared_scopes.clear
+            remove_scope(Band, :active)
           end
 
           it "raises no exception" do
@@ -589,10 +588,7 @@ describe Mongoid::Scopable do
           end
 
           after do
-            class << Band
-              undef_method :active
-            end
-            Band._declared_scopes.clear
+            remove_scope(Band, :active)
           end
 
           let(:scope) do
@@ -652,11 +648,8 @@ describe Mongoid::Scopable do
         end
 
         after do
-          class << Band
-            undef_method :active
-            undef_method :named_by
-          end
-          Band._declared_scopes.clear
+          remove_scope(Band, :active)
+          remove_scope(Band, :named_by)
         end
 
         it "adds a method for the scope" do
@@ -698,10 +691,7 @@ describe Mongoid::Scopable do
             end
 
             after do
-              class << Band
-                undef_method :english
-              end
-              Band._declared_scopes.clear
+              remove_scope(Band, :english)
             end
 
             let(:scope) do
@@ -775,15 +765,9 @@ describe Mongoid::Scopable do
             end
 
             after do
-              class << Article
-                undef_method :is_public
-                undef_method :authored
-              end
-              Article._declared_scopes.clear
-              class << Author
-                undef_method :author
-              end
-              Author._declared_scopes.clear
+              remove_scope(Article, :is_public)
+              remove_scope(Article, :authored)
+              remove_scope(Author, :author)
             end
 
             context "when calling another model's scope from within a scope" do
@@ -816,10 +800,7 @@ describe Mongoid::Scopable do
           config_override :scope_overwrite_exception, true
 
           after do
-            class << Band
-              undef_method :active
-            end
-            Band._declared_scopes.clear
+            remove_scope(Band, :active)
           end
 
           it "raises an exception" do
@@ -834,10 +815,7 @@ describe Mongoid::Scopable do
           config_override :scope_overwrite_exception, false
 
           after do
-            class << Band
-              undef_method :active
-            end
-            Band._declared_scopes.clear
+            remove_scope(Band, :active)
           end
 
           it "raises no exception" do
@@ -867,11 +845,8 @@ describe Mongoid::Scopable do
         end
 
         after do
-          class << Band
-            undef_method :xxx
-            undef_method :yyy
-          end
-          Band._declared_scopes.clear
+          remove_scope(Band, :xxx)
+          remove_scope(Band, :yyy)
         end
 
         let(:criteria) do
@@ -901,15 +876,8 @@ describe Mongoid::Scopable do
       end
 
       after do
-        class << Shape
-          undef_method :located_at
-        end
-        Shape._declared_scopes.clear
-
-        class << Circle
-          undef_method :with_radius
-        end
-        Circle._declared_scopes.clear
+        remove_scope(Shape, :located_at)
+        remove_scope(Circle, :with_radius)
       end
 
       let(:shape_scope_keys) do
@@ -950,16 +918,9 @@ describe Mongoid::Scopable do
       end
 
       after do
-        class << Shape
-          undef_method :visible
-          undef_method :large
-        end
-        Shape._declared_scopes.clear
-
-        class << Circle
-          undef_method :large
-        end
-        Circle._declared_scopes.clear
+        remove_scope(Shape, :visible)
+        remove_scope(Shape, :large)
+        remove_scope(Circle, :large)
       end
 
       it "uses subclass context for all the other used scopes" do
@@ -1099,9 +1060,7 @@ describe Mongoid::Scopable do
           end
 
           after do
-            class << Band
-              undef_method :active
-            end
+            remove_scope(Band, :active)
           end
 
           let(:unscoped) do
@@ -1143,10 +1102,7 @@ describe Mongoid::Scopable do
         end
 
         after do
-          class << Band
-            undef_method :skipped
-          end
-          Band._declared_scopes.clear
+          remove_scope(Band, :skipped)
         end
 
         it "does not allow the default scope to be applied" do
@@ -1287,6 +1243,53 @@ describe Mongoid::Scopable do
     it "does not affect other models' default scopes within the given block" do
       Appointment.without_default_scope do
         expect(Audio.all.selector).not_to be_empty
+      end
+    end
+  end
+
+  describe "scoped queries" do
+    context "with a default scope" do
+      let(:criteria) do
+        Band.where(name: "Depeche Mode")
+      end
+
+      before do
+        Band.default_scope ->{ criteria }
+        Band.scope :unscoped_everyone, -> { unscoped }
+        Band.scope :removed_default, -> { scoped.remove_scoping(all) }
+
+        Band.create name: 'Depeche Mode'
+        Band.create name: 'They Might Be Giants'
+      end
+
+      after do
+        Band.default_scoping = nil
+        remove_scope Band, :unscoped_everyone
+        remove_scope Band, :removed_default
+      end
+
+      context "when allow_scopes_to_unset_default_scope == false" do # default for <= 9
+        config_override :allow_scopes_to_unset_default_scope, false
+
+        it 'merges the default scope into the query with unscoped' do
+          expect(Band.unscoped_everyone.selector).to include('name' => 'Depeche Mode')
+        end
+
+        it 'merges the default scope into the query with remove_scoping' do
+          expect(Band.removed_default.selector).to include('name' => 'Depeche Mode')
+        end
+      end
+
+      context "when allow_scopes_to_unset_default_scope == true" do # default for >= 10
+        config_override :allow_scopes_to_unset_default_scope, true
+
+        it 'does not merge the default scope into the query with unscoped' do
+          expect(Band.unscoped_everyone.selector).not_to include('name' => 'Depeche Mode')
+        end
+
+        it 'does not merge merges the default scope into the query with remove_scoping' do
+          expect(Band.removed_default.selector).not_to include('name' => 'Depeche Mode')
+        end
       end
     end
   end


### PR DESCRIPTION
As currently implemented, named scopes are merged with the default scope (see [here](https://github.com/mongodb/mongoid/blob/a5657dc6044c1f870dc36db3aed3cfdea66e7b66/lib/mongoid/scopable.rb#L297)). This means you cannot declare a named scope that unsets any part of the default scope; if you try, the default scope will simply be merged back into it.

Merging the default scope is not necessary, because any scope you pass in will already be based on the default scope:

```ruby
class Person
  include Mongoid::Document

  default_scope { where(deleted_at: nil) }
  scope :germans, -> { where(country: 'DE') }
end
```

Here, `Person.germans` will always use the default scope, even without it being merged in, because calling `where` will initialize a new `Criteria` object using that default scope. Merging the default scope is redundant.

However, because this has been this way for a very long time (basically since the feature was first introduced prior to 2014), we risk breaking code that inadvertently depends on this behavior. Thus, I've opted to put the fix behind a flag, which we can flip when we eventually release Mongoid 10.