### PR TITLE
MONGOID-5863 `#last` overrides `#skip`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       TESTOPTS: "-v"
       BUNDLE_GEMFILE: "${{ matrix.rails == '' && 'Gemfile' || format('gemfiles/rails-{0}.gemfile', matrix.rails) }}"
     runs-on: ubuntu-22.04
-    continue-on-error: "${{matrix.experimental}}"
+    continue-on-error: false
     strategy:
       fail-fast: false
       matrix:
@@ -23,8 +23,6 @@ jobs:
         rails: [ ~, "8.0" ]
         fle: [ ~, "helper" ]
         topology: [ replica_set, sharded_cluster ]
-        experimental: false
-        task: test
 
     steps:
     - name: repo checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     env:
       CI: true
       TESTOPTS: "-v"
-      BUNDLE_GEMFILE: ${{ matrix.rails == "" && "Gemfile" || format("gemfiles/rails-{0}.gemfile", matrix.rails) }}
+      BUNDLE_GEMFILE: "${{ matrix.rails == '' && 'Gemfile' || format('gemfiles/rails-{0}.gemfile', matrix.rails) }}"
     runs-on: ubuntu-22.04
     continue-on-error: "${{matrix.experimental}}"
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,145 +7,24 @@ name: Run Mongoid Tests
 - pull_request
 jobs:
   build:
-    name: "${{matrix.ruby}} drv:${{matrix.driver}} db:${{matrix.mongodb}}
+    name: "${{matrix.ruby}} db:${{matrix.mongodb}}
       rails:${{matrix.rails}} fle:${{matrix.fle}} ${{matrix.topology}}"
     env:
       CI: true
       TESTOPTS: "-v"
-    runs-on: ${{matrix.os}}
+      BUNDLE_GEMFILE: ${{ matrix.rails == "" && "Gemfile" || format("gemfiles/rails-{0}.gemfile", matrix.rails) }}
+    runs-on: ubuntu-22.04
     continue-on-error: "${{matrix.experimental}}"
     strategy:
       fail-fast: false
       matrix:
-        include:
-        - mongodb: '7.0'
-          ruby: ruby-3.3
-          topology: replica_set
-          os: ubuntu-20.04
-          task: test
-          driver: current
-          gemfile: Gemfile
-          experimental: false
-        - mongodb: '6.0'
-          ruby: ruby-3.2
-          topology: replica_set
-          os: ubuntu-20.04
-          task: test
-          driver: current
-          gemfile: Gemfile
-          experimental: false
-        - mongodb: '6.0'
-          ruby: ruby-3.1
-          topology: replica_set
-          os: ubuntu-20.04
-          task: test
-          driver: current
-          gemfile: Gemfile
-          experimental: false
-        - mongodb: '6.0'
-          ruby: ruby-3.0
-          topology: replica_set
-          os: ubuntu-20.04
-          task: test
-          driver: stable
-          gemfile: gemfiles/driver_stable.gemfile
-          experimental: false
-        - mongodb: '7.0'
-          ruby: ruby-3.3
-          topology: server
-          os: ubuntu-22.04
-          task: test
-          driver: current
-          rails: '8.0'
-          fle: helper
-          gemfile: gemfiles/rails-8.0.gemfile
-          experimental: false
-        - mongodb: '7.0'
-          ruby: ruby-3.2
-          topology: server
-          os: ubuntu-20.04
-          task: test
-          driver: current
-          rails: '7.2'
-          fle: helper
-          gemfile: gemfiles/rails-7.2.gemfile
-          experimental: false
-        - mongodb: '7.0'
-          ruby: ruby-3.2
-          topology: server
-          os: ubuntu-20.04
-          task: test
-          driver: current
-          rails: '7.1'
-          fle: helper
-          gemfile: gemfiles/rails-7.1.gemfile
-          experimental: false
-        - mongodb: '7.0'
-          ruby: ruby-3.1
-          topology: server
-          os: ubuntu-20.04
-          task: test
-          driver: current
-          rails: '7.0'
-          fle: helper
-          gemfile: gemfiles/rails-7.0.gemfile
-          experimental: false
-        - mongodb: '6.0'
-          ruby: ruby-3.1
-          topology: server
-          os: ubuntu-20.04
-          task: test
-          driver: current
-          rails: '6.1'
-          fle: helper
-          gemfile: gemfiles/rails-6.1.gemfile
-          experimental: false
-        - mongodb: '6.0'
-          ruby: ruby-3.0
-          topology: server
-          os: ubuntu-20.04
-          task: test
-          driver: current
-          rails: '6.1'
-          fle: helper
-          gemfile: gemfiles/rails-6.1.gemfile
-          experimental: false
-        - mongodb: '6.0'
-          ruby: ruby-3.0
-          topology: server
-          os: ubuntu-20.04
-          task: test
-          driver: current
-          rails: '6.0'
-          fle: helper
-          gemfile: gemfiles/rails-6.0.gemfile
-          experimental: false
-        - mongodb: '6.0'
-          ruby: jruby-9.4
-          topology: server
-          os: ubuntu-20.04
-          task: test
-          driver: current
-          rails: '6.0'
-          fle: helper
-          gemfile: gemfiles/rails-6.0.gemfile
-          experimental: false
-        - mongodb: '5.0'
-          ruby: ruby-3.1
-          topology: replica_set
-          os: ubuntu-20.04
-          task: test
-          driver: current
-          gemfile: Gemfile
-          experimental: false
-        - mongodb: '4.4'
-          ruby: ruby-2.7
-          topology: replica_set
-          os: ubuntu-20.04
-          task: test
-          driver: current
-          gemfile: Gemfile
-          experimental: false
+        ruby: [ "3.3" ]
+        mongodb: [ "8.0" ]
+        rails: [ ~, "8.0" ]
+        fle: [ ~, "helper" ]
+        topology: [ replica_set, sharded_cluster ]
+        experimental: false
+        task: test
 
     steps:
     - name: repo checkout
