### PR TITLE
MONGOID-5822: Embedded association validations break when association depends on parent update (backport for 8.1)

### DIFF
--- a/lib/mongoid/validatable/associated.rb
+++ b/lib/mongoid/validatable/associated.rb
@@ -73,7 +73,7 @@ module Mongoid
           # use map.all? instead of just all?, because all? will do short-circuit
           # evaluation and terminate on the first failed validation.
           list.map do |value|
-            if value && !value.flagged_for_destroy? && (!value.persisted? || value.changed?)
+            if value && !value.flagged_for_destroy?
               value.validated? ? true : value.valid?
             else
               true


### PR DESCRIPTION
[MONGOID-5822](https://jira.mongodb.org/browse/MONGOID-5822)

In the case where there is an association with validation dependent on a parent condition, the document is not marked as invalid if the parent update results in an invalid association unless there was also a change in the child.