### PR TITLE
Release process updates for 8.1-stable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,68 +1,88 @@
-name: "Mongoid Release"
-run-name: "Mongoid Release for ${{ github.ref }}"
+name: "Gem Release"
+run-name: "Gem Release for ${{ github.ref }}"
 
 on:
+  # for auto-deploy when merging a release-candidate PR
+  push:
+    branches:
+      - 'master'
+      - '*-stable'
+
+  # for manual release
   workflow_dispatch:
     inputs:
-      dry_run:
-        description: Whether this is a dry run or not
+      pr:
+        description: "The number of the merged release candidate PR"
         required: true
-        default: true
-        type: boolean
 
 env:
   SILK_ASSET_GROUP: mongoid
-  RELEASE_MESSAGE_TEMPLATE: |
-    Version {0} of the [Mongoid ODM for MongoDB](https://rubygems.org/gems/mongoid) is now available.
+  GEM_NAME: mongoid
+  PRODUCT_NAME: Mongoid
+  PRODUCT_ID: mongoid
 
-    **Release Highlights**
+permissions:
+  # required for all workflows
+  security-events: write
 
-    TODO: one or more paragraphs describing important changes in this release
+  # required to fetch internal or private CodeQL packs
+  packages: read
 
-    **Documentation**
+  # only required for workflows in private repositories
+  actions: read
+  pull-requests: read
+  contents: write
 
-    Documentation is available at [MongoDB.com](https://www.mongodb.com/docs/mongoid/current/).
-
-    **Installation**
-
-    You may install this version via RubyGems, with:
-
-    gem install --version {0} mongoid
+  # required by the mongodb-labs/drivers-github-tools/setup@v2 step
+  # also required by `rubygems/release-gem`
+  id-token: write
 
 jobs:
-  release:
-    name: "Mongoid Release"
+  check:
+    name: "Check Release"
+    runs-on: ubuntu-latest
+    outputs:
+      message: ${{ steps.check.outputs.message }}
+      ref: ${{ steps.check.outputs.ref }}
+    steps:
+      - name: "Run the check action"
+        id: check
+        uses: jamis/drivers-github-tools/ruby/pr-check@ruby-3643-update-release-process
+
+  build:
+    name: "Build Gems"
+    needs: check
+    environment: release
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Run the build action"
+        uses: jamis/drivers-github-tools/ruby/build@ruby-3643-update-release-process
+        with:
+          app_id: ${{ vars.APP_ID }}
+          app_private_key: ${{ secrets.APP_PRIVATE_KEY }}
+          artifact: 'ruby-3.2'
+          gem_name: ${{ env.GEM_NAME }}
+          ruby_version: 'ruby-3.2'
+          ref: ${{ needs.check.outputs.ref }}
+
+  publish:
+    name: "Publish Gems"
+    needs: [ check, build ]
     environment: release
     runs-on: 'ubuntu-latest'
-
-    permissions:
-      # required for all workflows
-      security-events: write
-
-      # required to fetch internal or private CodeQL packs
-      packages: read
-
-      # only required for workflows in private repositories
-      actions: read
-      contents: write
-
-      # required by the mongodb-labs/drivers-github-tools/setup@v2 step
-      # also required by `rubygems/release-gem`
-      id-token: write
-
     steps:
       - name: "Run the publish action"
-        uses: mongodb-labs/drivers-github-tools/ruby/publish@v2
+        uses: jamis/drivers-github-tools/ruby/publish@ruby-3643-update-release-process
         with:
           app_id: ${{ vars.APP_ID }}
           app_private_key: ${{ secrets.APP_PRIVATE_KEY }}
           aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}
           aws_region_name: ${{ vars.AWS_REGION_NAME }}
           aws_secret_id: ${{ secrets.AWS_SECRET_ID }}
-          bundler_cache_version: 1
-          dry_run: ${{ inputs.dry_run }}
-          gem_name: mongoid
-          product_name: Mongoid
-          product_id: mongoid
-          release_message_template: ${{ env.RELEASE_MESSAGE_TEMPLATE }}
+          dry_run: false
+          gem_name: ${{ env.GEM_NAME }}
+          product_name: ${{ env.PRODUCT_NAME }}
+          product_id: ${{ env.PRODUCT_ID }}
+          release_message: ${{ needs.check.outputs.message }}
           silk_asset_group: ${{ env.SILK_ASSET_GROUP }}
+          ref: ${{ needs.check.outputs.ref }}

--- a/Rakefile
+++ b/Rakefile
@@ -10,16 +10,16 @@ $: << File.join(ROOT, 'spec/shared/lib')
 require "rake"
 require "rspec/core/rake_task"
 
-# stands in for the Bundler-provided `build` task, which builds the
-# gem for this project. Our release process builds the gems in a
-# particular way, in a GitHub action. This task is just to help remind
-# developers of that fact.
+if File.exist?('./spec/shared/lib/tasks/candidate.rake')
+  load 'spec/shared/lib/tasks/candidate.rake'
+end
+
+desc 'Build the gem'
 task :build do
-  abort <<~WARNING
-    `rake build` does nothing in this project. The gem must be built via
-    the `Mongoid Release` action on GitHub, which is triggered manually when
-    a new release is ready.
-  WARNING
+  command = %w[ gem build ]
+  command << "--output=#{ENV['GEM_FILE_NAME']}" if ENV['GEM_FILE_NAME']
+  command << (ENV['GEMSPEC'] || 'mongoid.gemspec')
+  system(*command)
 end
 
 # `rake version` is used by the deployment system so get the release version

--- a/lib/mongoid/version.rb
+++ b/lib/mongoid/version.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
 module Mongoid
-  VERSION = "8.1.10"
+  # The current version of Mongoid
+  #
+  # Note that this file is automatically updated via `rake candidate:create`.
+  # Manual changes to this file will be overwritten by that rake task.
+  VERSION = '8.1.10'
 end

--- a/product.yml
+++ b/product.yml
@@ -1,0 +1,8 @@
+---
+name: Mongoid
+description: a Ruby ODM for MongoDB
+package: mongoid
+jira: https://jira.mongodb.org/projects/MONGOID
+version:
+  number: 8.1.10
+  file: lib/mongoid/version.rb


### PR DESCRIPTION
This PR backports the release process updates from master to the 8.1 branch, preparing us to be able to release a new patch release from 8.1-stable.