### PR TITLE
perf: Optimize field access to eliminate memory allocations

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ name: Run Mongoid Tests
 jobs:
   build:
     name: "${{matrix.ruby}} db:${{matrix.mongodb}}
-      rails:${{matrix.rails}} fle:${{matrix.fle}} ${{matrix.topology}}"
+      rails:${{matrix.rails}} fle:${{matrix.fle}} ${{matrix.topology}} cache:${{matrix.cache}}"
     env:
       CI: true
       TESTOPTS: "-v"
@@ -23,6 +23,7 @@ jobs:
         rails: [ ~, "8.1" ]
         fle: [ ~, "helper" ]
         topology: [ replica_set, sharded_cluster ]
+        cache: [ "0", "1" ]
 
     steps:
     - name: repo checkout
@@ -60,4 +61,5 @@ jobs:
       env:
         BUNDLE_GEMFILE: "${{env.BUNDLE_GEMFILE}}"
         FLE: "${{matrix.fle}}"
+        MONGOID_CACHING_ENABLED: "${{matrix.cache}}"
         MONGODB_URI: "${{ steps.start-mongodb.outputs.cluster-uri }}"

--- a/gemfiles/standard.rb
+++ b/gemfiles/standard.rb
@@ -27,6 +27,7 @@ def standard_dependencies
 
     platform :mri do
       gem 'byebug'
+      gem 'allocation_stats', require: false
     end
 
     platform :jruby do

--- a/lib/mongoid/attributes.rb
+++ b/lib/mongoid/attributes.rb
@@ -143,9 +143,91 @@ module Mongoid
           attribute_will_change!(access)
           delayed_atomic_unsets[atomic_attribute_name(access)] = [] unless new_record?
           attributes.delete(access)
+          # Clear cache since the attribute is being removed
+          clear_demongoized_cache(access)
         end
       end
     end
+
+    # Clear the demongoized cache for a specific field.
+    #
+    # This method centralizes cache invalidation to ensure all attribute
+    # mutation paths (write, remove, unset, rename) remain consistent.
+    #
+    # @param [ String ] name The field name to clear from cache.
+    #
+    # @return [ void ]
+    #
+    # @since 9.1.0
+    #
+    # @api private
+    def clear_demongoized_cache(name)
+      @__demongoized_cache&.delete(name) if Mongoid::Config.cache_attribute_values?
+    end
+    private :clear_demongoized_cache
+
+    # Lazily allocate demongoized cache to avoid document initialization overhead.
+    #
+    # @return [ Hash | nil ] The cache map when caching is enabled.
+    #
+    # @api private
+    def demongoized_cache
+      return unless Mongoid::Config.cache_attribute_values?
+
+      @__demongoized_cache ||= {}
+    end
+    private :demongoized_cache
+
+    # Demongoize and cache a raw field value together with any metadata needed
+    # to determine whether the cached value remains valid.
+    #
+    # Set and Range demongoize into objects that are distinct from their raw
+    # Array or Hash values, so retain a deep copy to detect in-place raw-value
+    # mutations. Time and DateTime demongoization depends on the configured
+    # UTC behavior and the current thread's time zone, so retain that context.
+    #
+    # @param [ Hash ] cache The document's demongoized value cache.
+    # @param [ String ] name The field name.
+    # @param [ Object ] raw The raw field value.
+    # @param [ Field ] field The field definition.
+    # @param [ true | false ] track_raw_content Whether to snapshot raw content.
+    # @param [ true | false ] track_time_zone Whether to retain time zone context.
+    #
+    # @return [ Object ] The demongoized field value.
+    #
+    # @api private
+    def cache_demongoized_value(cache, name, raw, field, track_raw_content, track_time_zone)
+      if track_time_zone
+        use_utc = Mongoid::Config.use_utc?
+        time_zone = use_utc ? nil : ::Time.zone
+      end
+
+      demongoized = process_raw_attribute(name, raw, field)
+
+      cache[name] =
+        if track_raw_content
+          [ raw, demongoized, raw.__deep_copy__ ]
+        elsif track_time_zone
+          [ raw, demongoized, use_utc, time_zone ]
+        else
+          [ raw, demongoized ]
+        end
+
+      demongoized
+    end
+    private :cache_demongoized_value
+
+    # Lazily allocate projector cache to avoid document initialization overhead.
+    #
+    # @return [ Concurrent::Map | nil ] The cache map when caching is enabled.
+    #
+    # @api private
+    def projector_cache
+      return unless Mongoid::Config.cache_attribute_values?
+
+      @__projector_cache ||= Concurrent::Map.new
+    end
+    private :projector_cache
 
     # Write a single attribute to the document attribute hash. This will
     # also fire the before and after update callbacks, and perform any
@@ -168,14 +250,15 @@ module Mongoid
 
       if attribute_writable?(field_name)
         _assigning do
-          localized = fields[field_name].try(:localized?)
+          field = fields[field_name]
+          localized = field&.localized?
           attributes_before_type_cast[name.to_s] = value
           typed_value = typed_value_for(field_name, value)
           unless attribute_will_not_change?(field_name, typed_value) || attribute_changed?(field_name)
             attribute_will_change!(field_name)
           end
           if localized
-            present = fields[field_name].try(:localize_present?)
+            present = field&.localize_present?
             loc_key, loc_val = typed_value.first
             if present && loc_val.blank?
               attributes[field_name]&.delete(loc_key)
@@ -185,6 +268,7 @@ module Mongoid
             end
           else
             attributes[field_name] = typed_value
+            clear_demongoized_cache(field_name)
           end
 
           # when writing an attribute, also remove it from the unsets,
@@ -236,6 +320,9 @@ module Mongoid
     # Determine if the attribute is missing from the document, due to loading
     # it from the database with missing fields.
     #
+    # Cache the projector keyed by __selected_fields to automatically handle
+    # invalidation when selected fields change (only if caching is enabled).
+    #
     # @example Is the attribute missing?
     #   document.attribute_missing?("test")
     #
@@ -243,7 +330,16 @@ module Mongoid
     #
     # @return [ true | false ] If the attribute is missing.
     def attribute_missing?(name)
-      !Projector.new(__selected_fields).attribute_or_path_allowed?(name)
+      return false unless __selected_fields
+
+      if Mongoid::Config.cache_attribute_values?
+        projector = projector_cache.compute_if_absent(__selected_fields) do
+          Projector.new(__selected_fields)
+        end
+        !projector.attribute_or_path_allowed?(name)
+      else
+        !Projector.new(__selected_fields).attribute_or_path_allowed?(name)
+      end
     end
 
     # Return type-casted attributes.

--- a/lib/mongoid/attributes.rb
+++ b/lib/mongoid/attributes.rb
@@ -168,13 +168,13 @@ module Mongoid
 
     # Lazily allocate demongoized cache to avoid document initialization overhead.
     #
-    # @return [ Hash | nil ] The cache map when caching is enabled.
+    # @return [ Concurrent::Map | nil ] The cache map when caching is enabled.
     #
     # @api private
     def demongoized_cache
       return unless Mongoid::Config.cache_attribute_values?
 
-      @__demongoized_cache ||= {}
+      @__demongoized_cache ||= Concurrent::Map.new
     end
     private :demongoized_cache
 

--- a/lib/mongoid/config.rb
+++ b/lib/mongoid/config.rb
@@ -242,6 +242,30 @@ module Mongoid
     # document might be ignored, or it might work, depending on the situation.
     option :immutable_ids, default: true
 
+    # When this flag is true, Mongoid will cache demongoized attribute values
+    # to improve read performance. The cache stores the demongoized Ruby object
+    # with a raw BSON value snapshot, automatically refreshing when the
+    # underlying raw value changes.
+    #
+    # This optimization can significantly improve performance for fields with
+    # expensive demongoization (e.g., Time, Date, custom types), especially
+    # in read-heavy workloads.
+    #
+    # The cache is disabled by default to maintain backward compatibility.
+    # Enable it to gain performance improvements:
+    #
+    #   Mongoid.configure do |config|
+    #     config.cache_attribute_values = true
+    #   end
+    #
+    # @note This option must be set during application initialization and
+    #   should not be changed at runtime. Changing this flag at runtime is
+    #   unsupported and may lead to inconsistent behavior across document
+    #   instances created before and after the change. Documents that already
+    #   allocated caches may retain them after caching is disabled, but those
+    #   caches will no longer be consulted.
+    option :cache_attribute_values, default: false
+
     # When this flag is true, callbacks for every embedded document will be
     # called only once, even if the embedded document is embedded in multiple
     # documents in the root document's dependencies graph.

--- a/lib/mongoid/document.rb
+++ b/lib/mongoid/document.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'concurrent/map'
 require 'mongoid/positional'
 require 'mongoid/evolvable'
 require 'mongoid/extensions'
@@ -235,8 +236,31 @@ module Mongoid
     def prepare_to_process_attributes
       @new_record = true
       @attributes ||= {}
+      initialize_field_caches
       apply_pre_processed_defaults
       apply_default_scoping
+    end
+
+    # Initialize field cache instance variables to ensure consistent object shape.
+    #
+    # Initializes @__projector_cache and @__demongoized_cache early in all document
+    # creation paths. This ensures all documents have the same instance variable
+    # layout from the start, allowing Ruby's JIT compilers (YJIT, MJIT) to generate
+    # optimized code. Without this, lazy cache creation would cause shape polymorphism,
+    # preventing JIT optimizations.
+    #
+    # @return [ void ]
+    #
+    # @since 9.1.0
+    #
+    # @api private
+    def initialize_field_caches
+      return unless Mongoid::Config.cache_attribute_values?
+
+      # Keep instance variable shape stable, but defer map allocations
+      # until caches are first used.
+      @__projector_cache = nil
+      @__demongoized_cache = nil
     end
 
     # Returns the logger
