### PR TITLE
MONGOID-5887 Include server hint for aggregate operations

### DIFF
--- a/lib/mongoid/contextual/aggregable/mongo.rb
+++ b/lib/mongoid/contextual/aggregable/mongo.rb
@@ -27,7 +27,12 @@ module Mongoid
         #   If no documents are found, then returned Hash will have
         #   count, sum of 0 and max, min, avg of nil.
         def aggregates(field)
-          result = collection.aggregate(pipeline(field), session: _session).to_a
+          result = collection.aggregate(
+                    pipeline(field),
+                    session: _session,
+                    hint: view.hint
+                  ).to_a
+
           if result.empty?
             Aggregable::EMPTY_RESULT.dup
           else


### PR DESCRIPTION
When a hint was specified for an aggregate operation (e.g. `Person.hint({ age: 1 }).aggregates(:age)`) the hint was not being included with the constructed command. This PR fixes that.