### PR TITLE
MONGOID-5836 Don't repeat callbacks for embedded grandchildren.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -152,6 +152,13 @@ jobs:
       uses: actions/checkout@v2
       with:
         submodules: recursive
+
+    # the default python 3.8 doesn't cut it, and causes mongo-orchestration
+    # to fail in mongodb-labs/drivers-evergreen-tools.
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.13'
+
     - id: start-mongodb
       name: start mongodb
       uses: mongodb-labs/drivers-evergreen-tools@master

--- a/lib/mongoid/interceptable.rb
+++ b/lib/mongoid/interceptable.rb
@@ -235,9 +235,6 @@ module Mongoid
         return false if env.halted
         env.value = !env.halted
         callback_list << [next_sequence, env]
-        if (grandchildren = child.send(:cascadable_children, kind))
-          _mongoid_run_child_before_callbacks(kind, children: grandchildren, callback_list: callback_list)
-        end
       end
       callback_list
     end

--- a/lib/mongoid/interceptable.rb
+++ b/lib/mongoid/interceptable.rb
@@ -152,9 +152,13 @@ module Mongoid
     # @api private
     def _mongoid_run_child_callbacks(kind, children: nil, &block)
       if Mongoid::Config.around_callbacks_for_embeds
-        _mongoid_run_child_callbacks_with_around(kind, children: children, &block)
+        _mongoid_run_child_callbacks_with_around(kind,
+                                                 children: children,
+                                                 &block)
       else
-        _mongoid_run_child_callbacks_without_around(kind, children: children, &block)
+        _mongoid_run_child_callbacks_without_around(kind,
+                                                    children: children,
+                                                    &block)
       end
     end
 

--- a/spec/mongoid/interceptable_spec.rb
+++ b/spec/mongoid/interceptable_spec.rb
@@ -391,21 +391,80 @@ describe Mongoid::Interceptable do
     end
 
     context 'with embedded grandchildren' do
-      DCFCG = DuplicateCallbacksForCascadableGrandchildren
+      IS = InterceptableSpec
 
-      let(:parent) do
-        parent = DCFCG::Parent.new
-        child = DCFCG::Child.new
-        grandchild = DCFCG::Child.new
+      context 'when creating' do
+        let(:registry) { IS::CallbackRegistry.new(only: %i[ before_save ]) }
 
-        child.children = [ grandchild ]
-        parent.children = [ child ]
+        let(:expected_calls) do
+          [
+            # the parent
+            [ IS::CbParent, :before_save ],
 
-        parent.tap(&:save)
+            # the immediate child of the parent
+            [ IS::CbCascadedNode, :before_save ],
+
+            # the grandchild of the parent
+            [ IS::CbCascadedNode, :before_save ],
+          ]
+        end
+
+        let!(:parent) do
+          parent = IS::CbParent.new(registry)
+          child = IS::CbCascadedNode.new(registry)
+          grandchild = IS::CbCascadedNode.new(registry)
+
+          child.cb_cascaded_nodes = [ grandchild ]
+          parent.cb_cascaded_nodes = [ child ]
+
+          parent.tap(&:save)
+        end
+
+        it 'should cascade callbacks to grandchildren' do
+          expect(registry.calls).to be == expected_calls
+        end
       end
 
-      it 'should not repeat any before callbacks' do
-        expect { parent }.not_to raise_exception(DCFCG::DuplicateCallbackDetected)
+      context 'when updating' do
+        let(:registry) { IS::CallbackRegistry.new(only: %i[ before_update ]) }
+
+        let(:expected_calls) do
+          [
+            # the parent
+            [ IS::CbParent, :before_update ],
+
+            # the immediate child of the parent
+            [ IS::CbCascadedNode, :before_update ],
+
+            # the grandchild of the parent
+            [ IS::CbCascadedNode, :before_update ],
+          ]
+        end
+
+        let!(:parent) do
+          parent = IS::CbParent.new(nil)
+          child = IS::CbCascadedNode.new(nil)
+          grandchild = IS::CbCascadedNode.new(nil)
+
+          child.cb_cascaded_nodes = [ grandchild ]
+          parent.cb_cascaded_nodes = [ child ]
+
+          parent.save
+
+          parent.callback_registry = registry
+          child.callback_registry = registry
+          grandchild.callback_registry = registry
+
+          parent.name = 'updated'
+          child.name = 'updated'
+          grandchild.name = 'updated'
+
+          parent.tap(&:save)
+        end
+
+        it 'should cascade callbacks to grandchildren' do
+          expect(registry.calls).to be == expected_calls
+        end
       end
     end
   end

