### PR TITLE
MONGOID-5810 make sure we don't leak internal state via as_document (backport to 8.0-stable)

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -625,24 +625,13 @@ buildvariants:
   tasks:
     - name: "test"
 
-- matrix_name: "ruby-3.0"
-  matrix_spec:
-    ruby: ["ruby-3.0"]
-    driver: ["current"]
-    topology: ['replica-set']
-    mongodb-version: ['5.0']
-    os: rhel80
-  display_name: "${ruby}, ${driver}, ${mongodb-version}, ${topology}"
-  tasks:
-    - name: "test"
-
 - matrix_name: "jruby"
   matrix_spec:
     jruby: ["jruby-9.3"]
     driver: ["current"]
     topology: ['replica-set', 'sharded-cluster']
     mongodb-version: '5.0'
-    os: rhel80
+    os: ubuntu-22.04
   display_name: "${jruby}, ${driver}, ${mongodb-version}, ${topology}"
   tasks:
     - name: "test"
@@ -720,7 +709,8 @@ buildvariants:
     ruby: ["ruby-2.7"]
     mongodb-version: "5.0"
     topology: "standalone"
-    os: rhel80
+    os: ubuntu-20.04
+    toolchain: 2024-09-06
   display_name: "${ruby}, ${driver}, ${mongodb-version}, ${topology}"
   tasks:
     - name: "test"
@@ -728,10 +718,10 @@ buildvariants:
 - matrix_name: "bson-master"
   matrix_spec:
     driver: [bson-master]
-    ruby: ["ruby-3.0"]
+    ruby: ["ruby-3.1"]
     mongodb-version: "5.0"
     topology: "standalone"
-    os: rhel80
+    os: ubuntu-22.04
   display_name: "${ruby}, ${driver}, ${mongodb-version}, ${topology}"
   tasks:
     - name: "test"
@@ -739,12 +729,12 @@ buildvariants:
 
 - matrix_name: "rails-6"
   matrix_spec:
-    ruby: ["ruby-3.0"]
+    ruby: ["ruby-3.1"]
     driver: ["current"]
     mongodb-version: "6.0"
     topology: "standalone"
     rails: ['6.0', '6.1']
-    os: rhel80
+    os: ubuntu-22.04
   display_name: "${rails}, ${driver}, ${mongodb-version}"
   tasks:
      - name: "test"
@@ -775,13 +765,14 @@ buildvariants:
 
 - matrix_name: "i18n-fallbacks"
   matrix_spec:
-    ruby: "ruby-2.6"
+    ruby: "ruby-2.7"
     driver: ["current"]
     mongodb-version: "4.2"
     topology: "standalone"
     i18n: '*'
     test-i18n-fallbacks: yes
-    os: rhel80
+    os: ubuntu-20.04
+    toolchain: 2024-09-06
   display_name: "i18n fallbacks ${rails}, ${driver}, ${mongodb-version}, ${i18n}"
   tasks:
      - name: "test"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -38,6 +38,12 @@ functions:
 
           git submodule update --init --recursive
 
+          if [ ! -d .mod ]; then
+            mkdir -p .mod
+            cd .mod
+            git clone https://github.com/mongodb-labs/drivers-evergreen-tools
+          fi
+
   "fetch egos":
     - command: shell.exec
       params:
@@ -61,7 +67,7 @@ functions:
               CURRENT_VERSION=latest
            fi
 
-           export DRIVERS_TOOLS="$(pwd)/../drivers-tools"
+           export DRIVERS_TOOLS="$(pwd)/.mod/drivers-evergreen-tools"
 
            export MONGO_ORCHESTRATION_HOME="$DRIVERS_TOOLS/.evergreen/orchestration"
            export MONGODB_BINARIES="$DRIVERS_TOOLS/mongodb/bin"
@@ -95,6 +101,15 @@ functions:
               export SSL=${SSL}
               export APP_TESTS=${APP_TESTS}
               export DOCKER_DISTRO=${DOCKER_DISTRO}
+
+              export MONGODB_URI="${MONGODB_URI}"
+              export RVM_RUBY="${RVM_RUBY}"
+              export RAILS="${RAILS}"
+              export DRIVER="${DRIVER}"
+              export I18N="${I18N}"
+              export TEST_I18N_FALLBACKS="${TEST_I18N_FALLBACKS}"
+              export FLE="${FLE}"
+              export TOOLCHAIN_OVERRIDE="${TOOLCHAIN_OVERRIDE}"
            EOT
            # See what we've done
            cat expansion.yml