@@ -415,6 +439,7 @@ module Mongoid
         doc.__selected_fields = selected_fields
         doc.instance_variable_set(:@attributes, attributes)
         doc.instance_variable_set(:@attributes_before_type_cast, attributes.dup)
+        doc.send(:initialize_field_caches)
 
         doc._handle_callbacks_after_instantiation(execute_callbacks, &block)
 

--- a/lib/mongoid/fields.rb
+++ b/lib/mongoid/fields.rb
@@ -52,6 +52,18 @@ module Mongoid
     # @api private
     TRANSLATIONS_SFX = '_translations'
 
+    # Field types where repeated demongoization usually costs more than a
+    # cache lookup. Cheap scalar types intentionally bypass the cache.
+    #
+    # @api private
+    CACHEABLE_FIELD_TYPES = [ Array, Date, DateTime, Hash, Range, Set, Time ].freeze
+
+    # Field types whose demongoized value is the raw value when it is already
+    # stored with the expected Ruby type.
+    #
+    # @api private
+    FAST_RAW_FIELD_TYPES = [ BSON::ObjectId, Float, Integer, String, Symbol ].freeze
+
     module ClassMethods
       # Returns the list of id fields for this model class, as both strings
       # and symbols.
@@ -98,6 +110,17 @@ module Mongoid
       def cleanse_localized_field_names(name)
         name = database_field_name(name.to_s)
 
+        # Fast path: if no dots, avoid array allocations entirely
+        unless name.include?(".")
+          # Simple field without nesting - just check for translation suffix
+          if !fields.key?(name) && !relations.key?(name) && name.end_with?(TRANSLATIONS_SFX)
+            return name.delete_suffix(TRANSLATIONS_SFX)
+          end
+
+          return name
+        end
+
+        # Slow path for nested fields (original logic)
         klass = self
         [].tap do |res|
           ar = name.split('.')
@@ -186,6 +209,7 @@ module Mongoid
       return if default.nil? || field.lazy?
 
       attribute_will_change!(name)
+      clear_demongoized_cache(name)
       attributes[name] = default
     end
 
@@ -333,7 +357,14 @@ module Mongoid
       #   or no field was found for the given key.
       #
       # @api private
-      def traverse_association_tree(key, fields, associations, aliased_associations)
+      def traverse_association_tree(key, fields, associations, aliased_associations, &block)
+        # Fast path: if no dots, it's a simple field lookup
+        unless key.include?(".")
+          field, _klass = process_field_or_association(key, key, fields, associations, aliased_associations, &block)
+          return field
+        end
+
+        # Slow path for nested fields (original logic)
         klass = nil
         field = nil
         key.split('.').each_with_index do |meth, i|
@@ -341,30 +372,43 @@ module Mongoid
           rs = (i == 0) ? associations : klass&.relations
           as = (i == 0) ? aliased_associations : klass&.aliased_associations
 
-          # Associations can possibly have two "keys", their name and their alias.
-          # The fields name is what is used to store it in the klass's relations
-          # and field hashes, and the alias is what's used to store that field
-          # in the database. The key inputted to this function is the aliased
-          # key. We can convert them back to their names by looking in the
-          # aliased_associations hash.
-          aliased = meth
-          if as && a = as.fetch(meth, nil)
-            aliased = a.to_s
-          end
-
-          field = nil
-          klass = nil
-          if fs && f = fs[aliased]
-            field = f
-            yield(meth, f, true) if block_given?
-          elsif rs && rel = rs[aliased]
-            klass = rel.klass
-            yield(meth, rel, false) if block_given?
-          elsif block_given?
-            yield(meth, nil, false)
-          end
+          field, klass = process_field_or_association(meth, meth, fs, rs, as, &block)
         end
         field
+      end
+
+      # Process a single field or association segment.
+      #
+      # @param [ String ] key The original key for yielding.
+      # @param [ String ] meth The method/segment name to look up.
+      # @param [ Hash ] fields The fields hash to search.
+      # @param [ Hash ] associations The associations hash to search.
+      # @param [ Hash ] aliased_associations The aliased associations hash.
+      #
+      # @return [ Array<Field, Class> ] Returns [field, klass] where field is
+      #   the found field (or nil) and klass is the relation klass (or nil).
+      #
+      # @api private
+      def process_field_or_association(key, meth, fields, associations, aliased_associations)
+        # Resolve alias if present
+        aliased = meth
+        if aliased_associations && a = aliased_associations.fetch(meth, nil)
+          aliased = a.to_s
+        end
+
+        field = nil
+        klass = nil
+        if fields && f = fields[aliased]
+          field = f
+          yield(key, f, true) if block_given?
+        elsif associations && rel = associations[aliased]
+          klass = rel.klass
+          yield(key, rel, false) if block_given?
+        else
+          yield(key, nil, false) if block_given?
+        end
+
+        [field, klass]
       end
 
       # Get the name of the provided field as it is stored in the database.
@@ -412,6 +456,13 @@ module Mongoid
         return '' unless name.present?
 
         key = name.to_s
+
+        # Fast path: if no dots, avoid split allocation
+        unless key.include?(".")
+          return aliased_fields[key]&.dup || key
+        end
+
+        # Slow path for nested fields (original logic with split)
         segment, remaining = key.split('.', 2)
 
         # Don't get the alias for the field when a belongs_to association
@@ -737,13 +788,64 @@ module Mongoid
       #
       # @api private
       def create_field_getter(name, meth, field)
+        name_string = name.to_s
+        field_type = field.type
+        cacheable = CACHEABLE_FIELD_TYPES.include?(field.type)
+        track_resizable = field.type.resizable? && !relations.key?(name_string)
+        object_id_field = (name == :_id || name == "_id") && field.object_id_field?
+        boolean_field = field_type == Mongoid::Boolean
+        fast_raw_field = FAST_RAW_FIELD_TYPES.include?(field_type) || boolean_field
+        track_raw_content = field_type == Set || field_type == Range
+        track_time_zone = field_type == Time || field_type == DateTime
+
         generated_methods.module_eval do
           re_define_method(meth) do
+            # Handle lazy defaults first (before reading raw value)
             raw = read_raw_attribute(name)
             if lazy_settable?(field, raw)
               write_attribute(name, field.eval_default(self))
+            # Don't cache localized fields as they depend on I18n.locale
+            elsif field.localized?
+              process_raw_attribute(name_string, raw, field)
+            # BSON::ObjectId reads (_id/id) are already cheap and don't benefit
+            # from caching; bypass cache to avoid lookup overhead.
+            elsif object_id_field
+              raw
+            # Cheap scalar demongoization is faster than a cache lookup.
+            elsif !cacheable
+              if fast_raw_field && (raw.nil? || raw.is_a?(field_type) || (boolean_field && (raw == true || raw == false)))
+                raw
+              else
+                process_raw_attribute(name_string, raw, field)
+              end
+            # Check if caching is enabled
+            elsif Mongoid::Config.cache_attribute_values?
+              cache = demongoized_cache
+
+              if value = cache[name]
+                cache_valid = value[0].equal?(raw)
+
+                if cache_valid && track_raw_content
+                  cache_valid = value[2] == raw
+                elsif cache_valid && track_time_zone
+                  use_utc = Mongoid::Config.use_utc?
+                  time_zone = use_utc ? nil : ::Time.zone
+                  cache_valid = value[2] == use_utc && value[3] == time_zone
+                end
+
+                if cache_valid
+                  demongoized_value = value[1]
+                  attribute_will_change!(name_string) if track_resizable
+                  demongoized_value
+                else
+                  cache_demongoized_value(cache, name, raw, field, track_raw_content, track_time_zone)
+                end
+              else
+                cache_demongoized_value(cache, name, raw, field, track_raw_content, track_time_zone)
+              end
             else
-              process_raw_attribute(name.to_s, raw, field)
+              # Caching disabled - use original behavior
+              process_raw_attribute(name_string, raw, field)
             end
           end
         end

--- a/lib/mongoid/persistable/incrementable.rb
+++ b/lib/mongoid/persistable/incrementable.rb
@@ -24,6 +24,7 @@ module Mongoid
             new_value = (current || 0) + increment
             process_attribute field, new_value if executing_atomically?
             attributes[field] = new_value
+            clear_demongoized_cache(field)
             ops[atomic_attribute_name(field)] = increment
           end
           { '$inc' => ops } unless ops.empty?

--- a/lib/mongoid/persistable/logical.rb
+++ b/lib/mongoid/persistable/logical.rb
@@ -25,6 +25,7 @@ module Mongoid
             end
             process_attribute field, value if executing_atomically?
             attributes[field] = value
+            clear_demongoized_cache(field)
             ops[atomic_attribute_name(field)] = values
           end
           { '$bit' => ops } unless ops.empty?

--- a/lib/mongoid/persistable/multipliable.rb
+++ b/lib/mongoid/persistable/multipliable.rb
@@ -24,6 +24,7 @@ module Mongoid
             new_value = (current || 0) * factor
             process_attribute field, new_value if executing_atomically?
             attributes[field] = new_value
+            clear_demongoized_cache(field)
             ops[atomic_attribute_name(field)] = factor
           end
           { '$mul' => ops } unless ops.empty?

--- a/lib/mongoid/persistable/poppable.rb
+++ b/lib/mongoid/persistable/poppable.rb
@@ -25,6 +25,7 @@ module Mongoid
           process_atomic_operations(pops) do |field, value|
             values = send(field)
             (value > 0) ? values.pop : values.shift
