### PR TITLE
MONGOID-5800 When initializing an embedded association with an invalid hash, got undefined method `with_indifferent_access' error

### DIFF
--- a/lib/mongoid/association/nested/many.rb
+++ b/lib/mongoid/association/nested/many.rb
@@ -48,7 +48,11 @@ module Mongoid
         # @param [ Hash ] attributes The attributes hash to attempt to set.
         # @param [ Hash ] options The options defined.
         def initialize(association, attributes, options = {})
-          if attributes.respond_to?(:with_indifferent_access)
+          # If a hash is passed, and the first key is not an integer,
+          # we assume it's a single document being passed in.
+          if attributes.is_a?(Hash) && !attributes.keys.first.is_a?(Integer)
+            @attributes = [attributes]
+          elsif attributes.respond_to?(:with_indifferent_access)
             @attributes = attributes.with_indifferent_access.sort do |a, b|
               a[0].to_i <=> b[0].to_i
             end

--- a/lib/mongoid/association/nested/many.rb
+++ b/lib/mongoid/association/nested/many.rb
@@ -35,7 +35,7 @@ module Mongoid
             elsif attrs[1].respond_to?(:with_indifferent_access)
               process_attributes(parent, attrs[1].with_indifferent_access)
             else
-              process_attributes(parent, [attrs[1]])
+              process_attributes(parent, [attrs[1]].with_indifferent_access)
             end
           end
         end

--- a/lib/mongoid/association/nested/many.rb
+++ b/lib/mongoid/association/nested/many.rb
@@ -32,8 +32,10 @@ module Mongoid
           attributes.each do |attrs|
             if attrs.is_a?(::Hash)
               process_attributes(parent, attrs.with_indifferent_access)
-            else
+            elsif attrs[1].respond_to?(:with_indifferent_access)
               process_attributes(parent, attrs[1].with_indifferent_access)
+            else
+              process_attributes(parent, [attrs[1]])
             end
           end
         end
@@ -50,9 +52,7 @@ module Mongoid
         def initialize(association, attributes, options = {})
           # If a hash is passed, and the first key is not an integer,
           # we assume it's a single document being passed in.
-          if attributes.is_a?(Hash) && !attributes.keys.first.is_a?(Integer)
-            @attributes = [attributes]
-          elsif attributes.respond_to?(:with_indifferent_access)
+          if attributes.respond_to?(:with_indifferent_access)
             @attributes = attributes.with_indifferent_access.sort do |a, b|
               a[0].to_i <=> b[0].to_i
             end

--- a/lib/mongoid/association/nested/many.rb
+++ b/lib/mongoid/association/nested/many.rb
@@ -32,7 +32,7 @@ module Mongoid
           attributes.each do |attrs|
             if attrs.is_a?(::Hash)
               process_attributes(parent, attrs.with_indifferent_access)
-            elsif attrs[1].respond_to?(:with_indifferent_access)
+            elsif attrs.is_a?(Array) && attrs.length > 1 && attrs[1].respond_to?(:with_indifferent_access)
               process_attributes(parent, attrs[1].with_indifferent_access)
             else
               process_attributes(parent, Hash[*attrs].with_indifferent_access)
@@ -50,8 +50,6 @@ module Mongoid
         # @param [ Hash ] attributes The attributes hash to attempt to set.
         # @param [ Hash ] options The options defined.
         def initialize(association, attributes, options = {})
-          # If a hash is passed, and the first key is not an integer,
-          # we assume it's a single document being passed in.
           if attributes.respond_to?(:with_indifferent_access)
             @attributes = attributes.with_indifferent_access.sort do |a, b|
               a[0].to_i <=> b[0].to_i

--- a/lib/mongoid/association/nested/many.rb
+++ b/lib/mongoid/association/nested/many.rb
@@ -35,7 +35,7 @@ module Mongoid
             elsif attrs[1].respond_to?(:with_indifferent_access)
               process_attributes(parent, attrs[1].with_indifferent_access)
             else
-              process_attributes(parent, [attrs[1]].with_indifferent_access)
+              process_attributes(parent, Hash[*attrs].with_indifferent_access)
             end
           end
         end

--- a/lib/mongoid/association/nested/many.rb
+++ b/lib/mongoid/association/nested/many.rb
@@ -16,6 +16,9 @@ module Mongoid
         # This attempts to perform 3 operations, either one of an update of
         # the existing association, a replacement of the association with a new
         # document, or a removal of the association.
+        # 
+        # It raises an argument error if the attributes are not a Hash or an 
+        # Array of key/value pairs.
         #
         # @example Build the nested attrs.
         #   many.build(person)
@@ -34,8 +37,10 @@ module Mongoid
               process_attributes(parent, attrs.with_indifferent_access)
             elsif attrs.is_a?(Array) && attrs.length > 1 && attrs[1].respond_to?(:with_indifferent_access)
               process_attributes(parent, attrs[1].with_indifferent_access)
-            else
+            elsif attrs.is_a?(Array) && attrs.length.even?
               process_attributes(parent, Hash[*attrs].with_indifferent_access)
+            else
+              raise ArgumentError, "Attributes for nested association '#{association.name}' must be a Hash or an Array of key/value pairs."
             end
           end
         end

--- a/spec/integration/associations/embeds_many_spec.rb
+++ b/spec/integration/associations/embeds_many_spec.rb
@@ -327,4 +327,20 @@ describe 'embeds_many associations' do
       end
     end
   end
+
+  context "when a hash is provided instead of an array for an embeds_many association" do
+    let(:post) { EmbedsManySpec::Post.new(title: 'Broken post', comments: { content: 'Comment' }) }
+
+    it "does not raise an error on initialization" do
+      expect { post }.to_not raise_error
+    end
+
+    it "does not raise an error when accessing the association" do
+      expect { post.comments }.to_not raise_error
+    end
+
+    it "allows building new documents on the association" do
+      expect(post.comments.build).to be_a EmbedsManySpec::Comment
+    end
+  end
 end


### PR DESCRIPTION
Currently, if a document with an `embeds_many` relationship is created with the embedded field set to a single hash, instead of an array of hashes, an error is raised with `undefined method 'with_indifferent_access'`. This behavior is new in 8.0. This PR allows backwards compatibility by checking if a value has the method `with_indifferent_access`, and, if not, we can assume it is an array that should be a hash. We convert it to a hash and call `with_indifferent_access` on the result.