### PR TITLE
MONGOID-5839 Fix eager-loading from STI subclasses (backport to 9.0-stable)

### DIFF
--- a/lib/mongoid/association/eager_loadable.rb
+++ b/lib/mongoid/association/eager_loadable.rb
@@ -42,6 +42,9 @@ module Mongoid
         docs_map = {}
         queue = [ klass.to_s ]
 
+        # account for single-collection inheritance
+        queue.push(klass.root_class.to_s) if klass != klass.root_class
+
         while klass = queue.shift
           if as = assoc_map.delete(klass)
             as.each do |assoc|

--- a/lib/mongoid/traversable.rb
+++ b/lib/mongoid/traversable.rb
@@ -44,6 +44,18 @@ module Mongoid
         !!(superclass < Mongoid::Document)
       end
 
+      # Returns the root class of the STI tree that the current
+      # class participates in. If the class is not an STI subclass, this
+      # returns the class itself.
+      #
+      # @return [ Mongoid::Document ] the root of the STI tree
+      def root_class
+        root = self
+        root = root.superclass while root.hereditary?
+
+        root
+      end
+
       # When inheriting, we want to copy the fields from the parent class and
       # set the on the child to start, mimicking the behavior of the old
       # class_inheritable_accessor that was deprecated in Rails edge.


### PR DESCRIPTION
(backport to 9.0-stable)

If the root of a query is an STI subclass (e.g. `Subclass.all`) AND the query tries to eager load (`includes`) another association, the eager load was failing because it was looking for inverse associations using the STI subclass name, instead of the class at the root of the hierarchy.