+            clear_demongoized_cache(field)
             ops[atomic_attribute_name(field)] = value
           end
           { '$pop' => ops }

--- a/lib/mongoid/persistable/pullable.rb
+++ b/lib/mongoid/persistable/pullable.rb
@@ -20,6 +20,7 @@ module Mongoid
         prepare_atomic_operation do |ops|
           process_atomic_operations(pulls) do |field, value|
             (send(field) || []).delete(value)
+            clear_demongoized_cache(field)
             ops[atomic_attribute_name(field)] = value
           end
           { '$pull' => ops }
@@ -39,6 +40,7 @@ module Mongoid
           process_atomic_operations(pulls) do |field, value|
             existing = send(field) || []
             value.each { |val| existing.delete(val) }
+            clear_demongoized_cache(field)
             ops[atomic_attribute_name(field)] = value
           end
           { '$pullAll' => ops }

--- a/lib/mongoid/persistable/pushable.rb
+++ b/lib/mongoid/persistable/pushable.rb
@@ -29,6 +29,7 @@ module Mongoid
             values.each do |val|
               existing.push(val) unless existing.include?(val)
             end
+            clear_demongoized_cache(field)
             ops[atomic_attribute_name(field)] = { '$each' => values }
           end
           { '$addToSet' => ops }
@@ -55,6 +56,7 @@ module Mongoid
             end
             values = [ value ].flatten(1)
             values.each { |val| existing.push(val) }
+            clear_demongoized_cache(field)
             ops[atomic_attribute_name(field)] = { '$each' => values }
           end
           { '$push' => ops }

--- a/lib/mongoid/persistable/renamable.rb
+++ b/lib/mongoid/persistable/renamable.rb
@@ -25,6 +25,8 @@ module Mongoid
               process_attribute old_field, nil
             else
               attributes[new_name] = attributes.delete(old_field)
+              clear_demongoized_cache(old_field)
+              clear_demongoized_cache(new_name)
             end
             ops[atomic_attribute_name(old_field)] = atomic_attribute_name(new_name)
           end

--- a/lib/mongoid/persistable/unsettable.rb
+++ b/lib/mongoid/persistable/unsettable.rb
@@ -24,6 +24,7 @@ module Mongoid
               process_attribute normalized, nil
             else
               attributes.delete(normalized)
+              clear_demongoized_cache(normalized)
             end
             ops[atomic_attribute_name(normalized)] = true
           end

--- a/lib/mongoid/stateful.rb
+++ b/lib/mongoid/stateful.rb
@@ -151,6 +151,7 @@ module Mongoid
 
     def reset_readonly
       self.__selected_fields = nil
+      initialize_field_caches
     end
   end
 end

