### PR TITLE
Invalidate bundler cache when cutting a new gem

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,13 +52,14 @@ jobs:
 
     steps:
       - name: "Run the publish action"
-        uses: mongodb-labs/drivers-github-tools/ruby/publish@v2
+        uses: jamis/drivers-github-tools/ruby/publish@bundler-cache-version
         with:
           app_id: ${{ vars.APP_ID }}
           app_private_key: ${{ secrets.APP_PRIVATE_KEY }}
           aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}
           aws_region_name: ${{ vars.AWS_REGION_NAME }}
           aws_secret_id: ${{ secrets.AWS_SECRET_ID }}
+          bundler_cache_version: 1
           dry_run: ${{ inputs.dry_run }}
           gem_name: mongoid
           product_name: Mongoid


### PR DESCRIPTION
Experimental: trying to work around the problem with the wrong securerandom version being activated when pushing a new gem version.

Note: it is not possible to test the branch fully because my personal fork does not have the necessary AWS permissions to assume roles needed for the standard deployment steps. I've done a simple dry run and confirmed that there are no problems with syntax, and that our "release" github action is able to get my own fork of the drivers-github-tools repository, which has the necessary changes to support invalidating the bundler cache.