### PR TITLE
MONGOID-5882 Isolation state

### DIFF
--- a/lib/config/locales/en.yml
+++ b/lib/config/locales/en.yml
@@ -712,6 +712,16 @@ en:
             the expression %{javascript} is not allowed."
           resolution: "Please provide a standard hash to #where when the criteria
             is for an embedded association."
+        unsupported_isolation_level:
+          message: "The isolation level '%{level}' is not supported."
+          summary: >
+            You requested an isolation level of '%{level}', which is not
+            supported. Only `:thread` and `:fiber` isolation levels are
+            currently supported; note that the `:fiber` level is only
+            supported on Ruby versions 3.2 and higher.
+          resolution: >
+            Use `:thread` as the isolation level. If you are using Ruby 3.2
+            or higher, you may also use `:fiber`.
         validations:
           message: "Validation of %{document} failed."
           summary: "The following errors were found: %{errors}"

--- a/lib/config/locales/en.yml
+++ b/lib/config/locales/en.yml
@@ -716,12 +716,13 @@ en:
           message: "The isolation level '%{level}' is not supported."
           summary: >
             You requested an isolation level of '%{level}', which is not
-            supported. Only `:thread` and `:fiber` isolation levels are
-            currently supported; note that the `:fiber` level is only
-            supported on Ruby versions 3.2 and higher.
+            supported. Only `:rails`, `:thread` and `:fiber` isolation
+            levels are currently supported; note that the `:fiber` level is
+            only supported on Ruby versions 3.2 and higher.
           resolution: >
             Use `:thread` as the isolation level. If you are using Ruby 3.2
-            or higher, you may also use `:fiber`.
+            or higher, you may also use `:fiber`. If using Rails 7+, you
+            may also use `:rails` to inherit the isolation level from Rails.
         validations:
           message: "Validation of %{document} failed."
           summary: "The following errors were found: %{errors}"

--- a/lib/mongoid/config.rb
+++ b/lib/mongoid/config.rb
@@ -110,6 +110,19 @@ module Mongoid
     # to `:global_thread_pool`.
     option :global_executor_concurrency, default: nil
 
+    # Defines the isolation level that Mongoid uses to store its internal
+    # state.
+    #
+    # This option may be set to either `:thread` (the default) or `:fiber`.
+    #
+    # If set to `:thread`, Mongoid will use thread-local storage to manage
+    # its internal state.
+    #
+    # If set to `:fiber`, Mongoid will use fiber-local storage instead. This
+    # may be necessary if you are using libraries like Falcon, which use
+    # fibers to manage concurrency.
+    option :isolation_level, default: :thread
+
     # When this flag is false, a document will become read-only only once the
     # #readonly! method is called, and an error will be raised on attempting
     # to save or update such documents, instead of just on delete. When this

--- a/lib/mongoid/config.rb
+++ b/lib/mongoid/config.rb
@@ -110,13 +110,16 @@ module Mongoid
     # to `:global_thread_pool`.
     option :global_executor_concurrency, default: nil
 
+    VALID_ISOLATION_LEVELS = %i[ rails thread fiber ].freeze
+
     # Defines the isolation level that Mongoid uses to store its internal
     # state.
     #
-    # This option may be set to either `:thread` (the default) or `:fiber`.
-    #
-    # If set to `:thread`, Mongoid will use thread-local storage to manage
-    # its internal state.
+    # Valid values are:
+    # - `:rails` - Uses the isolation level that Rails currently has
+    #  configured. (This is the default.)
+    # - `:thread` - Uses thread-local storage.
+    # - `:fiber` - Uses fiber-local storage (only supported in Ruby 3.2+).
     #
     # If set to `:fiber`, Mongoid will use fiber-local storage instead. This
     # may be necessary if you are using libraries like Falcon, which use
@@ -125,8 +128,46 @@ module Mongoid
     # Note that the `:fiber` isolation level is only supported in Ruby 3.2
     # and later, due to semantic differences in how fiber storage is handled
     # in earlier Ruby versions.
