### PR TITLE
MONGOID-5900 Fix #pluck on associations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -72,6 +72,15 @@ Metrics/ModuleLength:
 Metrics/MethodLength:
   Max: 20
 
+Metrics/PerceivedComplexity:
+  Max: 10
+
+Metrics/CyclomaticComplexity:
+  Max: 10
+
+Metrics/AbcSize:
+  Max: 20
+
 RSpec/BeforeAfterAll:
   Enabled: false
 

--- a/lib/mongoid/association/embedded/embeds_many/proxy.rb
+++ b/lib/mongoid/association/embedded/embeds_many/proxy.rb
@@ -14,6 +14,7 @@ module Mongoid
         # the array of child documents.
         class Proxy < Association::Many
           include Batchable
+          extend Forwardable
 
           # Class-level methods for the Proxy class.
           module ClassMethods
@@ -53,6 +54,8 @@ module Mongoid
           end
 
           extend ClassMethods
+
+          def_delegators :criteria, :find, :pluck
 
           # Instantiate a new embeds_many association.
           #
@@ -310,35 +313,6 @@ module Mongoid
             when Hash then where(id_or_conditions).any?(&:persisted?)
             else where(_id: id_or_conditions).any?(&:persisted?)
             end
-          end
-
-          # Finds a document in this association through several different
-          # methods.
-          #
-          # This method delegates to +Mongoid::Criteria#find+. If this method is
-          # not given a block, it returns one or many documents for the provided
-          # _id values.
-          #
-          # If this method is given a block, it returns the first document
-          # of those found by the current Criteria object for which the block
-          # returns a truthy value.
-          #
-          # @example Find a document by its id.
-          #   person.addresses.find(BSON::ObjectId.new)
-          #
-          # @example Find documents for multiple ids.
-          #   person.addresses.find([ BSON::ObjectId.new, BSON::ObjectId.new ])
-          #
-          # @example Finds the first matching document using a block.
-          #   person.addresses.find { |addr| addr.state == 'CA' }
-          #
-          # @param [ Object... ] *args Various arguments.
-          # @param &block Optional block to pass.
-          # @yield [ Object ] Yields each enumerable element to the block.
-          #
-          # @return [ Document | Array<Document> | nil ] A document or matching documents.
-          def find(...)
-            criteria.find(...)
           end
 
           # Get all the documents in the association that are loaded into memory.

--- a/lib/mongoid/association/referenced/has_and_belongs_to_many/proxy.rb
+++ b/lib/mongoid/association/referenced/has_and_belongs_to_many/proxy.rb
@@ -53,8 +53,6 @@ module Mongoid
           # @param [ Document... ] *args Any number of documents.
           #
           # @return [ Array<Document> ] The loaded docs.
-          #
-          # rubocop:disable Metrics/AbcSize
           def <<(*args)
             docs = args.flatten
             return concat(docs) if docs.size > 1
@@ -89,7 +87,6 @@ module Mongoid
             end
             unsynced(_base, foreign_key) and self
           end
-          # rubocop:enable Metrics/AbcSize
 
           alias push <<
 
@@ -360,8 +357,6 @@ module Mongoid
           #   in bulk
           # @param [ Array ] inserts the list of Hashes of attributes that will
           #   be inserted (corresponding to the ``docs`` list)
-          #
-          # rubocop:disable Metrics/AbcSize
           def append_document(doc, ids, docs, inserts)
             return unless doc
 
@@ -379,7 +374,6 @@ module Mongoid
               unsynced(_base, foreign_key)
             end
           end
-          # rubocop:enable Metrics/AbcSize
         end
       end
     end

--- a/lib/mongoid/association/referenced/has_many/proxy.rb
+++ b/lib/mongoid/association/referenced/has_many/proxy.rb
@@ -33,7 +33,7 @@ module Mongoid
 
           extend ClassMethods
 
