### PR TITLE
MONGOID-5892 - Treat serialize option only with values of nil and [] differently

### DIFF
--- a/lib/mongoid/config.rb
+++ b/lib/mongoid/config.rb
@@ -259,15 +259,15 @@ module Mongoid
     # consequences of duplicate index checking.
     option :allow_duplicate_index_declarations, default: false
 
-    # When this flag is false, performing a serializable_hash(only: []) will
+    # When this flag is true, performing a serializable_hash(only: []) will
     # result in all fields being included. This is the traditional (and default)
     # behavior in Mongoid 9 and earlier.
     #
-    # Setting this flag to true will change the behavior to suppress all fields
+    # Setting this flag to false will change the behavior to suppress all fields
     # in the serialized hash. This will be the default in Mongoid 10.
     #
     # See https://jira.mongodb.org/browse/MONGOID-5892 for more details.
-    option :serializable_hash_with_legacy_only, default: false
+    option :serializable_hash_with_legacy_only, default: true
 
     # Returns the Config singleton, for use in the configure DSL.
     #

--- a/lib/mongoid/config.rb
+++ b/lib/mongoid/config.rb
@@ -259,6 +259,16 @@ module Mongoid
     # consequences of duplicate index checking.
     option :allow_duplicate_index_declarations, default: false
 
+    # When this flag is false, performing a serializable_hash(only: []) will
+    # result in all fields being included. This is the traditional (and default)
+    # behavior in Mongoid 9 and earlier.
+    #
+    # Setting this flag to true will change the behavior to suppress all fields
+    # in the serialized hash. This will be the default in Mongoid 10.
+    #
+    # See https://jira.mongodb.org/browse/MONGOID-5892 for more details.
+    option :serializable_hash_with_legacy_only, default: false
+
     # Returns the Config singleton, for use in the configure DSL.
     #
     # @return [ self ] The Config singleton.

--- a/lib/mongoid/serializable.rb
+++ b/lib/mongoid/serializable.rb
@@ -79,11 +79,11 @@ module Mongoid
     def field_names(options)
       names = (as_attributes.keys + attribute_names).uniq.sort
 
+      only = Array.wrap(options[:only]).map(&:to_s)
       except = Array.wrap(options[:except]).map(&:to_s)
       except |= [self.class.discriminator_key] unless Mongoid.include_type_for_serialization
 
-      only = Array.wrap(options[:only]).map(&:to_s)
-      if !options[:only].nil? && (!Mongoid.serializable_hash_with_legacy_only || !only.empty?)
+      if !options[:only].nil? && (Mongoid.serializable_hash_with_legacy_only || !only.empty?)
         names &= only
       elsif !except.empty?
         names -= except

--- a/lib/mongoid/serializable.rb
+++ b/lib/mongoid/serializable.rb
@@ -82,8 +82,8 @@ module Mongoid
       except = Array.wrap(options[:except]).map(&:to_s)
       except |= [self.class.discriminator_key] unless Mongoid.include_type_for_serialization
 
-      if !options[:only].nil?
-        only = Array.wrap(options[:only]).map(&:to_s)
+      only = Array.wrap(options[:only]).map(&:to_s)
+      if !options[:only].nil? && (!Mongoid.serializable_hash_with_legacy_only || !only.empty?)
         names &= only
       elsif !except.empty?
         names -= except

--- a/lib/mongoid/serializable.rb
+++ b/lib/mongoid/serializable.rb
@@ -83,7 +83,7 @@ module Mongoid
       except = Array.wrap(options[:except]).map(&:to_s)
       except |= [self.class.discriminator_key] unless Mongoid.include_type_for_serialization
 
-      if !options[:only].nil? && (Mongoid.serializable_hash_with_legacy_only || !only.empty?)
+      if !options[:only].nil? && (!Mongoid.serializable_hash_with_legacy_only || !only.empty?)
         names &= only
       elsif !except.empty?
         names -= except