--- a/perf/benchmark_cache_attribute_values.rb
+++ b/perf/benchmark_cache_attribute_values.rb
@@ -1,0 +1,482 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# rubocop:todo all
+
+# Benchmark script to compare field access performance between master and current branch.
+# This measures timing improvements from field access caching optimizations.
+#
+# Usage:
+#   ruby perf/benchmark_cache_attribute_values.rb
+#
+# The script will:
+#   1. Run benchmark on current branch
+#   2. Switch to master and run benchmark
+#   3. Switch back to original branch
+#   4. Display comparison
+
+require "tempfile"
+require "fileutils"
+require "tmpdir"
+require "set"
+
+# Save original branch
+ORIGINAL_BRANCH = `git rev-parse --abbrev-ref HEAD`.strip
+
+# Create temp benchmark script that can run on any branch
+BENCHMARK_SCRIPT = <<~'RUBY'
+  repo_root = ENV.fetch("MONGOID_BENCH_REPO_ROOT")
+  $LOAD_PATH.unshift(File.join(repo_root, "lib"))
+
+  require "benchmark/ips"
+  require "mongoid"
+
+  # Define models inline to work on both branches
+  class Band
+    include Mongoid::Document
+
+    field :name, type: String
+    field :origin, type: String
+    field :tags, type: Hash
+    field :genres, type: Array
+    field :rating, type: Float
+    field :member_count, type: Integer
+    field :active, type: Mongoid::Boolean
+    field :founded, type: Date
+    field :updated, type: Time
+    field :decibels, type: Range
+  end
+
+  class Person
+    include Mongoid::Document
+
+    field :birth_date, type: Date
+    field :title, type: String
+
+    embeds_many :addresses, validate: false
+  end
+
+  class Address
+    include Mongoid::Document
+
+    field :street, type: String
+    field :city, type: String
+    field :post_code, type: String
+    embedded_in :person
+  end
+
+  Mongoid.connect_to("mongoid_perf_field_cache")
+  Mongo::Logger.logger.level = ::Logger::FATAL
+
+  # Configure time zone for Date handling
+  Time.zone = "UTC"
+
+  puts "Branch: #{`git rev-parse --abbrev-ref HEAD`.strip} | Commit: #{`git rev-parse --short HEAD`.strip}"
+
+  # Check if caching config is available (current branch has it, master doesn't)
+  cache_available = Mongoid::Config.respond_to?(:cache_attribute_values=)
+
+  if cache_available
+    cache_enabled = ENV.fetch("MONGOID_BENCH_CACHE_MODE", "enabled") == "enabled"
+    Mongoid::Config.cache_attribute_values = cache_enabled
+    puts "Field caching: #{cache_enabled ? 'enabled' : 'disabled'}"
+  else
+    puts "Field caching: not available (baseline)"
+  end
+
+  Mongoid.purge!
+
+  # Create test data with all field types from performance_spec
+  band = Band.create!(
+    name: 'Test Band',
+    origin: 'Test City',
+    tags: { 'genre' => 'rock', 'era' => '80s' },
+    genres: %w[rock metal],
+    rating: 8.5,
+    member_count: 4,
+    active: true,
+    founded: Date.current,
+    updated: Time.current,
+    decibels: (50..120)
+  )
+
+  # Also test with embedded documents
+  person = Person.create!(
+    title: "Senior Engineer",
+    birth_date: Date.new(1985, 6, 15)
+  )
+
+  5.times do |n|
+    person.addresses.create!(
+      street: "Wienerstr. #{n}",
+      city: "Berlin",
+      post_code: "10999"
+    )
+  end
+
+  # Isolated documents for each benchmark path.
+  cold_band = Band.new(name: "Cold Read Band")
+  dotted_band = Band.new(tags: { "genre" => "rock", "era" => "80s" })
+  projected_band = Band.only(:name).find(band.id)
+  string_write_band = Band.new(name: "Write Path Band")
+  scalar_band = Band.new(member_count: 0)
+  array_band = Band.new(genres: %w[rock metal])
+  hash_band = Band.new(tags: { "genre" => "rock", "era" => "80s" })
+  write_then_read_band = Band.new(name: "Initial Name")
+
+  string_write_counter = 0
+  scalar_counter = 0
+  array_counter = 0
+  hash_counter = 0
+  write_then_read_counter = 0
+  mem_time = (ENV["MONGOID_BENCH_MEM_TIME"] || "3").to_i
+  mem_warmup = (ENV["MONGOID_BENCH_MEM_WARMUP"] || "1").to_i
+
+  # Run GC before starting to ensure clean state
+  3.times { GC.start }
+
+  # In-memory microbenchmarks: disable GC to reduce runtime noise from collections.
+  GC.disable
+  Benchmark.ips do |x|
+    x.config(time: mem_time, warmup: mem_warmup)
+
+    puts "\n[ Existing Benchmarks ]"
+    x.report("String 10x") { 10.times { band.name } }
+    x.report("Integer 10x") { 10.times { band.member_count } }
+    x.report("Float 10x") { 10.times { band.rating } }
+    x.report("Boolean 10x") { 10.times { band.active } }
+    x.report("Date 10x") { 10.times { band.founded } }
+    x.report("Time 10x") { 10.times { band.updated } }
+    x.report("Hash 10x") { 10.times { band.tags } }
+    x.report("Array 10x") { 10.times { band.genres } }
+    x.report("Range 10x") { 10.times { band.decibels } }
+    x.report("BSON::ObjectId 10x") { 10.times { band.id } }
+
+    x.report("iterate embedded (5 docs)") do
+      person.addresses.each do |addr|
+        addr.street
+        addr.city
+        addr.post_code
+      end
+    end
+
+    x.report("write then read") do
+      band.name = "Modified Band"
+      band.name
+    end
+
+    puts "\n[ Split Write/Read Paths ]"
+    x.report("cold string read") do
+      if cache_available
+        cache = cold_band.instance_variable_get(:@__demongoized_cache)
+        cache&.delete(:name)
+        cache&.delete("name")
+      end
+      cold_band.name
+    end
+
+    x.report("dotted field read 10x") do
+      10.times { dotted_band.read_attribute("tags.genre") }
+    end
+
+    x.report("projected field access 10x") do
+      10.times { projected_band.name }
+    end
+
+    x.report("string write only") do
+      string_write_counter += 1
+      string_write_band.name = "Modified Band #{string_write_counter}"
+    end
+
+    x.report("scalar replace then read") do
+      scalar_counter += 1
+      scalar_band.member_count = scalar_counter
+      scalar_band.member_count
+    end
+
+    x.report("array in-place mutate then read") do
+      arr = array_band.genres
+      arr << "genre_#{array_counter}"
+      arr.pop
+      array_counter += 1
+      array_band.genres
+    end
+
+    x.report("hash in-place mutate then read") do
+      key = "k#{hash_counter}"
+      hash_band.tags[key] = hash_counter
+      hash_band.tags.delete(key)
+      hash_counter += 1
+      hash_band.tags
+    end
+
+    x.report("string write then read") do
+      write_then_read_counter += 1
+      write_then_read_band.name = "Modified Name #{write_then_read_counter}"
+      write_then_read_band.name
+    end
+
+  end
+  GC.enable
+
+RUBY
+
+def parse_results(text)
+  results = {}
+  return results unless text
+
+  # benchmark-ips lines include "(...)" but fixed-iteration DB lines do not.
+  text.scan(/^\s*(.+?)\s+([\d.]+)\s*([kM]?)\s+(?:\([^)]+\)\s+)?i\/s/) do |name, ips, suffix|
+    multiplier =
+      case suffix
+      when 'M' then 1_000_000
+      when 'k' then 1_000
+      else 1
+      end
+    value = ips.to_f * multiplier
+    results[name.strip] = value
+  end
+  results
+end
+
+def median(values)
+  sorted = values.sort
+  size = sorted.size
+  return 0 if size == 0
+
+  midpoint = size / 2
+  if size.odd?
+    sorted[midpoint]
+  else
+    (sorted[midpoint - 1] + sorted[midpoint]) / 2.0
+  end
+end
+
+def aggregate_results(files)
+  parsed = files.map { |f| parse_results(File.read(f.path)) }
+  test_names = parsed.flat_map(&:keys).uniq
+
+  test_names.each_with_object({}) do |name, acc|
+    values = parsed.map { |h| h[name] }.compact
+    next if values.empty?
+
+    acc[name] = median(values)
+  end
+end
+
+def format_ips(ips)
+  if ips >= 1_000_000
+    "%.1fM" % (ips / 1_000_000.0)
+  elsif ips >= 1_000
+    "%.1fk" % (ips / 1_000.0)
+  else
+    "%.1f" % ips
+  end
+end
+
+def benchmark_groups
+  {
+    "Core Field Reads" => [
+      "String 10x",
+      "Integer 10x",
+      "Float 10x",
+      "Boolean 10x",
+      "Date 10x",
+      "Time 10x",
+      "Hash 10x",
+      "Array 10x",
+      "Range 10x",
+      "BSON::ObjectId 10x",
+      "iterate embedded (5 docs)"
+    ],
+    "Read/Write Scenarios" => [
+      "write then read",
+      "cold string read",
+      "dotted field read 10x",
+      "projected field access 10x",
+      "string write only",
+      "scalar replace then read",
+      "array in-place mutate then read",
+      "hash in-place mutate then read",
+      "string write then read"
+    ]
+  }
+end
+
+def print_table_header
+  printf "%-30s  %15s  %16s  %12s\n", "Test", "Cache enabled", "Cache disabled", "Master"
+  puts [ "━" * 30, "━" * 15, "━" * 16, "━" * 12 ].join("  ")
+end
+
+def print_table_separator
+  puts [ "─" * 30, "─" * 15, "─" * 16, "─" * 12 ].join("  ")
+end
+
+def compare_results(cache_enabled_files, cache_disabled_files, master_files)
+  cache_enabled_results = aggregate_results(cache_enabled_files)
+  cache_disabled_results = aggregate_results(cache_disabled_files)
+  master_results = aggregate_results(master_files)
+  rows = []
+
+  cache_enabled_results.each do |test, cache_enabled_ips|
+    cache_disabled_ips = cache_disabled_results[test]
+    master_ips = master_results[test]
+    next unless cache_disabled_ips && master_ips
+
+    rows << {
+      test: test,
+      cache_enabled: cache_enabled_ips,
+      cache_disabled: cache_disabled_ips,
+      master: master_ips
+    }
+  end
+
+  puts ""
+  puts "=" * 79
+  puts "BENCHMARK COMPARISON (median): Cache Enabled vs Cache Disabled vs Master"
+  puts "=" * 79
+
+  printed = Set.new
+
+  benchmark_groups.each do |group_name, tests|
+    group_rows = rows.select { |r| tests.include?(r[:test]) }
+    next if group_rows.empty?
+
+    puts ""
+    puts "[ #{group_name} ]"
+    print_table_header
+
+    group_rows.each_with_index do |row, index|
+      printed << row[:test]
+      printf "%-30s  %15s  %16s  %12s\n",
+        row[:test],
+        format_ips(row[:cache_enabled]),
+        format_ips(row[:cache_disabled]),
+        format_ips(row[:master])
+      print_table_separator if index < group_rows.length - 1
+    end
+  end
+
+  other_rows = rows.reject { |r| printed.include?(r[:test]) }
+  unless other_rows.empty?
+    puts ""
+    puts "[ Other ]"
+    print_table_header
+
+    other_rows.each_with_index do |row, index|
+      printf "%-30s  %15s  %16s  %12s\n",
+        row[:test],
+        format_ips(row[:cache_enabled]),
+        format_ips(row[:cache_disabled]),
+        format_ips(row[:master])
+      print_table_separator if index < other_rows.length - 1
+    end
+  end
+
+  puts ""
+  puts "Legend:"
+  puts "  Cache enabled  - current branch with cache_attribute_values=true."
+  puts "  Cache disabled - current branch with cache_attribute_values=false; all other branch optimizations remain active."
+  puts "  Master         - local master branch baseline, where attribute-value caching is unavailable."
+  puts "  Values         - median iterations per second across independent process runs; higher is better."
+  puts "=" * 79
+end
+
+# Main execution
+if ORIGINAL_BRANCH == 'master'
+  # Just run benchmark on master
+  eval(BENCHMARK_SCRIPT)
+else
+  repetitions = [ (ENV["MONGOID_BENCH_REPETITIONS"] || "2").to_i, 1 ].max
+
+  # Get repository root
+  repo_root = File.expand_path('..', __dir__)
+
+  # Create temp script
+  temp_script = Tempfile.new(['benchmark', '.rb'])
+  temp_script.write(BENCHMARK_SCRIPT)
+  temp_script.close
+
+  cache_enabled_outputs = []
+  cache_disabled_outputs = []
+  master_outputs = []
+  master_worktree = nil
+
+  begin
+    puts "Running benchmark on current branch with cache enabled (#{repetitions} runs)..."
+    repetitions.times do |i|
+      puts "  cache enabled run #{i + 1}/#{repetitions}"
+      output = Tempfile.new(["benchmark_cache_enabled_#{i}", '.txt'])
+      output.close
+      system(
+        {
+          "MONGOID_BENCH_REPO_ROOT" => repo_root,
+          "MONGOID_BENCH_CACHE_MODE" => "enabled"
+        },
+        "bundle", "exec", "ruby", temp_script.path,
+        chdir: repo_root,
+        out: output.path,
+        err: [ :child, :out ],
+        exception: true
+      )
+      cache_enabled_outputs << output
+    end
+
+    puts "\nRunning benchmark on current branch with cache disabled (#{repetitions} runs)..."
+    repetitions.times do |i|
+      puts "  cache disabled run #{i + 1}/#{repetitions}"
+      output = Tempfile.new(["benchmark_cache_disabled_#{i}", '.txt'])
+      output.close
+      system(
+        {
+          "MONGOID_BENCH_REPO_ROOT" => repo_root,
+          "MONGOID_BENCH_CACHE_MODE" => "disabled"
+        },
+        "bundle", "exec", "ruby", temp_script.path,
+        chdir: repo_root,
+        out: output.path,
+        err: [ :child, :out ],
+        exception: true
+      )
+      cache_disabled_outputs << output
+    end
+
+    # Use a temporary worktree for master to avoid modifying/stashing current branch.
+    puts "\nPreparing temporary master worktree..."
+    master_worktree = Dir.mktmpdir("mongoid-bench-master-")
+    system("git", "-C", repo_root, "worktree", "add", "--detach", master_worktree, "master", "-q", exception: true)
+
+    # Bundle install might be needed if dependencies differ
+    puts "Ensuring dependencies are installed on master..."
+    system("bundle", "install", "--quiet", chdir: master_worktree, out: File::NULL, err: File::NULL)
+
+    puts "Running benchmark on master branch (#{repetitions} runs)..."
+    repetitions.times do |i|
+      puts "  master run #{i + 1}/#{repetitions}"
+      output = Tempfile.new(["benchmark_master_#{i}", '.txt'])
+      output.close
+      system(
+        { "MONGOID_BENCH_REPO_ROOT" => master_worktree },
+        "bundle", "exec", "ruby", temp_script.path,
+        chdir: master_worktree,
+        out: output.path,
+        err: [ :child, :out ],
+        exception: true
+      )
+      master_outputs << output
+    end
+  ensure
+    if master_worktree
+      system("git", "-C", repo_root, "worktree", "remove", master_worktree, "--force")
+      FileUtils.remove_entry(master_worktree, true) if File.exist?(master_worktree)
+    end
+  end
+
+  # Display comparison
+  compare_results(cache_enabled_outputs, cache_disabled_outputs, master_outputs)
+
+  # Cleanup
+  temp_script.unlink
+  cache_enabled_outputs.each(&:unlink)
+  cache_disabled_outputs.each(&:unlink)
+  master_outputs.each(&:unlink)
+end

--- a/spec/mongoid/config_spec.rb
+++ b/spec/mongoid/config_spec.rb
@@ -798,6 +798,91 @@ describe Mongoid::Config do
     end
   end
 
