### PR TITLE
MONGOID-5869 - Fix incorrectly named global_executor_concurrency config in code comment

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
 
     - id: start-mongodb
       name: start mongodb
-      uses: mongodb-labs/drivers-evergreen-tools@master
+      uses: mongodb-labs/drivers-evergreen-tools@8c66939e0f2ad8ec03522cd7e8631f5a55e2c9f2
       with:
         version: "${{matrix.mongodb}}"
         topology: "${{matrix.topology}}"

--- a/lib/mongoid/config.rb
+++ b/lib/mongoid/config.rb
@@ -102,7 +102,7 @@ module Mongoid
     #
     #   - :immediate - Initializes a single +Concurrent::ImmediateExecutor+
     #   - :global_thread_pool - Initializes a single +Concurrent::ThreadPoolExecutor+
-    #      that uses the +async_query_concurrency+ for the +max_threads+ value.
+    #      that uses the +global_executor_concurrency+ for the +max_threads+ value.
     option :async_query_executor, default: :immediate
 
     # Defines how many asynchronous queries can be executed concurrently.

--- a/lib/mongoid/railties/bson_object_id_serializer.rb
+++ b/lib/mongoid/railties/bson_object_id_serializer.rb
@@ -33,6 +33,13 @@ module Mongoid
         def deserialize(string)
           BSON::ObjectId.from_string(string)
         end
+
+        # Returns the klass this serializer handles.
+        #
+        # @return [ BSON::ObjectId ] The class this serializer handles.
+        def klass
+          BSON::ObjectId
+        end
       end
     end
   end


### PR DESCRIPTION
Backport #5978 to 9.0-stable