--- a/spec/mongoid/interceptable_spec.rb
+++ b/spec/mongoid/interceptable_spec.rb
@@ -389,6 +389,25 @@ describe Mongoid::Interceptable do
         end
       end
     end
+
+    context 'with embedded grandchildren' do
+      DCFCG = DuplicateCallbacksForCascadableGrandchildren
+
+      let(:parent) do
+        parent = DCFCG::Parent.new
+        child = DCFCG::Child.new
+        grandchild = DCFCG::Child.new
+
+        child.children = [ grandchild ]
+        parent.children = [ child ]
+
+        parent.tap(&:save)
+      end
+
+      it 'should not repeat any before callbacks' do
+        expect { parent }.not_to raise_exception(DCFCG::DuplicateCallbackDetected)
+      end
+    end
   end
 
   describe ".before_destroy" do

--- a/spec/mongoid/interceptable_spec_models.rb
+++ b/spec/mongoid/interceptable_spec_models.rb
@@ -318,3 +318,30 @@ class InterceptableUser
   end
 end
 
+module DuplicateCallbacksForCascadableGrandchildren
+  class DuplicateCallbackDetected < RuntimeError
+  end
+
+  class Parent
+    include Mongoid::Document
+
+    embeds_many :children, cascade_callbacks: true, as: :parent
+  end
+
+  class Child
+    include Mongoid::Document
+
+    embedded_in :parent, polymorphic: true
+    embeds_many :children, cascade_callbacks: true, as: :parent
+
+    before_save :check_for_duplicate_callback
+
+    private
+
+    def check_for_duplicate_callback
+      raise DuplicateCallbackDetected if @callback_invoked
+      @callback_invoked = true
+    end
+  end
+end
+

--- a/spec/mongoid/interceptable_spec_models.rb
+++ b/spec/mongoid/interceptable_spec_models.rb
@@ -1,11 +1,13 @@
 # rubocop:todo all
 module InterceptableSpec
   class CallbackRegistry
-    def initialize
+    def initialize(only: [])
       @calls = []
+      @only = only
     end
 
     def record_call(cls, cb)
+      return unless @only.empty? || @only.any? { |pat| pat == cb }
       @calls << [cls, cb]
     end
 
@@ -16,6 +18,8 @@ module InterceptableSpec
     extend ActiveSupport::Concern
 
     included do
+      field :name, type: String
+
       %i(
         validation save create update
       ).each do |what|
@@ -35,198 +39,109 @@ module InterceptableSpec
         end
       end
     end
+
+    attr_accessor :callback_registry
+
+    def initialize(callback_registry, *args, **kwargs)
+      @callback_registry = callback_registry
+      super(*args, **kwargs)
+    end
+  end
+
+  module RootInsertable
+    def insert_as_root
+      @callback_registry&.record_call(self.class, :insert_into_database)
+      super
+    end
   end
 
   class CbHasOneParent
     include Mongoid::Document
+    include CallbackTracking
+    include RootInsertable
 
     has_one :child, autosave: true, class_name: "CbHasOneChild", inverse_of: :parent
-
-    def initialize(callback_registry)
-      @callback_registry = callback_registry
-      super()
-    end
-
-    attr_accessor :callback_registry
-
-    def insert_as_root
-      @callback_registry&.record_call(self.class, :insert_into_database)
-      super
-    end
-
-    include CallbackTracking
   end
 
   class CbHasOneChild
     include Mongoid::Document
+    include CallbackTracking
 
     belongs_to :parent, class_name: "CbHasOneParent", inverse_of: :child
-
-    def initialize(callback_registry)
-      @callback_registry = callback_registry
-      super()
-    end
-
-    attr_accessor :callback_registry
-
-    include CallbackTracking
   end
 
   class CbHasManyParent
     include Mongoid::Document
+    include CallbackTracking
+    include RootInsertable
 
     has_many :children, autosave: true, class_name: "CbHasManyChild", inverse_of: :parent
-
-    def initialize(callback_registry)
-      @callback_registry = callback_registry
-      super()
-    end
-
-    attr_accessor :callback_registry
-
-    def insert_as_root
-      @callback_registry&.record_call(self.class, :insert_into_database)
-      super
-    end
-
-    include CallbackTracking
   end
 
   class CbHasManyChild
     include Mongoid::Document
+    include CallbackTracking
 
     belongs_to :parent, class_name: "CbHasManyParent", inverse_of: :children