-          def_delegators :criteria, :count, :pluck
+          def_delegators :criteria, :count
           def_delegators :_target, :first, :in_memory, :last, :reset, :uniq
 
           # Instantiate a new references_many association. Will set the foreign key
@@ -280,6 +280,22 @@ module Mongoid
           end
 
           alias nullify_all nullify
+
+          # Plucks the given field names from the documents in the
+          # association. It is safe to use whether the association is
+          # loaded or not, and whether there are unsaved documents in the
+          # association or not.
+          #
+          # @example Pluck the titles of all posts.
+          #   person.posts.pluck(:title)
+          #
+          # @param [ Symbol... ] *fields The field names to pluck.
+          #
+          # @return [ Array | Array<Array> ] The array of field values. If
+          #   multiple fields are given, an array of arrays is returned.
+          def pluck(*fields)
+            _target.pluck(*fields)
+          end
 
           # Clear the association. Will delete the documents from the db if they are
           # already persisted.

--- a/lib/mongoid/association/referenced/has_many/proxy.rb
+++ b/lib/mongoid/association/referenced/has_many/proxy.rb
@@ -33,7 +33,7 @@ module Mongoid
 
           extend ClassMethods
 
-          def_delegator :criteria, :count
+          def_delegators :criteria, :count, :pluck
           def_delegators :_target, :first, :in_memory, :last, :reset, :uniq
 
           # Instantiate a new references_many association. Will set the foreign key

--- a/lib/mongoid/contextual/mongo.rb
+++ b/lib/mongoid/contextual/mongo.rb
@@ -2,6 +2,7 @@
 # rubocop:todo all
 
 require 'mongoid/atomic_update_preparer'
+require 'mongoid/pluckable'
 require "mongoid/contextual/mongo/documents_loader"
 require "mongoid/contextual/atomic"
 require "mongoid/contextual/aggregable/mongo"
@@ -22,6 +23,7 @@ module Mongoid
       include Atomic
       include Association::EagerLoadable
       include Queryable