+  describe 'cache_attribute_values option' do
+    context 'when not set in the config' do
+      it 'defaults to false' do
+        Mongoid::Config.reset
+        configuration = CONFIG.merge(options: {})
+
+        Mongoid.configure { |config| config.load_configuration(configuration) }
+
+        expect(Mongoid::Config.cache_attribute_values).to be(false)
+      end
+    end
+
+    context 'when set to true in the config' do
+      it 'enables field value caching' do
+        Mongoid::Config.reset
+        configuration = CONFIG.merge(options: { cache_attribute_values: true })
+
+        Mongoid.configure { |config| config.load_configuration(configuration) }
+
+        expect(Mongoid::Config.cache_attribute_values).to be(true)
+      end
+    end
+
+    context 'when set to false in the config' do
+      it 'disables field value caching' do
+        Mongoid::Config.reset
+        configuration = CONFIG.merge(options: { cache_attribute_values: false })
+
+        Mongoid.configure { |config| config.load_configuration(configuration) }
+
+        expect(Mongoid::Config.cache_attribute_values).to be(false)
+      end
+    end
+
+    context 'functional behavior' do
+      let(:band_class) do
+        Class.new do
+          include Mongoid::Document
+          store_in collection: 'bands'
+          field :name, type: String
+          field :updated, type: Time
+        end
+      end
+
+      before do
+        stub_const('CacheBand', band_class)
+      end
+
+      around do |example|
+        original_value = Mongoid::Config.cache_attribute_values
+        example.run
+      ensure
+        Mongoid::Config.cache_attribute_values = original_value
+      end
+
+      it 'uses caching when enabled' do
+        Mongoid::Config.cache_attribute_values = true
+
+        band = CacheBand.new(name: 'Test', updated: Time.current)
+
+        # First access should populate cache
+        first_result = band.updated
+
+        # Second access should return cached value (same object_id if caching works)
+        second_result = band.updated
+
+        expect(first_result.object_id).to eq(second_result.object_id)
+      end
+
+      it 'does not use caching when disabled' do
+        Mongoid::Config.cache_attribute_values = false
+
+        band = CacheBand.new(name: 'Test', updated: Time.current)
+
+        # Each access should call process_raw_attribute
+        first_result = band.updated
+        second_result = band.updated
+
+        # When caching is disabled, cache objects should not be initialized
+        expect(band.instance_variable_get(:@__demongoized_cache)).to be_nil
+        expect(band.instance_variable_get(:@__projector_cache)).to be_nil
+      end
+    end
+  end
+
   describe 'deprecations' do
     {}.each do |option, default|
       context ":#{option} option" do

