### PR TITLE
MONGOID-5836 Don't repeat callbacks for embedded grandchildren. (backport to 8.0-stable)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -293,6 +293,13 @@ jobs:
       uses: actions/checkout@v2
       with:
         submodules: recursive
+
+    # the default python 3.8 doesn't cut it, and causes mongo-orchestration
+    # to fail in mongodb-labs/drivers-evergreen-tools.
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.13'
+
     - id: start-mongodb
       name: start mongodb
       uses: mongodb-labs/drivers-evergreen-tools@master

--- a/lib/mongoid/config.rb
+++ b/lib/mongoid/config.rb
@@ -142,6 +142,16 @@ module Mongoid
       end
     end
 
+    # When this flag is true, callbacks for every embedded document will be
+    # called only once, even if the embedded document is embedded in multiple
+    # documents in the root document's dependencies graph.
+    # This will be the default in 9.0. Setting this flag to false restores the
+    # pre-9.0 behavior, where callbacks are called for every occurrence of an
+    # embedded document. The pre-9.0 behavior leads to a problem that for multi
+    # level nested documents callbacks are called multiple times.
+    # See https://jira.mongodb.org/browse/MONGOID-5542
+    option :prevent_multiple_calls_of_embedded_callbacks, default: false
+
     # When this flag is true, callbacks for embedded documents will not be
     # called. This is the default in 8.x, but will be changed to false in 9.0.
     #

--- a/lib/mongoid/interceptable.rb
+++ b/lib/mongoid/interceptable.rb
@@ -141,9 +141,13 @@ module Mongoid
     # @api private
     def _mongoid_run_child_callbacks(kind, children: nil, &block)
       if Mongoid::Config.around_callbacks_for_embeds
-        _mongoid_run_child_callbacks_with_around(kind, children: children, &block)
+        _mongoid_run_child_callbacks_with_around(kind,
+                                                 children: children,
+                                                 &block)
       else
-        _mongoid_run_child_callbacks_without_around(kind, children: children, &block)
+        _mongoid_run_child_callbacks_without_around(kind,
+                                                    children: children,
+                                                    &block)
       end
     end
 
@@ -218,9 +222,6 @@ module Mongoid
         return false if env.halted
         env.value = !env.halted
         callback_list << [next_sequence, env]
-        if (grandchildren = child.send(:cascadable_children, kind))
-          _mongoid_run_child_before_callbacks(kind, children: grandchildren, callback_list: callback_list)
-        end
       end
       callback_list
     end

--- a/lib/mongoid/interceptable.rb
+++ b/lib/mongoid/interceptable.rb
@@ -170,9 +170,9 @@ module Mongoid
       if child.nil?
         block&.call
       elsif tail.empty?
-        child.run_callbacks(child_callback_type(kind, child), &block)
+        child.run_callbacks(child_callback_type(kind, child), with_children: false, &block)
       else
-        child.run_callbacks(child_callback_type(kind, child)) do
+        child.run_callbacks(child_callback_type(kind, child), with_children: false) do
           _mongoid_run_child_callbacks_with_around(kind, children: tail, &block)
         end
       end

--- a/lib/mongoid/interceptable.rb
+++ b/lib/mongoid/interceptable.rb
@@ -167,13 +167,14 @@ module Mongoid
     #  @api private
     def _mongoid_run_child_callbacks_with_around(kind, children: nil, &block)
       child, *tail = (children || cascadable_children(kind))
+      with_children = !Mongoid::Config.prevent_multiple_calls_of_embedded_callbacks
       if child.nil?
         block&.call
       elsif tail.empty?
-        child.run_callbacks(child_callback_type(kind, child), with_children: false, &block)
+        child.run_callbacks(child_callback_type(kind, child), with_children: with_children, &block)
       else
-        child.run_callbacks(child_callback_type(kind, child), with_children: false) do
-          _mongoid_run_child_callbacks_with_around(kind, children: tail, &block)
+        child.run_callbacks(child_callback_type(kind, child), with_children: with_children) do
+          _mongoid_run_child_callbacks(kind, children: tail, &block)
         end
       end
     end

--- a/spec/integration/callbacks_models.rb
+++ b/spec/integration/callbacks_models.rb
@@ -153,3 +153,40 @@ class Building
 
   has_and_belongs_to_many :architects, dependent: :nullify
 end
