### PR TITLE
Fix typos

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -39,7 +39,7 @@ functions:
           git submodule update --init --recursive
 
   "create expansions":
-    # Make an evergreen exapanstion file with dynamic values
+    # Make an evergreen expansion file with dynamic values
     - command: shell.exec
       params:
         working_dir: "src"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,7 +105,7 @@ For instructions on upgrading to newer versions, visit
 
 * \#4005 Fixed inclusion of mongoid with Rails components that don't have the Rails environment.
 
-* \#3993 Fixes issue where `dup`/`clone` fails for embedded documents that use store_as without using Mongoid::Atributes::Dynamic
+* \#3993 Fixes issue where `dup`/`clone` fails for embedded documents that use store_as without using Mongoid::Attributes::Dynamic
 
 * \#3991 Fixed embedded documents not flagging as changed after calling #changed? and modifying the
 child elements.
@@ -798,7 +798,7 @@ child elements.
         Band.where(name: "Placebo").unset(:members, :origin)
 
 * \#2669 Passing a block to `Criteria#new` now properly sends the
-  block through to the model's contructor. (Arthur Neves)
+  block through to the model's constructor. (Arthur Neves)
 
 * \#2667 `exists?` no longer hits the database in cases where we have
   the necessary information in memory.
@@ -1200,7 +1200,7 @@ child elements.
 
 * \#2571 Remove blank error message from locales. (Jordan Elver)
 
-* \#2568 Fix uniqueness validation for lacalized fields when a scope is also
+* \#2568 Fix uniqueness validation for localized fields when a scope is also
   provided.
 
 * \#2552 Ensure `InvalidPath` errors are raised when embedded documents try to
@@ -1609,7 +1609,7 @@ child elements.
 
         Band.first.touch
 
-    Update a specific time field along with the udpated_at.
+    Update a specific time field along with the updated_at.
 
         Band.first.touch(:founded)
 
@@ -1728,7 +1728,7 @@ child elements.
         # { "name" => "foo", "my_preferences" => [{ "value" => "ok" }]}
 
 * \#1806 `Model.find_or_create_by` and `Model.find_or_initialize_by` can now
-  take documents as paramters for belongs_to relations.
+  take documents as parameters for belongs_to relations.
 
         person = Person.first
         Game.find_or_create_by(person: person)
@@ -2506,7 +2506,7 @@ child elements.
 * \#2038 Allow inverse relations to be determined by foreign keys alone
   if defined on both sides, not just an inverse_of declaration.
 
-* \#2023 Allow serilialization of dynamic types that conflict with core
+* \#2023 Allow serialization of dynamic types that conflict with core
   Ruby methods to still be serialized.
 
 * \#2008 Presence validation should hit the db to check validity if the
@@ -2611,7 +2611,7 @@ child elements.
   had the foreign key link persisted.
 
 * \#1820 Destroying embedded documents in an embeds_many should also
-  removed the document from the underlying _uncoped target and reindex
+  removed the document from the underlying _unscoped target and reindex
   the relation.
 
 * \#1814 Don't cascade callbacks on after_initialize.
@@ -3059,7 +3059,7 @@ child elements.
   key without error.
 
 * \#1350, \#1351 Fixed errors in the string conversions of double quotes and
-  tilde when paramterizing keys.
+  tilde when parametrizing keys.
 
 * \#1349 Mongoid documents should not blow up when including Enumerable.
   (Jonas Nicklas)

--- a/lib/mongoid/association/embedded/embeds_many/proxy.rb
+++ b/lib/mongoid/association/embedded/embeds_many/proxy.rb
@@ -484,7 +484,7 @@ module Mongoid
           #
           # @return [ Criteria | Object ] A Criteria or return value from the target.
           #
-          # TODO: make sure we are consistingly using respond_to_missing
+          # TODO: make sure we are consistently using respond_to_missing
           #   anywhere we define method_missing.
           # rubocop:disable Style/MissingRespondToMissing
           ruby2_keywords def method_missing(name, *args, &block)