@@ -274,6 +289,16 @@ functions:
         working_dir: "src"
         script: |
           ${PREPARE_SHELL}
+          .evergreen/run-tests.sh
+
+  "run tests in docker":
+    - command: shell.exec
+      type: test
+      params:
+        shell: bash
+        working_dir: "src"
+        script: |
+          ${PREPARE_SHELL}
           env \
             MONGODB_URI="${MONGODB_URI}" \
             TOPOLOGY=${TOPOLOGY} \
@@ -442,19 +467,19 @@ axes:
     values:
       - id: ubuntu-22.04
         display_name: "Ubuntu 22.04"
+        run_on: ubuntu2204-small
+      - id: ubuntu-20.04
+        display_name: "Ubuntu 20.04"
         run_on: ubuntu2004-small
-        variables:
-          DOCKER_DISTRO: ubuntu2204
+      - id: ubuntu-18.04
+        display_name: "Ubuntu 18.04"
+        run_on: ubuntu1804-small
       - id: debian11
         display_name: "Debian 11"
-        run_on: ubuntu2004-small
-        variables:
-          DOCKER_DISTRO: debian11
+        run_on: debian11-small
       - id: rhel80
         display_name: "RHEL 8.0"
-        run_on: ubuntu2004-small
-        variables:
-          DOCKER_DISTRO: rhel80
+        run_on: rhel80-small
 
   - id: "driver"
     display_name: Driver Version
@@ -558,6 +583,25 @@ axes:
         variables:
           APP_TESTS: yes
 
+  - id: toolchain
+    display_name: Toolchain Version
+    values:
+      - id: 2023-05-11
+        display_name: 2023-05-11
+        variables:
+          TOOLCHAIN_OVERRIDE: e8c60866f54bed7e336a37df3a97d6ae1b971b7d
+      - id: 2023-11-02
+        display_name: 2023-11-02
+        variables:
+          TOOLCHAIN_OVERRIDE: ded7ea845b08cf96f11a747d9540ba3199580dea
+      - id: 2024-08-07
+        display_name: 2024-08-07
+        variables:
+          TOOLCHAIN_OVERRIDE: c950fe1e85fd7d5e4ea69cc2afff456825583716
+      - id: 2024-09-06
+        display_name: 2024-09-06
+        variables:
+          TOOLCHAIN_OVERRIDE: deefab59d8f539bdd4a0154505f1e7d39a0857d0
 buildvariants:
 - matrix_name: "mongodb-latest"
   matrix_spec:
@@ -565,7 +609,7 @@ buildvariants:
     driver: ["current"]
     topology: '*'
     mongodb-version: ['latest']
-    os: debian11
+    os: ubuntu-22.04
   display_name: "${ruby}, ${driver}, ${mongodb-version}, ${topology}"
   tasks:
     - name: "test"
@@ -744,13 +788,13 @@ buildvariants:
 
 - matrix_name: app-tests-ruby-3
   matrix_spec:
-    ruby: ["ruby-3.0", "ruby-3.1"]
+    ruby: "ruby-3.1"
     driver: ["current"]
     mongodb-version: '6.0'
     topology: standalone
     app-tests: yes
     rails: ['6.0', '6.1', '7.0', '7.1']
-    os: rhel80
+    os: ubuntu-22.04
   display_name: "app tests ${driver}, ${ruby}, ${rails}"
   tasks:
     - name: "test"
@@ -763,7 +807,8 @@ buildvariants:
     topology: standalone
     app-tests: yes
     rails: ['5.2']
-    os: rhel80
+    os: ubuntu-20.04
+    toolchain: 2024-09-06
   display_name: "app tests ${driver}, ${ruby}, ${rails}"
   tasks:
      - name: "test"
@@ -776,7 +821,7 @@ buildvariants:
     topology: standalone
     app-tests: yes
     rails: ['6.0']
-    os: ubuntu-22.04
+    os: ubuntu-18.04
   display_name: "app tests ${driver}, ${jruby}"
   tasks:
      - name: "test"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -722,6 +722,7 @@ buildvariants:
     mongodb-version: "5.0"
     topology: "standalone"
     os: ubuntu-20.04