+      include Pluckable
 
       # Options constant.
       OPTIONS = [ :hint,
@@ -331,23 +333,12 @@ module Mongoid
       #   in the array will be a single value. Otherwise, each
       #   result in the array will be an array of values.
       def pluck(*fields)
-        # Multiple fields can map to the same field name. For example, plucking
-        # a field and its _translations field map to the same field in the database.
-        # because of this, we need to keep track of the fields requested.
-        normalized_field_names = []
-        normalized_select = fields.inject({}) do |hash, f|
-          db_fn = klass.database_field_name(f)
-          normalized_field_names.push(db_fn)
-          hash[klass.cleanse_localized_field_names(f)] = true
-          hash
-        end
-
-        view.projection(normalized_select).reduce([]) do |plucked, doc|
-          values = normalized_field_names.map do |n|
-            extract_value(doc, n)
-          end
-          plucked << (values.size == 1 ? values.first : values)
-        end
+        # Multiple fields can map to the same field name. For example,
+        # plucking a field and its _translations field map to the same
+        # field in the database. because of this, we need to prepare the
+        # projection specifically.
+        prep = prepare_pluck(fields, prepare_projection: true)
+        pluck_from_documents(view.projection(prep[:projection]), prep[:field_names])
       end
 
       # Pick the single field values from the database.
@@ -901,78 +892,6 @@ module Mongoid
 
       def acknowledged_write?
         collection.write_concern.nil? || collection.write_concern.acknowledged?
-      end
-
-      # Fetch the element from the given hash and demongoize it using the
-      # given field. If the obj is an array, map over it and call this method
-      # on all of its elements.
-      #
-      # @param [ Hash | Array<Hash> ] obj The hash or array of hashes to fetch from.
-      # @param [ String ] meth The key to fetch from the hash.
-      # @param [ Field ] field The field to use for demongoization.
-      #
-      # @return [ Object ] The demongoized value.
-      #
-      # @api private
-      def fetch_and_demongoize(obj, meth, field)
-        if obj.is_a?(Array)
-          obj.map { |doc| fetch_and_demongoize(doc, meth, field) }
-        else
-          res = obj.try(:fetch, meth, nil)
-          field ? field.demongoize(res) : res.class.demongoize(res)
-        end
-      end
-
-      # Extracts the value for the given field name from the given attribute
-      # hash.
-      #
-      # @param [ Hash ] attrs The attributes hash.
-      # @param [ String ] field_name The name of the field to extract.
-      #
-      # @param [ Object ] The value for the given field name
-      def extract_value(attrs, field_name)
-        i = 1
-        num_meths = field_name.count('.') + 1
-        curr = attrs.dup
-
-        klass.traverse_association_tree(field_name) do |meth, obj, is_field|
-          field = obj if is_field
-          is_translation = false
-          # If no association or field was found, check if the meth is an
-          # _translations field.
-          if obj.nil? & tr = meth.match(/(.*)_translations\z/)&.captures&.first
-            is_translation = true
-            meth = tr
-          end
-
-          # 1. If curr is an array fetch from all elements in the array.
-          # 2. If the field is localized, and is not an _translations field
-          #    (_translations fields don't show up in the fields hash).
-          #    - If this is the end of the methods, return the translation for
-          #      the current locale.
-          #    - Otherwise, return the whole translations hash so the next method
-          #      can select the language it wants.
-          # 3. If the meth is an _translations field, do not demongoize the
-          #    value so the full hash is returned.
-          # 4. Otherwise, fetch and demongoize the value for the key meth.
-          curr = if curr.is_a? Array
-            res = fetch_and_demongoize(curr, meth, field)
-            res.empty? ? nil : res
-          elsif !is_translation && field&.localized?
-            if i < num_meths
-              curr.try(:fetch, meth, nil)
-            else
-              fetch_and_demongoize(curr, meth, field)
-            end
-          elsif is_translation
-            curr.try(:fetch, meth, nil)
-          else
-            fetch_and_demongoize(curr, meth, field)
-          end
-
-          i += 1
-        end
-        curr
       end
 
       # Recursively demongoize the given value. This method recursively traverses

--- a/lib/mongoid/pluckable.rb
+++ b/lib/mongoid/pluckable.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+module Mongoid
+  # Provides shared behavior for any document with "pluck" functionality.
+  #
+  # @api private
+  module Pluckable
+    extend ActiveSupport::Concern
+
+    private
+
+      # Prepares the field names for plucking by normalizing them to their
+      # database field names. Also prepares a projection hash if requested.
+      def prepare_pluck(field_names, document_class: klass, prepare_projection: false)
+        normalized_field_names = []
+        projection = {}
+
+        field_names.each do |f|
+          db_fn = document_class.database_field_name(f)
+          normalized_field_names.push(db_fn)
+
+          if prepare_projection
+            projection[document_class.cleanse_localized_field_names(f)] = true
+          end
+        end
+
+        { field_names: normalized_field_names, projection: projection }
+      end
+
+      # Plucks the given field names from the given documents.
+      def pluck_from_documents(documents, field_names, document_class: klass)
+        documents.reduce([]) do |plucked, doc|
+          values = field_names.map { |name| extract_value(doc, name.to_s, document_class) }
+          plucked << (values.size == 1 ? values.first : values)
+        end
+      end
+
+      # Fetch the element from the given hash and demongoize it using the
+      # given field. If the obj is an array, map over it and call this method
+      # on all of its elements.
+      #
+      # @param [ Hash | Array<Hash> ] obj The hash or array of hashes to fetch from.
+      # @param [ String ] key The key to fetch from the hash.
+      # @param [ Field ] field The field to use for demongoization.
+      #
+      # @return [ Object ] The demongoized value.
+      def fetch_and_demongoize(obj, key, field)
+        if obj.is_a?(Array)
+          obj.map { |doc| fetch_and_demongoize(doc, key, field) }
+        else
+          value = obj.try(:fetch, key, nil)
+          field ? field.demongoize(value) : value.class.demongoize(value)
+        end
+      end
+
+      # Extracts the value for the given field name from the given attribute
+      # hash.
+      #
+      # @param [ Hash ] attrs The attributes hash.
+      # @param [ String ] field_name The name of the field to extract.
+      #
+      # @param [ Object ] The value for the given field name
+      def extract_value(attrs, field_name, document_class)
+        i = 1
+        num_meths = field_name.count('.') + 1
+        curr = attrs.dup
+
+        document_class.traverse_association_tree(field_name) do |meth, obj, is_field|
+          field = obj if is_field
+          is_translation = false
+          # If no association or field was found, check if the meth is an
+          # _translations field.
+          if obj.nil? & tr = meth.match(/(.*)_translations\z/)&.captures&.first
+            is_translation = true
+            meth = tr
+          end
+
+          # 1. If curr is an array fetch from all elements in the array.
+          # 2. If the field is localized, and is not an _translations field
+          #    (_translations fields don't show up in the fields hash).
+          #    - If this is the end of the methods, return the translation for
+          #      the current locale.
+          #    - Otherwise, return the whole translations hash so the next method
+          #      can select the language it wants.
+          # 3. If the meth is an _translations field, do not demongoize the
+          #    value so the full hash is returned.
+          # 4. Otherwise, fetch and demongoize the value for the key meth.
+          curr = if curr.is_a? Array
+            res = fetch_and_demongoize(curr, meth, field)
+            res.empty? ? nil : res
+          elsif !is_translation && field&.localized?
+            if i < num_meths
+              curr.try(:fetch, meth, nil)
+            else
+              fetch_and_demongoize(curr, meth, field)
+            end
+          elsif is_translation
+            curr.try(:fetch, meth, nil)
+          else
+            fetch_and_demongoize(curr, meth, field)
+          end
+
+          i += 1
+        end
+        curr
+      end
+
+  end
+end

--- a/lib/mongoid/pluckable.rb
+++ b/lib/mongoid/pluckable.rb
@@ -61,7 +61,7 @@ module Mongoid
       # @param [ Hash ] attrs The attributes hash.
       # @param [ String ] field_name The name of the field to extract.
       #
-      # @param [ Object ] The value for the given field name
+      # @return [ Object ] The value for the given field name
       def extract_value(attrs, field_name, document_class)
         i = 1
         num_meths = field_name.count('.') + 1
@@ -77,7 +77,7 @@ module Mongoid
           is_translation = false
           # If no association or field was found, check if the meth is an
           # _translations field.
-          if obj.nil? & tr = meth.match(/(.*)_translations\z/)&.captures&.first
+          if obj.nil? && tr = meth.match(/(.*)_translations\z/)&.captures&.first
             is_translation = true
             meth = document_class.database_field_name(tr)
           end

--- a/lib/mongoid/pluckable.rb
+++ b/lib/mongoid/pluckable.rb
@@ -9,108 +9,120 @@ module Mongoid
 
     private
 
-      # Prepares the field names for plucking by normalizing them to their
-      # database field names. Also prepares a projection hash if requested.
-      def prepare_pluck(field_names, document_class: klass, prepare_projection: false)
-        normalized_field_names = []
-        projection = {}
+    # Prepares the field names for plucking by normalizing them to their
+    # database field names. Also prepares a projection hash if requested.
+    def prepare_pluck(field_names, document_class: klass, prepare_projection: false)
+      normalized_field_names = []
+      projection = {}
 
-        field_names.each do |f|
-          db_fn = document_class.database_field_name(f)
-          normalized_field_names.push(db_fn)
+      field_names.each do |f|
+        db_fn = document_class.database_field_name(f)
+        normalized_field_names.push(db_fn)
 
-          if prepare_projection
-            cleaned_name = document_class.cleanse_localized_field_names(f)
-            canonical_name = document_class.database_field_name(cleaned_name)
-            projection[canonical_name] = true
-          end
-        end
+        next unless prepare_projection
 
-        { field_names: normalized_field_names, projection: projection }
+        cleaned_name = document_class.cleanse_localized_field_names(f)
+        canonical_name = document_class.database_field_name(cleaned_name)
+        projection[canonical_name] = true
       end
 
-      # Plucks the given field names from the given documents.
-      def pluck_from_documents(documents, field_names, document_class: klass)
-        documents.reduce([]) do |plucked, doc|
-          values = field_names.map { |name| extract_value(doc, name.to_s, document_class) }
-          plucked << (values.size == 1 ? values.first : values)
-        end
-      end
+      { field_names: normalized_field_names, projection: projection }
+    end
 
-      # Fetch the element from the given hash and demongoize it using the
-      # given field. If the obj is an array, map over it and call this method
-      # on all of its elements.
-      #
-      # @param [ Hash | Array<Hash> ] obj The hash or array of hashes to fetch from.
-      # @param [ String ] key The key to fetch from the hash.
-      # @param [ Field ] field The field to use for demongoization.
-      #
-      # @return [ Object ] The demongoized value.
-      def fetch_and_demongoize(obj, key, field)
-        if obj.is_a?(Array)
-          obj.map { |doc| fetch_and_demongoize(doc, key, field) }
+    # Plucks the given field names from the given documents.
+    def pluck_from_documents(documents, field_names, document_class: klass)
+      documents.reduce([]) do |plucked, doc|
+        values = field_names.map { |name| extract_value(doc, name.to_s, document_class) }
+        plucked << ((values.size == 1) ? values.first : values)
+      end
+    end
+
+    # Fetch the element from the given hash and demongoize it using the
+    # given field. If the obj is an array, map over it and call this method
+    # on all of its elements.
+    #
+    # @param [ Hash | Array<Hash> ] obj The hash or array of hashes to fetch from.
+    # @param [ String ] key The key to fetch from the hash.
+    # @param [ Field ] field The field to use for demongoization.
+    #
+    # @return [ Object ] The demongoized value.
+    def fetch_and_demongoize(obj, key, field)
+      if obj.is_a?(Array)
+        obj.map { |doc| fetch_and_demongoize(doc, key, field) }
+      else
+        value = obj.try(:fetch, key, nil)
+        field ? field.demongoize(value) : value.class.demongoize(value)
+      end
+    end
+
+    # Extracts the value for the given field name from the given attribute
+    # hash.
+    #
+    # @param [ Hash ] attrs The attributes hash.
+    # @param [ String ] field_name The name of the field to extract.
+    #
+    # @return [ Object ] The value for the given field name
+    def extract_value(attrs, field_name, document_class)
+      i = 1
+      num_meths = field_name.count('.') + 1
+      curr = attrs.dup
+
+      document_class.traverse_association_tree(field_name) do |meth, obj, is_field|
+        field = obj if is_field
+
+        # use the correct document class to check for localized fields on
+        # embedded documents.
+        document_class = obj.klass if obj.respond_to?(:klass)
+
+        is_translation = false
+        # If no association or field was found, check if the meth is an
+        # _translations field.
+        if obj.nil? && (tr = meth.match(/(.*)_translations\z/)&.captures&.first)
+          is_translation = true
+          meth = document_class.database_field_name(tr)
+        end
+
+        curr = descend(curr, meth, field, num_meths, is_translation)
+
+        i += 1
+      end
+      curr
+    end
+
+    # Descend one level in the attribute hash.
+    #
+    # @param [ Hash | Array<Hash> ] current The current level in the attribute hash.
+    # @param [ String ] method_name The method name to descend to.
+    # @param [ Field|nil ] field The field to use for demongoization.
+    # @param [ Boolean ] is_translation Whether the method is an _translations field.
+    # @param [ Integer ] part_count The total number of parts in the field name.
+    #
+    # @return [ Object ] The value at the next level.
+    def descend(current, method_name, field, part_count, is_translation)
+      # 1. If curr is an array fetch from all elements in the array.
+      # 2. If the field is localized, and is not an _translations field
+      #    (_translations fields don't show up in the fields hash).
+      #    - If this is the end of the methods, return the translation for
+      #      the current locale.
+      #    - Otherwise, return the whole translations hash so the next method
+      #      can select the language it wants.
+      # 3. If the meth is an _translations field, do not demongoize the
+      #    value so the full hash is returned.
+      # 4. Otherwise, fetch and demongoize the value for the key meth.
+      if current.is_a? Array
+        res = fetch_and_demongoize(current, method_name, field)
+        res.empty? ? nil : res
+      elsif !is_translation && field&.localized?
+        if i < part_count
+          current.try(:fetch, method_name, nil)
         else
-          value = obj.try(:fetch, key, nil)
-          field ? field.demongoize(value) : value.class.demongoize(value)
+          fetch_and_demongoize(current, method_name, field)
         end
+      elsif is_translation
+        current.try(:fetch, method_name, nil)
+      else
+        fetch_and_demongoize(current, method_name, field)
       end
-
-      # Extracts the value for the given field name from the given attribute
-      # hash.
-      #
-      # @param [ Hash ] attrs The attributes hash.
-      # @param [ String ] field_name The name of the field to extract.
-      #
-      # @return [ Object ] The value for the given field name
-      def extract_value(attrs, field_name, document_class)
-        i = 1
-        num_meths = field_name.count('.') + 1
-        curr = attrs.dup
-
-        document_class.traverse_association_tree(field_name) do |meth, obj, is_field|
-          field = obj if is_field
-
-          # use the correct document class to check for localized fields on
-          # embedded documents.
-          document_class = obj.klass if obj.respond_to?(:klass)
-
-          is_translation = false
-          # If no association or field was found, check if the meth is an
-          # _translations field.
-          if obj.nil? && tr = meth.match(/(.*)_translations\z/)&.captures&.first
-            is_translation = true
-            meth = document_class.database_field_name(tr)
-          end
-
-          # 1. If curr is an array fetch from all elements in the array.
-          # 2. If the field is localized, and is not an _translations field
-          #    (_translations fields don't show up in the fields hash).
-          #    - If this is the end of the methods, return the translation for
-          #      the current locale.
-          #    - Otherwise, return the whole translations hash so the next method
-          #      can select the language it wants.
-          # 3. If the meth is an _translations field, do not demongoize the
-          #    value so the full hash is returned.
-          # 4. Otherwise, fetch and demongoize the value for the key meth.
-          curr = if curr.is_a? Array
-            res = fetch_and_demongoize(curr, meth, field)
-            res.empty? ? nil : res
-          elsif !is_translation && field&.localized?
-            if i < num_meths
-              curr.try(:fetch, meth, nil)
-            else
-              fetch_and_demongoize(curr, meth, field)
-            end
-          elsif is_translation
-            curr.try(:fetch, meth, nil)
-          else
-            fetch_and_demongoize(curr, meth, field)
-          end
-
-          i += 1
-        end
-        curr
-      end
-
+    end
   end
 end

--- a/lib/mongoid/pluckable.rb
+++ b/lib/mongoid/pluckable.rb
@@ -82,7 +82,7 @@ module Mongoid
           meth = document_class.database_field_name(tr)
         end
 
-        curr = descend(curr, meth, field, num_meths, is_translation)
+        curr = descend(i, curr, meth, field, num_meths, is_translation)
 
         i += 1
       end
@@ -91,6 +91,7 @@ module Mongoid
 
     # Descend one level in the attribute hash.
     #
+    # @param [ Integer ] part The current part index.
     # @param [ Hash | Array<Hash> ] current The current level in the attribute hash.
     # @param [ String ] method_name The method name to descend to.
     # @param [ Field|nil ] field The field to use for demongoization.
@@ -98,7 +99,9 @@ module Mongoid
     # @param [ Integer ] part_count The total number of parts in the field name.
     #
     # @return [ Object ] The value at the next level.
-    def descend(current, method_name, field, part_count, is_translation)
+    #
+    # rubocop:disable Metrics/ParameterLists
+    def descend(part, current, method_name, field, part_count, is_translation)
       # 1. If curr is an array fetch from all elements in the array.
       # 2. If the field is localized, and is not an _translations field
       #    (_translations fields don't show up in the fields hash).
@@ -113,7 +116,7 @@ module Mongoid
         res = fetch_and_demongoize(current, method_name, field)
         res.empty? ? nil : res
       elsif !is_translation && field&.localized?
-        if i < part_count
+        if part < part_count
           current.try(:fetch, method_name, nil)
         else
           fetch_and_demongoize(current, method_name, field)
@@ -124,5 +127,6 @@ module Mongoid
         fetch_and_demongoize(current, method_name, field)
       end
     end
+    # rubocop:enable Metrics/ParameterLists
   end
 end

--- a/lib/mongoid/traversable.rb
+++ b/lib/mongoid/traversable.rb
@@ -131,7 +131,6 @@ module Mongoid
       # @param [ String ] value The discriminator key to set.
       #
       # @api private
-      # rubocop:disable Metrics/AbcSize
       def discriminator_key=(value)
         raise Errors::InvalidDiscriminatorKeyTarget.new(self, superclass) if hereditary?
 
@@ -159,7 +158,6 @@ module Mongoid
         default_proc = -> { self.class.discriminator_value }
         field(discriminator_key, default: default_proc, type: String)
       end
-      # rubocop:enable Metrics/AbcSize
 
       # Returns the discriminator key.
       #

--- a/spec/mongoid/association/referenced/has_many/enumerable_spec.rb
+++ b/spec/mongoid/association/referenced/has_many/enumerable_spec.rb
@@ -1881,7 +1881,7 @@ describe Mongoid::Association::Referenced::HasMany::Enumerable do
     context 'when the enumerable is loaded' do
       let(:enumerable) { described_class.new([post], base, association) }
 
-      it 'returns the values from the loaded' do
+      it 'returns the values from the loaded documents' do
         result = enumerable.pluck(:title)
         expect(result).to eq(['Test Title'])
       end

--- a/spec/support/models/company.rb
+++ b/spec/support/models/company.rb
@@ -5,4 +5,6 @@ class Company
   include Mongoid::Document
 
   embeds_many :staffs
+
+  has_many :products
 end

--- a/spec/support/models/passport.rb
+++ b/spec/support/models/passport.rb
@@ -8,6 +8,7 @@ class Passport
   field :country, type: String
   field :exp, as: :expiration_date, type: Date
   field :name, localize: true
+  field :bp, as: :birthplace, localize: true
   field :localized_translations, localize: true
 
   embedded_in :person, autobuild: true

--- a/spec/support/models/product.rb
+++ b/spec/support/models/product.rb
@@ -18,4 +18,6 @@ class Product
   validates :website, format: { with: URI.regexp, allow_blank: true }
 
   embeds_one :seo, as: :seo_tags, cascade_callbacks: true, autobuild: true
+
+  belongs_to :company
 end

--- a/spec/support/models/seo.rb
+++ b/spec/support/models/seo.rb
@@ -5,6 +5,8 @@ class Seo
   include Mongoid::Document
   include Mongoid::Timestamps
   field :title, type: String
+  field :name, type: String, localize: true
+  field :desc, as: :description, type: String, localize: true
 
   embedded_in :seo_tags, polymorphic: true
 end


### PR DESCRIPTION
This addresses a few bugs with the implementation of `#pluck` on associations.

1. It now respects localized fields, and the current localization settings.
2. It now plucks loaded and unloaded records from the association.
3. It now does the right thing when fields are referenced by an alias.

Tests from #6044 (from @johnnyshields) are included in this PR (thank you, Johnny!).