### PR TITLE
MONGOID-4889 Optimize batch assignment of embedded documents (backport to 9.0)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -64,7 +64,7 @@ Layout/SpaceInsidePercentLiteralDelimiters:
   Enabled: false
 
 Metrics/ClassLength:
-  Max: 200
+  Enabled: false
 
 Metrics/ModuleLength:
   Enabled: false

--- a/lib/mongoid/association/embedded/batchable.rb
+++ b/lib/mongoid/association/embedded/batchable.rb
@@ -313,18 +313,19 @@ module Mongoid
         #
         # @return [ Array<Hash> ] The documents as an array of hashes.
         def pre_process_batch_insert(docs)
-          docs.map do |doc|
-            next unless doc
-            append(doc)
-            if persistable? && !_assigning?
-              self.path = doc.atomic_path unless path
-              if doc.valid?(:create)
-                doc.run_before_callbacks(:save, :create)
-              else
-                self.inserts_valid = false
+          [].tap do |results|
+            append_many(docs) do |doc|
+              if persistable? && !_assigning?
+                self.path = doc.atomic_path unless path
+                if doc.valid?(:create)
+                  doc.run_before_callbacks(:save, :create)
+                else
+                  self.inserts_valid = false
+                end
               end
+
+              results << doc.send(:as_attributes)
             end
-            doc.send(:as_attributes)
           end
         end
 

--- a/lib/mongoid/association/referenced/has_many/proxy.rb
+++ b/lib/mongoid/association/referenced/has_many/proxy.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-# TODO: consider refactoring this Proxy class, to satisfy the following
-# cops...
-# rubocop:disable Metrics/ClassLength
 module Mongoid
   module Association
     module Referenced
@@ -588,4 +585,3 @@ module Mongoid
     end
   end
 end
-# rubocop:enable Metrics/ClassLength

--- a/spec/integration/associations/embeds_many_spec.rb
+++ b/spec/integration/associations/embeds_many_spec.rb
@@ -201,6 +201,47 @@ describe 'embeds_many associations' do
         include_examples 'persists correctly'
       end
     end
+
+    context 'including duplicates in the assignment' do
+      let(:canvas) do
+        Canvas.create!(shapes: [Shape.new])
+      end
+
+      shared_examples 'persists correctly' do
+        it 'persists correctly' do
+          canvas.shapes.length.should eq 2
+          _canvas = Canvas.find(canvas.id)
+          _canvas.shapes.length.should eq 2
+        end
+      end
+
+      context 'via assignment operator' do
+        before do
+          canvas.shapes = [ canvas.shapes.first, Shape.new, canvas.shapes.first ]
+          canvas.save!
+        end
+
+        include_examples 'persists correctly'
+      end
+
+      context 'via attributes=' do
+        before do
+          canvas.attributes = { shapes: [ canvas.shapes.first, Shape.new, canvas.shapes.first ] }
+          canvas.save!
+        end
+
+        include_examples 'persists correctly'
+      end
+
+      context 'via assign_attributes' do
+        before do
+          canvas.assign_attributes(shapes: [ canvas.shapes.first, Shape.new, canvas.shapes.first ])
+          canvas.save!
+        end
+
+        include_examples 'persists correctly'
+      end
+    end
   end
 
   context 'when an anonymous class defines an embeds_many association' do


### PR DESCRIPTION
_(Backported to 9.0-stable)_

When associating multiple embedded documents in a single assignment, the existing code was inefficiently looping over all records repeatedly, resulting in a significant performance impact. This PR attempts to minimize the number of loops needed to accomplish the same thing, while keeping the ordering of callbacks the same and otherwise attempting to not break backward compatibility.

To test the performance of this PR, the following benchmark (from MONGOID-4889) was used:

```ruby
class Foo
  include Mongoid::Document
  embeds_many :bars
end

class Bar
  include Mongoid::Document
  embedded_in :foo
end

require 'benchmark'
array_1k = Array.new(1000) { Bar.new }
array_2k = Array.new(2000) { Bar.new }
array_3k = Array.new(3000) { Bar.new }
array_4k = Array.new(4000) { Bar.new }
array_5k = Array.new(5000) { Bar.new }

Benchmark.bm do |x|
  x.report('1k') { Foo.new.bars = array_1k }
  x.report('2k') { Foo.new.bars = array_2k }
  x.report('3k') { Foo.new.bars = array_3k }
  x.report('4k') { Foo.new.bars = array_4k }
  x.report('5k') { Foo.new.bars = array_5k }
end
```

With the previous implementation, the timings were abyssmal:

```
        user     system      total        real
1k  0.721604   0.002515   0.724119 (  0.724148)
2k  2.834939   0.008708   2.843647 (  2.843895)
3k  6.383648   0.017409   6.401057 (  6.401207)
4k 11.313247   0.035579  11.348826 ( 11.349941)
5k 17.895191   0.096859  17.992050 ( 18.048693)
```

Things look much better with the optimized implementation:

```
        user     system      total        real
1k  0.031262   0.000538   0.031800 (  0.031798)
2k  0.041094   0.000543   0.041637 (  0.041638)
3k  0.058909   0.000606   0.059515 (  0.059517)
4k  0.090872   0.000752   0.091624 (  0.091641)
5k  0.096289   0.001358   0.097647 (  0.097666)
```