### PR TITLE
MONGOID-5816: attr_readonly leaks into sibling classes

### DIFF
--- a/lib/mongoid/attributes/readonly.rb
+++ b/lib/mongoid/attributes/readonly.rb
@@ -9,12 +9,8 @@ module Mongoid
       extend ActiveSupport::Concern
 
       included do
-        class_attribute :readonly_attributes
+        class_attribute :readonly_attributes, instance_accessor: false
         self.readonly_attributes = ::Set.new
-        def self.inherited(subclass)
-          super
-          subclass.readonly_attributes = readonly_attributes.dup
-        end
       end
 
       # Are we able to write the attribute with the provided name?
@@ -27,7 +23,7 @@ module Mongoid
       # @return [ true | false ] If the document is new, or if the field is not
       #   readonly.
       def attribute_writable?(name)
-        new_record? || (!readonly_attributes.include?(name) && _loaded?(name))
+        new_record? || (!self.class.readonly_attributes.include?(name) && _loaded?(name))
       end
 
       private
@@ -68,8 +64,9 @@ module Mongoid
         #
         # @param [ Symbol... ] *names The names of the fields.
         def attr_readonly(*names)
+          self.readonly_attributes = self.readonly_attributes.dup
           names.each do |name|
-            readonly_attributes << database_field_name(name)
+            self.readonly_attributes << database_field_name(name)
           end
         end
       end

--- a/lib/mongoid/attributes/readonly.rb
+++ b/lib/mongoid/attributes/readonly.rb
@@ -9,8 +9,12 @@ module Mongoid
       extend ActiveSupport::Concern
 
       included do
-        class_attribute :readonly_attributes
+        class_attribute :readonly_attributes, instance_writer: false, instance_reader: false
         self.readonly_attributes = ::Set.new
+        def self.inherited(subclass)
+          super
+          subclass.readonly_attributes = readonly_attributes.dup
+        end
       end
 
       # Are we able to write the attribute with the provided name?

--- a/lib/mongoid/attributes/readonly.rb
+++ b/lib/mongoid/attributes/readonly.rb
@@ -9,7 +9,7 @@ module Mongoid
       extend ActiveSupport::Concern
 
       included do
-        class_attribute :readonly_attributes, instance_accessor: false
+        class_attribute :readonly_attributes
         self.readonly_attributes = ::Set.new
       end
 
@@ -63,6 +63,10 @@ module Mongoid
         #   end
         #
         # @param [ Symbol... ] *names The names of the fields.
+        # @note When a parent class contains readonly attributes and is then
+        # inherited by a child class, the child class will inherit the
+        # parent's readonly attribute at the time of its creation.
+        # Updating the parent does not propagate down to child classes after wards.
         def attr_readonly(*names)
           self.readonly_attributes = self.readonly_attributes.dup
           names.each do |name|

--- a/lib/mongoid/attributes/readonly.rb
+++ b/lib/mongoid/attributes/readonly.rb
@@ -9,7 +9,7 @@ module Mongoid
       extend ActiveSupport::Concern
 
       included do
-        class_attribute :readonly_attributes, instance_writer: false, instance_reader: false
+        class_attribute :readonly_attributes
         self.readonly_attributes = ::Set.new
         def self.inherited(subclass)
           super

--- a/lib/mongoid/attributes/readonly.rb
+++ b/lib/mongoid/attributes/readonly.rb
@@ -65,7 +65,7 @@ module Mongoid
         # @param [ Symbol... ] *names The names of the fields.
         # @note When a parent class contains readonly attributes and is then
         # inherited by a child class, the child class will inherit the
-        # parent's readonly attribute at the time of its creation.
+        # parent's readonly attributes at the time of its creation.
         # Updating the parent does not propagate down to child classes after wards.
         def attr_readonly(*names)
           self.readonly_attributes = self.readonly_attributes.dup

--- a/spec/mongoid/attributes/readonly_spec.rb
+++ b/spec/mongoid/attributes/readonly_spec.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+lib/mongoid/attributes/readonly.rb# frozen_string_literal: true
 # rubocop:todo all
 
 require "spec_helper"
@@ -279,11 +279,11 @@ describe Mongoid::Attributes::Readonly do
         end
       end
 
-      it "ensures child inherits the readonly attributes from parent" do
+      it "ensures subclass inherits the readonly attributes from parent" do
         expect(OldPerson.readonly_attributes.to_a).to include("title","terms")
       end
 
-      it "ensures child does not modify parent's readonly attributes" do
+      it "ensures subclass does not modify parent's readonly attributes" do
         expect(Person.readonly_attributes.to_a).not_to include("age")
       end
     end

--- a/spec/mongoid/attributes/readonly_spec.rb
+++ b/spec/mongoid/attributes/readonly_spec.rb
@@ -1,4 +1,4 @@
-lib/mongoid/attributes/readonly.rb# frozen_string_literal: true
+# frozen_string_literal: true
 # rubocop:todo all
 
 require "spec_helper"

--- a/spec/mongoid/attributes/readonly_spec.rb
+++ b/spec/mongoid/attributes/readonly_spec.rb
@@ -266,7 +266,26 @@ describe Mongoid::Attributes::Readonly do
           expect(child.mother).to be_nil
         end
       end
+    end
 
+    context "when a subclass inherits readonly fields" do
+      let(:attributes) do
+        [:title, :terms]
+      end
+
+      before do
+        class OldPerson < Person
+          attr_readonly :age
+        end
+      end
+
+      it "ensures child inherits the readonly attributes from parent" do
+        expect(OldPerson.readonly_attributes.to_a).to include("title","terms")
+      end
+
+      it "ensures child does not modify parent's readonly attributes" do
+        expect(Person.readonly_attributes.to_a).not_to include("age")
+      end
     end
   end
 end


### PR DESCRIPTION
MONGOID-5816

When we have two classes A and B that are subclasses from Base, declaring attr_readonly in the context of A or B leaks that declaration into the entire class hierarchy. Currently, all classses share the same readonly attributes at the end of declaration. Fixed so that A and B inherit the read only attributes of Base but including additional readonly attributes in the subclasses is instance specific.