### PR TITLE
Prepare for v9.0.5

### DIFF
--- a/lib/mongoid/version.rb
+++ b/lib/mongoid/version.rb
@@ -2,5 +2,5 @@
 # rubocop:todo all
 
 module Mongoid
-  VERSION = "9.0.4"
+  VERSION = "9.0.5"
 end


### PR DESCRIPTION
Release highlights:

* MONGOID-5836 - Callbacks were being duplicated on deeply embedded children.
* MONGOID-5839 - When using single-collection inheritance, eager loading (with `#includes`) was not producing the correct query when the root of the query was the document subclass.
* MONGOID-5825 - The `Mongoid::Timestamps` module would (in certain cases) attempt to timestamp deleted documents, which resulted in a `FrozenError` being raised.