### PR TITLE
MONGOID-5820 Fix the session object leak when using transactions

### DIFF
--- a/lib/mongoid/clients/sessions.rb
+++ b/lib/mongoid/clients/sessions.rb
@@ -62,6 +62,7 @@ module Mongoid
         rescue *transactions_not_supported_exceptions
           raise Mongoid::Errors::TransactionsNotSupported
         ensure
+          Threaded.clear_modified_documents(session)
           Threaded.clear_session(client: persistence_context.client)
         end
 

--- a/lib/mongoid/threaded.rb
+++ b/lib/mongoid/threaded.rb
@@ -18,6 +18,7 @@ module Mongoid
     CURRENT_SCOPE_KEY = '[mongoid]:current-scope'
 
     AUTOSAVES_KEY = '[mongoid]:autosaves'
+
     VALIDATIONS_KEY = '[mongoid]:validations'
 
     STACK_KEYS = Hash.new do |hash, key|
@@ -376,9 +377,7 @@ module Mongoid
     # @return [ Set<Mongoid::Document> ] Collection of modified documents before
     #   it was cleared.
     def clear_modified_documents(session)
-      modified_documents[session].dup
-    ensure
-      modified_documents.delete(session)
+      modified_documents.delete(session) || []
     end
 
     # Queries whether document callbacks should be executed by default for the

--- a/lib/mongoid/threaded.rb
+++ b/lib/mongoid/threaded.rb
@@ -378,7 +378,7 @@ module Mongoid
     def clear_modified_documents(session)
       modified_documents[session].dup
     ensure
-      modified_documents[session].clear
+      modified_documents.delete(session)
     end
 
     # Queries whether document callbacks should be executed by default for the

--- a/spec/lite_spec_helper.rb
+++ b/spec/lite_spec_helper.rb
@@ -82,13 +82,13 @@ RSpec.configure do |config|
     config.add_formatter(RSpec::Core::Formatters::JsonFormatter, File.join(File.dirname(__FILE__), '../tmp/rspec.json'))
   end
 
-  if SpecConfig.instance.ci? && !%w(1 true yes).include?(ENV['INTERACTIVE']&.downcase)
-    config.around(:each) do |example|
-      TimeoutInterrupt.timeout(example_timeout_seconds) do
-        example.run
-      end
-    end
-  end
+  # if SpecConfig.instance.ci? && !%w(1 true yes).include?(ENV['INTERACTIVE']&.downcase)
+  #   config.around(:each) do |example|
+  #     TimeoutInterrupt.timeout(example_timeout_seconds) do
+  #       example.run
+  #     end
+  #   end
+  # end
 
   def local_env(env = nil, &block)
     around do |example|

--- a/spec/lite_spec_helper.rb
+++ b/spec/lite_spec_helper.rb
@@ -82,13 +82,13 @@ RSpec.configure do |config|
     config.add_formatter(RSpec::Core::Formatters::JsonFormatter, File.join(File.dirname(__FILE__), '../tmp/rspec.json'))
   end
 
-  # if SpecConfig.instance.ci? && !%w(1 true yes).include?(ENV['INTERACTIVE']&.downcase)
-  #   config.around(:each) do |example|
-  #     TimeoutInterrupt.timeout(example_timeout_seconds) do
-  #       example.run
-  #     end
-  #   end
-  # end
+  if SpecConfig.instance.ci? && !%w(1 true yes).include?(ENV['INTERACTIVE']&.downcase)
+    config.around(:each) do |example|
+      TimeoutInterrupt.timeout(example_timeout_seconds) do
+        example.run
+      end
+    end
+  end
 
   def local_env(env = nil, &block)
     around do |example|

--- a/spec/mongoid/threaded_spec.rb
+++ b/spec/mongoid/threaded_spec.rb
@@ -341,4 +341,27 @@ describe Mongoid::Threaded do
       end
     end
   end
+
+  describe '#clear_modified_documents' do
+    let(:session) do
+      double(Mongo::Session).tap do |session|
+        allow(session).to receive(:in_transaction?).and_return(true)
+      end
+    end
+
+    context 'when there are modified documents' do
+      before do
+        described_class.add_modified_document(session, Minim.new)
+        described_class.clear_modified_documents(session)
+      end
+
+      it 'removes the documents' do
+        expect(described_class.modified_documents).to be_empty
+      end
+
+      it 'removes the key' do
+        expect(described_class.modified_documents.key?(session)).to be_falsey
+      end
+    end
+  end
 end

--- a/spec/mongoid/threaded_spec.rb
+++ b/spec/mongoid/threaded_spec.rb
@@ -343,23 +343,24 @@ describe Mongoid::Threaded do
   end
 
   describe '#clear_modified_documents' do
-    let(:session) do
-      double(Mongo::Session).tap do |session|
-        allow(session).to receive(:in_transaction?).and_return(true)
-      end
+    around do |example|
+      session = Mongoid.default_client.start_session
+      session.start_transaction
+      doc = Minim.create!
+      described_class.add_modified_document(session, doc)
+      described_class.clear_modified_documents(session)
+      example.run(session)
+    ensure
+      session.abort_transaction
+      session.end_session
     end
 
     context 'when there are modified documents' do
-      before do
-        described_class.add_modified_document(session, Minim.new)
-        described_class.clear_modified_documents(session)
-      end
-
       it 'removes the documents' do
         expect(described_class.modified_documents).to be_empty
       end
 
-      it 'removes the key' do
+      it 'removes the key' do |session|
         expect(described_class.modified_documents.key?(session)).to be_falsey
       end
     end


### PR DESCRIPTION
## The issue
I found the memory leak inside `Threaded` class, when saving documents within transaction: session object is retained forever inside thread-local variable.

> Affected version: Mongoid **9.0.2** / Ruby **3.3.4**

## Explanation
* Mongoid uses thread-local variables to temporarily hold `modified_documents` until transaction is committed. 
* The `[mongoid]:modified-documents` contains a hash with `session` as key and Set of documents as value. 
* During transaction commit phase, the `Mongoid::Threaded::clear_modified_documents` is called, which clears documents from the set, however, the hash inside `[mongoid]:modified-documents` still contains a session object as a key.
* This session object is then persists in memory, even after the session was finished by the `Mongoid::Threaded::clear_session` call.

## Testing
I used the following code to reproduce the issue:
``` ruby
require_relative 'spec_helper'
require 'memory_profiler'

describe "Mongoid test" do
  let(:model) do
    Class.new do
      include Mongoid::Document

      store_in collection: 'tests'
      field :name, type: String
    end
  end

  context 'memory leak test' do
    it 'store in transaction' do
      run_memory_profiling do
        model.transaction do
          model.create!(name: 'test')
        end
      end
    end
  end

  def run_memory_profiling(&block)
    # Warmup
    yield

    report = MemoryProfiler.report do
      2000.times(&block)
      GC.start(full_mark: true, immediate_sweep: true)
    end
    p "Total retained: #{report.total_retained_memsize / 1024} KB (#{report.total_retained} objects). "
  end
end
```

### Initial results:
```
Total retained: 3430 KB (36053 objects). 
```
Report shows a number of retained objects, which corresponds to 2000 iterations of test:
<img width="910" alt="image" src="https://github.com/user-attachments/assets/036a00bf-8e04-4c2c-9af1-03d46ffaa662">


### Results after modification:
```
Total retained: 6 KB (61 objects).
```