### PR TITLE
MONGOID-5887 Update mongo.rb to add hint in the aggregates

### DIFF
--- a/lib/mongoid/contextual/aggregable/mongo.rb
+++ b/lib/mongoid/contextual/aggregable/mongo.rb
@@ -27,8 +27,7 @@ module Mongoid
         #   If no documents are found, then returned Hash will have
         #   count, sum of 0 and max, min, avg of nil.
         def aggregates(field)
-          hint = options[:hint]
-          result = collection.aggregate(pipeline(field), session: _session, hint: hint).to_a
+          result = collection.aggregate(pipeline(field), session: _session, hint: options[:hint]).to_a
           if result.empty?
             Aggregable::EMPTY_RESULT.dup
           else


### PR DESCRIPTION
MongoID aggregates dont propagate the hint passed in the criteria, into the pipeline aggregate.

This causes the query to ignore the hint and use an index decided by the planner, which is not ideal for the cases where the user intentionally passed a certain hint.