### PR TITLE
Prep for 8.0.9

### DIFF
--- a/lib/mongoid/version.rb
+++ b/lib/mongoid/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Mongoid
-  VERSION = "8.0.8"
+  VERSION = "8.0.9"
 end


### PR DESCRIPTION
_Proposed release announcement:_

Mongoid 8.0.9 is now available. This is the most recent patch release in the 8.0 series, and includes the following bug fixes.

* MONGOID-5836 - Callbacks were being duplicated on deeply embedded children. A related issue (MONGOID-5542) was also backported to 8.0, exposing the `Mongoid.prevent_multiple_calls_of_embedded_callbacks` setting to preserve backwards compatibility in most cases (defaults to `false`).
* MONGOID-5757 - Child validations were being short-circuited, resulting in subsequent validation callbacks not being called after the first failing validation.
* MONGOID-5797 - Accessing the parent document from an embedded document was failing with an error when the original query applied a projection.
* MONGOID-5810 - When `Mongoid.legacy_attributes` is `true`, the `#as_document` method was returning a hash that leaked internal model state. The hash is now deep-duplicated before being returned (which may have performance implications for large documents or complex hashes).
* MONGOID-5839 - When using single-collection inheritance, eager loading (with `#includes`) was not producing the correct query when the root of the query was the document subclass.
* MONGOID-5825 - The `Mongoid::Timestamps` module would (in certain cases) attempt to timestamp deleted documents, which resulted in a `FrozenError` being raised.