+
+class Root
+  include Mongoid::Document
+  embeds_many :embedded_once, cascade_callbacks: true
+  after_save :trace
+
+  attr_accessor :logger
+
+  def trace
+    logger << :root
+  end
+end
+
+class EmbeddedOnce
+  include Mongoid::Document
+  embeds_many :embedded_twice, cascade_callbacks: true
+  embedded_in :root
+  after_save :trace
+
+  attr_accessor :logger
+
+  def trace
+    logger << :embedded_once
+  end
+end
+
+class EmbeddedTwice
+  include Mongoid::Document
+  embedded_in :embedded_once
+  after_save :trace
+
+  attr_accessor :logger
+
+  def trace
+    logger << :embedded_twice
+  end
+end

--- a/spec/integration/callbacks_spec.rb
+++ b/spec/integration/callbacks_spec.rb
@@ -467,4 +467,31 @@ describe 'callbacks integration tests' do
       expect { book.save! }.not_to raise_error(SystemStackError)
     end
   end
+
+  context 'nested embedded documents' do
+    config_override :prevent_multiple_calls_of_embedded_callbacks, true
+
+    let(:logger) { Array.new }
+
+    let(:root) do
+      Root.new(
+        embedded_once: [
+          EmbeddedOnce.new(
+            embedded_twice: [EmbeddedTwice.new]
+          )
+        ]
+      )
+    end
+
+    before(:each) do
+      root.logger = logger
+      root.embedded_once.first.logger = logger
+      root.embedded_once.first.embedded_twice.first.logger = logger
+    end
+
+    it 'runs callbacks in the correct order' do
+      root.save!
+      expect(logger).to eq(%i[embedded_twice embedded_once root])
+    end
+  end
 end

--- a/spec/mongoid/interceptable_spec.rb
+++ b/spec/mongoid/interceptable_spec.rb
@@ -392,6 +392,8 @@ describe Mongoid::Interceptable do
     context 'with embedded grandchildren' do
       IS = InterceptableSpec
 
+      config_override :prevent_multiple_calls_of_embedded_callbacks, true
+
       context 'when creating' do
         let(:registry) { IS::CallbackRegistry.new(only: %i[ before_save ]) }
 
@@ -655,6 +657,26 @@ describe Mongoid::Interceptable do
         before do
           band.notes.push(note)
           record.notes.push(note)
+        end
+
+        context "when saving the root" do
+          context 'with prevent_multiple_calls_of_embedded_callbacks enabled' do
+            config_override :prevent_multiple_calls_of_embedded_callbacks, true
+
+            it "executes the callbacks only once for each document" do
+              expect(note).to receive(:update_saved).once
+              band.save!
+            end
+          end
+
+          context 'with prevent_multiple_calls_of_embedded_callbacks disabled' do
+            config_override :prevent_multiple_calls_of_embedded_callbacks, false
+
+            it "executes the callbacks once for each ember" do
+              expect(note).to receive(:update_saved).twice
+              band.save!
+            end
+          end
         end
       end
     end

--- a/spec/mongoid/interceptable_spec.rb
+++ b/spec/mongoid/interceptable_spec.rb
@@ -388,6 +388,84 @@ describe Mongoid::Interceptable do
         end
       end
     end