--- a/lib/mongoid/association/referenced/has_many/enumerable.rb
+++ b/lib/mongoid/association/referenced/has_many/enumerable.rb
@@ -253,7 +253,7 @@ module Mongoid
           # Initialize the new enumerable either with a criteria or an array.
           #
           # @example Initialize the enumerable with a criteria.
-          #   Enumberable.new(Post.where(:person_id => id))
+          #   Enumerable.new(Post.where(:person_id => id))
           #
           # @example Initialize the enumerable with an array.
           #   Enumerable.new([ post ])

--- a/lib/mongoid/association/referenced/has_many/proxy.rb
+++ b/lib/mongoid/association/referenced/has_many/proxy.rb
@@ -160,7 +160,7 @@ module Mongoid
           # @example Delete all documents in the association.
           #   person.posts.delete_all
           #
-          # @example Conditonally delete all documents in the association.
+          # @example Conditionally delete all documents in the association.
           #   person.posts.delete_all({ :title => "Testing" })
           #
           # @param [ Hash ] conditions Optional conditions to delete with.
@@ -462,7 +462,7 @@ module Mongoid
           #
           # @return [ Criteria | Object ] A Criteria or return value from the target.
           #
-          # TODO: make sure we are consistingly using respond_to_missing
+          # TODO: make sure we are consistently using respond_to_missing
           #   anywhere we define method_missing.
           # rubocop:disable Style/MissingRespondToMissing
           ruby2_keywords def method_missing(name, *args, &block)
@@ -512,7 +512,7 @@ module Mongoid
           # @example Delete all documents in the association.
           #   person.posts.delete_all
           #
-          # @example Conditonally delete all documents in the association.
+          # @example Conditionally delete all documents in the association.
           #   person.posts.delete_all({ :title => "Testing" })
           #
           # @param [ Hash ] conditions Optional conditions to delete with.

--- a/lib/mongoid/atomic/modifiers.rb
+++ b/lib/mongoid/atomic/modifiers.rb
@@ -119,7 +119,7 @@ module Mongoid
       end
 
       # Adds or appends an array operation with the $each specifier used
-      # in conjuction with $push.
+      # in conjunction with $push.
       #
       # @example Add the operation.
       #   modifications.add_operation(mods, field, value)

--- a/lib/mongoid/attributes.rb
+++ b/lib/mongoid/attributes.rb
@@ -137,7 +137,7 @@ module Mongoid
     # @param [ String | Symbol ] name The name of the attribute to remove.
     #
     # @raise [ Errors::ReadonlyAttribute ] If the field cannot be removed due
-    #   to being flagged as reaodnly.
+    #   to being flagged as readonly.
     def remove_attribute(name)
       validate_writable_field_name!(name.to_s)
       as_writable_attribute!(name) do |access|

--- a/lib/mongoid/config.rb
+++ b/lib/mongoid/config.rb
@@ -166,7 +166,7 @@ module Mongoid
     #
     # Setting this flag to true restores the pre-9.0 behavior, where callbacks
     # for embedded documents are called. This may lead to stack overflow errors
-    # if there are more than cicrca 1000 embedded documents in the root
+    # if there are more than circa 1000 embedded documents in the root
     # document's dependencies graph.
     # See https://jira.mongodb.org/browse/MONGOID-5658 for more details.
     option :around_callbacks_for_embeds, default: false

--- a/lib/mongoid/contextual/aggregable/memory.rb
+++ b/lib/mongoid/contextual/aggregable/memory.rb
@@ -90,7 +90,7 @@ module Mongoid
         # @example Get the sum for the provided block.
         #   aggregable.sum(&:likes)
         #
-        # @param [ Symbol | Numeric ] field The field to sum, or the intial
+        # @param [ Symbol | Numeric ] field The field to sum, or the initial
         #   value of the sum when a block is given.
         #
         # @return [ Numeric ] The sum value.

