### PR TITLE
Prepare for v8.1.9

### DIFF
--- a/lib/mongoid/version.rb
+++ b/lib/mongoid/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Mongoid
-  VERSION = "8.1.8"
+  VERSION = "8.1.9"
 end


### PR DESCRIPTION
Release highlights:

* MONGOID-5836 - Callbacks were being duplicated on deeply embedded children.
* MONGOID-5839 - When using single-collection inheritance, eager loading (with `#includes`) was not producing the correct query when the root of the query was the document subclass.
* MONGOID-5825 - The `Mongoid::Timestamps` module would (in certain cases) attempt to timestamp deleted documents, which resulted in a `FrozenError` being raised.