--- a/spec/mongoid/fields/performance_spec.rb
+++ b/spec/mongoid/fields/performance_spec.rb
@@ -1,0 +1,864 @@
+# frozen_string_literal: true
+
+# rubocop:disable RSpec/ContextWording, RSpec/ExampleLength
+
+require 'spec_helper'
+require 'concurrent/array'
+
+# Allocation tracking is optional (only available on MRI with allocation_stats gem)
+begin
+  require 'allocation_stats'
+  allocation_stats_available = true
+rescue LoadError
+  allocation_stats_available = false
+end
+
+# Performance tests validate that field access optimizations achieve zero allocations.
+# Core field types (String, Integer, Float, etc.) must have exactly 0 allocations
+# to verify the caching optimization is working correctly.
+describe 'Mongoid::Fields performance optimizations' do
+  # Enable caching for all performance tests
+  around do |example|
+    original_value = Mongoid::Config.cache_attribute_values
+    Mongoid::Config.cache_attribute_values = true
+    example.run
+  ensure
+    Mongoid::Config.cache_attribute_values = original_value
+  end
+
+  let(:band) do
+    Band.new(
+      name: 'Test Band',
+      origin: 'Test City',
+      tags: { 'genre' => 'rock', 'era' => '80s' },
+      genres: %w[rock metal],
+      rating: 8.5,
+      member_count: 4,
+      active: true,
+      founded: Date.current,
+      updated: Time.current
+    )
+  end
+
+  shared_examples 'zero allocation field access' do |field_name|
+    it "achieves zero allocations for #{field_name}" do
+      subject.public_send(field_name) # warm up
+      stats = AllocationStats.trace { 10.times { subject.public_send(field_name) } }
+      expect(stats.new_allocations.size).to eq(0)
+    end
+  end
+
+  describe 'allocation optimizations' do
+    before do
+      skip 'allocation_stats gem not available' unless allocation_stats_available
+    end
+
+    context 'field access' do
+      subject { band }
+
+      %i[name tags genres member_count rating active updated founded].each do |field|
+        include_examples 'zero allocation field access', field
+      end
+
+      it 'achieves zero allocations for BSON::ObjectId fields' do
+        band.save!
+        band.id # warm up
+        stats = AllocationStats.trace { 10.times { band.id } }
+        expect(stats.new_allocations.size).to eq(0)
+      end
+
+      it 'does not cache BSON::ObjectId field reads' do
+        band.save!
+        band.id
+        band._id
+
+        cache = band.instance_variable_get(:@__demongoized_cache)
+        expect(cache).to be_nil
+      end
+
+      it 'handles custom _id field reads without BSON::ObjectId bypass' do
+        custom_id_class = Class.new do
+          include Mongoid::Document
+          store_in collection: 'custom_id_cache_tests'
+          field :_id, type: String, overwrite: true
+        end
+
+        stub_const('CustomIdCacheTest', custom_id_class)
+
+        doc = CustomIdCacheTest.new(_id: 'custom-id')
+        expect(doc._id).to eq('custom-id')
+
+        stats = AllocationStats.trace { 10.times { doc._id } }
+        expect(stats.new_allocations.size).to eq(0)
+      end
+
+      it 'achieves zero allocations for Symbol fields' do
+        # Use a test-specific class to avoid polluting Band with extra fields
+        symbol_band_class = Class.new do
+          include Mongoid::Document
+          store_in collection: 'bands'
+          field :status, type: Symbol
+        end
+        stub_const('SymbolBand', symbol_band_class)
+
+        band = SymbolBand.new(status: :active)
+        band.status # warm up
+        stats = AllocationStats.trace { 10.times { band.status } }
+        expect(stats.new_allocations.size).to eq(0)
+      end
+
+      it 'achieves zero allocations for Range fields' do
+        band.decibels = (50..120)
+        band.decibels # warm up
+        stats = AllocationStats.trace { 10.times { band.decibels } }
+        expect(stats.new_allocations.size).to eq(0)
+      end
+
+      it 'achieves zero allocations for Set fields' do
+        set_band_class = Class.new do
+          include Mongoid::Document
+          store_in collection: 'bands'
+          field :genres, type: Set
+        end
+        stub_const('SetBand', set_band_class)
+
+        band = SetBand.new(genres: Set.new(%w[rock metal]))
+        band.genres # warm up
+        stats = AllocationStats.trace { 10.times { band.genres } }
+        expect(stats.new_allocations.size).to eq(0)
+      end
+    end
+
+    context 'field access after setter' do
+      subject { band }
+
+      { tags: { 'new' => 'value' }, name: 'New Name', updated: Time.current }.each do |field, value|
+        it "maintains zero allocations after #{field} setter" do
+          band.public_send("#{field}=", value)
+          band.public_send(field) # warm up
+          stats = AllocationStats.trace { 10.times { band.public_send(field) } }
+          expect(stats.new_allocations.size).to eq(0)
+        end
+      end
+    end
+
+    context 'class-level methods' do
+      it 'achieves zero allocations for database_field_name' do
+        Band.database_field_name('name') # warm up
+        stats = AllocationStats.trace { 10.times { Band.database_field_name('name') } }
+        # NOTE: aliased fields require .dup for safety, which allocates.
+        # This test uses 'name' which is not aliased, achieving zero allocations.
+        expect(stats.new_allocations.size).to eq(0)
+      end
+
+      it 'achieves zero allocations for cleanse_localized_field_names' do
+        Band.cleanse_localized_field_names('name') # warm up
+        stats = AllocationStats.trace { 10.times { Band.cleanse_localized_field_names('name') } }
+        expect(stats.new_allocations.size).to eq(0)
+      end
+
+      it 'handles aliased fields correctly' do
+        # 'id' is aliased to '_id'
+        expect(Band.database_field_name('id')).to eq('_id')
+        expect(Band.database_field_name('name')).to eq('name')
+      end
+    end
+
+    context 'database-loaded documents' do
+      subject { loaded_band }
+
+      before { band.save! }
+
+      let(:loaded_band) { Band.find(band.id) }
+
+      %i[name tags genres member_count rating active updated].each do |field|
+        include_examples 'zero allocation field access', field
+      end
+    end
+  end
+
+  describe 'correctness verification' do
+    it 'returns correct values for all field types' do
+      expect(band.name).to eq('Test Band')
+      expect(band.tags).to eq({ 'genre' => 'rock', 'era' => '80s' })
+      expect(band.genres).to eq(%w[rock metal])
+      expect(band.rating).to eq(8.5)
+      expect(band.member_count).to eq(4)
+      expect(band.active).to be(true)
+    end
+
+    it 'preserves getter-after-setter behavior' do
+      band.name = 'New Band'
+      expect(band.name).to eq('New Band')
+
+      band.tags = { 'key' => 'value' }
+      expect(band.tags).to eq({ 'key' => 'value' })
+
+      band.rating = 9.5
+      expect(band.rating).to eq(9.5)
+
+      band.name = nil
+      expect(band.name).to be_nil
+    end
+  end
+
+  describe 'critical edge cases' do
+    context 'Time field transformations' do
+      config_override :use_utc, true
+
+      it 'applies UTC conversion when configured' do
+        time_with_zone = Time.new(2020, 1, 1, 12, 0, 0, '+03:00')
+        band.updated = time_with_zone
+        band.save!
+
+        reloaded = Band.find(band.id)
+
+        expect(reloaded.updated.utc?).to be(true)
+        expect(reloaded.updated.hour).to eq(9) # 12:00 +03:00 = 09:00 UTC
+      end
+
+      it 'preserves timezone conversions after caching' do
+        band.save!
+        band.updated # First read - caches value
+        band.updated # Second read - from cache
+
+        expect(band.updated.utc?).to be(true)
+      end
+    end
+
+    context 'timezone-dependent caching' do
+      config_override :use_utc, false
+
+      let(:time_zone_class) do
+        Class.new do
+          include Mongoid::Document
+          field :occurred_at, type: Time
+          field :scheduled_at, type: DateTime
+        end
+      end
+
+      before do
+        stub_const('TimeZoneCacheTest', time_zone_class)
+      end
+
+      it 'refreshes a cached Time when Time.zone changes' do
+        document = TimeZoneCacheTest.new(occurred_at: Time.utc(2024, 1, 1, 12))
+
+        utc = Time.use_zone('UTC') { document.occurred_at }
+        pacific = Time.use_zone('Pacific Time (US & Canada)') { document.occurred_at }
+        utc_again = Time.use_zone('UTC') { document.occurred_at }
+
+        expect(utc.time_zone.name).to eq('UTC')
+        expect(utc.hour).to eq(12)
+        expect(pacific.time_zone.name).to eq('Pacific Time (US & Canada)')
+        expect(pacific.hour).to eq(4)
+        expect(utc_again.time_zone.name).to eq('UTC')
+        expect(utc_again.hour).to eq(12)
+      end
+
+      it 'refreshes a cached DateTime when Time.zone changes' do
+        document = TimeZoneCacheTest.new(scheduled_at: Time.utc(2024, 1, 1, 12))
+
+        utc = Time.use_zone('UTC') { document.scheduled_at }
+        pacific = Time.use_zone('Pacific Time (US & Canada)') { document.scheduled_at }
+        utc_again = Time.use_zone('UTC') { document.scheduled_at }
+
+        expect(utc.offset).to eq(0)
+        expect(utc.hour).to eq(12)
+        expect(pacific.offset).to eq(Rational(-8, 24))
+        expect(pacific.hour).to eq(4)
+        expect(utc_again.offset).to eq(0)
+        expect(utc_again.hour).to eq(12)
+      end
+    end
+
+    context 'database persistence' do
+      before { band.save! }
+
+      it 'correctly demongoizes fields loaded from database' do
+        loaded_band = Band.find(band.id)
+
+        expect(loaded_band.name).to be_a(String)
+        expect(loaded_band.tags).to be_a(Hash)
+        expect(loaded_band.genres).to be_a(Array)
+        expect(loaded_band.rating).to be_a(Float)
+        expect(loaded_band.member_count).to be_a(Integer)
+        expect(loaded_band.updated).to be_a(Time)
+      end
+
+      it 'converts BSON::Document to Hash' do
+        loaded_band = Band.find(band.id)
+
+        # MongoDB returns BSON::Document, should be converted to Hash
+        expect(loaded_band.tags).to be_a(Hash)
+        expect(loaded_band.tags).to eq({ 'genre' => 'rock', 'era' => '80s' })
+      end
+    end
+
+    context 'cache invalidation' do
+      before { band.save! }
+
+      it 'clears cache on reload' do
+        band.name = 'Modified Name'
+        band.reload
+        expect(band.name).to eq('Test Band') # Original value
+      end
+
+      it 'handles projector cache when selected_fields change' do
+        # Load with different field selections
+        limited1 = Band.only(:name).find(band.id)
+        limited2 = Band.only(:name, :rating).find(band.id)
+
+        # Both should work correctly with different projections
+        expect(limited1.attribute_missing?('rating')).to be(true)
+        expect(limited2.attribute_missing?('rating')).to be(false)
+
+        # Projector cache is keyed by selected_fields, so both are cached independently
+        expect(limited1.attribute_missing?('rating')).to be(true)
+        expect(limited2.attribute_missing?('rating')).to be(false)
+      end
+
+      it 'correctly caches nil values' do
+        nil_test_class = Class.new do
+          include Mongoid::Document
+          store_in collection: 'nil_cache_tests'
+          field :name, type: String
+          field :optional_field, type: String
+          field :nullable_int, type: Integer
+        end
+
+        stub_const('NilCacheTest', nil_test_class)
+
+        # Create with explicit nil values
+        doc = NilCacheTest.create!(name: 'Test', optional_field: nil, nullable_int: nil)
+
+        # First read should cache nil
+        expect(doc.optional_field).to be_nil
+        expect(doc.nullable_int).to be_nil
+
+        # Second read should return cached nil (not re-demongoize)
+        expect(doc.optional_field).to be_nil
+        expect(doc.nullable_int).to be_nil
+
+        # Verify zero allocations if available
+        if allocation_stats_available
+          stats = AllocationStats.trace { 10.times { doc.optional_field } }
+          expect(stats.new_allocations.size).to eq(0)
+        end
+
+        # Change from nil to value and back to nil
+        doc.optional_field = 'something'
+        expect(doc.optional_field).to eq('something')
+
+        doc.optional_field = nil
+        expect(doc.optional_field).to be_nil
+
+        # Verify cached nil still works
+        3.times { expect(doc.optional_field).to be_nil }
+      end
+
+      it 'clears cache for written field only' do
+        next unless allocation_stats_available
+
+        band.name # cache it
+        band.rating # cache it
+
+        band.name = 'New Name' # Only clears name cache
+
+        # rating cache should still work
+        stats = AllocationStats.trace { 10.times { band.rating } }
+        expect(stats.new_allocations.size).to eq(0)
+      end
+
+      it 'gets fresh value after write' do
+        band.name # cache it
+        original_name = band.name
+
+        band.name = 'New Name'
+
+        expect(band.name).to eq('New Name')
+        expect(band.name).not_to eq(original_name)
+      end
+
+      it 'gets fresh value after direct mutable raw attribute mutation' do
+        expect(band.tags).to eq({ 'genre' => 'rock', 'era' => '80s' })
+
+        band.attributes['tags']['genre'] = 'jazz'
+
+        expect(band.tags).to eq({ 'genre' => 'jazz', 'era' => '80s' })
+      end
+
+      it 'gets fresh Set and Range values after in-place raw attribute mutation' do
+        raw_mutation_class = Class.new do
+          include Mongoid::Document
+          field :genres, type: Set
+          field :decibels, type: Range
+        end
+        stub_const('RawMutationCacheTest', raw_mutation_class)
+
+        document = RawMutationCacheTest.new(
+          genres: Set.new(%w[rock metal]),
+          decibels: (50..120)
+        )
+
+        expect(document.genres).to eq(Set.new(%w[rock metal]))
+        expect(document.decibels).to eq(50..120)
+
+        document.attributes['genres'] << 'jazz'
+        document.attributes['decibels']['max'] = 130
+
+        expect(document.genres).to eq(Set.new(%w[rock metal jazz]))
+        expect(document.decibels).to eq(50..130)
+      end
+
+      it 'clears cache when attribute is removed' do
+        band.name # cache it
+        expect(band.name).to eq('Test Band')
+
+        band.remove_attribute(:name)
+
+        expect(band.name).to be_nil
+      end
+
+      it 'clears cache when attribute is unset' do
+        band.name # cache it
+        expect(band.name).to eq('Test Band')
+
+        band.unset(:name)
+
+        expect(band.name).to be_nil
+      end
+
+      it 'clears cache when field is renamed' do
+        band.name # cache it
+        expect(band.name).to eq('Test Band')
+
+        band.rename(name: :band_name)
+
+        # Old field should be nil
+        expect(band.attributes['name']).to be_nil
+        # New field should have the value
+        expect(band.attributes['band_name']).to eq('Test Band')
+      end
+
+      it 'clears cache when defaults are applied via apply_default' do
+        # Test for the fix: apply_default must invalidate cache
+        doc_class = Class.new do
+          include Mongoid::Document
+          store_in collection: 'apply_default_tests'
+          field :_id, type: String, overwrite: true, default: -> { name.try(:parameterize) }
+          field :name, type: String
+        end
+
+        stub_const('ApplyDefaultTest', doc_class)
+
+        # Create document without executing callbacks (simulating build in associations)
+        doc = Mongoid::Factory.execute_build(ApplyDefaultTest, { name: 'test value' }, execute_callbacks: false)
+
+        # Reading _id before apply_post_processed_defaults might cache nil
+        cached_id = doc._id
+        expect(cached_id).to be_nil
+
+        # apply_post_processed_defaults sets the _id
+        doc.apply_post_processed_defaults
+
+        # This should return the actual _id, not the cached nil
+        # (tests that apply_default invalidates the cache)
+        expect(doc._id).to eq('test-value')
+        expect(doc._id).not_to be_nil
+      end
+
+      it 'tracks changes for resizable fields on every read' do
+        # Test for the fix: resizable fields must call attribute_will_change! on every read
+        person_class = Class.new do
+          include Mongoid::Document
+          store_in collection: 'resizable_tracking_tests'
+          has_and_belongs_to_many :preferences
+        end
+
+        preference_class = Class.new do
+          include Mongoid::Document
+          store_in collection: 'preferences_tracking_tests'
+          field :name, type: String
+          has_and_belongs_to_many :people
+        end
+
+        stub_const('PersonTracking', person_class)
+        stub_const('PreferenceTracking', preference_class)
+
+        person = PersonTracking.create!
+        pref = PreferenceTracking.create!(name: 'test')
+
+        # First read - caches the array
+        ids = person.preference_ids
+        expect(ids).to eq([])
+
+        # Mutate the array (simulating << operator)
+        ids << pref.id
+
+        # Person should be marked as changed
+        # (tests that attribute_will_change! is called on cached reads)
+        expect(person.changed?).to be(true)
+        expect(person.changes.keys).to include('preference_ids')
+      end
+
+      it 'maintains correct array identity across reads' do
+        # Verify that cached arrays maintain object identity (mutations persist)
+        person_class = Class.new do
+          include Mongoid::Document
+          store_in collection: 'array_identity_tests'
+          has_and_belongs_to_many :items
+        end
+
+        stub_const('PersonArrayIdentity', person_class)
+
+        person = PersonArrayIdentity.create!
+
+        # First read
+        arr1 = person.item_ids
+
+        # Mutate it
+        test_id = BSON::ObjectId.new
+        arr1 << test_id
+
+        # Second read should return same object with mutation
+        arr2 = person.item_ids
+        expect(arr2.object_id).to eq(arr1.object_id)
+        expect(arr2).to include(test_id)
+      end
+    end
+
+    context 'field projections' do
+      before { band.save! }
+
+      it 'works with .only() projection' do
+        limited = Band.only(:name, :rating).find(band.id)
+
+        expect(limited.name).to eq('Test Band')
+        expect(limited.rating).to eq(8.5)
+        expect(limited.attribute_missing?('origin')).to be(true)
+      end
+
+      it 'works with .without() projection' do
+        limited = Band.without(:tags).find(band.id)
+
+        expect(limited.name).to eq('Test Band')
+        expect(limited.attribute_missing?('tags')).to be(true)
+      end
+    end
+
+    context 'thread safety' do
+      it 'handles concurrent field access safely' do
+        band = Band.new(name: 'Test Band', rating: 8.5)
+        errors = Concurrent::Array.new
+        results = Concurrent::Array.new
+
+        threads = Array.new(10) do
+          Thread.new do
+            100.times do
+              name = band.name
+              rating = band.rating
+              results << [ name, rating ]
+            rescue StandardError => e
+              errors << e
+            end
+          end
+        end
+
+        threads.each(&:join)
+        expect(errors).to be_empty
+
+        # Verify all threads read correct values
+        results.each do |name, rating|
+          expect(name).to eq('Test Band')
+          expect(rating).to eq(8.5)
+        end
+      end
+
+      it 'handles concurrent projector cache access safely' do
+        band = Band.create!(name: 'Test')
+        limited = Band.only(:name).find(band.id)
+        errors = Concurrent::Array.new
+
+        threads = Array.new(10) do
+          Thread.new do
+            100.times do
+              limited.attribute_missing?('rating')
+            rescue StandardError => e
+              errors << e
+            end
+          end
+        end
+
+        threads.each(&:join)
+        expect(errors).to be_empty
+      end
+    end
+
+    context 'localized fields' do
+      around do |example|
+        previous_available_locales = I18n.available_locales
+        previous_locale = I18n.locale
+
+        I18n.available_locales = %i[en es]
+        I18n.locale = :en
+
+        begin
+          example.run
+        ensure
+          I18n.available_locales = previous_available_locales
+          I18n.locale = previous_locale
+        end
+      end
+
+      it 'does not cache localized fields to preserve i18n behavior' do
+        # Create a simple model with localized field using stub_const to avoid test pollution
+        localized_band_class = Class.new do
+          include Mongoid::Document
+          field :title, type: String, localize: true
+        end
+        stub_const('LocalizedBand', localized_band_class)
+
+        band = LocalizedBand.new
+        band.title = 'English Title'
+
+        I18n.locale = :es
+        band.title = 'Spanish Title'
+
+        # Verify both locales return correct values
+        expect(band.title).to eq('Spanish Title')
+        I18n.locale = :en
+        expect(band.title).to eq('English Title')
+
+        # Verify repeated reads work correctly (not cached)
+        I18n.locale = :es
+        3.times { expect(band.title).to eq('Spanish Title') }
+        I18n.locale = :en
+        3.times { expect(band.title).to eq('English Title') }
+      end
+    end
+
+    context 'with lazy-settable fields' do
+      it 'correctly handles foreign key Array fields with default values' do
+        # Create test models with has_and_belongs_to_many relationship
+        # This creates a foreign key field with Array type and default: []
+        team_class = Class.new do
+          include Mongoid::Document
+          store_in collection: 'teams'
+          field :name, type: String
+          has_and_belongs_to_many :players
+        end
+
+        player_class = Class.new do
+          include Mongoid::Document
+          store_in collection: 'players'
+          field :name, type: String
+          has_and_belongs_to_many :teams
+        end
+
+        stub_const('Team', team_class)
+        stub_const('Player', player_class)
+
+        team = Team.new(name: 'Test Team')
+
+        # First access triggers lazy evaluation of default value
+        expect(team.player_ids).to eq([])
+
+        # Verify the field is properly cached and subsequent access is zero-allocation
+        if allocation_stats_available
+          team.player_ids # warm up
+          stats = AllocationStats.trace { 10.times { team.player_ids } }
+          expect(stats.new_allocations.size).to eq(0)
+        end
+      end
+
+      it 'correctly handles Hash foreign key fields with default values' do
+        # Create a model with a Hash-type foreign key field
+        metadata_doc_class = Class.new do
+          include Mongoid::Document
+          store_in collection: 'metadata_docs'
+          field :refs, type: Hash, default: -> { {} }
+        end
+
+        stub_const('MetadataDoc', metadata_doc_class)
+
+        doc = MetadataDoc.new
+
+        # First access triggers lazy evaluation
+        expect(doc.refs).to eq({})
+
+        # Verify proper caching
+        if allocation_stats_available
+          doc.refs # warm up
+          stats = AllocationStats.trace { 10.times { doc.refs } }
+          expect(stats.new_allocations.size).to eq(0)
+        end
+      end
+
+      it 'does not cache before lazy evaluation' do
+        team_class = Class.new do
+          include Mongoid::Document
+          store_in collection: 'teams'
+          has_and_belongs_to_many :players
+        end
+
+        player_class = Class.new do
+          include Mongoid::Document
+          store_in collection: 'players'
+          has_and_belongs_to_many :teams
+        end
+
+        stub_const('Team', team_class)
+        stub_const('Player', player_class)
+
+        team = Team.new
+
+        # Before first access, the field should be nil in attributes
+        expect(team.attributes['player_ids']).to be_nil
+
+        # First access evaluates and sets the default
+        result = team.player_ids
+        expect(result).to eq([])
+
+        # Now it should be present in attributes
+        expect(team.attributes['player_ids']).to eq([])
+      end
+
+      it 'handles modifications to lazy-evaluated fields' do
+        team_class = Class.new do
+          include Mongoid::Document
+          store_in collection: 'teams'
+          has_and_belongs_to_many :players
+        end
+
+        player_class = Class.new do
+          include Mongoid::Document
+          store_in collection: 'players'
+          field :name, type: String
+          has_and_belongs_to_many :teams
+        end
+
+        stub_const('Team', team_class)
+        stub_const('Player', player_class)
+
+        team = Team.new
+        player = Player.new(name: 'John')
+
+        # Lazy evaluation happens on first access
+        team.player_ids # => []
+
+        # Modification should work correctly
+        team.player_ids << player.id
+        expect(team.player_ids).to eq([ player.id ])
+
+        # Cache should be invalidated and re-read correctly
+        expect(team.player_ids).to eq([ player.id ])
+      end
+    end
+
+    context 'atomic operations' do
+      it 'invalidates cache on inc operations' do
+        atomic_test_class = Class.new do
+          include Mongoid::Document
+          store_in collection: 'atomic_tests'
+          field :counter, type: Integer, default: 0
+          field :score, type: Integer, default: 0
+        end
+
+        stub_const('AtomicTest', atomic_test_class)
+
+        doc = AtomicTest.new(counter: 10, score: 5)
+
+        # First read to cache the value
+        expect(doc.counter).to eq(10)
+        expect(doc.score).to eq(5)
+
+        # Perform atomic increment
+        doc.inc(counter: 5, score: 3)
+
+        # Verify cache was invalidated and new values are returned
+        expect(doc.counter).to eq(15)
+        expect(doc.score).to eq(8)
+
+        # Verify repeated reads return correct values (from fresh cache)
+        3.times do
+          expect(doc.counter).to eq(15)
+          expect(doc.score).to eq(8)
+        end
+
+        # Verify zero allocations on cached reads if available
+        if allocation_stats_available
+          stats = AllocationStats.trace { 10.times { doc.counter } }
+          expect(stats.new_allocations.size).to eq(0)
+        end
+      end
+
+      it 'invalidates cache on mul operations' do
+        atomic_test_class = Class.new do
+          include Mongoid::Document
+          store_in collection: 'atomic_mul_tests'
+          field :multiplier, type: Integer, default: 1
+        end
+
+        stub_const('AtomicMulTest', atomic_test_class)
+
+        doc = AtomicMulTest.new(multiplier: 5)
+
+        # First read to cache the value
+        expect(doc.multiplier).to eq(5)
+
+        # Perform atomic multiplication
+        doc.mul(multiplier: 3)
+
+        # Verify cache was invalidated and new value is returned
+        expect(doc.multiplier).to eq(15)
+
+        # Verify repeated reads return correct value
+        3.times { expect(doc.multiplier).to eq(15) }
+
+        # Verify zero allocations on cached reads if available
+        if allocation_stats_available
+          stats = AllocationStats.trace { 10.times { doc.multiplier } }
+          expect(stats.new_allocations.size).to eq(0)
+        end
+      end
+
+      it 'invalidates cache on bit operations' do
+        atomic_test_class = Class.new do
+          include Mongoid::Document
+          store_in collection: 'atomic_bit_tests'
+          field :flags, type: Integer, default: 0
+        end
+
+        stub_const('AtomicBitTest', atomic_test_class)
+
+        doc = AtomicBitTest.new(flags: 15) # Binary: 1111
+
+        # First read to cache the value
+        expect(doc.flags).to eq(15)
+
+        # Perform atomic bitwise AND operation
+        doc.bit(flags: { and: 7 }) # Binary: 0111, result should be 7 (0111)
+
+        # Verify cache was invalidated and new value is returned
+        expect(doc.flags).to eq(7)
+
+        # Perform atomic bitwise OR operation
+        doc.bit(flags: { or: 8 }) # Binary: 1000, result should be 15 (1111)
+
+        # Verify cache was invalidated and new value is returned
+        expect(doc.flags).to eq(15)
+
+        # Verify repeated reads return correct value
+        3.times { expect(doc.flags).to eq(15) }
+
+        # Verify zero allocations on cached reads if available
+        if allocation_stats_available
+          stats = AllocationStats.trace { 10.times { doc.flags } }
+          expect(stats.new_allocations.size).to eq(0)
+        end
+      end
+    end
+  end
+end
+# rubocop:enable RSpec/ContextWording, RSpec/ExampleLength

