### PR TITLE
MONGOID-5890 Handle BSON::Decimal128 specially when checking for changes

### DIFF
--- a/lib/mongoid/attributes.rb
+++ b/lib/mongoid/attributes.rb
@@ -371,7 +371,7 @@ module Mongoid
     # comparison purposes. This is necessary because `BSON::Decimal128` does
     # not implement `#==` in a way that is compatible with `BigDecimal`.
     def normalize_value(value)
-      value.is_a?(BSON::Decimal128) ? value.to_d : value
+      value.is_a?(BSON::Decimal128) ? BigDecimal(value.to_s) : value
     end
 
     # Determine if the attribute will not change, by comparing the current

--- a/lib/mongoid/attributes.rb
+++ b/lib/mongoid/attributes.rb
@@ -175,7 +175,7 @@ module Mongoid
           localized = fields[field_name].try(:localized?)
           attributes_before_type_cast[name.to_s] = value
           typed_value = typed_value_for(field_name, value)
-          unless attributes[field_name] == typed_value || attribute_changed?(field_name)
+          unless attribute_will_not_change?(field_name, typed_value) || attribute_changed?(field_name)
             attribute_will_change!(field_name)
           end
           if localized
@@ -365,6 +365,24 @@ module Mongoid
         value = localized_fields[name].send(:lookup, value)
       end
       value.present?
+    end
+
+    # If `value` is a `BSON::Decimal128`, convert it to a `BigDecimal` for
+    # comparison purposes. This is necessary because `BSON::Decimal128` does
+    # not implement `#==` in a way that is compatible with `BigDecimal`.
+    def normalize_value(value)
+      value.is_a?(BSON::Decimal128) ? value.to_d : value
+    end
+
+    # Determine if the attribute will not change, by comparing the current
+    # value with the new value. The values are normalized to account for
+    # types that do not implement `#==` in a way that is compatible with
+    # each other, such as `BSON::Decimal128` and `BigDecimal`.
+    def attribute_will_not_change?(field_name, typed_value)
+      normalized_attribute = normalize_value(attributes[field_name])
+      normalized_typed_value = normalize_value(typed_value)
+
+      normalized_attribute == normalized_typed_value
     end
   end
 end

--- a/spec/mongoid/attributes_spec.rb
+++ b/spec/mongoid/attributes_spec.rb
@@ -1730,7 +1730,7 @@ describe Mongoid::Attributes do
       end
     end
 
-    context 'when map_big_decimal_as_bson_decimal128 is enabled' do
+    context 'when map_big_decimal_to_decimal128 is enabled' do
       config_override :map_big_decimal_to_decimal128, true
 
       context 'when writing an identical number' do

--- a/spec/mongoid/attributes_spec.rb
+++ b/spec/mongoid/attributes_spec.rb
@@ -1729,6 +1729,19 @@ describe Mongoid::Attributes do
         end
       end
     end
+
+    context 'when map_big_decimal_as_bson_decimal128 is enabled' do
+      config_override :map_big_decimal_to_decimal128, true
+
+      context 'when writing an identical number' do
+        let(:band) { Band.create!(name: 'Nirvana', sales: 123456.78).reload }
+
+        it 'does not mark the document as changed' do
+          band.sales = 123456.78
+          expect(band.changed?).to be false
+        end
+      end
+    end
   end
 
   describe "#typed_value_for" do


### PR DESCRIPTION
With the `map_big_decimal_to_decimal128` option enabled, Mongoid will translate between `BSON::Decimal128` and `BigDecimal` when records are loaded and saved. However, if you assign an identical floating point value to the field, it will mark the record as changed, even though it (functionally) did not. This is because `BSON::Decimal128` is not an actual numeric type, and equality comparisons with numeric types will return false.

This PR fixes the dirty tracking with regard to `BigDecimal` and `BSON::Decimal128` by adding a normalization step to the comparison and handling the `Decimal128` type specially.