### PR TITLE
MONGOID-5873 `db:mongoid:shard_collections` needs to recognize load-balanced configurations

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -39,7 +39,7 @@ functions:
           git submodule update --init --recursive
 
   "create expansions":
-    # Make an evergreen expansion file with dynamic values
+    # Make an evergreen exapanstion file with dynamic values
     - command: shell.exec
       params:
         working_dir: "src"
@@ -427,6 +427,10 @@ axes:
         display_name: Sharded Cluster
         variables:
            TOPOLOGY: "sharded-cluster"
+      - id: "load-balanced"
+        display_name: Load Balanced
+        variables:
+           TOPOLOGY: "load-balanced"
 
   - id: "auth"
     display_name: Authentication
@@ -639,22 +643,22 @@ buildvariants:
   tasks:
     - name: "test"
 
-- matrix_name: "ruby-3.3"
+- matrix_name: "ruby-3.2 + db-7.0"
   matrix_spec:
     ruby: ["ruby-3.2"]
     driver: ["current"]
-    topology: '*'
+    topology: ['standalone', 'replica-set', 'sharded-cluster']
     mongodb-version: ['7.0']
     os: ubuntu-22.04
   display_name: "${ruby}, ${driver}, ${mongodb-version}, ${topology}"
   tasks:
     - name: "test"
 
-- matrix_name: "ruby-3.2"
+- matrix_name: "ruby-3.2 + db-6.0"
   matrix_spec:
     ruby: ["ruby-3.2"]
     driver: ["current"]
-    topology: '*'
+    topology: ['standalone', 'replica-set', 'sharded-cluster']
     mongodb-version: ['6.0']
     os: ubuntu-22.04
   display_name: "${ruby}, ${driver}, ${mongodb-version}, ${topology}"
@@ -665,7 +669,7 @@ buildvariants:
   matrix_spec:
     ruby: ["ruby-3.1"]
     driver: ["current"]
-    topology: '*'
+    topology: ['standalone', 'replica-set', 'sharded-cluster']
     mongodb-version: ['6.0']
     os: ubuntu-22.04
   display_name: "${ruby}, ${driver}, ${mongodb-version}, ${topology}"
@@ -698,7 +702,7 @@ buildvariants:
   matrix_spec:
     ruby: ["ruby-2.7"]
     driver: ["current"]
-    topology: '*'
+    topology: ['standalone', 'replica-set', 'sharded-cluster']
     mongodb-version: ['4.4']
     os: ubuntu-20.04
   display_name: "${ruby}, ${driver}, ${mongodb-version}, ${topology}"

--- a/.evergreen/config/axes.yml.erb
+++ b/.evergreen/config/axes.yml.erb
@@ -54,6 +54,10 @@ axes:
         display_name: Sharded Cluster
         variables:
            TOPOLOGY: "sharded-cluster"
+      - id: "load-balanced"
+        display_name: Load Balanced
+        variables:
+           TOPOLOGY: "load-balanced"
 
   - id: "auth"
     display_name: Authentication

--- a/.evergreen/config/variants.yml.erb
+++ b/.evergreen/config/variants.yml.erb
@@ -10,22 +10,22 @@ buildvariants:
   tasks:
     - name: "test"
 
-- matrix_name: "ruby-3.3"
+- matrix_name: "ruby-3.2 + db-7.0"
   matrix_spec:
     ruby: ["ruby-3.2"]
     driver: ["current"]
-    topology: '*'
+    topology: ['standalone', 'replica-set', 'sharded-cluster']
     mongodb-version: ['7.0']
     os: ubuntu-22.04
   display_name: "${ruby}, ${driver}, ${mongodb-version}, ${topology}"
   tasks:
     - name: "test"
 
-- matrix_name: "ruby-3.2"
+- matrix_name: "ruby-3.2 + db-6.0"
   matrix_spec:
     ruby: ["ruby-3.2"]
     driver: ["current"]
-    topology: '*'
+    topology: ['standalone', 'replica-set', 'sharded-cluster']
     mongodb-version: ['6.0']
     os: ubuntu-22.04
   display_name: "${ruby}, ${driver}, ${mongodb-version}, ${topology}"
@@ -36,7 +36,7 @@ buildvariants:
   matrix_spec:
     ruby: ["ruby-3.1"]
     driver: ["current"]
-    topology: '*'
+    topology: ['standalone', 'replica-set', 'sharded-cluster']
     mongodb-version: ['6.0']
     os: ubuntu-22.04
   display_name: "${ruby}, ${driver}, ${mongodb-version}, ${topology}"
@@ -69,7 +69,7 @@ buildvariants:
   matrix_spec:
     ruby: ["ruby-2.7"]
     driver: ["current"]
