### PR TITLE
Fix error in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,9 @@ run-name: "Gem Release for ${{ github.ref }}"
 on:
   # for auto-deploy when merging a release-candidate PR
   push:
-    - 'master'
-    - '*-stable'
+    branches:
+      - 'master'
+      - '*-stable'
 
   # for manual release
   workflow_dispatch:


### PR DESCRIPTION
The `push` trigger takes a `branches` key, not a list of patterns.