### PR TITLE
[WIP] MONGOID-5865 - BSON::Document should be correctly demongoized into a Hash

### DIFF
--- a/spec/integration/persistence/hash_field_spec.rb
+++ b/spec/integration/persistence/hash_field_spec.rb
@@ -1,0 +1,175 @@
+# frozen_string_literal: true
+# rubocop:todo all
+
+require 'spec_helper'
+
+describe 'Hash field persistence' do
+  let(:person) { Person.create!(field => value).reload }
+  subject { person.send(field) }
+
+  shared_examples_for 'Hash persistence behavior' do
+    context 'when Hash with Strings' do
+      let(:value) { { 'foo' => 'bar', 'baz' => 'qux' } }
+
+      it 'returns a Hash' do
+        expect(subject).to be_a Hash
+        expect(subject).not_to be_a BSON::Document
+      end
+
+      it 'returns the keys and values as Strings' do
+        expect(subject).to eq({ 'foo' => 'bar', 'baz' => 'qux' })
+      end
+    end
+
+    context 'when Hash with Symbols' do
+      let(:value) { { foo: :bar, baz: 'qux' } }
+
+      it 'returns a Hash' do
+        expect(subject).to be_a Hash
+        expect(subject).not_to be_a BSON::Document
+      end
+
+      it 'returns the keys as Strings and values as Symbols' do
+        expect(subject).to eq({ 'foo' => :bar, 'baz' => 'qux' })
+      end
+    end
+
+    context 'when Hash with Integer keys' do
+      let(:value) { { 1 => 'bar', 2 => 2, 3 => 3.1 } }
+
+      it 'returns a Hash' do
+        expect(subject).to be_a Hash
+        expect(subject).not_to be_a BSON::Document
+      end
+
+      it 'returns the keys as Strings' do
+        expect(subject).to eq({ '1' => 'bar', '2' => 2, '3' => 3.1 })
+      end
+    end
+
+    context 'when Hash with nested Hash' do
+      let(:value) { { outer: { inner: 'value' } } }
+
+      it 'returns a Hash' do
+        expect(subject).to be_a Hash
+        expect(subject).not_to be_a BSON::Document
+      end
+
+      it 'returns the nested Hash as a Hash' do
+        nested = subject['outer']
+        expect(nested).to be_a Hash
+        expect(nested).not_to be_a BSON::Document
+      end
+
+      it 'returns the keys as Strings' do
+        expect(subject).to eq({ 'outer' => { 'inner' => 'value' } })
+      end
+    end
+
+    context 'when Hash with mixed types' do
+      let(:value) do
+        {
+          'name' => :test,
+          2 => 3,
+          count: 42,
+          'created_at' => [
+            { foo: 1 },
+            true,
+            2.1
+          ]
+        }
+      end
+
+      let(:expected) do
+        {
+          'name' => :test,
+          '2' => 3,
+          'count' => 42,
+          'created_at' => [
+            { 'foo' => 1 },
+            true,
+            2.1
+          ]
+        }
+      end
+
+      it { expect(subject).to eq(expected) }
+    end
+
+    context 'when Hash with Float key' do
+      let(:value) { { 1.0 => 'bar' } }
+
+      it 'raises a TypeError' do
+        expect { subject }.to raise_error(BSON::Error::InvalidKey, /Float instances are not allowed/)
+      end
+    end
+
+    context 'when Hash with Array key' do
+      let(:value) { { %w[foo bar] => 'baz' } }
+
+      it 'raises a TypeError' do
+        expect { subject }.to raise_error(BSON::Error::InvalidKey, /Array instances are not allowed/)
+      end
+    end
+
+    context 'when Hash with Hash key' do
+      let(:value) { { { 'foo' => 'bar' } => 'baz' } }
+
+      it 'raises a TypeError' do
+        expect { subject }.to raise_error(BSON::Error::InvalidKey, /Hash instances are not allowed/)
+      end
+    end
+
+    context 'when Hash with TrueClass key' do
+      let(:value) { { true => 'baz' } }
+
+      it 'raises a TypeError' do
+        expect { subject }.to raise_error(BSON::Error::InvalidKey, /TrueClass instances are not allowed/)
+      end
+    end
+
+    context 'when Hash with FalseClass key' do
+      let(:value) { { false => 'baz' } }
+
+      it 'raises a TypeError' do
+        expect { subject }.to raise_error(BSON::Error::InvalidKey, /FalseClass instances are not allowed/)
+      end
+    end
+
+    context 'when Hash with NilClass key' do
+      let(:value) { { nil => 'baz' } }
+
+      it 'raises a TypeError' do
+        expect { subject }.to raise_error(BSON::Error::InvalidKey, /NilClass instances are not allowed/)
+      end
+    end
+
+    context 'when Hash with BSON::ObjectId key' do
+      let(:value) { { BSON::ObjectId('a' * 24) => 'bar' } }
+
+      it 'raises a TypeError' do
+        expect { subject }.to raise_error(BSON::Error::InvalidKey, /BSON::ObjectId instances are not allowed/)
+      end
+    end
+  end
+
+  context 'static field' do
+    before do
+      Person.field(:hash_testing, type: Hash, default: {}, overwrite: true)
+    end
+
+    after do
+      Person.fields.delete('hash_testing')
+    end
+
+    let(:field) { :hash_testing }
+
+    it_behaves_like 'Hash persistence behavior'
+  end
+
+  context 'dynamic field' do
+    let(:field) { :hash_dynamic }
+
+    it_behaves_like 'Hash persistence behavior'
+  end
+end

