### PR TITLE
MONGOID-5789 Allow nil attribute access (backport of #5836)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -197,6 +197,8 @@ jobs:
       with:
         ruby-version: "${{matrix.ruby}}"
         bundler: 2
+    - name: Change permissions
+      run: chmod -R o-w /opt/hostedtoolcache/Ruby
     - name: bundle
       run: bundle install --jobs 4 --retry 3
       env:

--- a/lib/mongoid/fields.rb
+++ b/lib/mongoid/fields.rb
@@ -405,12 +405,12 @@ module Mongoid
       #
       # @api private
       def database_field_name(name, relations, aliased_fields, aliased_associations)
+        return '' unless name.present?
+
         if Mongoid.broken_alias_handling
-          return nil unless name
           normalized = name.to_s
           aliased_fields[normalized] || normalized
         else
-          return nil unless name.present?
           key = name.to_s
           segment, remaining = key.split('.', 2)
 

--- a/lib/mongoid/touchable.rb
+++ b/lib/mongoid/touchable.rb
@@ -25,7 +25,7 @@ module Mongoid
         current = Time.configured.now
         field = database_field_name(field)
         write_attribute(:updated_at, current) if respond_to?("updated_at=")
-        write_attribute(field, current) if field
+        write_attribute(field, current) if field.present?
 
         # If the document being touched is embedded, touch its parents
         # all the way through the composition hierarchy to the root object,

--- a/spec/mongoid/attributes_spec.rb
+++ b/spec/mongoid/attributes_spec.rb
@@ -288,6 +288,22 @@ describe Mongoid::Attributes do
         end
       end
 
+      context "when given nil" do
+
+        it "returns nil" do
+         expect(person[nil]).to be nil
+        end
+
+      end
+
+      context "when given an empty string" do
+
+        it "returns nil" do
+         expect(person[""]).to be nil
+        end
+
+      end
+
       context "when the field was not explicitly defined" do
 
         context "when excluding with only and the field was not excluded" do

--- a/spec/mongoid/fields_spec.rb
+++ b/spec/mongoid/fields_spec.rb
@@ -1845,12 +1845,12 @@ describe Mongoid::Fields do
 
       context 'given nil' do
         subject { Person.database_field_name(nil) }
-        it { is_expected.to eq nil }
+        it { is_expected.to eq '' }
       end
 
       context 'given an empty String' do
         subject { Person.database_field_name('') }
-        it { is_expected.to eq nil }
+        it { is_expected.to eq '' }
       end
 
       context 'given a String' do
@@ -1869,7 +1869,7 @@ describe Mongoid::Fields do
 
       context 'given nil' do
         subject { Person.database_field_name(nil) }
-        it { is_expected.to eq nil }
+        it { is_expected.to eq '' }
       end
 
       context 'given an empty String' do


### PR DESCRIPTION
Allow `nil` attribute access (returning `nil` instead of raising an obscure exception). See #5836.