### PR TITLE
MONGOID-5805 Short-circuit the logic in extract_attribute to fix performance regression

### DIFF
--- a/lib/mongoid/matcher.rb
+++ b/lib/mongoid/matcher.rb
@@ -44,6 +44,13 @@ module Mongoid
     #
     # @return [ Object | Array ] Field value or values.
     module_function def extract_attribute(document, key)
+      # Performance optimization; if the key does not include a '.' character,
+      # it must reference an immediate attribute of the document.
+      unless key.include?('.')
+        hash = document.respond_to?(:attributes) ? document.attributes : document
+        return [ hash[key] ] if hash.key?(key)
+      end
+
       if document.respond_to?(:as_attributes, true)
         # If a document has hash fields, as_attributes would keep those fields
         # as Hash instances which do not offer indifferent access.

--- a/lib/mongoid/matcher.rb
+++ b/lib/mongoid/matcher.rb
@@ -54,7 +54,8 @@ module Mongoid
       # it must reference an immediate attribute of the document.
       unless key.include?('.')
         hash = document.respond_to?(:attributes) ? document.attributes : document
-        return [ hash[key] ] if hash.key?(key)
+        key = find_exact_key(hash, key)
+        return key ? [ hash[key] ] : []
       end
 
       if document.respond_to?(:as_attributes, true)

--- a/lib/mongoid/matcher.rb
+++ b/lib/mongoid/matcher.rb
@@ -39,11 +39,17 @@ module Mongoid
     # from and behaves identically to association traversal for the purposes
     # of, for example, subsequent array element retrieval.
     #
-    # @param [ Document | Hash ] document The document to extract from.
+    # @param [ Document | Hash | String ] document The document to extract from.
     # @param [ String ] key The key path to extract.
     #
     # @return [ Object | Array ] Field value or values.
     module_function def extract_attribute(document, key)
+      # The matcher system will wind up sending atomic values to this as well,
+      # when attepting to match more complex types. If anything other than a
+      # Document or a Hash is given, we'll short-circuit the logic and just
+      # return an empty array.
+      return [] unless document.is_a?(Hash) || document.is_a?(Document)
+
       # Performance optimization; if the key does not include a '.' character,
       # it must reference an immediate attribute of the document.
       unless key.include?('.')

--- a/spec/mongoid/association/referenced/belongs_to/proxy_spec.rb
+++ b/spec/mongoid/association/referenced/belongs_to/proxy_spec.rb
@@ -751,6 +751,10 @@ describe Mongoid::Association::Referenced::BelongsTo::Proxy do
           person.save!
         end
 
+        # NOTE: there as a bad interdependency here, with the auto_save_spec.rb
+        # file. If auto_save_spec.rb runs before this, the following specs fail
+        # with "undefined method `nullify' for an instance of Person".
+
         context "when parent exists" do
 
           context "when child is destroyed" do


### PR DESCRIPTION
Fixes a performance regression caused by always splitting keys at `.` characters, whether the string has them or not. By short-circuiting the common case, we can recover a significant performance improvement.