+
+    context 'with embedded grandchildren' do
+      IS = InterceptableSpec
+
+      context 'when creating' do
+        let(:registry) { IS::CallbackRegistry.new(only: %i[ before_save ]) }
+
+        let(:expected_calls) do
+          [
+            # the parent
+            [ IS::CbParent, :before_save ],
+
+            # the immediate child of the parent
+            [ IS::CbCascadedNode, :before_save ],
+
+            # the grandchild of the parent
+            [ IS::CbCascadedNode, :before_save ],
+          ]
+        end
+
+        let!(:parent) do
+          parent = IS::CbParent.new(registry)
+          child = IS::CbCascadedNode.new(registry)
+          grandchild = IS::CbCascadedNode.new(registry)
+
+          child.cb_cascaded_nodes = [ grandchild ]
+          parent.cb_cascaded_nodes = [ child ]
+
+          parent.tap(&:save)
+        end
+
+        it 'should cascade callbacks to grandchildren' do
+          expect(registry.calls).to be == expected_calls
+        end
+      end
+
+      context 'when updating' do
+        let(:registry) { IS::CallbackRegistry.new(only: %i[ before_update ]) }
+
+        let(:expected_calls) do
+          [
+            # the parent
+            [ IS::CbParent, :before_update ],
+
+            # the immediate child of the parent
+            [ IS::CbCascadedNode, :before_update ],
+
+            # the grandchild of the parent
+            [ IS::CbCascadedNode, :before_update ],
+          ]
+        end
+
+        let!(:parent) do
+          parent = IS::CbParent.new(nil)
+          child = IS::CbCascadedNode.new(nil)
+          grandchild = IS::CbCascadedNode.new(nil)
+
+          child.cb_cascaded_nodes = [ grandchild ]
+          parent.cb_cascaded_nodes = [ child ]
+
+          parent.save
+
+          parent.callback_registry = registry
+          child.callback_registry = registry
+          grandchild.callback_registry = registry
+
+          parent.name = 'updated'
+          child.name = 'updated'
+          grandchild.name = 'updated'
+
+          parent.tap(&:save)
+        end
+
+        it 'should cascade callbacks to grandchildren' do
+          expect(registry.calls).to be == expected_calls
+        end
+      end
+    end
   end
 
   describe ".before_destroy" do

--- a/spec/mongoid/interceptable_spec_models.rb
+++ b/spec/mongoid/interceptable_spec_models.rb
@@ -10,6 +10,10 @@ module InterceptableSpec
       @calls << [cls, cb]
     end
 
+    def reset!
+      @calls.clear
+    end
+
     attr_reader :calls
   end
 

--- a/spec/mongoid/interceptable_spec_models.rb
+++ b/spec/mongoid/interceptable_spec_models.rb
@@ -1,10 +1,12 @@
 module InterceptableSpec
   class CallbackRegistry
-    def initialize
+    def initialize(only: [])
       @calls = []
+      @only = only
     end
 
     def record_call(cls, cb)
+      return unless @only.empty? || @only.any? { |pat| pat == cb }
       @calls << [cls, cb]
     end
 
@@ -15,6 +17,8 @@ module InterceptableSpec
     extend ActiveSupport::Concern
 
     included do
+      field :name, type: String
+
       %i(
         validation save create update
       ).each do |what|
@@ -34,196 +38,128 @@ module InterceptableSpec
         end
       end
     end
+
+    attr_accessor :callback_registry
+
+    def initialize(callback_registry, *args, **kwargs)
+      @callback_registry = callback_registry
+      super(*args, **kwargs)
+    end
+  end
+
+  module RootInsertable
+    def insert_as_root
+      @callback_registry&.record_call(self.class, :insert_into_database)
+      super
+    end
   end
 
   class CbHasOneParent
     include Mongoid::Document
+    include CallbackTracking
+    include RootInsertable
 
     has_one :child, autosave: true, class_name: "CbHasOneChild", inverse_of: :parent
-
-    def initialize(callback_registry)
-      @callback_registry = callback_registry
-      super()
-    end
-
-    attr_accessor :callback_registry
-
-    def insert_as_root
-      @callback_registry&.record_call(self.class, :insert_into_database)
-      super
-    end
-
-    include CallbackTracking
   end
 
   class CbHasOneChild
     include Mongoid::Document
+    include CallbackTracking
 
     belongs_to :parent, class_name: "CbHasOneParent", inverse_of: :child
-
-    def initialize(callback_registry)
-      @callback_registry = callback_registry
-      super()
-    end
-
-    attr_accessor :callback_registry
-
-    include CallbackTracking
   end
 
   class CbHasManyParent
     include Mongoid::Document
+    include CallbackTracking
+    include RootInsertable
 
     has_many :children, autosave: true, class_name: "CbHasManyChild", inverse_of: :parent
-
-    def initialize(callback_registry)
-      @callback_registry = callback_registry
-      super()
-    end
-
-    attr_accessor :callback_registry
-
-    def insert_as_root
-      @callback_registry&.record_call(self.class, :insert_into_database)
-      super
-    end
-
-    include CallbackTracking
   end
 
   class CbHasManyChild
     include Mongoid::Document
+    include CallbackTracking
 
     belongs_to :parent, class_name: "CbHasManyParent", inverse_of: :children
