### PR TITLE
MONGOID-5815 Respect client_override for new docs

### DIFF
--- a/lib/mongoid/clients/options.rb
+++ b/lib/mongoid/clients/options.rb
@@ -118,10 +118,10 @@ module Mongoid
         return storage_options if Threaded.client_override.nil? && Threaded.database_override.nil?
 
         storage_options.tap do |opts|
-          # Client defined on the document class level has higher priority than global override.
-          opts[:client] ||= Threaded.client_override unless Threaded.client_override.nil?
-          # Database defined on the document class level has higher priority than global override.
-          opts[:database] ||= Threaded.database_override unless Threaded.database_override.nil?
+          # Globally overridden client replaces client defined for the document class.
+          opts[:client] = Threaded.client_override unless Threaded.client_override.nil?
+          # Globally overridden database replaces database defined for the document class.
+          opts[:database] = Threaded.database_override unless Threaded.database_override.nil?
         end
       end
 

--- a/lib/mongoid/clients/options.rb
+++ b/lib/mongoid/clients/options.rb
@@ -113,11 +113,15 @@ module Mongoid
       private
 
       def default_storage_options
-        byebug
+        # Nothing is overridden, we use either the default storage_options
+        # or storage_options defined for the document class.
         return storage_options if Threaded.client_override.nil? && Threaded.database_override.nil?
-        {}.tap do |opts|
-          opts[:client] = Threaded.client_override unless Threaded.client_override.nil?
-          opts[:database] = Threaded.database_override unless Threaded.database_override.nil?
+
+        storage_options.tap do |opts|
+          # Client defined on the document class level has higher priority than global override.
+          opts[:client] ||= Threaded.client_override unless Threaded.client_override.nil?
+          # Database defined on the document class level has higher priority than global override.
+          opts[:database] ||= Threaded.database_override unless Threaded.database_override.nil?
         end
       end
 

--- a/lib/mongoid/clients/options.rb
+++ b/lib/mongoid/clients/options.rb
@@ -86,7 +86,7 @@ module Mongoid
         else
           PersistenceContext.get(self) ||
             PersistenceContext.get(self.class) ||
-            PersistenceContext.new(self.class, storage_options)
+            PersistenceContext.new(self.class, default_storage_options)
         end
       end
 
@@ -111,6 +111,10 @@ module Mongoid
       end
 
       private
+
+      def default_storage_options
+        Threaded.client_override ? { client: Threaded.client_override } : storage_options
+      end
 
       def set_persistence_context(options_or_context)
         PersistenceContext.set(self, options_or_context)

--- a/lib/mongoid/clients/options.rb
+++ b/lib/mongoid/clients/options.rb
@@ -113,7 +113,12 @@ module Mongoid
       private
 
       def default_storage_options
-        Threaded.client_override ? { client: Threaded.client_override } : storage_options
+        byebug
+        return storage_options if Threaded.client_override.nil? && Threaded.database_override.nil?
+        {}.tap do |opts|
+          opts[:client] = Threaded.client_override unless Threaded.client_override.nil?
+          opts[:database] = Threaded.database_override unless Threaded.database_override.nil?
+        end
       end
 
       def set_persistence_context(options_or_context)

--- a/spec/mongoid/clients/options_spec.rb
+++ b/spec/mongoid/clients/options_spec.rb
@@ -522,4 +522,49 @@ describe Mongoid::Clients::Options, retry: 3 do
       end
     end
   end
+
+  context 'when global client is overriden' do
+    before do
+      Mongoid.clients['override_client'] = { hosts: SpecConfig.instance.addresses, database: 'default_override_database' }
+      Mongoid.override_client('override_client')
+    end
+
+    after do
+      Mongoid.override_client(nil)
+      Mongoid.clients['override_client'] = nil
+    end
+
+    it 'sets the overriden client for new model' do
+      expect(Minim.create.persistence_context.client_name).to eq('override_client')
+    end
+
+    context 'when the client is set on the model level' do
+      before do
+        Mongoid.clients['train_client'] = { hosts: SpecConfig.instance.addresses, database: 'trains_database' }
+      end
+
+      after do
+        Mongoid.clients['train_client'] = nil
+      end
+
+      it 'does not override the client' do
+        Train.create
+        expect(Train.create.persistence_context.client_name).to eq('train_client')
+      end
+    end
+  end
+
+  context 'when global databse is overriden' do
+    before do
+      Mongoid.override_database('override_database')
+    end
+
+    after do
+      Mongoid.override_database(nil)
+    end
+
+    it 'sets the overriden database for new model' do
+      expect(Minim.new.persistence_context.database_name).to eq(:override_database)
+    end
+  end
 end