-    option :isolation_level, default: :thread, on_change: -> (level) do
-      if %i[ thread fiber ].exclude?(level)
+    option :isolation_level, default: :rails, on_change: -> (level) do
+      validate_isolation_level!(level)
+    end
+
+    # Returns the (potentially-dereferenced) isolation level that Mongoid
+    # will use to store its internal state. If `isolation_level` is set to
+    # `:rails`, this will return the isolation level that Rails is current
+    # configured to use (`ActiveSupport::IsolatedExecutionState.isolation_level`).
+    #
+    # If using an older version of Rails that does not support
+    # ActiveSupport::IsolatedExecutionState, this will return `:thread`
+    # instead.
+    #
+    # @api private
+    def real_isolation_level
+      return isolation_level unless isolation_level == :rails
+
+      if defined?(ActiveSupport::IsolatedExecutionState)
+        ActiveSupport::IsolatedExecutionState.isolation_level.tap do |level|
+          # We can't guarantee that Rails will always support the same
+          # isolation levels as Mongoid, so we check here to make sure
+          # it's something we can work with.
+          validate_isolation_level!(level)
+        end
+      else
+        # The default, if Rails does not support IsolatedExecutionState,
+        :thread
+      end
+    end
+
+    # Checks to see if the provided isolation level is something that Mongoid
+    # supports. Raises Errors::UnsupportedIsolationLevel if it is not.
+    #
+    # This will also raise an error if the isolation level is set to `:fiber`
+    # and the Ruby version is less than 3.2, since fiber-local storage
+    # is not supported in earlier Ruby versions.
+    #
+    # @api private
+    def validate_isolation_level!(level)
+      unless VALID_ISOLATION_LEVELS.include?(level)
         raise Errors::UnsupportedIsolationLevel.new(level)
       end
 

--- a/lib/mongoid/config/options.rb
+++ b/lib/mongoid/config/options.rb
@@ -40,8 +40,17 @@ module Mongoid
           end
 
           define_method("#{name}=") do |value|
+            old_value = settings[name]
             settings[name] = value
-            options[:on_change]&.call(value)
+
+            begin
+              options[:on_change]&.call(value)
+            rescue
+              # If the on_change callback raises an error, we need to roll
+              # the change back.
+              settings[name] = old_value
+              raise
+            end
           end
 
           define_method("#{name}?") do

--- a/lib/mongoid/errors.rb
+++ b/lib/mongoid/errors.rb
@@ -74,5 +74,6 @@ require 'mongoid/errors/unrecognized_resolver'
 require 'mongoid/errors/unregistered_class'
 require "mongoid/errors/unsaved_document"
 require "mongoid/errors/unsupported_javascript"
+require "mongoid/errors/unsupported_isolation_level"
 require "mongoid/errors/validations"
 require "mongoid/errors/delete_restriction"

--- a/lib/mongoid/errors/unsupported_isolation_level.rb
+++ b/lib/mongoid/errors/unsupported_isolation_level.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Mongoid
+  module Errors
+
+    # Raised when an unsupported isolation level is used in Mongoid
+    # configuration.
+    class UnsupportedIsolationLevel < MongoidError
+      # Create the new error caused by attempting to select an unsupported
+      # isolation level.
+      #
+      # @param [ Symbol ] level The requested isolation level.
+      def initialize(level)
+        super(
+          compose_message(
+            "unsupported_isolation_level",
+            { level: level }
+          )
+        )
+      end
+    end
+  end
+end

--- a/lib/mongoid/errors/unsupported_isolation_level.rb
+++ b/lib/mongoid/errors/unsupported_isolation_level.rb
@@ -2,7 +2,6 @@
 
 module Mongoid
   module Errors
-
     # Raised when an unsupported isolation level is used in Mongoid
     # configuration.
     class UnsupportedIsolationLevel < MongoidError
@@ -13,7 +12,7 @@ module Mongoid
       def initialize(level)
         super(
           compose_message(
-            "unsupported_isolation_level",
+            'unsupported_isolation_level',
             { level: level }
           )
         )