@@ -169,7 +48,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       env:
         FLE: "${{matrix.fle}}"
-        BUNDLE_GEMFILE: "${{matrix.gemfile}}"
+        BUNDLE_GEMFILE: "${{env.BUNDLE_GEMFILE}}"
       with:
         ruby-version: "${{matrix.ruby}}"
         bundler: 2
@@ -177,12 +56,12 @@ jobs:
       run: bundle install --jobs 4 --retry 3
       env:
         FLE: "${{matrix.fle}}"
-        BUNDLE_GEMFILE: "${{matrix.gemfile}}"
+        BUNDLE_GEMFILE: "${{env.BUNDLE_GEMFILE}}"
     - name: test
       timeout-minutes: 60
       continue-on-error: "${{matrix.experimental}}"
       run: bundle exec rake ci
       env:
-        BUNDLE_GEMFILE: "${{matrix.gemfile}}"
+        BUNDLE_GEMFILE: "${{env.BUNDLE_GEMFILE}}"
         FLE: "${{matrix.fle}}"
         MONGODB_URI: "${{ steps.start-mongodb.outputs.cluster-uri }}"

--- a/lib/mongoid/contextual/mongo.rb
+++ b/lib/mongoid/contextual/mongo.rb
@@ -1122,7 +1122,7 @@ module Mongoid
       end
 
       def retrieve_nth_to_last_with_limit(n, limit)
-        v = view.sort(inverse_sorting).skip(n).limit(limit || 1)
+        v = view.sort(inverse_sorting).limit(limit || 1)
         v = v.skip(n) if n > 0
         raw_docs = v.to_a.reverse
         process_raw_docs(raw_docs, limit)

--- a/spec/mongoid/contextual/mongo_spec.rb
+++ b/spec/mongoid/contextual/mongo_spec.rb
@@ -3292,6 +3292,12 @@ describe Mongoid::Contextual::Mongo do
     it "limits the results" do
       expect(context.skip(1).entries).to eq([ new_order ])
     end
+
+    context "with #last" do
+      it "returns the nth from last element" do
+        expect(context.skip(1).last).to eq(depeche_mode)
+      end
+    end
   end
 
   describe "#sort" do


### PR DESCRIPTION
Prior to Mongoid 8.1, `Model.skip(1).last` would return the next-to-last document. A refactoring in 8.1 resulted in this breaking, due to an extraneous call to `#skip` that would override any other invocation of `#skip`.

## Summary

Fixes `Model.skip(1).last` so it again returns the next-to-last document, instead of just the last document.