### PR TITLE
DOCSP-48435: 404-ing links

### DIFF
--- a/lib/mongoid/loadable.rb
+++ b/lib/mongoid/loadable.rb
@@ -94,8 +94,8 @@ module Mongoid
 
     # Returns the array of paths where the application's model definitions
     # are located. If Rails is loaded, this defaults to the configured
-    # "app/models" paths (e.g. `config.paths["app/models"]`); otherwise, it
-    # defaults to `%w(./app/models ./lib/models)`.
+    # "app/models" paths (e.g. 'config.paths["app/models"]'); otherwise, it
+    # defaults to '%w(./app/models ./lib/models)'.
     #
     # Note that these paths are the *roots* of the directory hierarchies where
     # the models are located; it is not necessary to indicate every subdirectory,

--- a/lib/mongoid/matcher/eq_impl.rb
+++ b/lib/mongoid/matcher/eq_impl.rb
@@ -53,7 +53,7 @@ module Mongoid
         end
       end
 
-      # Per https://www.mongodb.com/docs/ruby-driver/current/tutorials/bson-v4/#time-instances,
+      # Per https://www.mongodb.com/docs/ruby-driver/upcoming/data-formats/bson/#time-instances,
       # > Times in BSON (and MongoDB) can only have millisecond precision. When Ruby Time instances
       # are serialized to BSON or Extended JSON, the times are floored to the nearest millisecond.
       #

--- a/upload-api-docs
+++ b/upload-api-docs
@@ -66,8 +66,8 @@ class Options
     @options = {}
     parse_cli_options!
     parse_env_options!
-    @options[:prefix] = 'docs/mongoid/v9.0/api'
-    @options[:docs_path] = 'build/public/v9.0/api'
+    @options[:prefix] = 'docs/mongoid/master/api'
+    @options[:docs_path] = 'build/public/master/api'
   end
 
   def [](key)

--- a/upload-api-docs
+++ b/upload-api-docs
@@ -66,8 +66,8 @@ class Options
     @options = {}
     parse_cli_options!
     parse_env_options!
-    @options[:prefix] = 'docs/mongoid/master/api'
-    @options[:docs_path] = 'build/public/master/api'
+    @options[:prefix] = 'docs/mongoid/v9.0/api'
+    @options[:docs_path] = 'build/public/v9.0/api'
   end
 
   def [](key)


### PR DESCRIPTION
https://jira.mongodb.org/browse/DOCSP-48435

Fixes a few broken links in the API docs