### PR TITLE
Release candidate for 9.0.7

### DIFF
--- a/lib/mongoid/version.rb
+++ b/lib/mongoid/version.rb
@@ -2,5 +2,5 @@
 # rubocop:todo all
 
 module Mongoid
-  VERSION = "9.0.6"
+  VERSION = "9.0.7"
 end


### PR DESCRIPTION
Mongoid 9.0.7 is a new patch release.

Install it via RubyGems at a command-line:

~~~
gem install -v 9.0.7 mongoid
~~~

Or by adding it to your Gemfile:

~~~
gem 'mongoid', '9.0.7'
~~~

Notable changes in this release are:

# New Features

### [MONGOID-5827](https://jira.mongodb.org/browse/MONGOID-5827) Allow duplicate indexes to be declared (backport to 9.0) ([PR](https://github.com/mongodb/mongoid/pull/5970))

Mongoid will ignore indexes that differ only in the options used to declare them. _This includes index names!_ This behavior will change in the future, but to ease the transition, you can set `Mongoid.allow_duplicate_index_declarations = true` to allow these near-identical indexes to be declared and processed by the server.


# Bug Fixes

* [MONGOID-5843](https://jira.mongodb.org/browse/MONGOID-5843) Ensure BSON::Decimal128 is considered to be numeric (backport to 9.0) ([PR](https://github.com/mongodb/mongoid/pull/5963))
