### PR TITLE
MONGOID-5865 - Revert 9.0 Hash behavior

### DIFF
--- a/lib/mongoid/extensions/hash.rb
+++ b/lib/mongoid/extensions/hash.rb
@@ -122,12 +122,8 @@ module Mongoid
         # @return [ Hash | nil ] The object mongoized or nil.
         def mongoize(object)
           return if object.nil?
-          case object
-          when BSON::Document
-            object.dup.transform_values!(&:mongoize)
-          when Hash
-            BSON::Document.new(object.transform_values(&:mongoize))
-          end
+
+          object.dup.transform_values!(&:mongoize)
         end
 
         # Can the size of this object change?


### PR DESCRIPTION
In Mongoid 9.0, an unannounced breaking change was introduced that causes `field type: Hash` to become `BSON::Document`.

This change is not desirable and should be reverted.