### PR TITLE
Release action update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
 
     steps:
       - name: "Run the publish action"
-        uses: jamis/drivers-github-tools/ruby/publish@bundler-cache-version
+        uses: mongodb-labs/drivers-github-tools/ruby/publish@v2
         with:
           app_id: ${{ vars.APP_ID }}
           app_private_key: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
While troubleshooting the deploy issues earlier, I pointed the release action to my own fork of the drivers-github-tools. This PR changes it back, so it points to the canonical repo.