### PR TITLE
MONGOID-5895 Make Reload Properly Update new_record

### DIFF
--- a/lib/mongoid/reloadable.rb
+++ b/lib/mongoid/reloadable.rb
@@ -17,6 +17,12 @@ module Mongoid
       reloaded = _reload
       check_for_deleted_document!(reloaded)
 
+      # In an instance where we create a new document, but set the ID to an existing one,
+      #   when the document is reloaded, we want to set new_record to false.
+      #   This is necessary otherwise saving will fail, as it will try to insert the document,
+      #   instead of attempting to update the existing document.
+      @new_record = false unless reloaded.nil? || reloaded.empty?
+
       reset_object!(reloaded)
 
       run_callbacks(:find) unless _find_callbacks.empty?

--- a/spec/mongoid/reloadable_spec.rb
+++ b/spec/mongoid/reloadable_spec.rb
@@ -135,6 +135,16 @@ describe Mongoid::Reloadable do
           agent.title.should == '007'
         end
       end
+
+      it 'sets new_record to false' do
+        expect(agent.new_record?).to be true
+
+        lambda do
+          agent.reload
+        end.should_not raise_error
+
+        expect(agent.new_record?).to be false
+      end
     end
 
     context "when the document is embedded" do
@@ -594,6 +604,20 @@ describe Mongoid::Reloadable do
           band.id.should_not be nil
           # _id changes
           band.id.should_not == original_id
+        end
+      end
+
+      context 'when there is no document matching our id' do
+        let(:agent) { Agent.new(id: BSON::ObjectId.new) }
+
+        it 'does not set new_record to false' do
+          expect(agent.new_record?).to be true
+
+          lambda do
+            agent.reload
+          end.should_not raise_error
+
+          expect(agent.new_record?).to be true
         end
       end
     end

--- a/spec/mongoid/reloadable_spec.rb
+++ b/spec/mongoid/reloadable_spec.rb
@@ -134,16 +134,16 @@ describe Mongoid::Reloadable do
 
           agent.title.should == '007'
         end
-      end
 
-      it 'sets new_record to false' do
-        expect(agent.new_record?).to be true
+        it 'sets new_record to false' do
+          expect(agent.new_record?).to be true
 
-        lambda do
-          agent.reload
-        end.should_not raise_error
+          lambda do
+            agent.reload
+          end.should_not raise_error
 
-        expect(agent.new_record?).to be false
+          expect(agent.new_record?).to be false
+        end
       end
     end
 


### PR DESCRIPTION
We've run into an issue when reloading a document which has had it's ID set to one that matches the value of an existing document.

Right now, when `.reload` is called in these circumstances, the data is pulled from the database, but the document does not update it's `new_record` value to `false`. This results in errors when trying to save, as Mongoid attempts to insert the document instead of updating the existing one.

It's easy to reproduce with something like the pseudo-code below (the new specs also show this)
```ruby
doc1 = SomeDocument.create!

doc2 = SomeDocument.new(id: doc1.id)
doc2.save! # This will error
```