--- a/lib/mongoid/contextual/mongo.rb
+++ b/lib/mongoid/contextual/mongo.rb
@@ -85,7 +85,7 @@ module Mongoid
       # Get the estimated number of documents matching the query.
       #
       # Unlike count, estimated_count does not take a block because it is not
-      # traditionally defined (with a block) on Enumarable like count is.
+      # traditionally defined (with a block) on Enumerable like count is.
       #
       # @example Get the estimated number of matching documents.
       #   context.estimated_count
@@ -1018,7 +1018,7 @@ module Mongoid
             next
           end
 
-          # does the key represent an emebedded relation on the document?
+          # does the key represent an embedded relation on the document?
           aliased_name = klass.aliased_associations[key] || key
           if (assoc = klass.relations[aliased_name])
             case value

--- a/lib/mongoid/criteria.rb
+++ b/lib/mongoid/criteria.rb
@@ -88,7 +88,7 @@ module Mongoid
     # and finds one or many documents for the provided _id values.
     #
     # If this method is given a block, it delegates to +Enumerable#find+ and
-    # returns the first document of those found by the current Crieria object
+    # returns the first document of those found by the current Criteria object
     # for which the block returns a truthy value.
     #
     # Note that the "default proc" argument of Enumerable is not specially
@@ -99,7 +99,7 @@ module Mongoid
     #   a nested array. Each array will be flattened.
     #
     # @example Finds a document by its _id, invokes Findable#find.
-    #   critera.find("1234")
+    #   criteria.find("1234")
     #
     # @example Finds the first matching document using a block, invokes Enumerable#find.
     #   criteria.find { |item| item.name == "Depeche Mode" }
@@ -364,7 +364,7 @@ module Mongoid
       !!@none
     end
 
-    # Overriden to include _type in the fields.
+    # Overridden to include _type in the fields.
     #
     # @example Limit the fields returned from the database.
     #   Band.only(:name)
@@ -398,7 +398,7 @@ module Mongoid
       end
     end
 
-    # Overriden to exclude _id from the fields.
+    # Overridden to exclude _id from the fields.
     #
     # @example Exclude fields returned from the database.
     #   Band.without(:name)
@@ -414,7 +414,7 @@ module Mongoid
     # Returns true if criteria responds to the given method.
     #
     # @example Does the criteria respond to the method?
-    #   crtiteria.respond_to?(:each)
+    #   criteria.respond_to?(:each)
     #
     # @param [ Symbol ] name The name of the class method on the +Document+.
     # @param [ true | false ] include_private Whether to include privates.
@@ -483,8 +483,8 @@ module Mongoid
       # Historically this method required exactly one argument.
       # As of https://jira.mongodb.org/browse/MONGOID-4804 it also accepts
       # zero arguments.
-      # The underlying where implemetation that super invokes supports
-      # any number of arguments, but we don't presently allow mutiple
+      # The underlying where implementation that super invokes supports
+      # any number of arguments, but we don't presently allow multiple
       # arguments through this method. This API can be reconsidered in the
       # future.
       if args.length > 1

--- a/lib/mongoid/criteria/queryable/expandable.rb
+++ b/lib/mongoid/criteria/queryable/expandable.rb
@@ -23,7 +23,7 @@ module Mongoid
         #
         # The following parameter forms are accepted:
         #
-        # - field is a string or symbol; value is the field query expresision
+        # - field is a string or symbol; value is the field query expression
         # - field is a Key instance; value is the field query expression
         # - field is a string corresponding to a MongoDB operator; value is
         #   the operator value expression.

--- a/lib/mongoid/criteria/scopable.rb
+++ b/lib/mongoid/criteria/scopable.rb
@@ -66,7 +66,7 @@ module Mongoid
         self
       end
 
-      # Forces the criteria to be scoped, unless its inside an unscoped block.
+      # Forces the criteria to be scoped, unless it's inside an unscoped block.
       #
       # @example Force the criteria to be scoped.
       #   criteria.scoped(skip: 10)

