### PR TITLE
MONGOID-5790 MONGOID-5791 Fix error caused by loading a referenced class prematurely

### DIFF
--- a/lib/mongoid/touchable.rb
+++ b/lib/mongoid/touchable.rb
@@ -212,12 +212,6 @@ module Mongoid
     #
     # @return [ Symbol ] The method name.
     def define_relation_touch_method(name, association)
-      relation_classes = if association.polymorphic?
-                           association.send(:inverse_association_classes)
-                         else
-                           [ association.relation_class ]
-                         end
-
       method_name = "touch_#{name}_after_create_or_destroy"
       association.inverse_class.class_eval do
         define_method(method_name) do

--- a/spec/mongoid/association_spec.rb
+++ b/spec/mongoid/association_spec.rb
@@ -15,6 +15,20 @@ describe Mongoid::Association do
     )
   end
 
+  context "when class_name references an unknown class" do
+    context "when loading" do
+      it "does not raise an exception" do
+        expect do
+          class AssocationSpecModel
+            include Mongoid::Document
+
+            embedded_in :parent, class_name: 'SomethingBogusThatDoesNotExistYet'
+          end
+        end.not_to raise_exception
+      end
+    end
+  end
+
   describe "#embedded?" do
 
     let(:person) do


### PR DESCRIPTION
The problem manifested when a class declared an association on a class that hadn't yet been loaded; when the touchable module began adding its functionality, there were a few lines that tried to load the referenced class, e.g.:

```ruby
class Child
  include Mongoid::Document
  embedded_in :parent
end

class Parent
  include Mongoid::Document
  embeds_many :children
end
```

This would result in a `NameError` because the `embedded_in` association could not find the `Parent` class at load-time.

I started by checking to see if we could just raise a more informative error in this case, as a stop-gap before spending more time later to actually fix the issue. Imagine my joy when I realized that the entire problem was caused by a few lines of dead-code! By simply deleting the unused code, the problem went away. 🎉 

Edit: a bit more explanation here, after I went through and triple checked the logic. An `Association` has a `klass`, which is the class that the association references directly. In the above example, the `Child#parent` association would have `Parent` as the `klass`. An `Association` also has an `inverse_class`, which is the class that the association belongs to. Again, to use the `Child#parent` association as an example, this would be the `Child` class.

The reason everything "just works", even when the `klass` references haven't yet been defined, is because the touch behaviors are added to the `inverse_class`, and not the `klass`. That is to say, when the `Mongoid::Touchable` model works its magic in an `embedded_in` association, it adds the new methods to `Child`, and not `Parent`. Ditto for any of the other associations. Thus, it doesn't matter (at load time) whether the `klass` references exist yet or not, because all we care about are the `inverse_class` references, which are guaranteed to exist.