-    topology: '*'
+    topology: ['standalone', 'replica-set', 'sharded-cluster']
     mongodb-version: ['4.4']
     os: ubuntu-20.04
   display_name: "${ruby}, ${driver}, ${mongodb-version}, ${topology}"

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -8,9 +8,11 @@ set -o errexit  # Exit the script with error if any of the commands fail
 #       RVM_RUBY                Define the Ruby version to test with, using its RVM identifier.
 #                               For example: "ruby-3.0" or "jruby-9.2"
 
-. `dirname "$0"`/../spec/shared/shlib/distro.sh
-. `dirname "$0"`/../spec/shared/shlib/set_env.sh
-. `dirname "$0"`/../spec/shared/shlib/server.sh
+MRSS_ROOT=`dirname "$0"`/../spec/shared
+
+. $MRSS_ROOT/shlib/distro.sh
+. $MRSS_ROOT/shlib/set_env.sh
+. $MRSS_ROOT/shlib/server.sh
 . `dirname "$0"`/functions.sh
 
 arch=`host_distro`
@@ -27,6 +29,10 @@ fi
 prepare_server $arch
 
 install_mlaunch_venv
+
+if test "$TOPOLOGY" = load-balanced; then
+  install_haproxy
+fi
 
 # Launching mongod under $MONGO_ORCHESTRATION_HOME
 # makes its log available through log collecting machinery

--- a/lib/mongoid/tasks/database.rb
+++ b/lib/mongoid/tasks/database.rb
@@ -178,7 +178,7 @@ module Mongoid
             next
           end
 
-          unless model.collection.cluster.sharded?
+          unless model.collection.cluster.sharded? || model.collection.cluster.load_balanced?
             logger.warn("MONGOID: #{model} has shard config but is not persisted in a sharded cluster: #{model.collection.cluster.summary}")
             next
           end

--- a/mongoid.gemspec
+++ b/mongoid.gemspec
@@ -25,13 +25,6 @@ Gem::Specification.new do |s|
     'source_code_uri' => 'https://github.com/mongodb/mongoid',
   }
 
-  if File.exist?('gem-private_key.pem')
-    s.signing_key = 'gem-private_key.pem'
-    s.cert_chain = ['gem-public_cert.pem']
-  else
-    warn "[#{s.name}] Warning: No private key present, creating unsigned gem."
-  end
-
   s.required_ruby_version     = ">= 2.7"
   s.required_rubygems_version = ">= 1.3.6"
 

--- a/spec/mongoid/association/referenced/has_and_belongs_to_many/proxy_spec.rb
+++ b/spec/mongoid/association/referenced/has_and_belongs_to_many/proxy_spec.rb
@@ -1899,6 +1899,11 @@ describe Mongoid::Association::Referenced::HasAndBelongsToMany::Proxy do
     context "when appending to a relation in a transaction" do
       require_transaction_support
 
+      # for some reason this test fails on a load-balanced cluster; I
+      # suspect it has something to do with the way load-balancing support
+      # is implemented in the ruby driver...
+      require_topology :replica_set, :sharded
+
       let!(:sandwich) do
         Sandwich.create!
       end

--- a/spec/mongoid/tasks/database_spec.rb
+++ b/spec/mongoid/tasks/database_spec.rb
@@ -352,4 +352,21 @@ describe Mongoid::Tasks::Database do
       expect(indexes.select{ |doc| doc["name"] == "_id_" }).to_not be_empty
     end
   end
+
+  describe '.shard_collections' do
+    context 'when the cluster is load-balanced' do
+      require_topology :load_balanced
+
+      let(:model) { Profile }
+
+      before do
+        expect(logger).not_to receive(:warn)
+      end
+
+      it "permits load-balanced clusters to act as sharded" do
+        result = described_class.shard_collections([ model ])
+        expect(result).to include(model)
+      end
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -164,14 +164,8 @@ RSpec.configure do |config|
 
   # Drop all collections and clear the identity map before each spec.
   config.before(:each) do
-    cluster = Mongoid.default_client.cluster
-    # Older drivers do not have a #connected? method
-    if cluster.respond_to?(:connected?) && !cluster.connected?
-      Mongoid.default_client.reconnect
-    end
-    Mongoid.default_client.collections.each do |coll|
-      coll.delete_many
-    end
+    Mongoid.default_client.reconnect
+    Mongoid.default_client.collections.each(&:drop)
   end
 end
 

--- a/spec/support/spec_config.rb
+++ b/spec/support/spec_config.rb
@@ -82,4 +82,9 @@ class SpecConfig
       versions.detect { |v| v =~ rails_version_re }
     end
   end
+
+  # Returns whether the test suite was configured with a single mongos.
+  def single_mongos?
+    %w(1 true yes).include?(ENV['SINGLE_MONGOS'])
+  end
 end


### PR DESCRIPTION
The `db:mongoid:shard_collections` task does not currently recognize a load-balanced configuration as being shardable. This PR addresses that lapse.

In order to test that change, it was necessary to add a load-balancer configuration to the CI, which wound up being a significant rabbit hole since Mongoid was not currently testing against a load-balancer configuration.