--- a/lib/mongoid/errors/unregistered_class.rb
+++ b/lib/mongoid/errors/unregistered_class.rb
@@ -6,7 +6,7 @@ module Mongoid
     # class in a polymorphic association, but the class has not previously
     # been registered by resolver that was used for the query.
     #
-    # Here's an exammple:
+    # Here's an example:
     #
     #   class Department
     #     include Mongoid::Document

--- a/lib/mongoid/factory.rb
+++ b/lib/mongoid/factory.rb
@@ -5,7 +5,7 @@ module Mongoid
   module Factory
     extend self
 
-    # A helper class for instantiating a model using either it's type
+    # A helper class for instantiating a model using either its type
     # class directly, or via a type class specified via a discriminator
     # key.
     #
@@ -99,7 +99,7 @@ module Mongoid
         )
       end
 
-      # Retreive the `Class` instance of the requested type, either by finding it
+      # Retrieve the `Class` instance of the requested type, either by finding it
       # in the `klass` discriminator mapping, or by otherwise finding a
       # Document model with the given name.
       #

--- a/lib/mongoid/fields.rb
+++ b/lib/mongoid/fields.rb
@@ -324,7 +324,7 @@ module Mongoid
       # @param [ String ] key The key used to search the association tree.
       # @param [ Hash ] fields The fields to begin the search with.
       # @param [ Hash ] associations The associations to begin the search with.
-      # @param [ Hash ] aliased_associations The alaised associations to begin
+      # @param [ Hash ] aliased_associations The aliased associations to begin
       #   the search with.
       # @param &block The block.
       # @yieldparam [ Symbol ] The current method.

--- a/lib/mongoid/findable.rb
+++ b/lib/mongoid/findable.rb
@@ -147,7 +147,7 @@ module Mongoid
     # during query construction.
     #
     # If this method is given a block, it delegates to +Enumerable#find+ and
-    # returns the first document of those found by the current Crieria object
+    # returns the first document of those found by the current Criteria object
     # for which the block returns a truthy value. If both a block and ids are
     # given, the block is ignored and the documents for the given ids are
     # returned. If a block and a Proc are given, the method delegates to

--- a/lib/mongoid/matcher.rb
+++ b/lib/mongoid/matcher.rb
@@ -45,7 +45,7 @@ module Mongoid
     # @return [ Object | Array ] Field value or values.
     module_function def extract_attribute(document, key)
       # The matcher system will wind up sending atomic values to this as well,
-      # when attepting to match more complex types. If anything other than a
+      # when attempting to match more complex types. If anything other than a
       # Document or a Hash is given, we'll short-circuit the logic and just
       # return an empty array.
       return [] unless document.is_a?(Hash) || document.is_a?(Document)

--- a/lib/mongoid/persistence_context.rb
+++ b/lib/mongoid/persistence_context.rb
@@ -292,7 +292,7 @@ module Mongoid
       # Get the persistence context for a given object from the thread local
       #   storage.
       #
-      # @param [ Object ] object Object to get the persistance context for.
+      # @param [ Object ] object Object to get the persistence context for.
       #
       # @return [ Mongoid::PersistenceContext | nil ] The persistence context
       #   for the object if previously stored, otherwise nil.
@@ -305,7 +305,7 @@ module Mongoid
       # Store persistence context for a given object in the thread local
       #   storage.
       #
-      # @param [ Object ] object Object to store the persistance context for.
+      # @param [ Object ] object Object to store the persistence context for.
       # @param [ Mongoid::PersistenceContext ] context Context to store
       #
       # @api private

--- a/lib/mongoid/railtie.rb
+++ b/lib/mongoid/railtie.rb
@@ -94,7 +94,7 @@ module Rails
       end
 
       # Rails runs all initializers first before getting into any generator
-      # code, so we have no way in the intitializer to know if we are
+      # code, so we have no way in the initializer to know if we are
       # generating a mongoid.yml. So instead of failing, we catch all the
       # errors and print them out.
       def handle_configuration_error(e)

