### PR TITLE
MONGOID-5872 - [🛠️ Let's Fix Mongoid's Broken CI] Actually test Rails 6.0.0, 7.0.0, 7.1.0, and released version of 8.0.0

### DIFF
--- a/gemfiles/rails-6.0.gemfile
+++ b/gemfiles/rails-6.0.gemfile
@@ -1,11 +1,11 @@
 # rubocop:todo all
 source 'https://rubygems.org'
 
-gem 'actionpack', '~> 6.0'
-gem 'activemodel', '~> 6.0'
+gem 'actionpack', '~> 6.0.0'
+gem 'activemodel', '~> 6.0.0'
 
 group :test do
-  gem 'activejob', '~> 6.0'
+  gem 'activejob', '~> 6.0.0'
 end
 
 gemspec path: '..'

--- a/gemfiles/rails-6.1.gemfile
+++ b/gemfiles/rails-6.1.gemfile
@@ -1,11 +1,11 @@
 # rubocop:todo all
 source 'https://rubygems.org'
 
-gem 'actionpack', '~> 6.1'
-gem 'activemodel', '~> 6.1'
+gem 'actionpack', '~> 6.1.0'
+gem 'activemodel', '~> 6.1.0'
 
 group :test do
-  gem 'activejob', '~> 6.1'
+  gem 'activejob', '~> 6.1.0'
 end
 gemspec path: '..'
 

--- a/gemfiles/rails-7.0.gemfile
+++ b/gemfiles/rails-7.0.gemfile
@@ -1,11 +1,15 @@
 # rubocop:todo all
 source 'https://rubygems.org'
 
-gem 'actionpack', '~> 7.0'
-gem 'activemodel', '~> 7.0'
+# These dependencies must be explicitly declared Ruby 3.4+
+gem 'bigdecimal'
+gem 'mutex_m'
+
+gem 'actionpack', '~> 7.0.0'
+gem 'activemodel', '~> 7.0.0'
 
 group :test do
-  gem 'activejob', '~> 7.0'
+  gem 'activejob', '~> 7.0.0'
 end
 gemspec path: '..'
 

--- a/gemfiles/rails-7.0.gemfile
+++ b/gemfiles/rails-7.0.gemfile
@@ -1,10 +1,6 @@
 # rubocop:todo all
 source 'https://rubygems.org'
 
-# These dependencies must be explicitly declared Ruby 3.4+
-gem 'bigdecimal'
-gem 'mutex_m'
-
 gem 'actionpack', '~> 7.0.0'
 gem 'activemodel', '~> 7.0.0'
 

--- a/gemfiles/rails-7.1.gemfile
+++ b/gemfiles/rails-7.1.gemfile
@@ -1,11 +1,11 @@
 # rubocop:todo all
 source 'https://rubygems.org'
 
-gem 'actionpack', '~> 7.1'
-gem 'activemodel', '~> 7.1'
+gem 'actionpack', '~> 7.1.0'
+gem 'activemodel', '~> 7.1.0'
 
 group :test do
-  gem 'activejob', '~> 7.1'
+  gem 'activejob', '~> 7.1.0'
 end
 gemspec path: '..'
 

--- a/gemfiles/rails-7.2.gemfile
+++ b/gemfiles/rails-7.2.gemfile
@@ -1,11 +1,11 @@
 # rubocop:todo all
 source 'https://rubygems.org'
 
-gem 'actionpack', '~> 7.2'
-gem 'activemodel', '~> 7.2'
+gem 'actionpack', '~> 7.2.0'
+gem 'activemodel', '~> 7.2.0'
 
 group :test do
-  gem 'activejob', '~> 7.2'
+  gem 'activejob', '~> 7.2.0'
 end
 gemspec path: '..'
 

--- a/gemfiles/rails-8.0.gemfile
+++ b/gemfiles/rails-8.0.gemfile
@@ -1,11 +1,11 @@
 # rubocop:todo all
 source 'https://rubygems.org'
 
-gem 'actionpack', '8.0.0.rc2'
-gem 'activemodel', '8.0.0.rc2'
+gem 'actionpack', '~> 8.0.0'
+gem 'activemodel', '~> 8.0.0'
 
 group :test do
-  gem 'activejob', '8.0.0.rc2'
+  gem 'activejob', '~> 8.0.0'
 end
 gemspec path: '..'
 

--- a/spec/integration/shardable_spec.rb
+++ b/spec/integration/shardable_spec.rb
@@ -48,6 +48,8 @@ describe 'Sharding helpers' do
     end
 
     context 'when database does not exist' do
+      max_server_version '8.2.99'
+
       let(:model_cls) { SmMovie }
 
       before do
@@ -61,20 +63,7 @@ describe 'Sharding helpers' do
       let(:model_cls) { SmMovie }
 
       before do
-        SmMovie.collection.database.drop
-        retried = false
-
-        begin
-          SmMovie.collection.create
-          SmMovie.collection.drop
-        rescue Mongo::Error::OperationFailure => exc
-          if !retried && exc.code == 26 # NamespaceNotFound
-            retried = true
-            retry
-          end
-
-          raise
-        end
+        SmMovie.collection.drop
       end
 
       it_behaves_like 'shards collection'

--- a/spec/integration/shardable_spec.rb
+++ b/spec/integration/shardable_spec.rb
@@ -62,8 +62,19 @@ describe 'Sharding helpers' do
 
       before do
         SmMovie.collection.database.drop
-        SmMovie.collection.create
-        SmMovie.collection.drop
+        retried = false
+
+        begin
+          SmMovie.collection.create
+          SmMovie.collection.drop
+        rescue Mongo::Error::OperationFailure => exc
+          if !retried && exc.code == 26 # NamespaceNotFound
+            retried = true
+            retry
+          end
+
+          raise
+        end
       end
 
       it_behaves_like 'shards collection'

--- a/spec/mongoid/validatable/numericality_spec.rb
+++ b/spec/mongoid/validatable/numericality_spec.rb
@@ -39,6 +39,8 @@ describe ActiveModel::Validations::NumericalityValidator do
     end
 
     context 'when the value is a BSON::Decimal128' do
+      min_rails_version '6.1'
+
       let(:model) { TestModel.new(amount: BSON::Decimal128.new('15.0')) }
 
       it 'returns true' do


### PR DESCRIPTION
Fun fact: Mongoid's CI is not testing the following versions of Rails at all:
- 6.0.x
- 7.0.x
- 7.1.x

The reason is that `gem 'actionpack', '~> 6.0'` resolves to `6.Y.Z` where Y and Z are the highest possible version. To enforce it is actually testing `6.0.Z`, one must declare it as `~> 6.0.0`

In addition, Rails 8.0 is pinned at 8.0.0-rc2, i.e. not the latest 8.0.Z release.

Please kindly backport this to any branches under stable maintenance to ensure that future patches to those branches also have proper test coverage.