### PR TITLE
MONGOID-5823 Use proper thread-local variables instead of fiber-local variables

### DIFF
--- a/lib/mongoid/interceptable.rb
+++ b/lib/mongoid/interceptable.rb
@@ -191,6 +191,12 @@ module Mongoid
       fibers.reverse.each(&:resume)
     end
 
+    def copy_thread_state(source, target)
+      source.keys.each do |key|
+        target[key] = source[key]
+      end
+    end
+
     # Execute the callbacks of given kind for embedded documents without
     # around callbacks.
     #

--- a/lib/mongoid/interceptable.rb
+++ b/lib/mongoid/interceptable.rb
@@ -191,12 +191,6 @@ module Mongoid
       fibers.reverse.each(&:resume)
     end
 
-    def copy_thread_state(source, target)
-      source.keys.each do |key|
-        target[key] = source[key]
-      end
-    end
-
     # Execute the callbacks of given kind for embedded documents without
     # around callbacks.
     #

--- a/lib/mongoid/persistence_context.rb
+++ b/lib/mongoid/persistence_context.rb
@@ -285,6 +285,10 @@ module Mongoid
       # @api private
       PERSISTENCE_CONTEXT_KEY = :"[mongoid]:persistence_context"
 
+      def context_store
+        Threaded.get(PERSISTENCE_CONTEXT_KEY) { {} }
+      end
+
       # Get the persistence context for a given object from the thread local
       #   storage.
       #
@@ -295,8 +299,7 @@ module Mongoid
       #
       # @api private
       def get_context(object)
-        Thread.current[PERSISTENCE_CONTEXT_KEY] ||= {}
-        Thread.current[PERSISTENCE_CONTEXT_KEY][object.object_id]
+        context_store[object.object_id]
       end
 
       # Store persistence context for a given object in the thread local
@@ -308,10 +311,9 @@ module Mongoid
       # @api private
       def store_context(object, context)
         if context.nil?
-          Thread.current[PERSISTENCE_CONTEXT_KEY]&.delete(object.object_id)
+          context_store.delete(object.object_id)
         else
-          Thread.current[PERSISTENCE_CONTEXT_KEY] ||= {}
-          Thread.current[PERSISTENCE_CONTEXT_KEY][object.object_id] = context
+          context_store[object.object_id] = context
         end
       end
     end

--- a/lib/mongoid/railties/controller_runtime.rb
+++ b/lib/mongoid/railties/controller_runtime.rb
@@ -78,7 +78,7 @@ module Mongoid
         #
         # @return [ Integer ] The runtime value.
         def self.runtime
-          Thread.current[VARIABLE_NAME] ||= 0
+          Threaded.get(VARIABLE_NAME) { 0 }
         end
 
         # Set the runtime value on the current thread.
@@ -87,7 +87,7 @@ module Mongoid
         #
         # @return [ Integer ] The runtime value.
         def self.runtime= value
-          Thread.current[VARIABLE_NAME] = value
+          Threaded.set(VARIABLE_NAME, value)
         end
 
         # Reset the runtime value to zero the current thread.

--- a/lib/mongoid/threaded.rb
+++ b/lib/mongoid/threaded.rb
@@ -59,7 +59,7 @@ module Mongoid
       result = Thread.current.thread_variable_get(key)
 
       if result.nil? && default
-        result = default.call
+        result = yield
         set(key, result)
       end
 

--- a/lib/mongoid/threaded.rb
+++ b/lib/mongoid/threaded.rb
@@ -90,7 +90,19 @@ module Mongoid
     #
     # @return [ true | false ] whether the given variable is present or not.
     def has?(key)
-      Thread.current.thread_variable?(key)
+      # Here we have a classic example of JRuby not behaving like MRI. In
+      # MRI, if you set a thread variable to nil, it removes it from the list
+      # and subsequent calls to thread_variable?(key) will return false. Not
+      # so with JRuby. Once set, you cannot unset the thread variable.
+      #
+      # However, because setting a variable to nil is supposed to remove it,
+      # we can assume a nil-valued variable doesn't actually exist.
+
+      # So, instead of this:
+      # Thread.current.thread_variable?(key)
+
+      # We have to do this:
+      !get(key).nil?
     end
 
     # Begin entry into a named thread local stack.

--- a/lib/mongoid/timestamps/timeless.rb
+++ b/lib/mongoid/timestamps/timeless.rb
@@ -46,6 +46,9 @@ module Mongoid
       class << self
         extend Forwardable
 
+        # The key to use to store the timeless table 
+        TIMELESS_TABLE_KEY = '[mongoid]:timeless'
+
         # Returns the in-memory thread cache of classes
         # for which to skip timestamping.
         #