--- a/lib/mongoid/stateful.rb
+++ b/lib/mongoid/stateful.rb
@@ -76,7 +76,7 @@ module Mongoid
     alias :marked_for_destruction? :flagged_for_destroy?
     alias :_destroy :flagged_for_destroy?
 
-    # Returns true if the +Document+ has been succesfully destroyed, and false
+    # Returns true if the +Document+ has been successfully destroyed, and false
     # if it hasn't. This is determined by the variable @destroyed and NOT
     # by checking the database.
     #

--- a/lib/mongoid/threaded.rb
+++ b/lib/mongoid/threaded.rb
@@ -41,7 +41,7 @@ module Mongoid
     # given, and the variable does not already exist, the return value of the
     # block will be set as the value of the variable before returning it.
     #
-    # It is very important that applications (and espcially Mongoid)
+    # It is very important that applications (and especially Mongoid)
     # use this method instead of Thread#[], since Thread#[] is actually for
     # fiber-local variables, and Mongoid uses Fibers as an implementation
     # detail in some callbacks. Putting thread-local state in a fiber-local

--- a/lib/rails/generators/mongoid/config/templates/mongoid.yml
+++ b/lib/rails/generators/mongoid/config/templates/mongoid.yml
@@ -135,7 +135,7 @@ development:
   driver_options:
     # When this flag is off, an aggregation done on a view will be executed over
     # the documents included in that view, instead of all documents in the
-    # collection. When this flag is on, the view fiter is ignored.
+    # collection. When this flag is on, the view filter is ignored.
     # broken_view_aggregate: true
 
     # When this flag is set to false, the view options will be correctly
@@ -143,7 +143,7 @@ development:
     # broken_view_options: true
 
     # When this flag is set to true, the update and replace methods will
-    # validate the paramters and raise an error if they are invalid.
+    # validate the parameters and raise an error if they are invalid.
     # validate_update_replace: false
 
 

--- a/perf/benchmark_ips.rb
+++ b/perf/benchmark_ips.rb
@@ -215,7 +215,7 @@ Benchmark.ips do |bm|
   end
 
   # IMPROVEME:
-  # the same problem here as was metioned above.
+  # the same problem here as was mentioned above.
   bm.report("#find") do
     person.posts.find(person_post_id)
   end

--- a/spec/integration/associations/belongs_to_spec.rb
+++ b/spec/integration/associations/belongs_to_spec.rb
@@ -15,7 +15,7 @@ def quarantine(context, polymorphic:, dept_aliases:, team_aliases:)
     # Have to eval this, because otherwise we get syntax errors when defining a class
     # inside a method.
     #
-    # I know the scissors are sharp! But I want to run with them anwyay!
+    # I know the scissors are sharp! But I want to run with them anyway!
     Object.class_eval <<-RUBY
       class SandboxManager; include Mongoid::Document; end
       class SandboxDepartment; include Mongoid::Document; end

--- a/spec/mongoid/association/embedded/embeds_many/proxy_spec.rb
+++ b/spec/mongoid/association/embedded/embeds_many/proxy_spec.rb
@@ -3806,7 +3806,7 @@ describe Mongoid::Association::Embedded::EmbedsMany::Proxy do
       person_two.addresses << address
     end
 
-    it "adds the document to the new paarent" do
+    it "adds the document to the new parent" do
       expect(person_two.addresses).to eq([ address ])
     end
 
@@ -4382,7 +4382,7 @@ describe Mongoid::Association::Embedded::EmbedsMany::Proxy do
           expect(artist.before_remove_embedded_called).to be true
         end
 
-        it "shoud clear the relation" do
+        it "clears the relation" do
           expect(artist.songs).to be_empty
         end
       end

--- a/spec/mongoid/association/embedded/embeds_one/proxy_spec.rb
+++ b/spec/mongoid/association/embedded/embeds_one/proxy_spec.rb
@@ -78,7 +78,7 @@ describe Mongoid::Association::Embedded::EmbedsOne::Proxy do
             end
           end
 
