### PR TITLE
MONGOID-4680 implement cache_version for better Rails caching support

### DIFF
--- a/lib/mongoid/association/many.rb
+++ b/lib/mongoid/association/many.rb
@@ -247,11 +247,11 @@ module Mongoid
 
       # Returns a 2-tuple of the number of elements in the relation, and the
       # largest timestamp value. This will query the database to perform a
-      # count and a max.
+      # $sum and a $max.
       def analyze_unloaded_target(timestamp_column)
         pipeline = criteria
           .group(_id: nil,
-                 count: { '$count' => {} },
+                 count: { '$sum' => 1 },
                  latest: { '$max' => "$#{timestamp_column}" })
           .pipeline
 

--- a/lib/mongoid/cacheable.rb
+++ b/lib/mongoid/cacheable.rb
@@ -15,20 +15,39 @@ module Mongoid
     # Print out the cache key. This will append different values on the
     # plural model name.
     #
-    # If new_record?     - will append /new
-    # If not             - will append /id-updated_at.to_formatted_s(cache_timestamp_format)
-    # Without updated_at - will append /id
+    # If new_record? - will append /new
+    # Non-nil cache_version? - append /id
+    # Non-nil updated_at - append /id-updated_at.to_formatted_s(cache_timestamp_format)
+    # Otherwise - append /id
     #
     # This is usually called inside a cache() block
     #
     # @example Returns the cache key
     #   document.cache_key
     #
-    # @return [ String ] the string with or without updated_at
+    # @return [ String ] the generated cache key
     def cache_key
       return "#{model_key}/new" if new_record?
+      return "#{model_key}/#{_id}" if cache_version
       return "#{model_key}/#{_id}-#{updated_at.utc.to_formatted_s(cache_timestamp_format)}" if try(:updated_at)
       "#{model_key}/#{_id}"
+    end
+
+    # Return the cache version for this model. By default, it returns the updated_at
+    # field (if present) formatted as a string, or nil if the model has no
+    # updated_at field. Models with different needs may override this method to
+    # suit their desired behavior.
+    #
+    # @return [ String | nil ] the cache version value
+    #
+    # TODO: we can test this by using a MemoryStore, putting something in
+    # it, then updating the timestamp on the record and trying to read the
+    # value from the memory store. It shouldn't find it, because the version
+    # has changed.
+    def cache_version
+      if has_attribute?('updated_at') && updated_at.present?
+        updated_at.utc.to_formatted_s(cache_timestamp_format)
+      end
     end
   end
 end

--- a/spec/integration/caching_spec.rb
+++ b/spec/integration/caching_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'caching integration tests' do
+  let(:store) { ActiveSupport::Cache::MemoryStore.new }
+
+  context 'without updated_at' do
+    let(:model1) { Person.create }
+    let(:model2) { Person.create }
+
+    before do
+      store.write(model1, 'model1')
+      store.write(model2, 'model2')
+    end
+
+    it 'uses a unique key' do
+      expect(store.read(model1)).to be == 'model1'
+      expect(store.read(model2)).to be == 'model2'
+    end
+
+    context 'when updating' do
+      before do
+        model1.update title: 'updated'
+        model2.update title: 'updated'
+      end
+
+      let(:reloaded_model1) { Person.find(model1.id) }
+      let(:reloaded_model2) { Person.find(model2.id) }
+
+      it 'still finds the models' do
+        expect(store.read(reloaded_model1)).to be == 'model1'
+        expect(store.read(reloaded_model2)).to be == 'model2'
+      end
+    end
+  end
+
+  context 'with updated_at' do
+    let(:model1) { Dokument.create }
+    let(:model2) { Dokument.create }
+
+    before do
+      store.write(model1, 'model1')
+      store.write(model2, 'model2')
+    end
+
+    it 'uses a unique key' do
+      expect(store.read(model1)).to be == 'model1'
+      expect(store.read(model2)).to be == 'model2'
+    end
+
+    context 'when updating' do
+      before do
+        model1.update title: 'updated'
+        model2.update title: 'updated'
+      end
+
+      let(:reloaded_model1) { Dokument.find(model1.id) }
+      let(:reloaded_model2) { Dokument.find(model2.id) }
+
+      it 'does not find the models' do
+        # because the update caused the cache_version to change
+        expect(store.read(reloaded_model1)).to be_nil
+        expect(store.read(reloaded_model2)).to be_nil
+      end
+    end
+  end
+end

--- a/spec/mongoid/association/referenced/has_many/proxy_spec.rb
+++ b/spec/mongoid/association/referenced/has_many/proxy_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:todo all
 
 require 'spec_helper'
 
@@ -2530,13 +2531,11 @@ describe Mongoid::Association::Referenced::HasMany::Proxy do
     let(:post_one) { Post.create!(rating: 5) }
     let(:post_two) { Post.create!(rating: 10) }
 
-    # rubocop:disable Performance/CompareWithBlock
     let(:max) do
       person.posts.max do |a, b|
         a.rating <=> b.rating
       end
     end
-    # rubocop:enable Performance/CompareWithBlock
 
     before do
       person.posts.push(post_one, post_two)
@@ -2619,13 +2618,11 @@ describe Mongoid::Association::Referenced::HasMany::Proxy do
     let(:post_one) { Post.create!(rating: 5) }
     let(:post_two) { Post.create!(rating: 10) }
 
