### PR TITLE
MONGOID-5872 - [🛠️ Let's Fix Mongoid's Broken CI] Fix #expect_query test helper for Ruby 3.3+

### DIFF
--- a/spec/support/expectations.rb
+++ b/spec/support/expectations.rb
@@ -3,15 +3,6 @@
 
 module Mongoid
   module Expectations
-    def connection_class
-      if defined?(Mongo::Server::ConnectionBase)
-        Mongo::Server::ConnectionBase
-      else
-        # Pre-2.8 drivers
-        Mongo::Server::Connection
-      end
-    end
-
     def expect_query(number)
       if %i[ sharded load-balanced ].include?(ClusterConfig.instance.topology) && number > 0
         skip 'This spec requires replica set or standalone topology'
@@ -19,9 +10,9 @@ module Mongoid
       rv = nil
       RSpec::Mocks.with_temporary_scope do
         if number > 0
-          expect_any_instance_of(connection_class).to receive(:command_started).exactly(number).times.and_call_original
+          expect_any_instance_of(Mongo::Server::ConnectionBase).to receive(:command_started).exactly(number).times.and_call_original
         else
-          expect_any_instance_of(connection_class).not_to receive(:command_started)
+          expect_any_instance_of(Mongo::Server::ConnectionBase).not_to receive(:command_started)
         end
         rv = yield
       end

--- a/spec/support/expectations.rb
+++ b/spec/support/expectations.rb
@@ -9,13 +9,13 @@ module Mongoid
         skip 'This spec requires replica set or standalone topology'
       end
 
-      RSpec::Mocks.with_temporary_scope do
-        klass = Mongo::Server::ConnectionBase
+      klass = Mongo::Server::ConnectionBase
+      original_method = klass.instance_method(:command_started)
 
+      RSpec::Mocks.with_temporary_scope do
         if number > 0
           # Due to changes in Ruby 3.3, RSpec's #and_call_original (which wraps the target
           # method) causes infinite recursion. We can achieve the same behavior with binding.
-          original_method = klass.instance_method(:command_started)
           expect_any_instance_of(klass).to receive(:command_started).exactly(number).times do |*args, **kwargs|
             original_method.bind_call(*args, **kwargs)
           end

--- a/spec/support/expectations.rb
+++ b/spec/support/expectations.rb
@@ -2,6 +2,8 @@
 
 module Mongoid
   module Expectations
+    # rubocop:disable Metrics/AbcSize
+    # rubocop:disable RSpec/AnyInstance
     def expect_query(number)
       if %i[ sharded load-balanced ].include?(ClusterConfig.instance.topology) && number > 0
         skip 'This spec requires replica set or standalone topology'
@@ -12,11 +14,10 @@ module Mongoid
 
         if number > 0
           # Due to changes in Ruby 3.3, RSpec's #and_call_original (which wraps the target
-          # method) causes infinite recursion. We can achieve the same behavior with #bind.
+          # method) causes infinite recursion. We can achieve the same behavior with binding.
           original_method = klass.instance_method(:command_started)
           expect_any_instance_of(klass).to receive(:command_started).exactly(number).times do |*args, **kwargs|
-            instance = args.shift
-            original_method.bind(instance).call(*args, **kwargs)
+            original_method.bind_call(*args, **kwargs)
           end
         else
           expect_any_instance_of(klass).not_to receive(:command_started)
@@ -25,6 +26,8 @@ module Mongoid
         yield
       end
     end
+    # rubocop:enable Metrics/AbcSize
+    # rubocop:enable RSpec/AnyInstance
 
     def expect_no_queries(&block)
       expect_query(0, &block)


### PR DESCRIPTION
The #expect_query test helper is basically broken on Ruby 3.3+. I'm not sure how CI tests are even passing with it in its current form... probably Mongoid is not running Ruby 3.3 / Ruby 3.4 tests properly.

I encountered this while testing older Mongoid versions--7.5, 8.0, etc.--on Ruby 3.3/3.4. Several tests which call this helper deterministically fail. To reproduce, you can check out [this commit](https://github.com/tablecheck/mongoid-ultra/commit/d29325f33c2238ae4107d0905484dee44f916db1), then run the tests for `Mongoid::Association::Referenced::BelongsTo::Eager`.

It appears the reason it broke it due to Ruby 3.3's "Object Shapes" changes which affected how method interception used by RSpec's .and_call_original works, creating an infinite loop of interception.