-          it "sets the target without an invinite recursion" do
+          it "sets the target without an infinite recursion" do
             person.name = name
             expect(person.name).to be_present
           end

--- a/spec/mongoid/association/nested/one_spec.rb
+++ b/spec/mongoid/association/nested/one_spec.rb
@@ -106,7 +106,7 @@ describe Mongoid::Association::Nested::One do
       end
     end
 
-    context "when attributes are replacable" do
+    context "when attributes are replaceable" do
 
       let(:options) do
         {}

--- a/spec/mongoid/association/referenced/has_many/enumerable_spec.rb
+++ b/spec/mongoid/association/referenced/has_many/enumerable_spec.rb
@@ -1126,7 +1126,7 @@ describe Mongoid::Association::Referenced::HasMany::Enumerable do
             enumerable.first
           end
 
-          context "when a perviously persisted unloaded doc exists" do
+          context "when a previously persisted unloaded doc exists" do
 
             it "returns the first added doc" do
               expect(first).to eq(post)

--- a/spec/mongoid/association/syncable_spec.rb
+++ b/spec/mongoid/association/syncable_spec.rb
@@ -44,7 +44,7 @@ describe "Syncable Association" do
       Object.send(:remove_const, :TestModel)
     end
 
-    it 'prohibits the use of :_sycned as an attribute' do
+    it 'prohibits the use of :_synced as an attribute' do
       expect {
         model_synced
       }.to raise_exception(Mongoid::Errors::InvalidField)

--- a/spec/mongoid/atomic_spec.rb
+++ b/spec/mongoid/atomic_spec.rb
@@ -292,7 +292,7 @@ describe Mongoid::Atomic do
             end
           end
 
-          context "when adding a new child beetween two existing and updating one of them" do
+          context "when adding a new child between two existing and updating one of them" do
 
             let!(:new_address) do
               person.addresses.build(street: "Ipanema")

--- a/spec/mongoid/attributes/nested_spec.rb
+++ b/spec/mongoid/attributes/nested_spec.rb
@@ -3039,7 +3039,7 @@ describe Mongoid::Attributes::Nested do
                   person.save!
                 end
 
-                it "does not perist the invalid value" do
+                it "does not persist the invalid value" do
                   expect(post_two.reload.title).to eq("First response")
                 end
               end

--- a/spec/mongoid/attributes_spec.rb
+++ b/spec/mongoid/attributes_spec.rb
@@ -1739,7 +1739,7 @@ describe Mongoid::Attributes do
 
     context "when the key has been specified as a field" do
 
-      it "retuns the typed value" do
+      it "returns the typed value" do
         person.send(:typed_value_for, "age", "51")
       end
     end
@@ -2695,7 +2695,7 @@ describe Mongoid::Attributes do
     end
   end
 
-  context "when modifiying a hash referenced with the [] notation" do
+  context "when modifying a hash referenced with the [] notation" do
     let(:church) { Church.create!(location: { x: 1 }) }
 
     before do
@@ -2709,7 +2709,7 @@ describe Mongoid::Attributes do
     end
   end
 
-  context "when modifiying a set referenced with the [] notation" do
+  context "when modifying a set referenced with the [] notation" do
     let(:catalog) { Catalog.create!(set_field: [ 1 ].to_set) }
 
     before do

--- a/spec/mongoid/clients/transactions_spec.rb
+++ b/spec/mongoid/clients/transactions_spec.rb
@@ -722,7 +722,7 @@ describe Mongoid::Clients::Sessions do
           end
         end
 
-        it 'commits the transacrion' do
+        it 'commits the transaction' do
           expect(other_events.count { |e| e.command_name == 'abortTransaction'}).to be(0)
           expect(other_events.count { |e| e.command_name == 'commitTransaction'}).to be(1)
         end

--- a/spec/mongoid/contextual/map_reduce_spec.rb
+++ b/spec/mongoid/contextual/map_reduce_spec.rb
@@ -149,7 +149,7 @@ describe Mongoid::Contextual::MapReduce do
         end
       end
 
