### PR TITLE
MONGOID-5841 Don't auto-build if the parent is frozen

### DIFF
--- a/lib/mongoid/association/accessors.rb
+++ b/lib/mongoid/association/accessors.rb
@@ -304,7 +304,7 @@ module Mongoid
         association.inverse_class.tap do |klass|
           klass.re_define_method(name) do |reload = false|
             value = get_relation(name, association, nil, reload)
-            if value.nil? && association.autobuilding? && !without_autobuild?
+            if !frozen? && value.nil? && association.autobuilding? && !without_autobuild?
               value = send("build_#{name}")
             end
             value

--- a/spec/mongoid/association/accessors_spec.rb
+++ b/spec/mongoid/association/accessors_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 
 describe Mongoid::Association::Accessors do
 
-  describe "\#{getter}?" do
+  describe '#{getter}?' do
 
     let(:person) do
       Person.create!
@@ -242,7 +242,7 @@ describe Mongoid::Association::Accessors do
     end
   end
 
-  describe "\#{getter}" do
+  describe '#{getter}' do
 
     let(:person) do
       Person.new
@@ -264,6 +264,16 @@ describe Mongoid::Association::Accessors do
 
           it "stores in the altered attribute" do
             expect(person.as_document["pass"]).to eq(passport.attributes)
+          end
+        end
+
+        context 'when the parent is frozen' do
+          before do
+            person.freeze
+          end
+
+          it 'returns nil' do
+            expect(person.passport).to be_nil
           end
         end
 


### PR DESCRIPTION
If a record is frozen (perhaps because it has just been destroyed), attempts to auto-build associations on it should return nil, instead of raising a mysterious `FrozenError`.