--- a/spec/mongoid/clients/options_spec.rb
+++ b/spec/mongoid/clients/options_spec.rb
@@ -525,47 +525,63 @@ describe Mongoid::Clients::Options, retry: 3 do
 
   context 'with global overrides' do
     context 'when global client is overridden' do
-    before do
-      Mongoid.clients['override_client'] = { hosts: SpecConfig.instance.addresses, database: 'default_override_database' }
-      Mongoid.override_client('override_client')
-    end
-
-    after do
-      Mongoid.override_client(nil)
-      Mongoid.clients['override_client'] = nil
-    end
-
-    it 'sets the overridden client for new model' do
-      expect(Minim.create.persistence_context.client_name).to eq('override_client')
-    end
-
-    context 'when the client is set on the model level' do
       before do
-        Mongoid.clients['train_client'] = { hosts: SpecConfig.instance.addresses, database: 'trains_database' }
+        Mongoid.clients['override_client'] = { hosts: SpecConfig.instance.addresses, database: 'default_override_database' }
+        Mongoid.override_client('override_client')
       end
 
       after do
-        Mongoid.clients['train_client'] = nil
+        Mongoid.override_client(nil)
+        Mongoid.clients['override_client'] = nil
       end
 
-      it 'does not override the client' do
-        expect(Train.create.persistence_context.client_name).to eq('train_client')
+      it 'sets the overridden client for new model' do
+        expect(Minim.create.persistence_context.client_name).to eq('override_client')
+      end
+
+      context 'when the client is set on the model level' do
+        before do
+          Mongoid.clients['train_client'] = { hosts: SpecConfig.instance.addresses, database: 'trains_database' }
+        end
+
+        after do
+          Mongoid.clients['train_client'] = nil
+        end
+
+        # This behaviour is consistent with 8.x
+        it 'sets the overridden client for new model' do
+          expect(Train.create.persistence_context.client_name).to eq('override_client')
+        end
       end
     end
-  end
 
     context 'when global database is overridden' do
-    before do
-      Mongoid.override_database('override_database')
-    end
+      before do
+        Mongoid.override_database('override_database')
+      end
 
-    after do
-      Mongoid.override_database(nil)
-    end
+      after do
+        Mongoid.override_database(nil)
+      end
 
-    it 'sets the overridden database for new model' do
-      expect(Minim.new.persistence_context.database_name).to eq(:override_database)
+      it 'sets the overridden database for new model' do
+        expect(Minim.new.persistence_context.database_name).to eq(:override_database)
+      end
+
+      context 'when the client is set on the model level' do
+        before do
+          Mongoid.clients['train_client'] = { hosts: SpecConfig.instance.addresses, database: 'trains_database' }
+        end
+
+        after do
+          Mongoid.clients['train_client'] = nil
+        end
+
+        # This behaviour is consistent with 8.x
+        it 'sets the overridden client for new model' do
+          expect(Train.create.persistence_context.database_name).to eq(:override_database)
+        end
+      end
     end
-  end
   end
 end

--- a/spec/mongoid/clients/options_spec.rb
+++ b/spec/mongoid/clients/options_spec.rb
@@ -2,7 +2,6 @@
 # rubocop:todo all
 
 require "spec_helper"
-require 'support/feature_sandbox'
 
 describe Mongoid::Clients::Options, retry: 3 do
 

--- a/spec/mongoid/clients/options_spec.rb
+++ b/spec/mongoid/clients/options_spec.rb
@@ -525,34 +525,75 @@ describe Mongoid::Clients::Options, retry: 3 do
   end
 
   context 'with global overrides' do
+    let(:default_subscriber) do
+      Mrss::EventSubscriber.new
+    end
+
+    let(:override_subscriber) do
+      Mrss::EventSubscriber.new
+    end
+
     context 'when global client is overridden' do
       before do
         Mongoid.clients['override_client'] = { hosts: SpecConfig.instance.addresses, database: 'default_override_database' }
         Mongoid.override_client('override_client')