-
-    def initialize(callback_registry)
-      @callback_registry = callback_registry
-      super()
-    end
-
-    attr_accessor :callback_registry
-
-    include CallbackTracking
   end
 
   class CbEmbedsOneParent
     include Mongoid::Document
+    include CallbackTracking
+    include RootInsertable
 
     field :name
 
     embeds_one :child, cascade_callbacks: true, class_name: "CbEmbedsOneChild", inverse_of: :parent
-
-    def initialize(callback_registry)
-      @callback_registry = callback_registry
-      super()
-    end
-
-    attr_accessor :callback_registry
-
-    def insert_as_root
-      @callback_registry&.record_call(self.class, :insert_into_database)
-      super
-    end
-
-    include CallbackTracking
   end
 
   class CbEmbedsOneChild
     include Mongoid::Document
+    include CallbackTracking
 
     field :age
 
     embedded_in :parent, class_name: "CbEmbedsOneParent", inverse_of: :child
-
-    def initialize(callback_registry)
-      @callback_registry = callback_registry
-      super()
-    end
-
-    attr_accessor :callback_registry
-
-    include CallbackTracking
   end
 
   class CbEmbedsManyParent
     include Mongoid::Document
+    include CallbackTracking
+    include RootInsertable
 
     embeds_many :children, cascade_callbacks: true, class_name: "CbEmbedsManyChild", inverse_of: :parent
-
-    def initialize(callback_registry)
-      @callback_registry = callback_registry
-      super()
-    end
-
-    attr_accessor :callback_registry
-
-    def insert_as_root
-      @callback_registry&.record_call(self.class, :insert_into_database)
-      super
-    end
-
-    include CallbackTracking
   end
 
   class CbEmbedsManyChild
     include Mongoid::Document
+    include CallbackTracking
 
     embedded_in :parent, class_name: "CbEmbedsManyParent", inverse_of: :children
-
-    def initialize(callback_registry)
-      @callback_registry = callback_registry
-      super()
-    end
-
-    attr_accessor :callback_registry
-
-    include CallbackTracking
   end
 
   class CbParent
     include Mongoid::Document
-
-    def initialize(callback_registry)
-      @callback_registry = callback_registry
-      super()
-    end
-
-    attr_accessor :callback_registry
+    include CallbackTracking
 
     embeds_many :cb_children
     embeds_many :cb_cascaded_children, cascade_callbacks: true
-
-    include CallbackTracking
+    embeds_many :cb_cascaded_nodes, cascade_callbacks: true, as: :parent
   end
 
   class CbChild
     include Mongoid::Document
+    include CallbackTracking
 
     embedded_in :cb_parent
-
-    def initialize(callback_registry, options)
-      @callback_registry = callback_registry
-      super(options)
-    end
-
-    attr_accessor :callback_registry
-
-    include CallbackTracking
   end
 
   class CbCascadedChild
     include Mongoid::Document
+    include CallbackTracking
 
     embedded_in :cb_parent
 
-    def initialize(callback_registry, options)
-      @callback_registry = callback_registry
-      super(options)
+    before_save :test_mongoid_state
+
+    private
+
+    # Helps test that cascading child callbacks have access to the Mongoid
+    # state objects; if the implementation uses fiber-local (instead of truly
+    # thread-local) variables, the related tests will fail because the
+    # cascading child callbacks use fibers to linearize the recursion.
+    def test_mongoid_state
+      Mongoid::Threaded.stack('interceptable').push(self)
     end
+  end
 
-    attr_accessor :callback_registry
-
+  class CbCascadedNode
+    include Mongoid::Document
     include CallbackTracking
+
+    embedded_in :parent, polymorphic: true
+
+    embeds_many :cb_cascaded_nodes, cascade_callbacks: true, as: :parent
   end
 end
 


### PR DESCRIPTION
(Backport to 8.0-stable)

* MONGOID-5836 don't explicitly process grandchildren

Grandchildren are already accounted for when this is invoked, because if called when callbacks are cascading, the input is the full list of all children and grandchildren. Processing grandchildren recursively here causes them to be processed twice.

* specify python version to address failing mongo-orchestration

* make sure we don't break update callbacks

This also backports the `:prevent_multiple_calls_of_embedded_callbacks` feature flag, from MONGOID-5542, so that we can safely prevent duplicate callbacks in a backwards-compatible way.