### PR TITLE
MONGOID-5922 fall back to #includes if #eager_load is given associations in different clusters

### DIFF
--- a/lib/mongoid/association/eager_loadable.rb
+++ b/lib/mongoid/association/eager_loadable.rb
@@ -27,8 +27,24 @@ module Mongoid
 
       # Load the associations for the given documents using $lookup.
       #
+      # If any of the associated collections reside in a different cluster than
+      # the root class, falls back to the #includes behavior and logs a warning.
+      #
       # @return [ Array<Mongoid::Document> ] The given documents.
       def eager_load_with_lookup
+        offenders = cross_cluster_inclusions
+        if offenders.any?
+          root_client = klass.client_name
+          offender_list = offenders.map { |a| "#{a.name} (#{a.klass.client_name})" }.join(', ')
+          Mongoid.logger.warn(
+            'eager_load cannot use $lookup aggregation because the following associations ' \
+            "reside in a different cluster than #{klass} (client: #{root_client}): " \
+            "#{offender_list}. Falling back to #includes behavior."
+          )
+          docs = view.map { |doc| Mongoid::Factory.from_db(klass, doc, criteria) }
+          return eager_load(docs)
+        end
+
         preload_for_lookup(criteria)
       end
 
@@ -101,6 +117,19 @@ module Mongoid
 
         Eager.new(criteria.inclusions, [], true, pipeline).run
       end
+
+      private
+
+      # Returns the inclusions whose target class resides in a different cluster
+      # than the root class.
+      #
+      # @return [ Array<Mongoid::Association::Relatable> ] The offending inclusions.
+      def cross_cluster_inclusions
+        root_client = klass.client_name
+        criteria.inclusions.reject { |assoc| assoc.klass.client_name == root_client }
+      end
+
+      public
 
       def switch_local_and_foreign_fields?(association)
         association.is_a?(Mongoid::Association::Referenced::BelongsTo) ||

--- a/lib/mongoid/association/eager_loadable.rb
+++ b/lib/mongoid/association/eager_loadable.rb
@@ -41,8 +41,7 @@ module Mongoid
             "reside in a different cluster than #{klass} (client: #{root_client}): " \
             "#{offender_list}. Falling back to #includes behavior."
           )
-          docs = view.map { |doc| Mongoid::Factory.from_db(klass, doc, criteria) }
-          return eager_load(docs)
+          return eager_load(docs_for_lookup_fallback)
         end
 
         preload_for_lookup(criteria)
@@ -119,6 +118,15 @@ module Mongoid
       end
 
       private
+
+      # Returns the materialized documents to use when falling back from
+      # $lookup to #includes-style preloading. Must be implemented by each
+      # concrete context class.
+      #
+      # @return [ Array<Mongoid::Document> ] The materialized documents.
+      def docs_for_lookup_fallback
+        raise NotImplementedError, "#{self.class} must implement #docs_for_lookup_fallback"
+      end
 
       # Returns the inclusions whose target class resides in a different cluster
       # than the root class.

--- a/lib/mongoid/contextual/memory.rb
+++ b/lib/mongoid/contextual/memory.rb
@@ -521,6 +521,14 @@ module Mongoid
 
       private
 
+      # Returns materialized documents for use in the cross-cluster $lookup
+      # fallback. In the memory context, documents are already instantiated.
+      #
+      # @api private
+      def docs_for_lookup_fallback
+        documents
+      end
+
       # Get the documents the context should iterate. This follows 3 rules:
       #
       # @api private

--- a/lib/mongoid/contextual/mongo.rb
+++ b/lib/mongoid/contextual/mongo.rb
@@ -821,6 +821,14 @@ module Mongoid
         @view = view.send(name, spec)
       end
 
+      # Returns materialized documents for use in the cross-cluster $lookup
+      # fallback. Reads from the collection view and instantiates documents.
+      #
+      # @api private
+      def docs_for_lookup_fallback
+        view.map { |doc| Factory.from_db(klass, doc, criteria) }
+      end
+
       # Map the inverse sort symbols to the correct MongoDB values.
       #
       # @api private

--- a/spec/mongoid/association/eager_spec.rb
+++ b/spec/mongoid/association/eager_spec.rb
@@ -618,6 +618,9 @@ describe Mongoid::Association::EagerLoadable do
   end
 
   describe '.eager_load_with_lookup' do
+    # 4.4 lookup does not support the lookup pipeline as it is currently written
+    min_server_version '5.0'
+
     let(:context) do
       Mongoid::Contextual::Mongo.new(criteria)
     end

--- a/spec/mongoid/association/eager_spec.rb
+++ b/spec/mongoid/association/eager_spec.rb
@@ -616,4 +616,72 @@ describe Mongoid::Association::EagerLoadable do
       end
     end
   end
+
+  describe '.eager_load_with_lookup' do
+    let(:context) do
+      Mongoid::Contextual::Mongo.new(criteria)
+    end
+
+    context 'when all associations are on the same cluster' do
+      let!(:person) do
+        Person.create!
+      end
+
+      let!(:post) do
+        Post.create!(person: person)
+      end
+
+      let(:criteria) do
+        Person.where(id: person.id).eager_load(:posts)
+      end
+
+      it 'uses $lookup aggregation' do
+        expect(context).not_to receive(:eager_load)
+        context.eager_load_with_lookup
+      end
+
+      it 'correctly loads associations' do
+        docs = context.eager_load_with_lookup
+        expect(docs.first.posts).to eq([ post ])
+      end
+    end
+
+    context 'when an association is on a different cluster' do
+      let!(:person) do
+        Person.create!
+      end
+
+      let!(:post) do
+        Post.create!(person: person)
+      end
+
+      let(:criteria) do
+        Person.where(id: person.id).eager_load(:posts)
+      end
+
+      before do
+        allow(Post).to receive(:client_name).and_return(:other_cluster)
+      end
+
+      it 'logs a warning' do
+        expect(Mongoid.logger).to receive(:warn).with(
+          /eager_load cannot use \$lookup aggregation.*posts.*Falling back to #includes/
+        )
+        context.eager_load_with_lookup
+      end
+
+      it 'falls back to #includes behavior and still loads associations' do
+        allow(Mongoid.logger).to receive(:warn)
+        docs = context.eager_load_with_lookup
+        expect(docs.first.posts).to eq([ post ])
+      end
+
+      it 'mentions the offending association and client in the warning' do
+        expect(Mongoid.logger).to receive(:warn).with(
+          /posts \(other_cluster\)/
+        )
+        context.eager_load_with_lookup
+      end
+    end
+  end
 end


### PR DESCRIPTION
MONGOID-5731 added a new `#eager_load` method that uses an aggregation pipeline to load all requested associations in a single call. This won't work if the associations reside in different clusters, though. This PR addresses that gap by adding a check to ensure that all associations are in the same cluster, and falling back to the `#includes` approach otherwise.