--- a/spec/integration/persistence/range_field_spec.rb
+++ b/spec/integration/persistence/range_field_spec.rb
@@ -249,6 +249,7 @@ describe 'Range field persistence' do
 
       it do
         expect(subject).to be_a Hash
+        expect(subject).not_to be_a BSON::Document
         expect(subject['exclude_end']).to eq nil
         expect(subject['min']).to be_within(0.01.second).of(now_utc)
         expect(subject['max']).to be_within(0.01.second).of(later_utc)
@@ -262,6 +263,7 @@ describe 'Range field persistence' do
 
       it do
         expect(subject).to be_a Hash
+        expect(subject).not_to be_a BSON::Document
         expect(subject['exclude_end']).to eq true
         expect(subject['min']).to be_within(0.01.second).of(now_utc)
         expect(subject['max']).to be_within(0.01.second).of(later_utc)
@@ -275,6 +277,7 @@ describe 'Range field persistence' do
 
       it do
         expect(subject).to be_a Hash
+        expect(subject).not_to be_a BSON::Document
         expect(subject['exclude_end']).to eq nil
         expect(subject['min']).to be_within(0.01.second).of(now_utc)
         expect(subject['max']).to be_within(0.01.second).of(later_utc)
@@ -288,6 +291,7 @@ describe 'Range field persistence' do
 
       it do
         expect(subject).to be_a Hash
+        expect(subject).not_to be_a BSON::Document
         expect(subject['exclude_end']).to eq true
         expect(subject['min']).to be_within(0.01.second).of(now_utc)
         expect(subject['max']).to be_within(0.01.second).of(later_utc)
@@ -301,6 +305,7 @@ describe 'Range field persistence' do
 
       it do
         expect(subject).to be_a Hash
+        expect(subject).not_to be_a BSON::Document
         expect(subject['exclude_end']).to eq nil
         expect(subject['min']).to be_within(0.01.second).of(now_utc)
         expect(subject['max']).to be_within(0.01.second).of(later_utc)
@@ -314,6 +319,7 @@ describe 'Range field persistence' do
 
       it do
         expect(subject).to be_a Hash
+        expect(subject).not_to be_a BSON::Document
         expect(subject['exclude_end']).to eq true
         expect(subject['min']).to be_within(0.01.second).of(now_utc)
         expect(subject['max']).to be_within(0.01.second).of(later_utc)
@@ -327,6 +333,7 @@ describe 'Range field persistence' do
 
       it do
         expect(subject).to be_a Hash
+        expect(subject).not_to be_a BSON::Document
         expect(subject['exclude_end']).to eq nil
         expect(subject['min']).to be_within(0.01.second).of(now_utc)
         expect(subject['max']).to be_within(0.01.second).of(later_utc)
@@ -340,6 +347,7 @@ describe 'Range field persistence' do
 
       it do
         expect(subject).to be_a Hash
+        expect(subject).not_to be_a BSON::Document
         expect(subject['exclude_end']).to eq true
         expect(subject['min']).to be_within(0.01.second).of(now_utc)
         expect(subject['max']).to be_within(0.01.second).of(later_utc)


### PR DESCRIPTION
This PR fixes a regression from Mongoid 7.

```ruby
def MyModel
  include Mongoid::Document
  field :my_hash, type: Hash
end

doc = MyModel.new(my_hash: { foo: { bar: 1 } }

doc = MyModel.all.first

# Mongoid 7.x:
doc.my_hash.class #=> Hash -- CORRECT
doc.my_hash['foo'].class #=> Hash -- CORRECT 

# Mongoid 9.x:
doc.my_hash.class #=> Mongoid::Document -- BAD
doc.my_hash['foo'].class #=> Mongoid::Document -- BAD
```

Three cases to consider:
1. When `field :foo, type: Hash` is explicitly declared.
2. When using a dynamic Hash field
3. Other cases, e.g. Range which is represented as a Hash { min: 1, max: 7 }

The code here currently only fixes case #1. Need to check the behavior of the other two cases on Mongoid 7.