### PR TITLE
Prep 8.0.10

### DIFF
--- a/gemfiles/rails-6.1.gemfile
+++ b/gemfiles/rails-6.1.gemfile
@@ -1,5 +1,8 @@
 source 'https://rubygems.org'
 
+# See https://stackoverflow.com/questions/79360526
+gem 'concurrent-ruby', '< 1.3.5'
+
 gem 'actionpack', '~> 6.1'
 gem 'activemodel', '~> 6.1'
 

--- a/lib/mongoid/version.rb
+++ b/lib/mongoid/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Mongoid
-  VERSION = "8.0.9"
+  VERSION = "8.0.10"
 end

--- a/spec/integration/app_spec.rb
+++ b/spec/integration/app_spec.rb
@@ -16,6 +16,10 @@ describe 'Mongoid application tests' do
       skip 'Set APP_TESTS=1 in environment to run application tests'
     end
 
+    if SpecConfig.instance.rails_version < '7.1'
+      skip 'App tests require Rails > 7.0 (see https://stackoverflow.com/questions/79360526)'
+    end
+
     require 'fileutils'
     require 'mrss/child_process_helper'
     require 'open-uri'

--- a/spec/support/models/book.rb
+++ b/spec/support/models/book.rb
@@ -15,4 +15,5 @@ class Book
   end
 
   embeds_many :pages, cascade_callbacks: true
+  embeds_many :covers, cascade_callbacks: true
 end

--- a/spec/support/models/cover.rb
+++ b/spec/support/models/cover.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class Cover
+  include Mongoid::Document
+  include Mongoid::Timestamps
+
+  field :title, type: String
+
+  embedded_in :book
+end


### PR DESCRIPTION
Mongoid 8.0.10 is a patch release that includes the following bug fix:

* MONGOID-5844: querying the number of elements in a `has_and_belongs_to_many` association could return the wrong count in specific situations.