-      context "when the statstics are requested" do
+      context "when the statistics are requested" do
         max_server_version '4.2'
 
         it "raises an error" do

--- a/spec/mongoid/contextual/mongo_spec.rb
+++ b/spec/mongoid/contextual/mongo_spec.rb
@@ -277,7 +277,7 @@ describe Mongoid::Contextual::Mongo do
         Band.create!(name: "New Order")
       end
 
-      context "when the selector is contraining" do
+      context "when the selector is constraining" do
 
         let(:criteria) do
           Band.where(name: "Depeche Mode")
@@ -331,7 +331,7 @@ describe Mongoid::Contextual::Mongo do
         end
       end
 
-      context "when the selector is not contraining" do
+      context "when the selector is not constraining" do
 
         let(:criteria) do
           Band.all
@@ -381,7 +381,7 @@ describe Mongoid::Contextual::Mongo do
         Band.create!(name: "New Order")
       end
 
-      context "when the selector is contraining" do
+      context "when the selector is constraining" do
 
         let(:criteria) do
           Band.where(name: "Depeche Mode")
@@ -435,7 +435,7 @@ describe Mongoid::Contextual::Mongo do
         end
       end
 
-      context "when the selector is not contraining" do
+      context "when the selector is not constraining" do
 
         let(:criteria) do
           Band.all

--- a/spec/mongoid/criteria/includable_spec.rb
+++ b/spec/mongoid/criteria/includable_spec.rb
@@ -1135,7 +1135,7 @@ describe Mongoid::Criteria::Includable do
           a.b = b
         end
 
-        context "when including the belongs_to assocation" do
+        context "when including the belongs_to association" do
           let!(:result) do
             C.includes(b: :a).first
           end
@@ -1153,7 +1153,7 @@ describe Mongoid::Criteria::Includable do
           end
         end
 
-        context "when including a doubly-nested belongs_to assocation" do
+        context "when including a doubly-nested belongs_to association" do
           let!(:result) do
             D.includes(c: { b: :a }).first
           end
@@ -1172,7 +1172,7 @@ describe Mongoid::Criteria::Includable do
           end
         end
 
-        context "when including the has_many assocation" do
+        context "when including the has_many association" do
           let!(:result) do
             A.includes(b: :c).first
           end
@@ -1190,7 +1190,7 @@ describe Mongoid::Criteria::Includable do
           end
         end
 
-        context "when including a doubly-nested has_many assocation" do
+        context "when including a doubly-nested has_many association" do
           let!(:result) do
             A.includes(b: { c: :d }).first
           end

--- a/spec/mongoid/document_spec.rb
+++ b/spec/mongoid/document_spec.rb
@@ -852,7 +852,7 @@ describe Mongoid::Document do
 
       context "when the document has embedded documents" do
 
-        context "when the attribtues are protected" do
+        context "when the attributes are protected" do
 
           let!(:appointment) do
             manager.appointments.build

--- a/spec/mongoid/extensions/string_spec.rb
+++ b/spec/mongoid/extensions/string_spec.rb
@@ -151,7 +151,7 @@ describe Mongoid::Extensions::String do
 
   describe "#collectionize" do
 
-    context "when class is namepaced" do
+    context "when class is namespaced" do
 
       module Medical
         class Patient

--- a/spec/mongoid/fields/foreign_key_spec.rb
+++ b/spec/mongoid/fields/foreign_key_spec.rb
@@ -448,7 +448,7 @@ describe Mongoid::Fields::ForeignKey do
       end
     end
 
-    context "when the association is polymoprhic" do
+    context "when the association is polymorphic" do
 
       let(:association) do
         Agent.reflect_on_association(:names)

--- a/spec/mongoid/fields_spec.rb
+++ b/spec/mongoid/fields_spec.rb
@@ -371,7 +371,7 @@ describe Mongoid::Fields do
         expect(klass.field(:test, type: :range).type).to be(Range)
       end
 