-    # rubocop:disable Performance/CompareWithBlock
     let(:min) do
       person.posts.min do |a, b|
         a.rating <=> b.rating
       end
     end
-    # rubocop:enable Performance/CompareWithBlock
 
     before do
       person.posts.push(post_one, post_two)
@@ -3228,6 +3225,139 @@ describe Mongoid::Association::Referenced::HasMany::Proxy do
 
     it 'works on the first attempt' do
       expect(agent.basic_ids).to eq [ basic.id ]
+    end
+  end
+
+  describe '#cache_version' do
+    context 'when the model does not have an updated_at column' do
+      let(:root_model) { Person.create! }
+      let(:root) { Person.find(root_model.id) }
+
+      let(:prepopulated_root) do
+        root_model.posts << Post.new(title: 'Post #1')
+        root_model.posts << Post.new(title: 'Post #2')
+        Person.find(root_model.id)
+      end
+
+      shared_examples_for 'a cache_version generator' do
+        it 'produces a trivial cache_version' do
+          expect(posts.cache_version).to be == "#{posts.length}"
+        end
+      end
+
+      context 'when the relation is already loaded' do
+        let(:posts) { root.posts.tap { |r| r.to_a } }
+
+        context 'when the relation is empty' do
+          it_behaves_like 'a cache_version generator'
+        end
+
+        context 'when the relation is not empty' do
+          let(:root) { prepopulated_root }
+
+          it_behaves_like 'a cache_version generator'
+        end
+      end
+
+      context 'when the relation is not already loaded' do
+        let(:posts) { root.posts }
+
+        context 'when the relation is empty' do
+          it_behaves_like 'a cache_version generator'
+        end
+
+        context 'when the relation is not empty' do
+          let(:root) { prepopulated_root }
+
+          it_behaves_like 'a cache_version generator'
+        end
+      end
+    end
+
+    context 'when the model has an updated_at column' do
+      let(:root_model) { WikiPage.create(title: 'Root') }
+      let(:root) { WikiPage.find(root_model.id) }
+
+      let(:child_page) { root_model.child_pages.first }
+      let(:original_cache_version) { root.child_pages.cache_version }
+
+      let(:prepopulated_root) do
+        root_model.child_pages << WikiPage.new(title: 'Child #1')
+        root_model.child_pages << WikiPage.new(title: 'Child #2')
+        WikiPage.find(root_model.id)
+      end
+
+      shared_examples_for 'a cache_version generator' do
+        it 'produces a consistent cache_version' do
+          expect(child_pages.cache_version).not_to be_nil
+          expect(child_pages.cache_version).to be == child_pages.cache_version
+        end
+      end
+
+      context 'when the relation is already loaded' do
+        let(:child_pages) { root.child_pages.tap { |r| r.to_a } }
+
+        context 'when the relation is empty' do
+          it_behaves_like 'a cache_version generator'
+        end
+
+        context 'when the relation is not empty' do
+          let(:root) { prepopulated_root }
+          it_behaves_like 'a cache_version generator'
+        end
+      end
+
+      context 'when the relation is not yet loaded' do
+        let(:child_pages) { root.child_pages }
+
+        context 'when the relation is empty' do
+          it_behaves_like 'a cache_version generator'
+        end
+
+        context 'when the relation is not empty' do
+          let(:root) { prepopulated_root }
+          it_behaves_like 'a cache_version generator'
+        end
+      end
+
+      context 'when an element is updated' do
+        let(:updated_cache_version) do
+          child_page.update description: 'modified'
+          root.reload.child_pages.cache_version
+        end
+
+        let(:root) { prepopulated_root }
+
+        it 'changes the cache_version' do
+          expect(original_cache_version).not_to be == updated_cache_version
+        end
+      end
+
+      context 'when an element is added' do
+        let(:updated_cache_version) do
+          root.child_pages << WikiPage.new(title: 'Another Child')
+          root.reload.child_pages.cache_version
+        end
+
+        let(:root) { prepopulated_root }
+
+        it 'changes the cache_version' do
+          expect(original_cache_version).not_to be == updated_cache_version
+        end
+      end
+
+      context 'when an element is removed' do
+        let(:updated_cache_version) do
+          child_page.destroy
+          root.reload.child_pages.cache_version
+        end
+
+        let(:root) { prepopulated_root }
+
+        it 'changes the cache_version' do
+          expect(original_cache_version).not_to be == updated_cache_version
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This PR adds a `#cache_version` method to `Mongoid::Document` instances, as well as to the `has_many` and `embeds_many` proxies, which brings Mongoid closer to API parity with ActiveRecord.

This also modifies `#cache_key` to better parallel how it works in ActiveRecord: if `cache_version` returns non-nil, `cache_key` will *not* embed the timestamp in the key. Instead, the timestamp is used as the version for the entry (which reduces key churn).

**Note**: this PR does slightly change the behavior of Mongoid when used with Rails caching (`#cache_key` will not embed the timestamp when `#cache_version` is non-nil, as mentioned). We discussed this as a team and do not believe this constitutes a breaking change; in the worst case, systems that depend on caching may find at least some of their caches invalidated the first time they deploy this change.

For systems where the new cache key format is a concern, you can "revert" to the original cache key format by defining a `#cache_version` of `nil`:

```ruby
def cache_version = nil

# or, for older, less glamorous, more boring and verbose rubies:
def cache_version; nil; end
```