### PR TITLE
MONGOID-5411 allow results to be returned as demongoized hashes

### DIFF
--- a/lib/mongoid/contextual/mongo.rb
+++ b/lib/mongoid/contextual/mongo.rb
@@ -883,7 +883,11 @@ module Mongoid
         doc = if document.respond_to?(:_id)
                 document
               elsif criteria.raw_results?
-                demongoize_hash(klass, document)
+                if criteria.typecast_results?
+                  demongoize_hash(klass, document)
+                else
+                  document
+                end
               else
                 Factory.from_db(klass, document, criteria)
               end
@@ -1062,7 +1066,11 @@ module Mongoid
       #   single document.
       def process_raw_docs(raw_docs, limit)
         docs = if criteria.raw_results?
-                 raw_docs.map { |doc| demongoize_hash(klass, doc) }
+                 if criteria.typecast_results?
+                   raw_docs.map { |doc| demongoize_hash(klass, doc) }
+                 else
+                   raw_docs
+                 end
                else
                  mapped = raw_docs.map { |doc| Factory.from_db(klass, doc, criteria) }
                  eager_load(mapped)

--- a/lib/mongoid/criteria.rb
+++ b/lib/mongoid/criteria.rb
@@ -172,6 +172,43 @@ module Mongoid
       !!@embedded
     end
 
+    # Produce a clone of the current criteria object with it's "raw"
+    # setting set to the given value. A criteria set to "raw" will return
+    # all results as raw, demongoized hashes. When "raw" is not set, the
+    # criteria will return all results as instantiated Document instances.
+    #
+    # @example Return query results as raw hashes:
+    #   Person.where(city: 'Boston').raw
+    #
+    # @param [ true | false ] raw_results Whether the new criteria should be
+    #   placed in "raw" mode or not.
+    #
+    # @return [ Criteria ] the cloned criteria object.
+    def raw(raw_results = true)
+      clone.tap do |criteria|
+        criteria._raw_results = raw_results
+      end
+    end
+
+    # An internal helper for setting the "raw" flag on a given criteria
+    # object.
+    #
+    # @param [ true | false ] raw_results Whether the criteria should be placed
+    #   in "raw" mode or not.
+    #
+    # @api private
+    def _raw_results=(raw_results)
+      @raw_results = raw_results
+    end
+
+    # Predicate that answers the question: is this criteria object currently
+    # in raw mode? (See #raw for a description of raw mode.)
+    #
+    # @return [ true | false ] whether the criteria is in raw mode or not.
+    def raw_results?
+      @raw_results
+    end
+
     # Extract a single id from the provided criteria. Could be in an $and
     # query or a straight _id query.
     #
@@ -278,6 +315,7 @@ module Mongoid
       self.documents = other.documents.dup unless other.documents.empty?
       self.scoping_options = other.scoping_options
       self.inclusions = (inclusions + other.inclusions).uniq
+      self._raw_results = self.raw_results? || other.raw_results?
       self
     end
 
@@ -513,6 +551,7 @@ module Mongoid
       @inclusions = other.inclusions.dup
       @scoping_options = other.scoping_options
       @documents = other.documents.dup
+      @raw_results = other.raw_results?
       @context = nil
       super
     end

--- a/lib/mongoid/findable.rb
+++ b/lib/mongoid/findable.rb
@@ -46,6 +46,7 @@ module Mongoid
       :none,
       :pick,
       :pluck,
+      :raw,
       :read,
       :second,
       :second!,

--- a/spec/mongoid/criteria_spec.rb
+++ b/spec/mongoid/criteria_spec.rb
@@ -2323,6 +2323,30 @@ describe Mongoid::Criteria do
         expect(result['pass']['exp']).to be_a(Date)
       end
     end
+
+    context 'with projections' do
+      before { Person.create(title: 'sir', dob: Date.new(1980, 1, 1)) }
+
+      context 'using #only' do
+        let(:criteria) { Person.only(:dob).raw }
+
+        it 'produces a hash with only the _id and the requested key' do
+          expect(result).to be_a(Hash)
+          expect(result.keys).to be == %w[ _id dob ]
+          expect(result['dob']).to be == Date.new(1980, 1, 1)
+        end
+      end
+
+      context 'using #without' do
+        let(:criteria) { Person.without(:dob).raw }
+
+        it 'produces a hash that excludes requested key' do
+          expect(result).to be_a(Hash)
+          expect(result.keys).not_to include('dob')
+          expect(result.keys).to be_present
+        end
+      end
+    end
   end
 
   describe "#max_scan" do

--- a/spec/mongoid/criteria_spec.rb
+++ b/spec/mongoid/criteria_spec.rb
@@ -2269,6 +2269,62 @@ describe Mongoid::Criteria do
     end
   end
 
+  describe '#raw' do
+    let(:results) { criteria.to_a }
+    let(:result) { results[0] }
+
+    context 'without associations' do
+      before do
+        Band.create(name: 'the band',
+                    active: true,
+                    genres: %w[ abc def ],
+                    member_count: 112,
+                    rating: 4.2,
+                    created: Time.now,
+                    updated: Time.now,
+                    sales: 1_234_567.89,
+                    decimal: 9_876_543.21,
+                    decibels: 140..170,
+                    deleted: false,
+                    mojo: Math::PI,
+                    tags: { 'one' => 1, 'two' => 2 },
+                    location: LatLng.new(41.74, -111.83))
+      end
+
+      let(:criteria) { Band.where(name: 'the band').raw }
+
+      it 'returns a hash' do
+        expect(result).to be_a(Hash)
+      end
+
+      it 'demongoizes the result' do
+        expect(result['genres']).to be_a(Array)
+        expect(result['decibels']).to be_a(Range)
+        expect(result['location']).to be_a(LatLng)
+      end
+    end
+
+    context 'with associations' do
+      before do
+        Person.create({
+          addresses: [ Address.new(end_date: 2.months.from_now) ],
+          passport: Passport.new(exp: 1.year.from_now)
+        })
+      end
+
+      let(:criteria) { Person.raw }
+
+      it 'demongoizes the embedded relation' do
+        expect(result['addresses']).to be_a(Array)
+        expect(result['addresses'][0]['end_date']).to be_a(Date)
+
+        # `pass` is how it is stored, `passport` is how it is aliased
+        expect(result['pass']).to be_a(Hash)
+        expect(result['pass']['exp']).to be_a(Date)
+      end
+    end
+  end
+
   describe "#max_scan" do
     max_server_version '4.0'
 


### PR DESCRIPTION
Mongoid now supports a new `raw` directive when building queries. When present, the resulting query will be returned as hashes, rather than instantiated document models. The hashes will not be "demongoized" -- the values will be returned exactly as provided by the database, directly.

If you specify `typed: true`, the hashes will be returned with the values translated from the raw value stored in the database, into the corresponding type defined by the `field` definitions on the model. (That is to say, they will be "demongoized".)

For example:

```ruby
result = Person.raw.first
p result  #=> {"_id"=>BSON::ObjectId(...), "name" => "...", "birth_date" => 2002-01-01 00:00:00 -0600, ... }

result = Person.raw(typed: true).first
p result  #=> {"_id"=>BSON::ObjectId(...), "name" => "...", "birth_date" => 2002-01-01, ... }

results = Person.where(...).limit(...).raw
p results.to_a #=> [ { "_id"=>BSON::ObjectId(...), ... }, { "_id"=>BSON::ObjectId(...), ... }, ... ]
```

The `typed: true` option will also honor embedded documents, correctly demongoizing the embedded hashes according to their declared types.