### PR TITLE
MONGOID-5810 Don't leak internal state via `#as_document`

### DIFF
--- a/lib/mongoid/document.rb
+++ b/lib/mongoid/document.rb
@@ -133,7 +133,14 @@ module Mongoid
     #
     # @return [ Hash ] A hash of all attributes in the hierarchy.
     def as_document
-      BSON::Document.new(as_attributes)
+      attrs = as_attributes
+
+      # legacy attributes have a tendency to leak internal state via
+      # `as_document`; we have to deep_dup the attributes here to prevent
+      # that.
+      attrs = attrs.deep_dup if Mongoid.legacy_attributes
+
+      BSON::Document.new(attrs)
     end
 
     # Calls #as_json on the document with additional, Mongoid-specific options.

--- a/spec/mongoid/document_spec.rb
+++ b/spec/mongoid/document_spec.rb
@@ -591,6 +591,33 @@ describe Mongoid::Document do
       expect(person.as_document["addresses"].first).to have_key(:locations)
     end
 
+    context 'when modifying the returned object' do
+      let(:record) do
+        RootCategory.create(categories: [{ name: 'tests' }]).reload
+      end
+
+      shared_examples_for 'an object with protected internal state' do
+        it 'does not expose internal state' do
+          before_change = record.as_document.dup
+          record.categories.first.name = 'things'
+          after_change = record.as_document
+          expect(before_change['categories'].first['name']).not_to eq('things')
+        end
+      end
+
+      context 'when legacy_attributes is true' do
+        config_override :legacy_attributes, true
+
+        it_behaves_like 'an object with protected internal state'
+      end
+
+      context 'when legacy_attributes is false' do
+        config_override :legacy_attributes, false
+
+        it_behaves_like 'an object with protected internal state'
+      end
+    end
+
     context "with relation define store_as option in embeded_many" do
 
       let!(:phone) do


### PR DESCRIPTION
Under certain situations, and when `legacy_attributes` is true, the hash returned from `#as_document` can be the actual hash used internally to represent the model. Modifying this hash will modify the internal state of the model, which is unexpected and dangerous.

To fix this, the attributes must be deep-duplicated before being returned by `#as_document`, if `legacy_attributes` is true.

This does not affect 9.0-stable and later, because the `legacy_attributes` setting was removed when 9.0 was released.

(This ought to be backported to 8.0-stable, however.)