+        Mongoid.client(:default).subscribe(Mongo::Monitoring::COMMAND, default_subscriber)
+        Mongoid.client('override_client').subscribe(Mongo::Monitoring::COMMAND, override_subscriber)
       end
 
       after do
+        Mongoid.client(:default).unsubscribe(Mongo::Monitoring::COMMAND, default_subscriber)
+        Mongoid.client('override_client').unsubscribe(Mongo::Monitoring::COMMAND, override_subscriber)
         Mongoid.override_client(nil)
         Mongoid.clients['override_client'] = nil
       end
 
-      it 'sets the overridden client for new model' do
-        expect(Minim.create.persistence_context.client_name).to eq('override_client')
+      it 'uses the overridden client for create' do
+        Minim.create!
+
+        expect(override_subscriber.single_command_started_event('insert').database_name).to eq('default_override_database')
+        expect(default_subscriber.command_started_events('insert')).to be_empty
+      end
+
+      it 'uses the overridden client for queries' do
+        Minim.where(name: 'Dmitry').to_a
+
+        expect(override_subscriber.single_command_started_event('find').database_name).to eq('default_override_database')
+        expect(default_subscriber.command_started_events('find')).to be_empty
       end
 
       context 'when the client is set on the model level' do
+        let(:model_level_subscriber) do
+          Mrss::EventSubscriber.new
+        end
+
         around(:example) do |example|
           opts = Minim.storage_options
-          Minim.storage_options = Minim.storage_options.merge( { client: 'train_client' } )
-          Mongoid.clients['train_client'] = { hosts: SpecConfig.instance.addresses, database: 'trains_database' }
+          Minim.storage_options = Minim.storage_options.merge( { client: 'model_level_client' } )
+          Mongoid.clients['model_level_client'] = { hosts: SpecConfig.instance.addresses, database: 'model_level_database' }
+          Mongoid.client('model_level_client').subscribe(Mongo::Monitoring::COMMAND, override_subscriber)
           example.run
-          Mongoid.clients['train_client'] = nil
+          Mongoid.client('model_level_client').unsubscribe(Mongo::Monitoring::COMMAND, override_subscriber)
+          Mongoid.clients['model_level_client'] = nil
           Minim.storage_options = opts
         end
 
         # This behaviour is consistent with 8.x
-        it 'sets the overridden client for new model' do
-          expect(Minim.create.persistence_context.client_name).to eq('override_client')
+        it 'uses the overridden client for create' do
+          Minim.create!
+
+          expect(override_subscriber.single_command_started_event('insert').database_name).to eq('default_override_database')
+          expect(default_subscriber.command_started_events('insert')).to be_empty
+          expect(model_level_subscriber.command_started_events('insert')).to be_empty
+        end
+
+        # This behaviour is consistent with 8.x
+        it 'uses the overridden client for queries' do
+          Minim.where(name: 'Dmitry').to_a
+
+          expect(override_subscriber.single_command_started_event('find').database_name).to eq('default_override_database')
+          expect(default_subscriber.command_started_events('find')).to be_empty
+          expect(model_level_subscriber.command_started_events('find')).to be_empty
         end
       end
     end
@@ -560,29 +601,49 @@ describe Mongoid::Clients::Options, retry: 3 do
     context 'when global database is overridden' do
       before do
         Mongoid.override_database('override_database')
+        Mongoid.client(:default).subscribe(Mongo::Monitoring::COMMAND, default_subscriber)
       end
 
       after do
+        Mongoid.client(:default).unsubscribe(Mongo::Monitoring::COMMAND, default_subscriber)
         Mongoid.override_database(nil)
       end
 
-      it 'sets the overridden database for new model' do
-        expect(Minim.new.persistence_context.database_name).to eq(:override_database)
+      it 'uses the overridden database for create' do
+        Minim.create!
+
+        expect(default_subscriber.single_command_started_event('insert').database_name).to eq('override_database')
+      end
+
+      it 'uses the overridden database for queries' do
+        Minim.where(name: 'Dmitry').to_a
+
+        expect(default_subscriber.single_command_started_event('find').database_name).to eq('override_database')
       end
 
       context 'when the database is set on the model level' do
         around(:example) do |example|
           opts = Minim.storage_options
