### PR TITLE
MONGOID-5819 Do not pass the :database option when creating a client (Backport to 9.0)

### DIFF
--- a/lib/mongoid/persistence_context.rb
+++ b/lib/mongoid/persistence_context.rb
@@ -117,12 +117,15 @@ module Mongoid
     def client
       @client ||= begin
         client = Clients.with_name(client_name)
+        options = client_options
+
         if database_name_option
           client = client.use(database_name)
+          options = options.except(:database, 'database')
         end
-        unless client_options.empty?
-          client = client.with(client_options)
-        end
+
+        client = client.with(options) unless options.empty?
+
         client
       end
     end

--- a/spec/mongoid/clients/options_spec.rb
+++ b/spec/mongoid/clients/options_spec.rb
@@ -27,7 +27,7 @@ describe Mongoid::Clients::Options, retry: 3 do
       let(:options) { { database: 'other' } }
 
       it 'sets the options on the client' do
-        expect(persistence_context.client.options['database']).to eq(options[:database])
+        expect(persistence_context.client.options['database'].to_s).to eq(options[:database].to_s)
       end
 
       it 'does not set the options on class level' do
@@ -319,7 +319,7 @@ describe Mongoid::Clients::Options, retry: 3 do
       end
 
       it 'sets the options on the client' do
-        expect(persistence_context.client.options['database']).to eq(options[:database])
+        expect(persistence_context.client.options['database'].to_s).to eq(options[:database].to_s)
       end
 
       it 'does not set the options on instance level' do

--- a/spec/mongoid/persistence_context_spec.rb
+++ b/spec/mongoid/persistence_context_spec.rb
@@ -536,6 +536,20 @@ describe Mongoid::PersistenceContext do
         end
       end
     end
+
+    context 'when the database is specified as a proc' do
+      let(:options) { { database: ->{ 'other' } } }
+
+      after { persistence_context.client.close }
+
+      it 'evaluates the proc' do
+        expect(persistence_context.database_name).to eq(:other)
+      end
+
+      it 'does not pass the proc to the client' do
+        expect(persistence_context.client.database.name).to eq('other')
+      end
+    end
   end
 
   describe '#client' do
@@ -605,6 +619,23 @@ describe Mongoid::PersistenceContext do
             expect(persistence_context.client).to eq(Mongoid::Clients.with_name(:alternative))
           end
         end
+      end
+    end
+
+    context 'when the client is set as a proc in the storage options' do
+      let(:options) { {} }
+
+      before do
+        Band.store_in client: ->{ :alternative }
+      end
+
+      after do
+        persistence_context.client.close
+        Band.store_in client: nil
+      end
+
+      it 'uses the client option' do
+        expect(persistence_context.client).to eq(Mongoid::Clients.with_name(:alternative))
       end
     end
 


### PR DESCRIPTION
(Backport of #5886 to the 9.0-stable branch.)

When [MONGOID-5472](https://jira.mongodb.org/browse/MONGOID-5472) was implemented (to enable models to remember the persistence context that was active when they were saved), it changed how storage options are interpreted in Mongoid. One overlooked pre-existing feature, however, was the ability to pass a Proc as the database name, and the new code did not account for that.

This PR updates the persistence context so that when a new client is instantiated, it does not receive the :database option (which was previously accounted for by calling client.use instead). This prevents the Proc-valued :database option from being reinterpreted as a String by the client, which was causing errors because the resulting "name" was not valid.