### PR TITLE
RUBY-3410 Updated release automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,24 @@
-name: "Mongoid Release"
-run-name: "Mongoid Release for ${{ github.ref }}"
+name: "Gem Release"
+run-name: "Gem Release for ${{ github.ref }}"
 
 on:
   # for auto-deploy when merging a release-candidate PR
-  pull_request:
-    types: [ closed ]
+  push:
+    - 'master'
+    - '*-stable'
+
+  # for manual release
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: "The number of the merged release candidate PR"
+        required: true
 
 env:
   SILK_ASSET_GROUP: mongoid
+  GEM_NAME: mongoid
+  PRODUCT_NAME: Mongoid
+  PRODUCT_ID: mongoid
 
 permissions:
   # required for all workflows
@@ -48,8 +59,8 @@ jobs:
         with:
           app_id: ${{ vars.APP_ID }}
           app_private_key: ${{ secrets.APP_PRIVATE_KEY }}
-          artifact: mongoid
-          gem_name: mongoid
+          artifact: 'ruby-3.2'
+          gem_name: ${{ env.GEM_NAME }}
           ruby_version: 'ruby-3.2'
           ref: ${{ needs.check.outputs.ref }}
 
@@ -68,9 +79,9 @@ jobs:
           aws_region_name: ${{ vars.AWS_REGION_NAME }}
           aws_secret_id: ${{ secrets.AWS_SECRET_ID }}
           dry_run: false