--- a/lib/mongoid/serializable.rb
+++ b/lib/mongoid/serializable.rb
@@ -79,11 +79,11 @@ module Mongoid
     def field_names(options)
       names = (as_attributes.keys + attribute_names).uniq.sort
 
-      only = Array.wrap(options[:only]).map(&:to_s)
       except = Array.wrap(options[:except]).map(&:to_s)
       except |= [self.class.discriminator_key] unless Mongoid.include_type_for_serialization
 
-      if !only.empty?
+      if !options[:only].nil?
+        only = Array.wrap(options[:only]).map(&:to_s)
         names &= only
       elsif !except.empty?
         names -= except

--- a/spec/mongoid/serializable_spec.rb
+++ b/spec/mongoid/serializable_spec.rb
@@ -306,7 +306,7 @@ describe Mongoid::Serializable do
           config_override :serializable_hash_with_legacy_only, false
 
           it "includes all fields when passed an empty array" do
-            expect(person.serializable_hash(only: [])).to eq(attributes)
+            expect(person.serializable_hash(only: [])).to include attributes
           end
         end
 

--- a/spec/mongoid/serializable_spec.rb
+++ b/spec/mongoid/serializable_spec.rb
@@ -302,8 +302,20 @@ describe Mongoid::Serializable do
           )
         end
 
-        it "doesn't include any fields when passed an empty array" do
-          expect(person.serializable_hash(only: [])).to be_empty
+        context "when serializable_hash_with_legacy_only == false" do # default for <= 9
+          config_override :serializable_hash_with_legacy_only, false
+
+          it "includes all fields when passed an empty array" do
+            expect(person.serializable_hash(only: [])).to eq(attributes)
+          end
+        end
+
+        context "when serializable_hash_with_legacy_only == true" do # default for >= 10
+          config_override :serializable_hash_with_legacy_only, true
+
+          it "doesn't include any fields when passed an empty array" do
+            expect(person.serializable_hash(only: [])).to be_empty
+          end
         end
       end
 

--- a/spec/mongoid/serializable_spec.rb
+++ b/spec/mongoid/serializable_spec.rb
@@ -301,6 +301,10 @@ describe Mongoid::Serializable do
             { "title" => attributes["title"] }
           )
         end
+
+        it "doesn't include any fields when passed an empty array" do
+          expect(person.serializable_hash(only: [])).to be_empty
+        end
       end
 
       context "when specifying extra inclusions" do

--- a/spec/mongoid/serializable_spec.rb
+++ b/spec/mongoid/serializable_spec.rb
@@ -302,16 +302,16 @@ describe Mongoid::Serializable do
           )
         end
 
-        context "when serializable_hash_with_legacy_only == false" do # default for <= 9
-          config_override :serializable_hash_with_legacy_only, false
+        context "when serializable_hash_with_legacy_only == true" do # default for <= 9
+          config_override :serializable_hash_with_legacy_only, true
 
           it "includes all fields when passed an empty array" do
             expect(person.serializable_hash(only: [])).to include attributes
           end
         end
 
-        context "when serializable_hash_with_legacy_only == true" do # default for >= 10
-          config_override :serializable_hash_with_legacy_only, true
+        context "when serializable_hash_with_legacy_only == false" do # default for >= 10
+          config_override :serializable_hash_with_legacy_only, false
 
           it "doesn't include any fields when passed an empty array" do
             expect(person.serializable_hash(only: [])).to be_empty


### PR DESCRIPTION
When calling serializable_hash(only: []) should suppress all fields.  Currently it's treated the same as nil where it gets ignored.

## Summary

Previously, passing `only: []` to `serializable_hash` was treated the same as passing `only: nil`, meaning all fields were included. The correct behavior is to treat an empty array as "include no fields," suppressing all output.

This fix is gated behind the `Mongoid.serializable_hash_with_legacy_only` feature flag. In 9.1 and later, the flag defaults to `true` (legacy behavior); set it to `false` to opt into the new behavior. The default will flip to `false` in Mongoid 10.0, and the flag will be removed in 11.0.