--- a/lib/mongoid/threaded.rb
+++ b/lib/mongoid/threaded.rb
@@ -42,16 +42,16 @@ module Mongoid
     # This is useful for making sure the state is clean when starting a new
     # thread or fiber.
     #
-    # The value of Mongoid::Config.isolation_level is used to determine
+    # The value of Mongoid::Config.real_isolation_level is used to determine
     # whether to reset the storage for the current thread or fiber.
     def reset!
-      case Config.isolation_level
+      case Config.real_isolation_level
       when :thread
         Thread.current.thread_variable_set(STORAGE_KEY, nil)
       when :fiber
         Fiber[STORAGE_KEY] = nil
       else
-        raise "Unknown isolation level: #{Config.isolation_level.inspect}"
+        raise "Unknown isolation level: #{Config.real_isolation_level.inspect}"
       end
     end
 
@@ -517,7 +517,7 @@ module Mongoid
 
     # Returns the current thread- or fiber-local storage as a Hash.
     def storage
-      case Config.isolation_level
+      case Config.real_isolation_level
       when :thread
         storage_hash = Thread.current.thread_variable_get(STORAGE_KEY)
 
@@ -532,7 +532,7 @@ module Mongoid
         Fiber[STORAGE_KEY] ||= {}
 
       else
-        raise "Unknown isolation level: #{Config.isolation_level.inspect}"
+        raise "Unknown isolation level: #{Config.real_isolation_level.inspect}"
       end
     end
   end

--- a/lib/mongoid/threaded.rb
+++ b/lib/mongoid/threaded.rb
@@ -515,21 +515,25 @@ module Mongoid
       delete(CURRENT_SCOPE_KEY) if scope.empty?
     end
 
-    # Returns the current thread- or fiber-local storage as a Hash. 
+    # Returns the current thread- or fiber-local storage as a Hash.
     def storage
       case Config.isolation_level
       when :thread
-        if !Thread.current.thread_variable?(STORAGE_KEY)
-          Thread.current.thread_variable_set(STORAGE_KEY, {})
+        storage_hash = Thread.current.thread_variable_get(STORAGE_KEY)
+
+        unless storage_hash
+          storage_hash = {}
+          Thread.current.thread_variable_set(STORAGE_KEY, storage_hash)
         end
 
-        Thread.current.thread_variable_get(STORAGE_KEY)
+        storage_hash
+
       when :fiber
         Fiber[STORAGE_KEY] ||= {}
+
       else
         raise "Unknown isolation level: #{Config.isolation_level.inspect}"
       end
     end
-
   end
 end

--- a/spec/integration/isolation_state_spec.rb
+++ b/spec/integration/isolation_state_spec.rb
@@ -20,6 +20,41 @@ describe 'Mongoid::Config.isolation_level' do
     end.resume
   end
 
+  context 'when set to an unsupported value' do
+    it 'raises an error' do
+      old_value = Mongoid::Config.isolation_level
+      expect { Mongoid::Config.isolation_level = :unsupported }
+        .to raise_error(Mongoid::Errors::UnsupportedIsolationLevel)
+      expect(Mongoid::Config.isolation_level).to eq(old_value)
+    end
+  end
+
+  context 'when using older Ruby' do
+    ruby_version_lt '3.2'
+
+    context 'when set to :fiber' do
+      it 'raises an error' do
+        expect { Mongoid::Config.isolation_level = :fiber }
+          .to raise_error(Mongoid::Errors::UnsupportedIsolationLevel)
+      end
+    end
+
+    context 'when set to :thread' do
+      around do |example|
+        save = Mongoid::Config.isolation_level
+        example.run
+      ensure
+        Mongoid::Config.isolation_level = save
+      end
+
+      it 'sets the isolation level' do
+        expect { Mongoid::Config.isolation_level = :thread }
+          .not_to raise_error
+        expect(Mongoid::Config.isolation_level).to eq(:thread)
+      end
+    end
+  end
+
   context 'when set to :thread' do
     config_override :isolation_level, :thread
 
