### PR TITLE
Use `ActiveSupport::IsolatedExecutionState` to get and set thread or fiber variables depending on the environment

### DIFF
--- a/lib/mongoid/threaded.rb
+++ b/lib/mongoid/threaded.rb
@@ -57,7 +57,7 @@ module Mongoid
     # @return [ Object | nil ] the value of the queried variable, or nil if
     #   it is not set and no default was given.
     def get(key, &default)
-      result = Thread.current.thread_variable_get(key)
+      result = ActiveSupport::IsolatedExecutionState[key]
 
       if result.nil? && default
         result = yield
@@ -75,7 +75,7 @@ module Mongoid
     # @param [ Object | nil ] value the value of the variable to set (or `nil`
     #   if you wish to unset the variable)
     def set(key, value)
-      Thread.current.thread_variable_set(key, value)
+      ActiveSupport::IsolatedExecutionState[key] = value
     end
 
     # Removes the named variable from thread-local storage.


### PR DESCRIPTION
Upon trying to use Mongoid in a Falcon environment we started getting some very weird errors. Specifically errors that looked like the Mongoid scope for a specific request was incorrect and very wrong. Upon taking a look at how the `Threaded` class is used within Mongoid, I believe the reason is because it uses threads to store the state of a bunch of different things throughout the lifecycle of a request.

It appears as though this was assumed to be safe given the fact that (more or less) every server until Falcon used either a single thread, or multiple threads for concurrency. In Falcon of course, this is not the case. All requests are processed in Fibers and there's no mutex around accessing these thread variables.

Now, it turns out in Rails 7.2, there was some work done to address this very problem and there's a new config called `ActiveSupport::IsolatedExecutionState.isolation_level` which defaults to `:thread`, but allows us to set `:fiber` instead.

```ruby
ActiveSupport::IsolatedExecutionState.isolation_level = :fiber
```

I don't know what the bigger plan for such a change should be, but at least this change is backwards compatible, always defaulting to `:thread`, just like it always was.

I've been running this change in production for a week now and all our problems have gone away. Falcon and Mongoid seem like good friends now.

There is the caveat here of being a Rails 7.2 feature, and I am not clear on how you guys handle minimum versions so perhaps there needs to be a `ActiveSupport` version check. In any case, I'm flagging the issue with a potential fix.