-
-    def initialize(callback_registry)
-      @callback_registry = callback_registry
-      super()
-    end
-
-    attr_accessor :callback_registry
-
-    include CallbackTracking
   end
 
   class CbEmbedsOneParent
     include Mongoid::Document
+    include CallbackTracking
+    include RootInsertable
 
     field :name
 
     embeds_one :child, cascade_callbacks: true, class_name: "CbEmbedsOneChild", inverse_of: :parent
-
-    def initialize(callback_registry)
-      @callback_registry = callback_registry
-      super()
-    end
-
-    attr_accessor :callback_registry
-
-    def insert_as_root
-      @callback_registry&.record_call(self.class, :insert_into_database)
-      super
-    end
-
-    include CallbackTracking
   end
 
   class CbEmbedsOneChild
     include Mongoid::Document
+    include CallbackTracking
 
     field :age
 
     embedded_in :parent, class_name: "CbEmbedsOneParent", inverse_of: :child
-
-    def initialize(callback_registry)
-      @callback_registry = callback_registry
-      super()
-    end
-
-    attr_accessor :callback_registry
-
-    include CallbackTracking
   end
 
   class CbEmbedsManyParent
     include Mongoid::Document
+    include CallbackTracking
+    include RootInsertable
 
     embeds_many :children, cascade_callbacks: true, class_name: "CbEmbedsManyChild", inverse_of: :parent
-
-    def initialize(callback_registry)
-      @callback_registry = callback_registry
-      super()
-    end
-
-    attr_accessor :callback_registry
-
-    def insert_as_root
-      @callback_registry&.record_call(self.class, :insert_into_database)
-      super
-    end
-
-    include CallbackTracking
   end
 
   class CbEmbedsManyChild
     include Mongoid::Document
+    include CallbackTracking
 
     embedded_in :parent, class_name: "CbEmbedsManyParent", inverse_of: :children
-
-    def initialize(callback_registry)
-      @callback_registry = callback_registry
-      super()
-    end
-
-    attr_accessor :callback_registry
-
-    include CallbackTracking
   end
 
   class CbParent
     include Mongoid::Document
-
-    def initialize(callback_registry)
-      @callback_registry = callback_registry
-      super()
-    end
-
-    attr_accessor :callback_registry
+    include CallbackTracking
 
     embeds_many :cb_children
     embeds_many :cb_cascaded_children, cascade_callbacks: true
-
-    include CallbackTracking
+    embeds_many :cb_cascaded_nodes, cascade_callbacks: true, as: :parent
   end
 
   class CbChild
     include Mongoid::Document
+    include CallbackTracking
 
     embedded_in :cb_parent
-
-    def initialize(callback_registry, options)
-      @callback_registry = callback_registry
-      super(options)
-    end
-
-    attr_accessor :callback_registry
-
-    include CallbackTracking
   end
 
   class CbCascadedChild
     include Mongoid::Document
+    include CallbackTracking
 
     embedded_in :cb_parent
 
-    def initialize(callback_registry, options)
-      @callback_registry = callback_registry
-      super(options)
-    end
-
-    attr_accessor :callback_registry
-
     before_save :test_mongoid_state
-
-    include CallbackTracking
 
     private
 
@@ -237,6 +152,15 @@ module InterceptableSpec
     def test_mongoid_state
       Mongoid::Threaded.stack('interceptable').push(self)
     end
+  end
+
+  class CbCascadedNode
+    include Mongoid::Document
+    include CallbackTracking
+
+    embedded_in :parent, polymorphic: true
+
+    embeds_many :cb_cascaded_nodes, cascade_callbacks: true, as: :parent
   end
 end
 
@@ -315,33 +239,6 @@ class InterceptableUser
 
   def break_mongoid
     company.shop_ids
-  end
-end
-
-module DuplicateCallbacksForCascadableGrandchildren
-  class DuplicateCallbackDetected < RuntimeError
-  end
-
-  class Parent
-    include Mongoid::Document
-
-    embeds_many :children, cascade_callbacks: true, as: :parent
-  end
-
-  class Child
-    include Mongoid::Document
-
-    embedded_in :parent, polymorphic: true
-    embeds_many :children, cascade_callbacks: true, as: :parent
-
-    before_save :check_for_duplicate_callback
-
-    private
-
-    def check_for_duplicate_callback
-      raise DuplicateCallbackDetected if @callback_invoked
-      @callback_invoked = true
-    end
   end
 end
 


### PR DESCRIPTION
When running the `before` callbacks on embedded children, the grandchildren were being explicitly processed (when callbacks were cascading). However, the input is already the full list of all children and grandchildren. Processing the grandchildren again results in duplicate callbacks being invoked.