--- a/spec/mongoid/fields/performance_spec.rb
+++ b/spec/mongoid/fields/performance_spec.rb
@@ -549,7 +549,8 @@ describe 'Mongoid::Fields performance optimizations' do
 
     context 'thread safety' do
       it 'handles concurrent field access safely' do
-        band = Band.new(name: 'Test Band', rating: 8.5)
+        updated = Time.current
+        band = Band.new(name: 'Test Band', rating: 8.5, updated: updated)
         errors = Concurrent::Array.new
         results = Concurrent::Array.new
 
@@ -558,7 +559,7 @@ describe 'Mongoid::Fields performance optimizations' do
             100.times do
               name = band.name
               rating = band.rating
-              results << [ name, rating ]
+              results << [ name, rating, band.updated ]
             rescue StandardError => e
               errors << e
             end
@@ -567,11 +568,13 @@ describe 'Mongoid::Fields performance optimizations' do
 
         threads.each(&:join)
         expect(errors).to be_empty
+        expect(band.instance_variable_get(:@__demongoized_cache)).to be_a(Concurrent::Map)
 
         # Verify all threads read correct values
-        results.each do |name, rating|
+        results.each do |name, rating, result_updated|
           expect(name).to eq('Test Band')
           expect(rating).to eq(8.5)
