### PR TITLE
Release candidate for 8.0.11

### DIFF
--- a/lib/mongoid/version.rb
+++ b/lib/mongoid/version.rb
@@ -5,5 +5,5 @@ module Mongoid
   #
   # Note that this file is automatically updated via `rake candidate:create`.
   # Manual changes to this file will be overwritten by that rake task.
-  VERSION = '8.0.10'
+  VERSION = '8.0.11'
 end

--- a/product.yml
+++ b/product.yml
@@ -4,5 +4,5 @@ description: a Ruby ODM for MongoDB
 package: mongoid
 jira: https://jira.mongodb.org/projects/MONGOID
 version:
-  number: 8.0.10
+  number: 8.0.11
   file: lib/mongoid/version.rb


### PR DESCRIPTION
The MongoDB Ruby team is pleased to announce version 8.0.11 of the `mongoid` gem - a Ruby ODM for MongoDB. This is a new patch release in the 8.0.x series of Mongoid.

Install this release using [RubyGems](https://rubygems.org/) via the command line as follows: 

~~~
gem install -v 8.0.11 mongoid
~~~

Or simply add it to your `Gemfile`:

~~~
gem 'mongoid', '8.0.11'
~~~

Have any feedback? Click on through to MongoDB's JIRA and [open a new ticket](https://jira.mongodb.org/projects/MONGOID) to let us know what's on your mind 🧠.

# Bug Fixes

### [MONGOID-5848](https://jira.mongodb.org/browse/MONGOID-5848) Revert MONGOID-5822 ([PR](https://github.com/mongodb/mongoid/pull/6015))

MONGOID-5822 attempted to fix a regression where child callbacks that depended on parent state were no longer invoked if the child had not changed. However, the fix itself introduced an unacceptable performance regression.

This PR restores the earlier functionality, which will break apps that depend on callbacks being invoked on unmodified children.

For now, the correct way to implement that behavior is to explicitly iterate over the children in a parent callback, e.g.:

```ruby
class Parent
  include Mongoid::Document
  has_many :children
  after_save { children.each(&:parent_changed_callback) }
end

class Child
  include Mongoid::Document
  belongs_to :parent
  
  def parent_changed_callback
    # ...
  end
end
```


### Other Bug Fixes

* [MONGOID-5843](https://jira.mongodb.org/browse/MONGOID-5843) Ensure BSON::Decimal128 is considered to be numeric ([PR](https://github.com/mongodb/mongoid/pull/5965))
* [MONGOID-5874](https://jira.mongodb.org/browse/MONGOID-5874) Fix persisting embedded children ([PR](https://github.com/mongodb/mongoid/pull/5988))