-          gem_name: mongoid
-          product_name: Mongoid
-          product_id: mongoid
+          gem_name: ${{ env.GEM_NAME }}
+          product_name: ${{ env.PRODUCT_NAME }}
+          product_id: ${{ env.PRODUCT_ID }}
           release_message: ${{ needs.check.outputs.message }}
           silk_asset_group: ${{ env.SILK_ASSET_GROUP }}
           ref: ${{ needs.check.outputs.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,66 +2,75 @@ name: "Mongoid Release"
 run-name: "Mongoid Release for ${{ github.ref }}"
 
 on:
-  workflow_dispatch:
-    inputs:
-      dry_run:
-        description: Whether this is a dry run or not
-        required: true
-        default: true
-        type: boolean
+  # for auto-deploy when merging a release-candidate PR
+  pull_request:
+    types: [ closed ]
 
 env:
   SILK_ASSET_GROUP: mongoid
-  RELEASE_MESSAGE_TEMPLATE: |
-    Version {0} of the [Mongoid ODM for MongoDB](https://rubygems.org/gems/mongoid) is now available.
 
-    **Release Highlights**
+permissions:
+  # required for all workflows
+  security-events: write
 
-    TODO: one or more paragraphs describing important changes in this release
+  # required to fetch internal or private CodeQL packs
+  packages: read
 
-    **Documentation**
+  # only required for workflows in private repositories
+  actions: read
+  pull-requests: read
+  contents: write
 
-    Documentation is available at [MongoDB.com](https://www.mongodb.com/docs/mongoid/current/).
-
-    **Installation**
-
-    You may install this version via RubyGems, with:
-
-    gem install --version {0} mongoid
+  # required by the mongodb-labs/drivers-github-tools/setup@v2 step
+  # also required by `rubygems/release-gem`
+  id-token: write
 
 jobs:
-  release:
-    name: "Mongoid Release"
+  check:
+    name: "Check Release"
+    runs-on: ubuntu-latest
+    outputs:
+      message: ${{ steps.check.outputs.message }}
+      ref: ${{ steps.check.outputs.ref }}
+    steps:
+      - name: "Run the check action"
+        id: check
+        uses: jamis/drivers-github-tools/ruby/pr-check@ruby-3643-update-release-process
+
+  build:
+    name: "Build Gems"
+    needs: check
+    environment: release
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Run the build action"
+        uses: jamis/drivers-github-tools/ruby/build@ruby-3643-update-release-process
+        with:
+          app_id: ${{ vars.APP_ID }}
+          app_private_key: ${{ secrets.APP_PRIVATE_KEY }}
+          artifact: mongoid
+          gem_name: mongoid
+          ruby_version: 'ruby-3.2'
+          ref: ${{ needs.check.outputs.ref }}
+
+  publish:
+    name: "Publish Gems"
+    needs: [ check, build ]
     environment: release
     runs-on: 'ubuntu-latest'
-
-    permissions:
-      # required for all workflows
-      security-events: write
-
-      # required to fetch internal or private CodeQL packs
-      packages: read
-
-      # only required for workflows in private repositories
-      actions: read
-      contents: write
-
-      # required by the mongodb-labs/drivers-github-tools/setup@v2 step
-      # also required by `rubygems/release-gem`
-      id-token: write
-
     steps:
       - name: "Run the publish action"
-        uses: mongodb-labs/drivers-github-tools/ruby/publish@v2
+        uses: jamis/drivers-github-tools/ruby/publish@ruby-3643-update-release-process
         with:
           app_id: ${{ vars.APP_ID }}
           app_private_key: ${{ secrets.APP_PRIVATE_KEY }}
           aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}
           aws_region_name: ${{ vars.AWS_REGION_NAME }}
           aws_secret_id: ${{ secrets.AWS_SECRET_ID }}
-          dry_run: ${{ inputs.dry_run }}
+          dry_run: false
           gem_name: mongoid
           product_name: Mongoid
           product_id: mongoid
-          release_message_template: ${{ env.RELEASE_MESSAGE_TEMPLATE }}
+          release_message: ${{ needs.check.outputs.message }}
           silk_asset_group: ${{ env.SILK_ASSET_GROUP }}
+          ref: ${{ needs.check.outputs.ref }}

--- a/Rakefile
+++ b/Rakefile
@@ -11,16 +11,16 @@ $: << File.join(ROOT, 'spec/shared/lib')
 require "rake"
 require "rspec/core/rake_task"
 
-# stands in for the Bundler-provided `build` task, which builds the
-# gem for this project. Our release process builds the gems in a
-# particular way, in a GitHub action. This task is just to help remind
-# developers of that fact.
+if File.exist?('./spec/shared/lib/tasks/candidate.rake')
+  load 'spec/shared/lib/tasks/candidate.rake'
+end
+
+desc 'Build the gem'
 task :build do
-  abort <<~WARNING
-    `rake build` does nothing in this project. The gem must be built via
-    the `Mongoid Release` action on GitHub, which is triggered manually when
-    a new release is ready.
-  WARNING
+  command = %w[ gem build ]
+  command << "--output=#{ENV['GEM_FILE_NAME']}" if ENV['GEM_FILE_NAME']
+  command << (ENV['GEMSPEC'] || 'mongoid.gemspec')
+  system(*command)
 end
 
 # `rake version` is used by the deployment system so get the release version

--- a/lib/mongoid/version.rb
+++ b/lib/mongoid/version.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
-# rubocop:todo all
 
 module Mongoid
+  # The current version of Mongoid
+  #
+  # Note that this file is automatically updated via `rake candidate:create`.
+  # Manual changes to this file will be overwritten by that rake task.
   VERSION = "9.0.2"
 end

--- a/product.yml
+++ b/product.yml
@@ -1,0 +1,8 @@
+---
+name: Mongoid
+description: an Ruby ODM for MongoDB
+package: mongoid
+jira: https://jira.mongodb.org/projects/MONGOID
+version:
+  number: 9.0.2
+  file: lib/mongoid/version.rb


### PR DESCRIPTION
This adds the necessary files and makes the necessary changes to the release process for the Mongoid gem. Some specific callouts:

- Adds `product.yml` file to hold release metadata used by the release process.
- The `VERSION` line in `lib/mongoid/version.rb` file is now considered to be autogenerated.
- Adds the `candidate:*` rake tasks to the Rakefile.
- Reworks the `release.yml` workflow to use the new `pr-check`, `build`, and `publish` actions, triggering on `push` and `workflow_dispatch`.