+          expect(result_updated).to eq(updated)
         end
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -129,6 +129,9 @@ end
 # Set the database that the spec suite connects to.
 Mongoid.configure do |config|
   config.load_configuration(CONFIG)
+  # Attribute caching defaults to disabled. CI sets MONGOID_CACHING_ENABLED=1
+  # in a separate matrix leg to exercise the opt-in cache path explicitly.
+  config.cache_attribute_values = ENV['MONGOID_CACHING_ENABLED'] == '1'
 end
 
 # Autoload every model for the test suite that sits in spec/support/models.


### PR DESCRIPTION
## Summary

This PR reduces allocations and improves Mongoid field-access performance through:

- Fast paths for common, non-nested field operations.
- Direct access paths for inexpensive scalar field types.
- Avoiding projection work for documents without selected fields.
- Optional caching of expensive demongoized values.
- Lazy cache allocation and targeted cache invalidation.

Demongoized-value caching is opt-in and disabled by default:

```ruby
Mongoid.configure do |config|
  config.cache_attribute_values = true
end
```

The configuration should be set during application initialization and should not be changed at runtime.

## Motivation

Reading a Mongoid field currently involves several generic operations, even for ordinary scalar fields:

- Splitting and traversing simple field names.
- Constructing `Projector` instances when no projection is active.
- Repeatedly demongoizing field values.
- Repeating field metadata and relation lookups.
- Allocating intermediate arrays and hashes.

These costs become significant in applications that repeatedly access fields across large numbers of documents.

The implementation deliberately separates two kinds of optimization:

1. Fast paths that benefit normal field access regardless of caching.
2. Optional caching for types where repeated demongoization is more expensive than a cache lookup.

## Changes

### 1. Fast paths for simple field names

The common case is a field name without dot notation. The following methods now avoid splitting strings and constructing intermediate arrays for that case:

- `cleanse_localized_field_names`
- `traverse_association_tree`
- `database_field_name`

Nested and association paths continue to use the existing traversal logic.

### 2. Projection fast path

`attribute_missing?` now immediately returns `false` when the document has no selected fields.

This avoids constructing or looking up a `Projector` during ordinary field access. Documents loaded with `.only` or `.without` continue to use projection checks, with lazily cached `Projector` instances when caching is enabled.

### 3. Scalar field getter fast paths

Repeated demongoization is not beneficial for types where the stored value is already the expected Ruby value.

The generated getters use direct raw-value access for safe scalar cases, including:

- `String`
- `Integer`
- `Float`
- `Symbol`
- `Mongoid::Boolean`
- `BSON::ObjectId` identifier fields

The direct path is only used when the raw value is already compatible with the declared field type. Values that still require conversion continue through `process_raw_attribute`.

Localized fields also continue through the normal demongoization path because their result depends on `I18n.locale`.

### 4. Optional demongoized-value caching

When `cache_attribute_values` is enabled, Mongoid caches repeated demongoization for selected types where conversion is relatively expensive:

- `Array`
- `Hash`
- `Date`
- `DateTime`
- `Time`
- `Range`
- `Set`

Each entry stores the raw value reference together with its demongoized result and any validity metadata required by the field type:

- `Time` and `DateTime` entries retain the UTC configuration and current thread's `Time.zone`, so changing the demongoization context refreshes the cached value.
- `Set` and `Range` entries retain a deep snapshot of their raw Array or Hash, so in-place raw-value mutations refresh the cached value.

Replacing the raw value, changing relevant demongoization context, mutating tracked raw content, or writing through Mongoid's attribute APIs causes the cached value to be recomputed.

Cheap scalar types intentionally bypass this cache because a cache lookup would cost more than their normal conversion.

### 5. Cache invalidation

Cached values are invalidated through the normal Mongoid mutation paths, including:

- Attribute writers
- Attribute removal and unsetting
- Renaming
- Default application
- Atomic increment, multiply, bit, push, pull, pop, and related operations
- Document reload

Invalidation is field-specific so modifying one attribute does not discard unrelated cached values.

### 6. Lazy cache allocation and stable document shape

When caching is enabled, cache instance variables are initialized to `nil` in every document construction path:

- New documents
- Documents instantiated from database results
- Reloaded documents

The underlying hashes are allocated only when first needed. This keeps document object shapes consistent while avoiding cache allocations for documents that never use them.

### 7. Benchmark improvements

`perf/benchmark_cache_attribute_values.rb` now runs three configurations:

- Current branch with caching enabled
- Current branch with caching disabled
- Local `master` baseline

This separates improvements caused by the general field-access fast paths from improvements caused specifically by demongoized-value caching.

The benchmark also reports dedicated read, write, projection, dotted-field, and mutable-value scenarios.

Run it with:

```bash
./perf/benchmark_cache_attribute_values.rb
```

For a shorter validation run:

```bash
MONGOID_BENCH_REPETITIONS=1 \
MONGOID_BENCH_MEM_TIME=1 \
MONGOID_BENCH_MEM_WARMUP=0 \
./perf/benchmark_cache_attribute_values.rb
```

## Performance Results

Representative local results, reported as median iterations per second; higher is better:

| Test | Cache enabled | Cache disabled | Master |
|---|---:|---:|---:|
| String 10x | 98.6k | 90.4k | 42.7k |
| Time 10x | 50.6k | 12.3k | 11.8k |
| Date 10x | 65.7k | 35.4k | 36.2k |
| Range 10x | 55.8k | 33.9k | 34.0k |

The three-way comparison shows two distinct effects:

- Scalar fields such as `String` improve primarily because of the general getter and projection fast paths. Cache-enabled and cache-disabled results are similar.
- `Time`, `Date`, and `Range` benefit from caching because their demongoization is more expensive.
- Results vary across Ruby versions and hardware, so the benchmark reports raw iterations per second rather than presenting the percentages as universal application-level improvements.

The benchmark includes write-only and write-then-read cases so the read/write trade-offs remain visible.

## Allocation Results

With `allocation_stats` available on MRI, the performance specifications verify zero allocations after warm-up for the tested native getter paths, including:

- String
- Integer
- Float
- Boolean
- Symbol
- BSON::ObjectId
- Array
- Hash
- Date
- Time
- Range
- Set

These checks cover both newly constructed and database-loaded documents where applicable.

## Test Coverage

The added coverage includes:

- Allocation behavior for common field types
- Cache-enabled and cache-disabled configurations
- Scalar getter fast paths
- Custom identifier fields
- Getter-after-setter behavior
- Cache invalidation
- Time-zone-aware `Time` and `DateTime` cache refreshes
- In-place raw-value mutation detection for `Set` and `Range`
- Atomic mutation operations
- Lazy defaults
- Database-loaded documents
- Document reload
- Field projections with `.only` and `.without`
- Localized fields
- Mutable array and hash access
- Embedded documents
- Concurrent field and projector access

CI runs the Mongoid suite with attribute-value caching both disabled and enabled.

## Compatibility

Caching is disabled by default, so existing applications retain the non-cached behavior unless they explicitly enable `cache_attribute_values`.

The simple-field, scalar getter, and non-projected document fast paths are active independently of the cache setting.

No public APIs are removed or renamed.

## Related Work

This PR addresses allocation and execution-time overhead in high-throughput field access while making the cost of optional caching measurable independently from the general field-access optimizations.