+    toolchain: 2024-09-06
   display_name: "${ruby}, ${driver}, ${mongodb-version}, ${topology}"
   tasks:
     - name: "test"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -631,7 +631,7 @@ buildvariants:
     driver: ["current"]
     topology: ['replica-set', 'sharded-cluster']
     mongodb-version: '5.0'
-    os: ubuntu-22.04
+    os: ubuntu-18.04
   display_name: "${jruby}, ${driver}, ${mongodb-version}, ${topology}"
   tasks:
     - name: "test"
@@ -721,7 +721,7 @@ buildvariants:
     ruby: ["ruby-3.1"]
     mongodb-version: "5.0"
     topology: "standalone"
-    os: ubuntu-22.04
+    os: ubuntu-20.04
   display_name: "${ruby}, ${driver}, ${mongodb-version}, ${topology}"
   tasks:
     - name: "test"
@@ -771,7 +771,7 @@ buildvariants:
     topology: "standalone"
     i18n: '*'
     test-i18n-fallbacks: yes
-    os: ubuntu-20.04
+    os: ubuntu-18.04
     toolchain: 2024-09-06
   display_name: "i18n fallbacks ${rails}, ${driver}, ${mongodb-version}, ${i18n}"
   tasks:

--- a/.evergreen/config/axes.yml.erb
+++ b/.evergreen/config/axes.yml.erb
@@ -117,19 +117,19 @@ axes:
     values:
       - id: ubuntu-22.04
         display_name: "Ubuntu 22.04"
+        run_on: ubuntu2204-small
+      - id: ubuntu-20.04
+        display_name: "Ubuntu 20.04"
         run_on: ubuntu2004-small
-        variables:
-          DOCKER_DISTRO: ubuntu2204
+      - id: ubuntu-18.04
+        display_name: "Ubuntu 18.04"
+        run_on: ubuntu1804-small
       - id: debian11
         display_name: "Debian 11"
-        run_on: ubuntu2004-small
-        variables:
-          DOCKER_DISTRO: debian11
+        run_on: debian11-small
       - id: rhel80
         display_name: "RHEL 8.0"
-        run_on: ubuntu2004-small
-        variables:
-          DOCKER_DISTRO: rhel80
+        run_on: rhel80-small
 
   - id: "driver"
     display_name: Driver Version
@@ -233,3 +233,22 @@ axes:
         variables:
           APP_TESTS: yes
 
+  - id: toolchain
+    display_name: Toolchain Version
+    values:
+      - id: 2023-05-11
+        display_name: 2023-05-11
+        variables:
+          TOOLCHAIN_OVERRIDE: e8c60866f54bed7e336a37df3a97d6ae1b971b7d
+      - id: 2023-11-02
+        display_name: 2023-11-02
+        variables:
+          TOOLCHAIN_OVERRIDE: ded7ea845b08cf96f11a747d9540ba3199580dea
+      - id: 2024-08-07
+        display_name: 2024-08-07
+        variables:
+          TOOLCHAIN_OVERRIDE: c950fe1e85fd7d5e4ea69cc2afff456825583716
+      - id: 2024-09-06
+        display_name: 2024-09-06
+        variables:
+          TOOLCHAIN_OVERRIDE: deefab59d8f539bdd4a0154505f1e7d39a0857d0

--- a/.evergreen/config/commands.yml.erb
+++ b/.evergreen/config/commands.yml.erb
@@ -12,6 +12,12 @@ functions:
 
           git submodule update --init --recursive
 
+          if [ ! -d .mod ]; then
+            mkdir -p .mod
+            cd .mod
+            git clone https://github.com/mongodb-labs/drivers-evergreen-tools
+          fi
+
   "fetch egos":
     - command: shell.exec
       params:
@@ -35,7 +41,7 @@ functions:
               CURRENT_VERSION=latest
            fi
 
-           export DRIVERS_TOOLS="$(pwd)/../drivers-tools"
+           export DRIVERS_TOOLS="$(pwd)/.mod/drivers-evergreen-tools"
 
            export MONGO_ORCHESTRATION_HOME="$DRIVERS_TOOLS/.evergreen/orchestration"
            export MONGODB_BINARIES="$DRIVERS_TOOLS/mongodb/bin"
