### PR TITLE
MONGOID-5737 Fix issue where <=> errors if there's a non-document (backport for 8.1)

### DIFF
--- a/lib/mongoid/equality.rb
+++ b/lib/mongoid/equality.rb
@@ -17,6 +17,7 @@ module Mongoid
     #
     # @return [ Integer ] -1, 0, 1.
     def <=>(other)
+      return super unless other.is_a?(Mongoid::Equality)
       attributes["_id"].to_s <=> other.attributes["_id"].to_s
     end
 

--- a/spec/mongoid/equality_spec.rb
+++ b/spec/mongoid/equality_spec.rb
@@ -291,6 +291,12 @@ describe Mongoid::Equality do
     it "compares based on the document id" do
       expect(first <=> second).to eq(-1)
     end
+    
+    it "doesn't break if one isn't a document" do
+      expect do
+        first <=> "Foo"
+      end.to_not raise_error
+    end
   end
 
   describe "#eql?" do


### PR DESCRIPTION
[MONGOID-5737](https://jira.mongodb.org/browse/MONGOID-5737)

Mongoid defines <=> but errors if both documents are not Mongoid::Document instance. Default to super's implementation of <=> if other doc is not of same class.