-      it "converts :regexp to Rexegp" do
+      it "converts :regexp to Regexp" do
         expect(klass.field(:test, type: :regexp).type).to be(Regexp)
       end
 
@@ -611,7 +611,7 @@ describe Mongoid::Fields do
 
     context "when the attribute has not been assigned" do
 
-      it "delgates to the getter" do
+      it "delegates to the getter" do
         expect(person.age_before_type_cast).to eq(person.age)
       end
     end

--- a/spec/mongoid/findable_spec.rb
+++ b/spec/mongoid/findable_spec.rb
@@ -864,7 +864,7 @@ describe Mongoid::Findable do
         Band.create!(name: "Photek")
       end
 
-      it 'returns the currect count' do
+      it 'returns the correct count' do
         expect(Band.count).to eq(2)
       end
     end

--- a/spec/mongoid/reloadable_spec.rb
+++ b/spec/mongoid/reloadable_spec.rb
@@ -289,7 +289,7 @@ describe Mongoid::Reloadable do
       end
     end
 
-    context "when embedded documents are unasssigned and reassigned" do
+    context "when embedded documents are unassigned and reassigned" do
 
       let(:palette) do
         Palette.new

--- a/spec/mongoid/search_indexable_spec.rb
+++ b/spec/mongoid/search_indexable_spec.rb
@@ -28,7 +28,7 @@ class SearchIndexHelper
 
   # Wait until all of the indexes with the given names are absent from the
   # search index list.
-  def wait_for_absense_of(*names)
+  def wait_for_absence_of(*names)
     names.flatten.each do |name|
       timeboxed_wait do
         break if collection.search_indexes(name: name).empty?
@@ -123,7 +123,7 @@ describe Mongoid::SearchIndexable do
 
       before do
         model.remove_search_index id: target_index['id']
-        helper.wait_for_absense_of target_index['name']
+        helper.wait_for_absence_of target_index['name']
       end
 
       it 'removes the requested index' do
@@ -135,7 +135,7 @@ describe Mongoid::SearchIndexable do
       before do
         actual_indexes # wait for the indexes to be created
         model.remove_search_indexes
-        helper.wait_for_absense_of(actual_indexes.map { |i| i['name'] })
+        helper.wait_for_absence_of(actual_indexes.map { |i| i['name'] })
       end
 
       it 'removes the indexes' do

--- a/spec/mongoid/touchable_spec.rb
+++ b/spec/mongoid/touchable_spec.rb
@@ -1460,7 +1460,7 @@ describe Mongoid::Touchable do
       expect(parent.after_touch_called).to eq(true)
     end
 
-    context 'when touch is calles on a child' do
+    context 'when touch is called on a child' do
       before do
         child.touch
       end

--- a/spec/mongoid/validatable/uniqueness_spec.rb
+++ b/spec/mongoid/validatable/uniqueness_spec.rb
@@ -337,7 +337,7 @@ describe Mongoid::Validatable::UniquenessValidator do
 
                 context "when the document is not the match" do
 
-                  context "when signle localization" do
+                  context "when single localization" do
 
                     before do
                       Dictionary.create!(description: "english")
@@ -539,7 +539,7 @@ describe Mongoid::Validatable::UniquenessValidator do
             Dictionary.reset_callbacks(:validate)
           end
 
-          context "when the document with the unqiue attribute is not in default scope" do
+          context "when the document with the unique attribute is not in default scope" do
 
             context "when the attribute is not unique" do
 


### PR DESCRIPTION
Hello and thanks to the Mongoid community for the incredible work on this project!

No one likes nit picking 😅 perhaps, but [I noticed a typo](https://github.com/mongodb/mongoid/blob/8d3c92f543cb1ebd6d125ea6fc3b76871e00600a/lib/rails/generators/mongoid/config/templates/mongoid.yml#L146) in my `mongoid.yml` and wanted to take a stab at fixing it. I ended up forking the repository and poking around using IntelliJ’s spell checker. I hope this is a welcome change and that it will not break some snapshot tests or does not introduce too much “noise” into _git blame_, etc. Thank you.