@@ -69,6 +75,15 @@ functions:
               export SSL=${SSL}
               export APP_TESTS=${APP_TESTS}
               export DOCKER_DISTRO=${DOCKER_DISTRO}
+
+              export MONGODB_URI="${MONGODB_URI}"
+              export RVM_RUBY="${RVM_RUBY}"
+              export RAILS="${RAILS}"
+              export DRIVER="${DRIVER}"
+              export I18N="${I18N}"
+              export TEST_I18N_FALLBACKS="${TEST_I18N_FALLBACKS}"
+              export FLE="${FLE}"
+              export TOOLCHAIN_OVERRIDE="${TOOLCHAIN_OVERRIDE}"
            EOT
            # See what we've done
            cat expansion.yml
@@ -241,6 +256,16 @@ functions:
         file: ./src/tmp/rspec.xml
 
   "run tests":
+    - command: shell.exec
+      type: test
+      params:
+        shell: bash
+        working_dir: "src"
+        script: |
+          ${PREPARE_SHELL}
+          .evergreen/run-tests.sh
+
+  "run tests in docker":
     - command: shell.exec
       type: test
       params:

--- a/.evergreen/config/variants.yml.erb
+++ b/.evergreen/config/variants.yml.erb
@@ -5,7 +5,7 @@ buildvariants:
     driver: ["current"]
     topology: '*'
     mongodb-version: ['latest']
-    os: debian11
+    os: ubuntu-22.04
   display_name: "${ruby}, ${driver}, ${mongodb-version}, ${topology}"
   tasks:
     - name: "test"
@@ -184,13 +184,13 @@ buildvariants:
 
 - matrix_name: app-tests-ruby-3
   matrix_spec:
-    ruby: ["ruby-3.0", "ruby-3.1"]
+    ruby: "ruby-3.1"
     driver: ["current"]
     mongodb-version: '6.0'
     topology: standalone
     app-tests: yes
     rails: ['6.0', '6.1', '7.0', '7.1']
-    os: rhel80
+    os: ubuntu-22.04
   display_name: "app tests ${driver}, ${ruby}, ${rails}"
   tasks:
     - name: "test"
@@ -203,7 +203,8 @@ buildvariants:
     topology: standalone
     app-tests: yes
     rails: ['5.2']
-    os: rhel80
+    os: ubuntu-20.04
+    toolchain: 2024-09-06
   display_name: "app tests ${driver}, ${ruby}, ${rails}"
   tasks:
      - name: "test"
@@ -216,7 +217,7 @@ buildvariants:
     topology: standalone
     app-tests: yes
     rails: ['6.0']
-    os: ubuntu-22.04
+    os: ubuntu-18.04
   display_name: "app tests ${driver}, ${jruby}"
   tasks:
      - name: "test"

--- a/.evergreen/config/variants.yml.erb
+++ b/.evergreen/config/variants.yml.erb
@@ -118,6 +118,7 @@ buildvariants:
     mongodb-version: "5.0"
     topology: "standalone"
     os: ubuntu-20.04
+    toolchain: 2024-09-06
   display_name: "${ruby}, ${driver}, ${mongodb-version}, ${topology}"
   tasks:
     - name: "test"

--- a/.evergreen/config/variants.yml.erb
+++ b/.evergreen/config/variants.yml.erb
@@ -27,7 +27,7 @@ buildvariants:
     driver: ["current"]
     topology: ['replica-set', 'sharded-cluster']
     mongodb-version: '5.0'
-    os: ubuntu-22.04
+    os: ubuntu-18.04
   display_name: "${jruby}, ${driver}, ${mongodb-version}, ${topology}"
   tasks:
     - name: "test"
@@ -117,7 +117,7 @@ buildvariants:
     ruby: ["ruby-3.1"]
     mongodb-version: "5.0"
     topology: "standalone"
-    os: ubuntu-22.04
+    os: ubuntu-20.04
   display_name: "${ruby}, ${driver}, ${mongodb-version}, ${topology}"
   tasks:
     - name: "test"
@@ -167,7 +167,7 @@ buildvariants:
     topology: "standalone"
     i18n: '*'
     test-i18n-fallbacks: yes
