### PR TITLE
MONGOID-5816: attr_readonly leaks into sibling classes (backport for 8.1)

### DIFF
--- a/lib/mongoid/attributes/readonly.rb
+++ b/lib/mongoid/attributes/readonly.rb
@@ -22,7 +22,7 @@ module Mongoid
       # @return [ true | false ] If the document is new, or if the field is not
       #   readonly.
       def attribute_writable?(name)
-        new_record? || (!readonly_attributes.include?(name) && _loaded?(name))
+        new_record? || (!self.class.readonly_attributes.include?(name) && _loaded?(name))
       end
 
       private
@@ -62,9 +62,14 @@ module Mongoid
         #   end
         #
         # @param [ Symbol... ] *names The names of the fields.
+        # @note When a parent class contains readonly attributes and is then
+        # inherited by a child class, the child class will inherit the
+        # parent's readonly attributes at the time of its creation.
+        # Updating the parent does not propagate down to child classes after wards.
         def attr_readonly(*names)
+          self.readonly_attributes = self.readonly_attributes.dup
           names.each do |name|
-            readonly_attributes << database_field_name(name)
+            self.readonly_attributes << database_field_name(name)
           end
         end
       end

--- a/spec/mongoid/attributes/readonly_spec.rb
+++ b/spec/mongoid/attributes/readonly_spec.rb
@@ -265,7 +265,26 @@ describe Mongoid::Attributes::Readonly do
           expect(child.mother).to be_nil
         end
       end
+    end
 
+    context "when a subclass inherits readonly fields" do
+      let(:attributes) do
+        [:title, :terms]
+      end
+
+      before do
+        class OldPerson < Person
+          attr_readonly :age
+        end
+      end
+
+      it "ensures subclass inherits the readonly attributes from parent" do
+        expect(OldPerson.readonly_attributes.to_a).to include("title","terms")
+      end
+
+      it "ensures subclass does not modify parent's readonly attributes" do
+        expect(Person.readonly_attributes.to_a).not_to include("age")
+      end
     end
   end
 end


### PR DESCRIPTION
[MONGOID-5816](https://jira.mongodb.org/browse/MONGOID-5816)

When we have two classes A and B that are subclasses from Base, declaring attr_readonly in the context of A or B leaks that declaration into the entire class hierarchy. Currently, all classses share the same readonly attributes at the end of declaration. Fixed so that A and B inherit the read only attributes of Base but including additional readonly attributes in the subclasses is instance specific.