### PR TITLE
MONGOID-5852 Fix after_action_commit callbacks

### DIFF
--- a/lib/mongoid/clients/sessions.rb
+++ b/lib/mongoid/clients/sessions.rb
@@ -213,8 +213,8 @@ module Mongoid
 
         # Transforms custom options for after_commit and after_rollback callbacks
         # into options for +set_callback+.
-        def set_options_for_callbacks!(args)
-          options = args.extract_options!
+        def set_options_for_callbacks!(args, enforced_options = {})
+          options = args.extract_options!.merge(enforced_options)
           args << options
 
           if options[:on]

--- a/spec/mongoid/clients/transactions_spec_models.rb
+++ b/spec/mongoid/clients/transactions_spec_models.rb
@@ -33,6 +33,38 @@ module TransactionsSpecCountable
   def after_rollback_counter=(new_counter)
     @after_rollback_counter = new_counter
   end
+
+  def after_save_commit_counter
+    @after_save_commit_counter ||= TransactionsSpecCounter.new
+  end
+
+  def after_save_commit_counter=(new_counter)
+    @after_save_commit_counter = new_counter
+  end
+
+  def after_create_commit_counter
+    @after_create_commit_counter ||= TransactionsSpecCounter.new
+  end
+
+  def after_create_commit_counter=(new_counter)
+    @after_create_commit_counter = new_counter
+  end
+
+  def after_update_commit_counter
+    @after_update_commit_counter ||= TransactionsSpecCounter.new
+  end
+
+  def after_update_commit_counter=(new_counter)
+    @after_update_commit_counter = new_counter
+  end
+
+  def after_destroy_commit_counter
+    @after_destroy_commit_counter ||= TransactionsSpecCounter.new
+  end
+
+  def after_destroy_commit_counter=(new_counter)
+    @after_destroy_commit_counter = new_counter
+  end
 end
 
 class TransactionsSpecPerson
@@ -65,6 +97,21 @@ class TransactionsSpecPersonWithOnCreate
   end
 end
 
+class TransactionsSpecPersonWithAfterCreateCommit
+  include Mongoid::Document
+  include TransactionsSpecCountable
+
+  field :name, type: String
+
+  after_create_commit do
+    after_commit_counter.inc
+  end
+
+  after_rollback on: :create do
+    after_rollback_counter.inc
+  end
+end
+
 class TransactionsSpecPersonWithOnUpdate
   include Mongoid::Document
   include TransactionsSpecCountable
@@ -76,6 +123,36 @@ class TransactionsSpecPersonWithOnUpdate
   end
 
   after_rollback on: :update do
+    after_rollback_counter.inc
+  end
+end
+
+class TransactionsSpecPersonWithAfterUpdateCommit
+  include Mongoid::Document
+  include TransactionsSpecCountable
+
+  field :name, type: String
+
+  after_update_commit do
+    after_commit_counter.inc
+  end
+
+  after_rollback on: :create do
+    after_rollback_counter.inc
+  end
+end
+
+class TransactionsSpecPersonWithAfterSaveCommit
+  include Mongoid::Document
+  include TransactionsSpecCountable
+
+  field :name, type: String
+
+  after_save_commit do
+    after_commit_counter.inc
+  end
+
+  after_rollback on: :create do
     after_rollback_counter.inc
   end
 end
@@ -94,6 +171,22 @@ class TransactionsSpecPersonWithOnDestroy
     after_rollback_counter.inc
   end
 end
+
+class TransactionsSpecPersonWithAfterDestroyCommit
+  include Mongoid::Document
+  include TransactionsSpecCountable
+
+  field :name, type: String
+
+  after_destroy_commit do
+    after_commit_counter.inc
+  end
+
+  after_rollback on: :create do
+    after_rollback_counter.inc
+  end
+end
+
 class TransactionSpecRaisesBeforeSave
   include Mongoid::Document
   include TransactionsSpecCountable


### PR DESCRIPTION
None of them worked due to a syntax error where
`set_options_for_callbacks` did not accept a second argument.


I thought this fix was relatively straightforward enough to be a quick PR without going through support. Apologies if I did something incorrectly, I'm new to Mongo in general.