@@ -42,54 +77,58 @@ describe 'Mongoid::Config.isolation_level' do
     end
   end
 
-  context 'when set to :fiber' do
-    config_override :isolation_level, :fiber
+  context 'when using Ruby 3.2+' do
+    ruby_version_gte '3.2'
 
-    context 'when operating inside threads' do
-      let(:result) { fiber_operation('a') { thread_operation('b') } }
+    context 'when set to :fiber' do
+      config_override :isolation_level, :fiber
 
-      it 'exposes the fiber state within the thread' do
-        expect(result).to eq(%w[ a b ])
-      end
-    end
+      context 'when operating inside threads' do
+        let(:result) { fiber_operation('a') { thread_operation('b') } }
 
-    context 'when operating in nested fibers' do
-      let(:result) { fiber_operation('a') { fiber_operation('b') } }
-
-      it 'propagates fiber state to nested fibers' do
-        expect(result).to eq(%w[ a b ])
-      end
-    end
-
-    context 'when operating in adjacent fibers' do
-      let(:result1) { fiber_operation('a') { fiber_operation('b') } }
-      let(:result2) { fiber_operation('c') { fiber_operation('d') } }
-
-      it 'maintains isolation between adjacent fibers' do
-        expect(result1).to eq(%w[ a b ])
-        expect(result2).to eq(%w[ c d ])
-      end
-    end
-
-    describe '#reset!' do
-      context 'when operating in nested fibers' do
-        let (:result) do
-          fiber_operation('a') do
-            Mongoid::Threaded.reset!
-
-            # once reset, subsequent nested fibers will each have their own
-            # state; they won't touch the reset state here.
-            fiber_operation('b')
-            fiber_operation('c')
-
-            # If we then add to the stack here, it will be unaffected by
-            # the previous fiber operations.
-            Mongoid::Threaded.stack(:testing) << 'd'
-          end
+        it 'exposes the fiber state within the thread' do
+          expect(result).to eq(%w[ a b ])
         end
+      end
 
-        it 'clears the fiber state' do
-          expect(result).to eq(%w[ d ])
+      context 'when operating in nested fibers' do
+        let(:result) { fiber_operation('a') { fiber_operation('b') } }
+
+        it 'propagates fiber state to nested fibers' do
+          expect(result).to eq(%w[ a b ])
+        end
+      end
+
+      context 'when operating in adjacent fibers' do
+        let(:result1) { fiber_operation('a') { fiber_operation('b') } }
+        let(:result2) { fiber_operation('c') { fiber_operation('d') } }
+
+        it 'maintains isolation between adjacent fibers' do
+          expect(result1).to eq(%w[ a b ])
+          expect(result2).to eq(%w[ c d ])
+        end
+      end
+
+      describe '#reset!' do
+        context 'when operating in nested fibers' do
+          let (:result) do
+            fiber_operation('a') do
+              Mongoid::Threaded.reset!
+
+              # once reset, subsequent nested fibers will each have their own
+              # state; they won't touch the reset state here.
+              fiber_operation('b')
+              fiber_operation('c')
+
+              # If we then add to the stack here, it will be unaffected by
+              # the previous fiber operations.
+              Mongoid::Threaded.stack(:testing) << 'd'
+            end
+          end
+
+          it 'clears the fiber state' do
+            expect(result).to eq(%w[ d ])
+          end
         end
       end
     end

