### PR TITLE
Tweaks for 9.0.8 deployment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,6 @@ on:
         required: true
 
 env:
-  SILK_ASSET_GROUP: mongoid
   GEM_NAME: mongoid
   PRODUCT_NAME: Mongoid
   PRODUCT_ID: mongoid
@@ -84,5 +83,4 @@ jobs:
           product_name: ${{ env.PRODUCT_NAME }}
           product_id: ${{ env.PRODUCT_ID }}
           release_message: ${{ needs.check.outputs.message }}
-          silk_asset_group: ${{ env.SILK_ASSET_GROUP }}
           ref: ${{ needs.check.outputs.ref }}


### PR DESCRIPTION
The MongoDB Ruby team is pleased to announce version 9.0.8 of the `mongoid` gem - a Ruby ODM for MongoDB. This is a new patch release in the 9.0.x series of Mongoid.

Install this release using [RubyGems](https://rubygems.org/) via the command line as follows: 

~~~
gem install -v 9.0.8 mongoid
~~~

Or simply add it to your `Gemfile`:

~~~
gem 'mongoid', '9.0.8'
~~~

Have any feedback? Click on through to MongoDB's JIRA and [open a new ticket](https://jira.mongodb.org/projects/MONGOID) to let us know what's on your mind 🧠.

# Bug Fixes

* [MONGOID-5852](https://jira.mongodb.org/browse/MONGOID-5852) Fix after_action_commit callbacks ([PR](https://github.com/mongodb/mongoid/pull/5969))
* [MONGOID-4889](https://jira.mongodb.org/browse/MONGOID-4889) Optimize batch assignment of embedded documents ([PR](https://github.com/mongodb/mongoid/pull/6010))
* [MONGOID-5888](https://jira.mongodb.org/browse/MONGOID-5888) Ensure deeply nested children are validated correctly ([PR](https://github.com/mongodb/mongoid/pull/6029))
* [MONGOID-5885](https://jira.mongodb.org/browse/MONGOID-5885) Return value from transaction yield to caller instead of internal state ([PR](https://github.com/mongodb/mongoid/pull/6030))
* [MONGOID-5895](https://jira.mongodb.org/browse/MONGOID-5895) Make Reload Properly Update new_record ([PR](https://github.com/mongodb/mongoid/pull/6037))
* [MONGOID-5887](https://jira.mongodb.org/browse/MONGOID-5887) Include server hint for aggregate operations ([PR](https://github.com/mongodb/mongoid/pull/6038))
* [MONGOID-5869](https://jira.mongodb.org/browse/MONGOID-5869) Fix incorrectly named global_executor_concurrency config in code comment ([PR](https://github.com/mongodb/mongoid/pull/6039))