@@ -53,7 +56,7 @@ module Mongoid
         #
         # @api private
         def timeless_table
-          Thread.current['[mongoid]:timeless'] ||= Hash.new
+          Threaded.get(TIMELESS_TABLE_KEY) { Hash.new }
         end
 
         def_delegators :timeless_table, :[]=, :[]

--- a/lib/mongoid/touchable.rb
+++ b/lib/mongoid/touchable.rb
@@ -195,7 +195,7 @@ module Mongoid
     # @return [ Hash ] The hash that contains touch callback suppression
     #   statuses
     def touch_callback_statuses
-      Thread.current[SUPPRESS_TOUCH_CALLBACKS_KEY] ||= {}
+      Threaded.get(SUPPRESS_TOUCH_CALLBACKS_KEY) { {} }
     end
 
     # Define the method that will get called for touching belongs_to

--- a/spec/mongoid/interceptable_spec.rb
+++ b/spec/mongoid/interceptable_spec.rb
@@ -1789,6 +1789,12 @@ describe Mongoid::Interceptable do
     context 'with around callbacks' do
       config_override :around_callbacks_for_embeds, true
 
+      after do
+        Mongoid::Threaded.stack('interceptable').clear
+      end
+
+      let(:stack) { Mongoid::Threaded.stack('interceptable') }
+
       let(:expected) do
         [
           [InterceptableSpec::CbCascadedChild, :before_validation],
@@ -1823,6 +1829,12 @@ describe Mongoid::Interceptable do
       it 'calls callbacks in the right order' do
         parent.save!
         expect(registry.calls).to eq expected
+      end
+
+      it 'shows that cascaded callbacks can access Mongoid state' do
+        expect(stack).to be_empty
+        parent.save!
+        expect(stack).not_to be_empty
       end
     end
 

--- a/spec/mongoid/interceptable_spec_models.rb
+++ b/spec/mongoid/interceptable_spec_models.rb
@@ -224,7 +224,19 @@ module InterceptableSpec
 
     attr_accessor :callback_registry
 
+    before_save :test_mongoid_state
+
     include CallbackTracking
+
+    private
+
+    # Helps test that cascading child callbacks have access to the Mongoid
+    # state objects; if the implementation uses fiber-local (instead of truly
+    # thread-local) variables, the related tests will fail because the
+    # cascading child callbacks use fibers to linearize the recursion.
+    def test_mongoid_state
+      Mongoid::Threaded.stack('interceptable').push(self)
+    end
   end
 end
 

--- a/spec/mongoid/threaded_spec.rb
+++ b/spec/mongoid/threaded_spec.rb
@@ -36,11 +36,11 @@ describe Mongoid::Threaded do
     context "when the stack has elements" do
 
       before do
-        Threaded.stack('load').push(true)
+        described_class.stack('load').push(true)
       end
 
       after do
-        Threaded.stack('load').clear
+        described_class.stack('load').clear
       end
 
       it "returns true" do
@@ -51,7 +51,7 @@ describe Mongoid::Threaded do
     context "when the stack has no elements" do
 
       before do
-        Threaded.stack('load').clear
+        described_class.stack('load').clear
       end
 
       it "returns false" do
@@ -76,7 +76,7 @@ describe Mongoid::Threaded do
     context "when a stack has been initialized" do
 
       before do
-        Threaded.stack('load').push(true)
+        described_class.stack('load').push(true)
       end
 
       let(:loading) do
@@ -84,7 +84,7 @@ describe Mongoid::Threaded do
       end
 
       after do
-        Threaded.stack('load').clear
+        described_class.stack('load').clear
       end
 
       it "returns the stack" do

--- a/spec/mongoid/threaded_spec.rb
+++ b/spec/mongoid/threaded_spec.rb
@@ -36,11 +36,11 @@ describe Mongoid::Threaded do
     context "when the stack has elements" do
 
       before do
-        Thread.current["[mongoid]:load-stack"] = [ true ]
+        Threaded.stack('load').push(true)
       end
 
       after do
-        Thread.current["[mongoid]:load-stack"] = []
+        Threaded.stack('load').clear
       end
 
       it "returns true" do
@@ -51,7 +51,7 @@ describe Mongoid::Threaded do
     context "when the stack has no elements" do
 
       before do
-        Thread.current["[mongoid]:load-stack"] = []
+        Threaded.stack('load').clear
       end
 
       it "returns false" do
@@ -76,7 +76,7 @@ describe Mongoid::Threaded do
     context "when a stack has been initialized" do
 
       before do
-        Thread.current["[mongoid]:load-stack"] = [ true ]
+        Threaded.stack('load').push(true)
       end
 
       let(:loading) do
@@ -84,7 +84,7 @@ describe Mongoid::Threaded do
       end
 
       after do
-        Thread.current["[mongoid]:load-stack"] = []
+        Threaded.stack('load').clear
       end
 
       it "returns the stack" do

--- a/spec/rails/controller_extension/controller_runtime_spec.rb
+++ b/spec/rails/controller_extension/controller_runtime_spec.rb
@@ -8,8 +8,8 @@ describe "Mongoid::Railties::ControllerRuntime" do
   controller_runtime = Mongoid::Railties::ControllerRuntime
   collector = controller_runtime::Collector
 
-  def set_metric value
-    Thread.current["Mongoid.controller_runtime"] = value
+  def set_metric(value)
+    Mongoid::Threaded.set(collector::VARIABLE_NAME, value)
   end
 
   def clear_metric!

--- a/spec/rails/controller_extension/controller_runtime_spec.rb
+++ b/spec/rails/controller_extension/controller_runtime_spec.rb
@@ -5,11 +5,11 @@ require "spec_helper"
 require "mongoid/railties/controller_runtime"
 
 describe "Mongoid::Railties::ControllerRuntime" do
-  controller_runtime = Mongoid::Railties::ControllerRuntime
-  collector = controller_runtime::Collector
+  CONTROLLER_RUNTIME = Mongoid::Railties::ControllerRuntime
+  COLLECTOR = CONTROLLER_RUNTIME::Collector
 
   def set_metric(value)
-    Mongoid::Threaded.set(collector::VARIABLE_NAME, value)
+    Mongoid::Threaded.set(COLLECTOR::VARIABLE_NAME, value)
   end
 
   def clear_metric!
@@ -20,30 +20,30 @@ describe "Mongoid::Railties::ControllerRuntime" do
 
     it "stores the metric in thread-safe manner" do
       clear_metric!
-      expect(collector.runtime).to eq(0)
+      expect(COLLECTOR.runtime).to eq(0)
       set_metric 42
-      expect(collector.runtime).to eq(42)
+      expect(COLLECTOR.runtime).to eq(42)
     end
 
     it "sets metric on both succeeded and failed" do
-      instance = collector.new
+      instance = COLLECTOR.new
       event_payload = OpenStruct.new duration: 42
 
       clear_metric!
       instance.succeeded event_payload
-      expect(collector.runtime).to eq(42000)
+      expect(COLLECTOR.runtime).to eq(42000)
 
       clear_metric!
       instance.failed event_payload
-      expect(collector.runtime).to eq(42000)
+      expect(COLLECTOR.runtime).to eq(42000)
     end
 
     it "resets the metric and returns the value" do
       clear_metric!
-      expect(collector.reset_runtime).to eq(0)
+      expect(COLLECTOR.reset_runtime).to eq(0)
       set_metric 42
-      expect(collector.reset_runtime).to eq(42)
-      expect(collector.runtime).to eq(0)
+      expect(COLLECTOR.reset_runtime).to eq(42)
+      expect(COLLECTOR.runtime).to eq(0)
     end
 
   end
@@ -67,7 +67,7 @@ describe "Mongoid::Railties::ControllerRuntime" do
   end
 
   controller_class = Class.new reference_controller_class do
-    include controller_runtime::ControllerExtension
+    include CONTROLLER_RUNTIME::ControllerExtension
   end
 
   let(:controller){ controller_class.new }
@@ -75,7 +75,7 @@ describe "Mongoid::Railties::ControllerRuntime" do
   it "resets the metric before each action" do
     set_metric 42
     controller.send(:process_action, 'foo')
-    expect(collector.runtime).to be(0)
+    expect(COLLECTOR.runtime).to be(0)
     expect(controller.instance_variable_get "@process_action").to be(true)
   end
 


### PR DESCRIPTION
MONGOID-5688 introduced a new way of processing cascading callbacks on embedded children, using Fibers to linearize the recursive calls. This proved very effective in avoiding `SystemStackError` exceptions caused by large numbers of embedded documents.

However, it turns out that `Thread#[]` and `Thread#[]=` get and set *fiber-local* variables, and not *thread-local* variables. Mongoid was using these methods quite a bit to set and manage its own internal state, which meant that any cascading callback on embedded children would be executed in a context that lacked all of Mongoid's state from the parent thread.

This PR fixes this issue by changing Mongoid's state handling routines (`Mongoid::Threaded`) to use actual thread-local storage (`Thread#thread_variable_get` and `Thread#thread_variable_set`) instead of the fiber-local variables.