### PR TITLE
Add 'tzinfo-data' for Windows development

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,3 +17,7 @@ if RUBY_PLATFORM =~ /java/
 end
 
 gem 'i18n', *i18n_versions
+
+platform :windows do
+  gem 'tzinfo-data'
+end


### PR DESCRIPTION
This is needed to run Mongoid tests (and any Rails gem test) on Windows. Rails adds it automatically when you do rails new on windows. Since it is in the **Gemfile** (**not** the gemspec) it doesn't affect anyone's actual code, it is purely for development purposes.