### PR TITLE
Bump version to 9.0.1

### DIFF
--- a/lib/mongoid/version.rb
+++ b/lib/mongoid/version.rb
@@ -2,5 +2,5 @@
 # rubocop:todo all
 
 module Mongoid
-  VERSION = "9.0.0"
+  VERSION = "9.0.1"
 end


### PR DESCRIPTION
Bumped the version of Mongoid from 9.0.0 to 9.0.1 in accordance with Semantic versioning. 

Here is a draft of the release notes: 

### 9.0.1 release notes
Version 9.0.1 of Mongoid is now available. 

Release Highlights 
* [MONGOID-5786](https://jira.mongodb.org/browse/MONGOID-5786): In accordance with Ruby's enumerable API, the `#sum` method now accepts an optional block. Thank you to Cristián Pérez for your contributions!
* [MONGOID-5688](https://jira.mongodb.org/browse/MONGOID-5688): Problematic recursive callstacks in cascading callbacks have been linearized using Ruby Fibers to prevent SystemStackErrors with greater numbers of embedded documents. Thank you to Adviti Mishra for your contributions! 
* [MONGOID-5769](https://jira.mongodb.org/browse/MONGOID-5769): $pop and $pull are now mongoized the same way as #addToSet or $push to ensure update_all functions as intended. Thank you to John Maguir and Michael Deryugin for your contributions! 
* [MONGOID-5789](https://jira.mongodb.org/browse/MONGOID-5789): querying an attribute with a `nil` name now returns an empty string, rather than raising an exception. Thank you to Dan Healy for your contribution!
* [MONGOID-5785](https://jira.mongodb.org/browse/MONGOID-5785): if you set `Mongoid.allow_scopes_to_unset_default_scope = true`, you can invoke (e.g.) `unscoped` in a named scope to reset the current scope. This is useful for overriding default scopes inside of a named scope. This option will default to `true` in Mongoid 10.
* [MONGOID-5791](https://jira.mongodb.org/browse/MONGOID-5791): If the parent document class is not loaded at the time of loading the embedded document class, a NameError used to be raised. This has been fixed. 
* [MONGOID-5796](https://jira.mongodb.org/browse/MONGOID-5796): The docs previously present in the Mongoid repository have been moved to the [docs-mongoid repository](https://github.com/mongodb/docs-mongoid). 