--- a/spec/integration/isolation_state_spec.rb
+++ b/spec/integration/isolation_state_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+# rubocop:todo all
+
+require 'spec_helper'
+
+describe 'Mongoid::Config.isolation_level' do
+  def thread_operation(value)
+    Thread.new do
+      Mongoid::Threaded.stack(:testing) << value
+      yield if block_given?
+      Mongoid::Threaded.stack(:testing)
+    end.join.value
+  end
+
+  def fiber_operation(value)
+    Fiber.new do
+      Mongoid::Threaded.stack(:testing) << value
+      yield if block_given?
+      Mongoid::Threaded.stack(:testing)
+    end.resume
+  end
+
+  context 'when set to :thread' do
+    config_override :isolation_level, :thread
+
+    context 'when not operating inside fibers' do
+      let(:result1) { thread_operation('a') { thread_operation('b') } }
+      let(:result2) { thread_operation('b') { thread_operation('c') } }
+
+      it 'isolates state per thread' do
+        expect(result1).to eq(%w[ a ])
+        expect(result2).to eq(%w[ b ])
+      end
+    end
+
+    context 'when operating inside fibers' do
+      let(:result) { thread_operation('a') { fiber_operation('b') } }
+
+      it 'exposes the thread state within the fiber' do
+        expect(result).to eq(%w[ a b ])
+      end
+    end
+  end
+
+  context 'when set to :fiber' do
+    config_override :isolation_level, :fiber
+
+    context 'when operating inside threads' do
+      let(:result) { fiber_operation('a') { thread_operation('b') } }
+
+      it 'exposes the fiber state within the thread' do
+        expect(result).to eq(%w[ a b ])
+      end
+    end
+
+    context 'when operating in nested fibers' do
+      let(:result) { fiber_operation('a') { fiber_operation('b') } }
+
+      it 'propagates fiber state to nested fibers' do
+        expect(result).to eq(%w[ a b ])
+      end
+    end
+
+    context 'when operating in adjacent fibers' do
+      let(:result1) { fiber_operation('a') { fiber_operation('b') } }
+      let(:result2) { fiber_operation('c') { fiber_operation('d') } }
+
+      it 'maintains isolation between adjacent fibers' do
+        expect(result1).to eq(%w[ a b ])
+        expect(result2).to eq(%w[ c d ])
+      end
+    end
+
+    describe '#reset!' do
+      context 'when operating in nested fibers' do
+        let (:result) do
+          fiber_operation('a') do
+            Mongoid::Threaded.reset!
+
+            # once reset, subsequent nested fibers will each have their own
+            # state; they won't touch the reset state here.
+            fiber_operation('b')
+            fiber_operation('c')
+
+            # If we then add to the stack here, it will be unaffected by
+            # the previous fiber operations.
+            Mongoid::Threaded.stack(:testing) << 'd'
+          end
+        end
+
+        it 'clears the fiber state' do
+          expect(result).to eq(%w[ d ])
+        end
+      end
+    end
+  end
+end

--- a/spec/integration/isolation_state_spec.rb
+++ b/spec/integration/isolation_state_spec.rb
@@ -59,13 +59,18 @@ describe 'Mongoid::Config.isolation_level' do
     config_override :isolation_level, :rails
     
     def self.with_rails_isolation_level(level)
-      puts "Rails version: #{ActiveSupport.version}"
       around do |example|
+        # changing the isolation level in Rails apparently can muck with the
+        # configured time zone, so we'll save and restore it, too.
+        tz_saved = Time.zone
+
         saved, ActiveSupport::IsolatedExecutionState.isolation_level =
           ActiveSupport::IsolatedExecutionState.isolation_level, level
+
         example.run
       ensure
         ActiveSupport::IsolatedExecutionState.isolation_level = saved
+        Time.zone = tz_saved
       end
     end
 


### PR DESCRIPTION
## Summary

Some applications will use threads for concurrency. Others will use fibers. Prior to this PR, Mongoid worked fine with threads, but it's internal state could get into odd states when run under fibers.

This PR allows applications to indicate which *isolation level* they wish to use, and Mongoid's state will be isolated to that scope.

```ruby
# the default -- inherit the isolation level from `ActiveSupport::IsolatedExecutionState` if possible
Mongoid.isolation_level = :rails

# The following two explicit settings are supported:
Mongoid.isolation_level = :thread # the classic behavior
Mongoid.isolation_level = :fiber  # NEW!
```

When using the `:fiber` isolation level, Mongoid's internal state will be inherited from any parent fiber. If you want to make sure a fiber begins with a clean slate, you can wipe the isolation state with `Mongoid::Threaded.reset!`.