-    os: ubuntu-20.04
+    os: ubuntu-18.04
     toolchain: 2024-09-06
   display_name: "i18n fallbacks ${rails}, ${driver}, ${mongodb-version}, ${i18n}"
   tasks:

--- a/.evergreen/config/variants.yml.erb
+++ b/.evergreen/config/variants.yml.erb
@@ -21,24 +21,13 @@ buildvariants:
   tasks:
     - name: "test"
 
-- matrix_name: "ruby-3.0"
-  matrix_spec:
-    ruby: ["ruby-3.0"]
-    driver: ["current"]
-    topology: ['replica-set']
-    mongodb-version: ['5.0']
-    os: rhel80
-  display_name: "${ruby}, ${driver}, ${mongodb-version}, ${topology}"
-  tasks:
-    - name: "test"
-
 - matrix_name: "jruby"
   matrix_spec:
     jruby: ["jruby-9.3"]
     driver: ["current"]
     topology: ['replica-set', 'sharded-cluster']
     mongodb-version: '5.0'
-    os: rhel80
+    os: ubuntu-22.04
   display_name: "${jruby}, ${driver}, ${mongodb-version}, ${topology}"
   tasks:
     - name: "test"
@@ -116,7 +105,8 @@ buildvariants:
     ruby: ["ruby-2.7"]
     mongodb-version: "5.0"
     topology: "standalone"
-    os: rhel80
+    os: ubuntu-20.04
+    toolchain: 2024-09-06
   display_name: "${ruby}, ${driver}, ${mongodb-version}, ${topology}"
   tasks:
     - name: "test"
@@ -124,10 +114,10 @@ buildvariants:
 - matrix_name: "bson-master"
   matrix_spec:
     driver: [bson-master]
-    ruby: ["ruby-3.0"]
+    ruby: ["ruby-3.1"]
     mongodb-version: "5.0"
     topology: "standalone"
-    os: rhel80
+    os: ubuntu-22.04
   display_name: "${ruby}, ${driver}, ${mongodb-version}, ${topology}"
   tasks:
     - name: "test"
@@ -135,12 +125,12 @@ buildvariants:
 
 - matrix_name: "rails-6"
   matrix_spec:
-    ruby: ["ruby-3.0"]
+    ruby: ["ruby-3.1"]
     driver: ["current"]
     mongodb-version: "6.0"
     topology: "standalone"
     rails: ['6.0', '6.1']
-    os: rhel80
+    os: ubuntu-22.04
   display_name: "${rails}, ${driver}, ${mongodb-version}"
   tasks:
      - name: "test"
@@ -171,13 +161,14 @@ buildvariants:
 
 - matrix_name: "i18n-fallbacks"
   matrix_spec:
-    ruby: "ruby-2.6"
+    ruby: "ruby-2.7"
     driver: ["current"]
     mongodb-version: "4.2"
     topology: "standalone"
     i18n: '*'
     test-i18n-fallbacks: yes
-    os: rhel80
+    os: ubuntu-20.04
+    toolchain: 2024-09-06
   display_name: "i18n fallbacks ${rails}, ${driver}, ${mongodb-version}, ${i18n}"
   tasks:
      - name: "test"

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -13,6 +13,13 @@ set -o errexit  # Exit the script with error if any of the commands fail
 . `dirname "$0"`/../spec/shared/shlib/server.sh
 . `dirname "$0"`/functions.sh
 
+# set_env.sh sets the TOOLCHAIN_VERSION variable to a default value based on
+# the version spec/shared that's available. Here, we let the evergreen task
+# override it, if necessary, to get a newer or older toolchain build.
+if [ -n "$TOOLCHAIN_OVERRIDE" ]; then
+  TOOLCHAIN_VERSION=$TOOLCHAIN_OVERRIDE
+fi
+
 arch=`host_distro`
 
 set_fcv

--- a/Rakefile
+++ b/Rakefile
@@ -126,3 +126,29 @@ namespace :docs do
     system "yardoc -o #{out} --title mongoid-#{Mongoid::VERSION}"
   end
 end
