### PR TITLE
Field definition should remove any existing accessors before setting its own ones

### DIFF
--- a/lib/mongoid/fields.rb
+++ b/lib/mongoid/fields.rb
@@ -622,6 +622,7 @@ module Mongoid
       def create_accessors(name, meth, options = {})
         field = fields[name]
 
+        remove_any_existing_accessors(meth)
         create_field_getter(name, meth, field)
         create_field_getter_before_type_cast(name, meth)
         create_field_setter(name, meth, field)
@@ -632,6 +633,19 @@ module Mongoid
           create_translations_setter(name, meth, field)
           localized_fields[name] = field
         end
+      end
+
+      # Remove any existing accessors that collide with field's ones
+      #
+      # @example Remove any existing accessors.
+      #   Model.remove_any_existing_accessors("name")
+      #
+      # @param [ String ] meth The name of the method.
+      #
+      # @api private
+      def remove_any_existing_accessors(meth)
+        remove_method(meth) if method_defined?(meth, false) || private_method_defined?(meth, false)
+        remove_method("#{meth}=") if method_defined?("#{meth}=", false) || private_method_defined?("#{meth}=", false)
       end
 
       # Create the getter method for the provided field.

--- a/spec/mongoid/fields_spec.rb
+++ b/spec/mongoid/fields_spec.rb
@@ -2103,4 +2103,45 @@ describe Mongoid::Fields do
       end
     end
   end
+
+  context "when accessors are already present and they are" do
+    shared_examples "replaced accessors tests" do
+      it "they are replaced by the field accessors" do
+        klass.create! name: "Mongoid"
+        expect(klass.find_by.name).to eq("Mongoid")
+      end
+    end
+
+    context "public or protected" do
+      let(:klass) do
+        Class.new do
+          attr_accessor :name
+
+          include Mongoid::Document
+          store_in collection: :any
+          field :name
+        end
+      end
+
+      include_examples "replaced accessors tests"
+    end
+
+    context "private" do
+      let(:klass) do
+        Class.new do
+          private
+
+          attr_accessor :name
+
+          public
+
+          include Mongoid::Document
+          store_in collection: :any
+          field :name
+        end
+      end
+
+      include_examples "replaced accessors tests"
+    end
+  end
 end


### PR DESCRIPTION
Hi, based on what we have been discussing in https://github.com/mongodb/mongoid/discussions/5851 I made a first attempt.

I was thinking that we should not take care about warnings. Instead, the ORM/ODM should do whatever necessary to map things correctly.

Tell me if I forgot something.

Thanks!