-          Minim.storage_options = Minim.storage_options.merge( { database: 'train_database' } )
-          Mongoid.clients['train_client'] = { hosts: SpecConfig.instance.addresses, database: 'trains_database' }
+          Minim.storage_options = Minim.storage_options.merge( { database: 'model_level_database' } )
+          Mongoid.clients['model_level_client'] = { hosts: SpecConfig.instance.addresses, database: 'model_level_database' }
+          Mongoid.client(:default).subscribe(Mongo::Monitoring::COMMAND, default_subscriber)
           example.run
-          Mongoid.clients['train_client'] = nil
+          Mongoid.client(:default).unsubscribe(Mongo::Monitoring::COMMAND, default_subscriber)
+          Mongoid.clients['model_level_client'] = nil
           Minim.storage_options = opts
         end
 
         # This behaviour is consistent with 8.x
-        it 'sets the overridden client for new model' do
-          expect(Minim.create.persistence_context.database_name).to eq(:override_database)
+        it 'uses the overridden database for create' do
+          Minim.create!
+
+          expect(default_subscriber.single_command_started_event('insert').database_name).to eq('override_database')
+        end
+
+        it 'uses the overridden database for queries' do
+          Minim.where(name: 'Dmitry').to_a
+
+          expect(default_subscriber.single_command_started_event('find').database_name).to eq('override_database')
         end
       end
     end

--- a/spec/mongoid/clients/options_spec.rb
+++ b/spec/mongoid/clients/options_spec.rb
@@ -523,7 +523,8 @@ describe Mongoid::Clients::Options, retry: 3 do
     end
   end
 
-  context 'when global client is overriden' do
+  context 'with global overrides' do
+    context 'when global client is overridden' do
     before do
       Mongoid.clients['override_client'] = { hosts: SpecConfig.instance.addresses, database: 'default_override_database' }
       Mongoid.override_client('override_client')
@@ -534,7 +535,7 @@ describe Mongoid::Clients::Options, retry: 3 do
       Mongoid.clients['override_client'] = nil
     end
 
-    it 'sets the overriden client for new model' do
+    it 'sets the overridden client for new model' do
       expect(Minim.create.persistence_context.client_name).to eq('override_client')
     end
 
@@ -548,13 +549,12 @@ describe Mongoid::Clients::Options, retry: 3 do
       end
 
       it 'does not override the client' do
-        Train.create
         expect(Train.create.persistence_context.client_name).to eq('train_client')
       end
     end
   end
 
-  context 'when global databse is overriden' do
+    context 'when global database is overridden' do
     before do
       Mongoid.override_database('override_database')
     end
@@ -563,8 +563,9 @@ describe Mongoid::Clients::Options, retry: 3 do
       Mongoid.override_database(nil)
     end
 
-    it 'sets the overriden database for new model' do
+    it 'sets the overridden database for new model' do
       expect(Minim.new.persistence_context.database_name).to eq(:override_database)
     end
+  end
   end
 end

--- a/spec/support/models/train.rb
+++ b/spec/support/models/train.rb
@@ -5,6 +5,5 @@ class Train
   include Mongoid::Document
   field :name, type: String
 
-  store_in client: 'train_client'
+  store_in client: 'train_client', database: 'train_database'
 end
-

--- a/spec/support/models/train.rb
+++ b/spec/support/models/train.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+# rubocop:todo all
+
+class Train
+  include Mongoid::Document
+  field :name, type: String
+
+  store_in client: 'train_client'
+end
+

--- a/spec/support/models/train.rb
+++ b/spec/support/models/train.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-# rubocop:todo all
-
-class Train
-  include Mongoid::Document
-  field :name, type: String
-
-  store_in client: 'train_client', database: 'train_database'
-end


### PR DESCRIPTION
This PR fixes the regression described in https://jira.mongodb.org/browse/MONGOID-5815. If client or database are overridden using `override_client` or `override_database` methods, they should be used for all persistence operations.

This behaviour is described nether in the docs nor in the comments. However, it used to be like this in 8, and we did not have an intention to change this behaviour in 9. 