+
+desc 'Build and validate the evergreen config'
+task eg: %w[ eg:build eg:validate ]
+
+# 'eg' == 'evergreen', but evergreen is too many letters for convenience
+namespace :eg do
+  desc 'Builds the .evergreen/config.yml file from the templates'
+  task :build do
+    ruby '.evergreen/update-evergreen-configs'
+  end
+
+  desc 'Validates the .evergreen/config.yml file'
+  task :validate do
+    system 'evergreen validate --project mongoid .evergreen/config.yml'
+  end
+
+  desc 'Updates the evergreen executable to the latest available version'
+  task :update do
+    system 'evergreen get-update --install'
+  end
+
+  desc 'Runs the current branch as an evergreen patch'
+  task :patch do
+    system 'evergreen patch --uncommitted --project mongoid --browse --auto-description --yes'
+  end
+end

--- a/gemfiles/bson_min.gemfile
+++ b/gemfiles/bson_min.gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 gemspec path: '..'
 
-gem 'bson', '4.14.0'
+gem 'bson', '4.14.1'
 gem 'mongo'
 
 gem 'actionpack'

--- a/gemfiles/standard.rb
+++ b/gemfiles/standard.rb
@@ -4,14 +4,6 @@ def standard_dependencies
   group :development do
     gem 'yard'
 
-    platform :mri do
-      # Debugger for VSCode.
-      if !ENV['CI'] && !ENV['DOCKER'] && RUBY_VERSION < '3.0'
-        gem 'debase'
-        gem 'ruby-debug-ide'
-      end
-    end
-
     # Evergreen configuration generation
     gem 'erubi'
     gem 'tilt'

--- a/gemfiles/standard.rb
+++ b/gemfiles/standard.rb
@@ -37,6 +37,16 @@ def standard_dependencies
     gem 'fuubar'
     gem 'rfc'
     gem 'childprocess'
+    gem 'puma' # for app tests
+
+    # to fix problem with modern net-imap requiring more modern ruby, on
+    # evergreen
+    if RUBY_VERSION < '2.7.3'
+      gem 'net-imap', '=0.3.7'
+
+    elsif RUBY_VERSION < '3.1'
+      gem 'net-imap', '=0.4.18'
+    end
 
     platform :mri do
       gem 'timeout-interrupt'

--- a/lib/mongoid/document.rb
+++ b/lib/mongoid/document.rb
@@ -133,7 +133,14 @@ module Mongoid
     #
     # @return [ Hash ] A hash of all attributes in the hierarchy.
     def as_document
-      BSON::Document.new(as_attributes)
+      attrs = as_attributes
+
+      # legacy attributes have a tendency to leak internal state via
+      # `as_document`; we have to deep_dup the attributes here to prevent
+      # that.
+      attrs = attrs.deep_dup if Mongoid.legacy_attributes
+
+      BSON::Document.new(attrs)
     end
 
     # Calls #as_json on the document with additional, Mongoid-specific options.

--- a/spec/mongoid/document_spec.rb
+++ b/spec/mongoid/document_spec.rb
@@ -591,6 +591,33 @@ describe Mongoid::Document do
       expect(person.as_document["addresses"].first).to have_key(:locations)
     end
 
+    context 'when modifying the returned object' do
+      let(:record) do
+        RootCategory.create(categories: [{ name: 'tests' }]).reload
+      end
+
+      shared_examples_for 'an object with protected internal state' do
+        it 'does not expose internal state' do
+          before_change = record.as_document.dup
+          record.categories.first.name = 'things'
+          after_change = record.as_document
+          expect(before_change['categories'].first['name']).not_to eq('things')
+        end
+      end
+
+      context 'when legacy_attributes is true' do
+        config_override :legacy_attributes, true
+
+        it_behaves_like 'an object with protected internal state'
+      end
+
+      context 'when legacy_attributes is false' do
+        config_override :legacy_attributes, false
+
+        it_behaves_like 'an object with protected internal state'
+      end
+    end
+
     context "with relation define store_as option in embeded_many" do
 
       let!(:phone) do


### PR DESCRIPTION
(Backport from 8.1-stable to 8.0-stable.)

Under certain situations, and when `legacy_attributes` is true, the hash returned from `#as_document` can be the actual hash used internally to represent the model. Modifying this hash will modify the internal state of the model, which is unexpected and dangerous.

To fix this, the attributes must be deep-duplicated before being returned by `#as_document`, if `legacy_attributes` is true.

This does not affect 9.0-stable and later, because the `legacy_attributes` setting was removed when 9.0 was released.
