### PR TITLE
MONGOID-5830 Client name may be a proc (backport to 9.0-stable)

### DIFF
--- a/lib/mongoid/persistence_context.rb
+++ b/lib/mongoid/persistence_context.rb
@@ -138,7 +138,7 @@ module Mongoid
     # @return [ Symbol ] The client name for this persistence
     #   context.
     def client_name
-      @client_name ||= options[:client] ||
+      @client_name ||= __evaluate__(options[:client]) ||
                          Threaded.client_override ||
                          __evaluate__(storage_options[:client])
     end

--- a/spec/mongoid/persistence_context_spec.rb
+++ b/spec/mongoid/persistence_context_spec.rb
@@ -584,6 +584,14 @@ describe Mongoid::PersistenceContext do
         expect(persistence_context.client).to eq(Mongoid::Clients.with_name(:alternative))
       end
 
+      context 'when the client option is a proc' do
+        let(:options) { { client: -> { :alternative } } }
+
+        it 'evaluates the proc' do
+          expect(persistence_context.client).to eq(Mongoid::Clients.with_name(:alternative))
+        end
+      end
+
       context 'when there is a client override' do
         persistence_context_override :client, :other
 


### PR DESCRIPTION
(This backports #5906 to 9.0-stable.)

Previously, it was possible to provide the client as a proc (returning the name of the client to use). This broke in Mongoid 9.

This PR adds a call to `__evaluate__` the client name to ensure that if it is a proc it is properly handled.