### PR TITLE
Fix artifacts from failed "rubocop -a"

### DIFF
--- a/spec/integration/app_spec.rb
+++ b/spec/integration/app_spec.rb
@@ -39,7 +39,7 @@ describe 'Mongoid application tests' do
             uri = URI.parse('http://localhost:4567/posts')
             resp = JSON.parse(uri.open.read)
 
-            resp.should == []
+            resp.should eq []
           end
         end
       end
@@ -63,7 +63,7 @@ describe 'Mongoid application tests' do
             uri = URI.parse('http://localhost:3000/posts')
             resp = JSON.parse(uri.open.read)
 
-            resp.should == []
+            resp.should eq []
           end
         end
       end

--- a/spec/integration/associations/embedded_spec.rb
+++ b/spec/integration/associations/embedded_spec.rb
@@ -17,25 +17,25 @@ describe 'embedded associations' do
     shared_examples_for 'an embedded association' do
       it 'adds child documents to parent association object' do
         legislator
-        congress.legislators._target.should == [ legislator ]
+        congress.legislators._target.should eq [ legislator ]
       end
 
       it 'adds child documents to parent association object criteria' do
         legislator
-        congress.legislators.criteria.documents.should == [ legislator ]
+        congress.legislators.criteria.documents.should eq [ legislator ]
       end
 
       it 'populates documents on parent association object' do
-        congress.legislators.documents.should == [ legislator ]
+        congress.legislators.documents.should eq [ legislator ]
       end
 
       it 'returns created child when referencing embedded association' do
-        congress.legislators.should == [ legislator ]
+        congress.legislators.should eq [ legislator ]
       end
 
       it 'returns created child when referencing Criteria created from embedded association' do
         congress.legislators.all.should be_a(Mongoid::Criteria)
-        congress.legislators.all.to_a.should == [ legislator ]
+        congress.legislators.all.to_a.should eq [ legislator ]
       end
     end
 
@@ -70,32 +70,32 @@ describe 'embedded associations' do
 
     shared_examples_for 'adds child documents to parent association' do
       it 'adds child documents to parent association' do
-        manufactory.products._target.should == [ product ]
+        manufactory.products._target.should eq [ product ]
       end
     end
 
     shared_examples_for 'an embedded association' do
       it 'adds child documents to parent association object' do
         product
-        manufactory.products._target.should == [ product ]
+        manufactory.products._target.should eq [ product ]
       end
 
       it 'adds child documents to parent association object criteria' do
         product
-        manufactory.products.criteria.documents.should == [ product ]
+        manufactory.products.criteria.documents.should eq [ product ]
       end
 
       it 'populates documents on parent association object' do
-        manufactory.products.documents.should == [ product ]
+        manufactory.products.documents.should eq [ product ]
       end
 
       it 'returns created child when referencing embedded association' do
-        manufactory.products.should == [ product ]
+        manufactory.products.should eq [ product ]
       end
 
       it 'returns created child when referencing Criteria created from embedded association' do
         manufactory.products.all.should be_a(Mongoid::Criteria)
-        manufactory.products.all.to_a.should == [ product ]
+        manufactory.products.all.to_a.should eq [ product ]
       end
     end
 
@@ -128,7 +128,7 @@ describe 'embedded associations' do
       shared_examples 'is set' do
         it 'is set' do
           parent.child = child_cls.new
-          parent.child.parent.should == parent
+          parent.child.parent.should eq parent
         end
       end
 
@@ -152,7 +152,7 @@ describe 'embedded associations' do
 
       shared_examples 'is set' do
         it 'is set' do
-          child.congress.should == parent
+          child.congress.should eq parent
         end
       end
 
@@ -292,7 +292,7 @@ describe 'embedded associations' do
 
         user.orders.map do |order|
           [ order.sku, order.amount ]
-        end.should == [ [ 1, 10 ], [ 2, 2 ] ]
+        end.should eq [ [ 1, 10 ], [ 2, 2 ] ]
       end
     end
 
@@ -305,7 +305,7 @@ describe 'embedded associations' do
 
         user.orders.map do |order|
           [ order.sku, order.amount ]
-        end.should == [ [ 1, 1 ], [ 2, 20 ] ]
+        end.should eq [ [ 1, 1 ], [ 2, 20 ] ]
       end
     end
   end
@@ -330,7 +330,7 @@ describe 'embedded associations' do
 
         user.orders.map do |order|
           [ order.sku, order.surcharges.first.amount ]
-        end.should == [ [ 1, 10 ], [ 2, 2 ] ]
+        end.should eq [ [ 1, 10 ], [ 2, 2 ] ]
       end
     end
 
@@ -343,7 +343,7 @@ describe 'embedded associations' do
 
         user.orders.map do |order|
           [ order.sku, order.surcharges.first.amount ]
-        end.should == [ [ 1, 1 ], [ 2, 20 ] ]
+        end.should eq [ [ 1, 1 ], [ 2, 20 ] ]
       end
     end
   end

--- a/spec/integration/associations/embeds_many_spec.rb
+++ b/spec/integration/associations/embeds_many_spec.rb
@@ -35,7 +35,7 @@ describe 'embeds_many associations' do
         canvas.shapes = [ shape ]
         canvas.save!
         canvas.reload
-        canvas.shapes.should == [ shape ]
+        canvas.shapes.should eq [ shape ]
       end
     end
   end
@@ -63,7 +63,7 @@ describe 'embeds_many associations' do
 
         unsaved_parent.new_record?.should be true
         parent.reload
-        parent.shapes.length.should == 1
+        parent.shapes.length.should eq 1
       end
     end
 

--- a/spec/integration/associations/has_many_spec.rb
+++ b/spec/integration/associations/has_many_spec.rb
@@ -25,8 +25,8 @@ describe 'has_many associations' do
       it 'destroys' do
         address
 
-        HmmCompany.count.should == 1
-        HmmAddress.count.should == 1
+        HmmCompany.count.should eq 1
+        HmmAddress.count.should eq 1
 
         company.with_session do |session|
           session.with_transaction do
@@ -34,8 +34,8 @@ describe 'has_many associations' do
           end
         end
 
-        HmmCompany.count.should == 0
-        HmmAddress.count.should == 0
+        HmmCompany.count.should eq 0
+        HmmAddress.count.should eq 0
       end
     end
 
@@ -49,8 +49,8 @@ describe 'has_many associations' do
       it 'destroys' do
         address
 
-        HmmCompany.count.should == 1
-        HmmAddress.count.should == 1
+        HmmCompany.count.should eq 1
+        HmmAddress.count.should eq 1
 
         lambda do
           company.with_session do |session|
@@ -60,8 +60,8 @@ describe 'has_many associations' do
           end
         end.should raise_error(Mongoid::Errors::DocumentNotDestroyed)
 
-        HmmCompany.count.should == 1
-        HmmAddress.count.should == 1
+        HmmCompany.count.should eq 1
+        HmmAddress.count.should eq 1
       end
     end
   end
@@ -97,11 +97,11 @@ describe 'has_many associations' do
       end
 
       it 'does not destroy the dependent object' do
-        wiki_page.comments.should == [comment]
+        wiki_page.comments.should eq [ comment ]
         wiki_page.comments = [ comment ]
         wiki_page.save!
         wiki_page.reload
-        wiki_page.comments.should == [ comment ]
+        wiki_page.comments.should eq [ comment ]
       end
     end
 
@@ -117,11 +117,11 @@ describe 'has_many associations' do
       end
 
       it 'does not destroy the dependent object' do
-        series.books.should == [book]
+        series.books.should eq [ book ]
         series.books = [ book ]
         series.save!
         series.reload
-        series.books.should == [ book ]
+        series.books.should eq [ book ]
       end
     end
   end

--- a/spec/integration/associations/has_many_spec.rb
+++ b/spec/integration/associations/has_many_spec.rb
@@ -25,8 +25,8 @@ describe 'has_many associations' do
       it 'destroys' do
         address
 
-        HmmCompany.count.should
-        HmmAddress.count.should
+        HmmCompany.count.should == 1
+        HmmAddress.count.should == 1
 
         company.with_session do |session|
           session.with_transaction do
@@ -34,7 +34,7 @@ describe 'has_many associations' do
           end
         end
 
-        HmmCompany.count.should
+        HmmCompany.count.should == 0
         HmmAddress.count.should == 0
       end
     end
@@ -49,8 +49,8 @@ describe 'has_many associations' do
       it 'destroys' do
         address
 
-        HmmCompany.count.should
-        HmmAddress.count.should
+        HmmCompany.count.should == 1
+        HmmAddress.count.should == 1
 
         lambda do
           company.with_session do |session|
@@ -60,7 +60,7 @@ describe 'has_many associations' do
           end
         end.should raise_error(Mongoid::Errors::DocumentNotDestroyed)
 
-        HmmCompany.count.should
+        HmmCompany.count.should == 1
         HmmAddress.count.should == 1
       end
     end
@@ -97,8 +97,7 @@ describe 'has_many associations' do
       end
 
       it 'does not destroy the dependent object' do
-        wiki_page.comments.should
-        [ comment ]
+        wiki_page.comments.should == [comment]
         wiki_page.comments = [ comment ]
         wiki_page.save!
         wiki_page.reload
@@ -118,8 +117,7 @@ describe 'has_many associations' do
       end
 
       it 'does not destroy the dependent object' do
-        series.books.should
-        [ book ]
+        series.books.should == [book]
         series.books = [ book ]
         series.save!
         series.reload

--- a/spec/integration/associations/has_one_spec.rb
+++ b/spec/integration/associations/has_one_spec.rb
@@ -25,8 +25,8 @@ describe 'has_one associations' do
       it 'destroys' do
         address
 
-        HomCollege.count.should
-        HomAddress.count.should
+        HomCollege.count.should == 1
+        HomAddress.count.should == 1
 
         HomCollege.with_session do |session|
           session.with_transaction do
@@ -34,7 +34,7 @@ describe 'has_one associations' do
           end
         end
 
-        HomCollege.count.should
+        HomCollege.count.should == 0
         HomAddress.count.should == 0
       end
     end
@@ -49,8 +49,8 @@ describe 'has_one associations' do
       it 'does not destroy' do
         address
 
-        HomCollege.count.should
-        HomAddress.count.should
+        HomCollege.count.should == 1
+        HomAddress.count.should == 1
 
         lambda do
           HomCollege.with_session do |session|
@@ -60,7 +60,7 @@ describe 'has_one associations' do
           end
         end.should raise_error(Mongoid::Errors::DocumentNotDestroyed)
 
-        HomCollege.count.should
+        HomCollege.count.should == 1
         HomAddress.count.should == 1
       end
     end
@@ -143,8 +143,7 @@ describe 'has_one associations' do
       end
 
       it 'does not destroy the dependent object' do
-        person.game.should
-        game
+        person.game.should == game
         person.game = person.game
         person.save!
         person.reload
@@ -164,8 +163,7 @@ describe 'has_one associations' do
       end
 
       it 'does not destroy the dependent object' do
-        person.account.should
-        account
+        person.account.should == account
         person.account = person.account
         person.save!
         person.reload

--- a/spec/integration/associations/has_one_spec.rb
+++ b/spec/integration/associations/has_one_spec.rb
@@ -25,8 +25,8 @@ describe 'has_one associations' do
       it 'destroys' do
         address
 
-        HomCollege.count.should == 1
-        HomAddress.count.should == 1
+        HomCollege.count.should eq 1
+        HomAddress.count.should eq 1
 
         HomCollege.with_session do |session|
           session.with_transaction do
@@ -34,8 +34,8 @@ describe 'has_one associations' do
           end
         end
 
-        HomCollege.count.should == 0
-        HomAddress.count.should == 0
+        HomCollege.count.should eq 0
+        HomAddress.count.should eq 0
       end
     end
 
@@ -49,8 +49,8 @@ describe 'has_one associations' do
       it 'does not destroy' do
         address
 
-        HomCollege.count.should == 1
-        HomAddress.count.should == 1
+        HomCollege.count.should eq 1
+        HomAddress.count.should eq 1
 
         lambda do
           HomCollege.with_session do |session|
@@ -60,8 +60,8 @@ describe 'has_one associations' do
           end
         end.should raise_error(Mongoid::Errors::DocumentNotDestroyed)
 
-        HomCollege.count.should == 1
-        HomAddress.count.should == 1
+        HomCollege.count.should eq 1
+        HomAddress.count.should eq 1
       end
     end
   end
@@ -76,26 +76,26 @@ describe 'has_one associations' do
     shared_examples 'delegates to the field' do |reloaded: false|
       context 'non-conflicting field name' do
         it 'delegates to the field' do
-          parent.accreditation.price.should == 42
+          parent.accreditation.price.should eq 42
         end
 
         context 'using send' do
           it 'delegates to the field' do
-            parent.accreditation.send(:price).should == 42
+            parent.accreditation.send(:price).should eq 42
           end
         end
       end
 
       context 'field name that conflicts with Kernel' do
         it 'delegates to the field' do
-          parent.accreditation.format.should == 'fmt'
+          parent.accreditation.format.should eq 'fmt'
         end
 
         context 'using send' do
           it 'delegates to the field' do
             pending 'MONGOID-5018' if reloaded
 
-            parent.accreditation.send(:format).should == 'fmt'
+            parent.accreditation.send(:format).should eq 'fmt'
           end
         end
       end
@@ -143,11 +143,11 @@ describe 'has_one associations' do
       end
 
       it 'does not destroy the dependent object' do
-        person.game.should == game
+        person.game.should eq game
         person.game = person.game
         person.save!
         person.reload
-        person.game.should == game
+        person.game.should eq game
       end
     end
 
@@ -163,11 +163,11 @@ describe 'has_one associations' do
       end
 
       it 'does not destroy the dependent object' do
-        person.account.should == account
+        person.account.should eq account
         person.account = person.account
         person.save!
         person.reload
-        person.account.should == account
+        person.account.should eq account
       end
     end
   end

--- a/spec/integration/associations/nested_attributes_assignment_spec.rb
+++ b/spec/integration/associations/nested_attributes_assignment_spec.rb
@@ -26,11 +26,11 @@ describe 'nested attributes assignment' do
           truck.save!
 
           _truck = Truck.find(truck.id)
-          _truck.capacity.should == 1
-          _truck.crates.length.should == 1
-          _truck.crates.first.volume.should == 2
-          _truck.crates.first.toys.length.should == 1
-          _truck.crates.first.toys.first.name.should == 'Bear'
+          _truck.capacity.should eq 1
+          _truck.crates.length.should eq 1
+          _truck.crates.first.volume.should eq 2
+          _truck.crates.first.toys.length.should eq 1
+          _truck.crates.first.toys.first.name.should eq 'Bear'
         end
       end
     end
@@ -70,11 +70,11 @@ describe 'nested attributes assignment' do
             truck.save!
 
             _truck = Truck.find(truck.id)
-            _truck.capacity.should == 2
-            _truck.crates.length.should == 1
-            _truck.crates.first.volume.should == 3
-            _truck.crates.first.toys.length.should == 1
-            _truck.crates.first.toys.first.name.should == 'Rhino'
+            _truck.capacity.should eq 2
+            _truck.crates.length.should eq 1
+            _truck.crates.first.volume.should eq 3
+            _truck.crates.first.toys.length.should eq 1
+            _truck.crates.first.toys.first.name.should eq 'Rhino'
           end
         end
 
@@ -97,14 +97,14 @@ describe 'nested attributes assignment' do
             truck.save!
 
             _truck = Truck.find(truck.id)
-            _truck.capacity.should == 2
-            _truck.crates.length.should == 2
-            _truck.crates.first.volume.should == 2
-            _truck.crates.first.toys.length.should == 1
-            _truck.crates.first.toys.first.name.should == 'Bear'
-            _truck.crates.last.volume.should == 3
-            _truck.crates.last.toys.length.should == 1
-            _truck.crates.last.toys.last.name.should == 'Rhino'
+            _truck.capacity.should eq 2
+            _truck.crates.length.should eq 2
+            _truck.crates.first.volume.should eq 2
+            _truck.crates.first.toys.length.should eq 1
+            _truck.crates.first.toys.first.name.should eq 'Bear'
+            _truck.crates.last.volume.should eq 3
+            _truck.crates.last.toys.length.should eq 1
+            _truck.crates.last.toys.last.name.should eq 'Rhino'
           end
         end
       end

--- a/spec/integration/associations/nested_attributes_assignment_spec.rb
+++ b/spec/integration/associations/nested_attributes_assignment_spec.rb
@@ -26,10 +26,10 @@ describe 'nested attributes assignment' do
           truck.save!
 
           _truck = Truck.find(truck.id)
-          _truck.capacity.should
-          _truck.crates.length.should
-          _truck.crates.first.volume.should
-          _truck.crates.first.toys.length.should
+          _truck.capacity.should == 1
+          _truck.crates.length.should == 1
+          _truck.crates.first.volume.should == 2
+          _truck.crates.first.toys.length.should == 1
           _truck.crates.first.toys.first.name.should == 'Bear'
         end
       end
@@ -70,10 +70,10 @@ describe 'nested attributes assignment' do
             truck.save!
 
             _truck = Truck.find(truck.id)
-            _truck.capacity.should
-            _truck.crates.length.should
-            _truck.crates.first.volume.should
-            _truck.crates.first.toys.length.should
+            _truck.capacity.should == 2
+            _truck.crates.length.should == 1
+            _truck.crates.first.volume.should == 3
+            _truck.crates.first.toys.length.should == 1
             _truck.crates.first.toys.first.name.should == 'Rhino'
           end
         end
@@ -97,13 +97,13 @@ describe 'nested attributes assignment' do
             truck.save!
 
             _truck = Truck.find(truck.id)
-            _truck.capacity.should
-            _truck.crates.length.should
-            _truck.crates.first.volume.should
-            _truck.crates.first.toys.length.should
-            _truck.crates.first.toys.first.name.should
-            _truck.crates.last.volume.should
-            _truck.crates.last.toys.length.should
+            _truck.capacity.should == 2
+            _truck.crates.length.should == 2
+            _truck.crates.first.volume.should == 2
+            _truck.crates.first.toys.length.should == 1
+            _truck.crates.first.toys.first.name.should == 'Bear'
+            _truck.crates.last.volume.should == 3
+            _truck.crates.last.toys.length.should == 1
             _truck.crates.last.toys.last.name.should == 'Rhino'
           end
         end

--- a/spec/integration/bson_regexp_raw_spec.rb
+++ b/spec/integration/bson_regexp_raw_spec.rb
@@ -6,14 +6,14 @@ describe BSON::Regexp::Raw do
   context 'fully qualified name' do
     it 'can be created' do
       regexp = BSON::Regexp::Raw.new('foo')
-      regexp.pattern.should == 'foo'
+      regexp.pattern.should eq 'foo'
     end
   end
 
   context 'via ::Regexp' do
     it 'can be created' do
       regexp = Regexp::Raw.new('foo')
-      regexp.pattern.should == 'foo'
+      regexp.pattern.should eq 'foo'
     end
   end
 end

--- a/spec/integration/callbacks_spec.rb
+++ b/spec/integration/callbacks_spec.rb
@@ -12,22 +12,22 @@ describe 'callbacks integration tests' do
         end
 
         it 'writes the attribute value into the model' do
-          instance.age.should == 100_000
+          instance.age.should eq 100_000
         end
 
         it 'persists the attribute value' do
-          Galaxy.find(instance.id).age.should == 100_000
+          Galaxy.find(instance.id).age.should eq 100_000
         end
       end
 
       context 'embedded document' do
         shared_examples 'persists the attribute value' do
           it 'writes the attribute value into the model' do
-            instance.stars.first.age.should == 42_000
+            instance.stars.first.age.should eq 42_000
           end
 
           it 'persists the attribute value' do
-            Galaxy.find(instance.id).stars.first.age.should == 42_000
+            Galaxy.find(instance.id).stars.first.age.should eq 42_000
           end
         end
 
@@ -51,11 +51,11 @@ describe 'callbacks integration tests' do
       context 'nested embedded document' do
         shared_examples 'persists the attribute value' do
           it 'writes the attribute value into the model' do
-            instance.stars.first.planets.first.age.should == 2_000
+            instance.stars.first.planets.first.age.should eq 2_000
           end
 
           it 'persists the attribute value' do
-            Galaxy.find(instance.id).stars.first.planets.first.age.should == 2_000
+            Galaxy.find(instance.id).stars.first.planets.first.age.should eq 2_000
           end
         end
 
@@ -89,11 +89,11 @@ describe 'callbacks integration tests' do
       context 'embedded document' do
         shared_examples 'persists the attribute value' do
           it 'writes the attribute value into the model' do
-            instance.stars.first.age.should == 42_000
+            instance.stars.first.age.should eq 42_000
           end
 
           it 'persists the attribute value' do
-            Galaxy.find(instance.id).stars.first.age.should == 42_000
+            Galaxy.find(instance.id).stars.first.age.should eq 42_000
           end
         end
 
@@ -119,11 +119,11 @@ describe 'callbacks integration tests' do
       context 'nested embedded document' do
         shared_examples 'persists the attribute value' do
           it 'writes the attribute value into the model' do
-            instance.stars.first.planets.first.age.should == 2_000
+            instance.stars.first.planets.first.age.should eq 2_000
           end
 
           it 'persists the attribute value' do
-            Galaxy.find(instance.id).stars.first.planets.first.age.should == 2_000
+            Galaxy.find(instance.id).stars.first.planets.first.age.should eq 2_000
           end
         end
 
@@ -155,11 +155,11 @@ describe 'callbacks integration tests' do
       context 'embedded document' do
         shared_examples 'persists the attribute value' do
           it 'writes the attribute value into the model' do
-            instance.stars.first.age.should == 42_000
+            instance.stars.first.age.should eq 42_000
           end
 
           it 'persists the attribute value' do
-            Galaxy.find(instance.id).stars.first.age.should == 42_000
+            Galaxy.find(instance.id).stars.first.age.should eq 42_000
           end
         end
 
@@ -183,11 +183,11 @@ describe 'callbacks integration tests' do
       context 'nested embedded document' do
         shared_examples 'persists the attribute value' do
           it 'writes the attribute value into the model' do
-            instance.stars.first.planets.first.age.should == 2_000
+            instance.stars.first.planets.first.age.should eq 2_000
           end
 
           it 'persists the attribute value' do
-            Galaxy.find(instance.id).stars.first.planets.first.age.should == 2_000
+            Galaxy.find(instance.id).stars.first.planets.first.age.should eq 2_000
           end
         end
 
@@ -217,11 +217,11 @@ describe 'callbacks integration tests' do
       context 'embedded document' do
         shared_examples 'persists the attribute value' do
           it 'writes the attribute value into the model' do
-            instance.president.age.should == 79
+            instance.president.age.should eq 79
           end
 
           it 'persists the attribute value' do
-            Country.find(instance.id).president.age.should == 79
+            Country.find(instance.id).president.age.should eq 79
           end
         end
 
@@ -245,11 +245,11 @@ describe 'callbacks integration tests' do
       context 'nested embedded document' do
         shared_examples 'persists the attribute value' do
           it 'writes the attribute value into the model' do
-            instance.president.first_spouse.age.should == 70
+            instance.president.first_spouse.age.should eq 70
           end
 
           it 'persists the attribute value' do
-            Country.find(instance.id).president.first_spouse.age.should == 70
+            Country.find(instance.id).president.first_spouse.age.should eq 70
           end
         end
 
@@ -279,7 +279,7 @@ describe 'callbacks integration tests' do
       obj.frequency = 2
       obj.save!
 
-      obj.previous.should == 2
+      obj.previous.should eq 2
     end
   end
 

--- a/spec/integration/contextual/empty_spec.rb
+++ b/spec/integration/contextual/empty_spec.rb
@@ -12,13 +12,13 @@ describe 'Contextual classes when dealing with empty result set' do
 
     describe '#count' do
       it 'is 0' do
-        context.count.should == 0
+        context.count.should eq 0
       end
     end
 
     describe '#length' do
       it 'is 0' do
-        context.length.should == 0
+        context.length.should eq 0
       end
     end
 
@@ -26,7 +26,7 @@ describe 'Contextual classes when dealing with empty result set' do
 
     describe '#distinct' do
       it 'is empty array' do
-        context.distinct(:foo).should == []
+        context.distinct(:foo).should eq []
       end
     end
 
@@ -47,7 +47,7 @@ describe 'Contextual classes when dealing with empty result set' do
         end
 
         it 'returns empty Enumerable' do
-          context.each.to_a.should == []
+          context.each.to_a.should eq []
         end
       end
     end
@@ -67,7 +67,7 @@ describe 'Contextual classes when dealing with empty result set' do
         it 'returns empty array' do
           skip 'MONGOID-5148'
 
-          context.map(:field).should == []
+          context.map(:field).should eq []
         end
       end
     end

--- a/spec/integration/criteria/alias_query_spec.rb
+++ b/spec/integration/criteria/alias_query_spec.rb
@@ -29,7 +29,7 @@ describe 'distinct on aliased fields' do
     it 'expands the alias' do
       query
 
-      command['key'].should == 't'
+      command['key'].should eq 't'
     end
   end
 
@@ -41,7 +41,7 @@ describe 'distinct on aliased fields' do
     it 'expands the alias' do
       query
 
-      command['key'].should == 'phone_numbers.ext'
+      command['key'].should eq 'phone_numbers.ext'
     end
   end
 end
@@ -73,7 +73,7 @@ describe 'pluck on aliased fields' do
     it 'expands the alias' do
       query
 
-      command['projection'].should == { 't' => true }
+      command['projection'].should eq({ 't' => true })
     end
   end
 
@@ -85,7 +85,7 @@ describe 'pluck on aliased fields' do
     it 'expands the alias' do
       query
 
-      command['projection'].should == { 'phone_numbers.ext' => true }
+      command['projection'].should eq({ 'phone_numbers.ext' => true })
     end
   end
 end

--- a/spec/integration/criteria/date_field_spec.rb
+++ b/spec/integration/criteria/date_field_spec.rb
@@ -11,7 +11,7 @@ describe 'Queries on Date fields' do
 
   shared_examples 'converts to beginning of day in UTC' do
     it 'converts to beginning of day in UTC' do
-      selector['founded'].should == Time.utc(arg.year, arg.month, arg.day)
+      selector['founded'].should eq Time.utc(arg.year, arg.month, arg.day)
     end
   end
 

--- a/spec/integration/criteria/default_scope_spec.rb
+++ b/spec/integration/criteria/default_scope_spec.rb
@@ -11,10 +11,10 @@ describe 'Criteria and default scope' do
     end
 
     it 'is added after order of default scope' do
-      sort_options.should == {'status' => -1, 'name' => 1}
+      sort_options.should eq({ 'status' => -1, 'name' => 1 })
 
       # Keys in Ruby are ordered
-      sort_options.keys.should == %w[name status]
+      sort_options.keys.should eq %w[name status]
     end
   end
 
@@ -23,7 +23,7 @@ describe 'Criteria and default scope' do
       let(:base) { Appointment.where }
 
       it 'has default scope' do
-        base.selector.should == { 'active' => true }
+        base.selector.should eq({ 'active' => true })
       end
 
       describe '.or' do
@@ -32,10 +32,14 @@ describe 'Criteria and default scope' do
         end
 
         it 'adds new condition in parallel to default scope conditions' do
-          criteria.selector.should == { '$or' => [
-            { 'active' => true },
-            { 'timed' => true }
-          ] }
+          criteria.selector.should eq(
+            {
+              '$or' => [
+                { 'active' => true },
+                { 'timed' => true }
+              ]
+            }
+          )
         end
       end
 
@@ -45,7 +49,7 @@ describe 'Criteria and default scope' do
         end
 
         it 'maintains default scope conditions' do
-          criteria.selector.should == { 'active' => true, 'timed' => true }
+          criteria.selector.should eq({ 'active' => true, 'timed' => true })
         end
       end
     end
@@ -59,10 +63,14 @@ describe 'Criteria and default scope' do
         end
 
         it 'adds new condition in parallel to default scope conditions' do
-          criteria.selector.should == { '$or' => [
-            { 'active' => true },
-            { 'timed' => true }
-          ] }
+          criteria.selector.should eq(
+            {
+              '$or' => [
+                { 'active' => true },
+                { 'timed' => true }
+              ]
+            }
+          )
         end
       end
     end

--- a/spec/integration/criteria/default_scope_spec.rb
+++ b/spec/integration/criteria/default_scope_spec.rb
@@ -11,7 +11,7 @@ describe 'Criteria and default scope' do
     end
 
     it 'is added after order of default scope' do
-      sort_options.should
+      sort_options.should == {'status' => -1, 'name' => 1}
 
       # Keys in Ruby are ordered
       sort_options.keys.should == %w[name status]

--- a/spec/integration/criteria/logical_spec.rb
+++ b/spec/integration/criteria/logical_spec.rb
@@ -67,7 +67,7 @@ describe 'Criteria logical operations' do
           scope = Dokument.or(:created_at.lte => DateTime.now).sort(id: 1)
           # input was converted from DateTime to Time
           scope.criteria.selector['$or'].first['created_at']['$lte'].should be_a(Time)
-          scope.to_a.should == [ doc ]
+          scope.to_a.should eq [ doc ]
         end
       end
     end

--- a/spec/integration/document_spec.rb
+++ b/spec/integration/document_spec.rb
@@ -11,7 +11,7 @@ describe Mongoid::Document do
     end
 
     it 'works for instance level delegation' do
-      patient.address.should == 'test@example.com'
+      patient.address.should eq 'test@example.com'
     end
 
     it 'works for class level delegation' do
@@ -23,8 +23,8 @@ describe Mongoid::Document do
     it 'persists separate id and _id values' do
       shirt = Shirt.create!(id: 'hello', _id: 'foo')
       shirt = Shirt.find(shirt._id)
-      shirt.id.should == 'hello'
-      shirt._id.should == 'foo'
+      shirt.id.should eq 'hello'
+      shirt._id.should eq 'foo'
     end
   end
 

--- a/spec/integration/document_spec.rb
+++ b/spec/integration/document_spec.rb
@@ -23,7 +23,7 @@ describe Mongoid::Document do
     it 'persists separate id and _id values' do
       shirt = Shirt.create!(id: 'hello', _id: 'foo')
       shirt = Shirt.find(shirt._id)
-      shirt.id.should
+      shirt.id.should == 'hello'
       shirt._id.should == 'foo'
     end
   end

--- a/spec/integration/i18n_fallbacks_spec.rb
+++ b/spec/integration/i18n_fallbacks_spec.rb
@@ -20,7 +20,7 @@ describe 'i18n fallbacks' do
         I18n.locale = :en
         product.description = 'Marvelous!'
         I18n.locale = :de
-        product.description.should == 'Marvelous in German'
+        product.description.should eq 'Marvelous in German'
       end
     end
 
@@ -30,7 +30,7 @@ describe 'i18n fallbacks' do
         I18n.locale = :en
         product.description = 'Marvelous!'
         I18n.locale = :de
-        product.description.should == 'Marvelous!'
+        product.description.should eq 'Marvelous!'
       end
     end
 

--- a/spec/integration/matcher_examples_spec.rb
+++ b/spec/integration/matcher_examples_spec.rb
@@ -716,13 +716,13 @@ describe 'Matcher' do
 
         context '$not with regexp' do
           it 'finds' do
-            band.records.where(producers: { '$elemMatch': { '$not': /bar/ } }).count.should == 1
+            band.records.where(producers: { '$elemMatch': { '$not': /bar/ } }).count.should eq 1
           end
         end
 
         context '$not with operator' do
           it 'finds' do
-            band.records.where(producers: { '$elemMatch': { '$not': { '$eq': 'bar' } } }).count.should == 1
+            band.records.where(producers: { '$elemMatch': { '$not': { '$eq': 'bar' } } }).count.should eq 1
           end
         end
       end

--- a/spec/integration/server_query_spec.rb
+++ b/spec/integration/server_query_spec.rb
@@ -19,7 +19,7 @@ describe 'Server queries' do
     end
 
     it 'finds' do
-      Survey.collection.find(query).to_a.should == [ document.attributes ]
+      Survey.collection.find(query).to_a.should eq [ document.attributes ]
     end
   end
 
@@ -42,7 +42,7 @@ describe 'Server queries' do
       end
 
       it 'finds' do
-        Bar.collection.find(query).to_a.should == [ document.attributes.with_indifferent_access ]
+        Bar.collection.find(query).to_a.should eq [ document.attributes.with_indifferent_access ]
       end
     end
 
@@ -53,7 +53,7 @@ describe 'Server queries' do
         end
 
         it 'matches array and does not find' do
-          Bar.collection.find(query).to_a.should == []
+          Bar.collection.find(query).to_a.should eq []
         end
       end
 
@@ -63,7 +63,7 @@ describe 'Server queries' do
         end
 
         it 'finds' do
-          Bar.collection.find(query).to_a.should == [ document.attributes.with_indifferent_access ]
+          Bar.collection.find(query).to_a.should eq [ document.attributes.with_indifferent_access ]
         end
       end
     end
@@ -75,7 +75,7 @@ describe 'Server queries' do
 
       it 'finds' do
         # This finds the document - https://jira.mongodb.org/browse/DOCSP-10717
-        Bar.collection.find(query).to_a.should == [ document.attributes.with_indifferent_access ]
+        Bar.collection.find(query).to_a.should eq [ document.attributes.with_indifferent_access ]
       end
     end
 
@@ -97,7 +97,7 @@ describe 'Server queries' do
       end
 
       it 'does not find' do
-        Bar.collection.find(query).to_a.should == []
+        Bar.collection.find(query).to_a.should eq []
       end
     end
 
@@ -119,7 +119,7 @@ describe 'Server queries' do
       end
 
       it 'finds' do
-        Bar.collection.find(query).to_a.should == [ document.attributes.with_indifferent_access ]
+        Bar.collection.find(query).to_a.should eq [ document.attributes.with_indifferent_access ]
       end
     end
 
@@ -141,7 +141,7 @@ describe 'Server queries' do
       end
 
       it 'finds' do
-        Bar.collection.find(query).to_a.should == [ document.attributes.with_indifferent_access ]
+        Bar.collection.find(query).to_a.should eq [ document.attributes.with_indifferent_access ]
       end
     end
   end

--- a/spec/integration/shardable_spec.rb
+++ b/spec/integration/shardable_spec.rb
@@ -18,7 +18,7 @@ describe 'Sharding helpers' do
 
     shared_examples_for 'shards collection' do
       it 'returns the model class' do
-        shard_collections.should == [ model_cls ]
+        shard_collections.should eq [ model_cls ]
       end
 
       it 'shards collection' do
@@ -99,7 +99,7 @@ describe 'Sharding helpers' do
       let(:model_cls) { SmActor }
 
       it 'returns empty array' do
-        shard_collections.should == []
+        shard_collections.should eq []
       end
 
       it 'does not shards collection' do
@@ -118,7 +118,7 @@ describe 'Sharding helpers' do
       end
 
       it 'returns empty array' do
-        shard_collections.should == []
+        shard_collections.should eq []
       end
 
       context 'pre-4.2' do

--- a/spec/mongoid/association/accessors_spec.rb
+++ b/spec/mongoid/association/accessors_spec.rb
@@ -591,7 +591,7 @@ describe Mongoid::Association::Accessors do
               end
 
               it 'retrieves other fields' do
-                persisted_person.passport.country.should == 'USA'
+                persisted_person.passport.country.should eq 'USA'
               end
             end
 

--- a/spec/mongoid/association/depending_spec.rb
+++ b/spec/mongoid/association/depending_spec.rb
@@ -373,7 +373,7 @@ describe Mongoid::Association::Depending do
           end
 
           it 'does not delete the associated documents' do
-            child.class.find(child.id).should == child
+            child.class.find(child.id).should eq child
           end
         end
       end
@@ -420,7 +420,7 @@ describe Mongoid::Association::Depending do
             end
 
             it 'does not remove the references to the removed document' do
-              from_db.ratable_id.should == parent.id
+              from_db.ratable_id.should eq parent.id
             end
           end
         end
@@ -851,7 +851,7 @@ describe Mongoid::Association::Depending do
           it 'adds an error to the parent object' do
             expect(person.destroy).to be(false)
 
-            person.errors[:restrictable_posts].first.should ==
+            person.errors[:restrictable_posts].first.should eq \
               'is not empty and prevents the document from being destroyed'
           end
         end

--- a/spec/mongoid/association/embedded/embeds_many_spec.rb
+++ b/spec/mongoid/association/embedded/embeds_many_spec.rb
@@ -766,7 +766,7 @@ describe Mongoid::Association::Embedded::EmbedsMany do
       pending 'MONGOID-5080'
 
       inverse_assoc.should be_a(Mongoid::Association::Embedded::EmbeddedIn)
-      inverse_assoc.name.should == :tank
+      inverse_assoc.name.should eq :tank
     end
 
     context 'when embedded association is not namespaced but has class_name' do
@@ -776,7 +776,7 @@ describe Mongoid::Association::Embedded::EmbedsMany do
 
       it 'has the correct inverses' do
         inverse_assoc.should be_a(Mongoid::Association::Embedded::EmbeddedIn)
-        inverse_assoc.name.should == :tank
+        inverse_assoc.name.should eq :tank
       end
     end
 
@@ -800,7 +800,7 @@ describe Mongoid::Association::Embedded::EmbedsMany do
         pending 'MONGOID-5080'
 
         inverse_assoc.should be_a(Mongoid::Association::Embedded::EmbeddedIn)
-        inverse_assoc.name.should == :car
+        inverse_assoc.name.should eq :car
       end
     end
 
@@ -813,7 +813,7 @@ describe Mongoid::Association::Embedded::EmbedsMany do
         pending 'unqualified class_name arguments do not work per MONGOID-5080'
 
         inverse_assoc.should be_a(Mongoid::Association::Embedded::EmbeddedIn)
-        inverse_assoc.name.should == :tank
+        inverse_assoc.name.should eq :tank
       end
     end
   end

--- a/spec/mongoid/association/referenced/belongs_to/eager_spec.rb
+++ b/spec/mongoid/association/referenced/belongs_to/eager_spec.rb
@@ -298,15 +298,15 @@ describe Mongoid::Association::Referenced::BelongsTo::Eager do
           end
 
           expect_no_queries do
-            eager.map(&:reviewable).compact.should == [ reviewable ]
+            eager.map(&:reviewable).compact.should eq [ reviewable ]
           end
 
           expect_no_queries do
-            eager.map(&:reviewer).compact.should == [ reviewer ]
+            eager.map(&:reviewer).compact.should eq [ reviewer ]
           end
 
           expect_no_queries do
-            eager.map(&:template).compact.should == [ template ]
+            eager.map(&:template).compact.should eq [ template ]
           end
         end
       end
@@ -322,7 +322,7 @@ describe Mongoid::Association::Referenced::BelongsTo::Eager do
         end
 
         it 'does not error' do
-          eager.map(&:reviewer).should == [ nil ]
+          eager.map(&:reviewer).should eq [ nil ]
         end
       end
     end

--- a/spec/mongoid/association/referenced/belongs_to/proxy_spec.rb
+++ b/spec/mongoid/association/referenced/belongs_to/proxy_spec.rb
@@ -124,11 +124,11 @@ describe Mongoid::Association::Referenced::BelongsTo::Proxy do
             # have a way to distinguish how method_missing was invoked
             # (i.e. via an explicit send or method call).
             # See https://jira.mongodb.org/browse/MONGOID-5009
-            game.person.secret_name.should == 'secret'
+            game.person.secret_name.should eq 'secret'
           end
 
           it 'allows private methods to be invoked' do
-            game.person.send(:secret_name).should == 'secret'
+            game.person.send(:secret_name).should eq 'secret'
           end
 
           it 'properly exposes delegated methods visibility' do

--- a/spec/mongoid/atomic/modifiers_spec.rb
+++ b/spec/mongoid/atomic/modifiers_spec.rb
@@ -340,12 +340,14 @@ describe Mongoid::Atomic::Modifiers do
       it 'does not conflict and adds push to top level' do
         pending 'https://jira.mongodb.org/browse/MONGOID-4982'
 
-        modifiers.should == {
-          '$set' => { 'addresses.0.name' => 'test' },
-          '$push' => { 'addresses.0.locations' => { '$each' => [
-            { 'street' => 'Oxford St' }
-          ] } }
-        }
+        modifiers.should eq(
+          {
+            '$set' => { 'addresses.0.name' => 'test' },
+            '$push' => { 'addresses.0.locations' => { '$each' => [
+              { 'street' => 'Oxford St' }
+            ] } }
+          }
+        )
       end
     end
   end

--- a/spec/mongoid/atomic_spec.rb
+++ b/spec/mongoid/atomic_spec.rb
@@ -357,13 +357,15 @@ describe Mongoid::Atomic do
           it 'correctly distributes the operations' do
             pending 'https://jira.mongodb.org/browse/MONGOID-4982'
 
-            truck.atomic_updates.should == {
-              '$set' => { 'crates.0.volume' => 2 },
-              '$push' => { 'crates.0.toys' => { '$each' => [ crate.toys.first.attributes ] } },
-              conflicts: {
-                '$push' => { 'crates' => { '$each' => [ truck.crates.last.attributes ] } }
+            truck.atomic_updates.should eq(
+              {
+                '$set' => { 'crates.0.volume' => 2 },
+                '$push' => { 'crates.0.toys' => { '$each' => [ crate.toys.first.attributes ] } },
+                conflicts: {
+                  '$push' => { 'crates' => { '$each' => [ truck.crates.last.attributes ] } }
+                }
               }
-            }
+            )
           end
         end
       end
@@ -378,16 +380,18 @@ describe Mongoid::Atomic do
       end
 
       it 'has the correct updates' do
-        account.atomic_updates.should == {
-          '$push' => {
-            'memberships' => {
-              '$each' => [
-                { '_id' => nil, 'name' => 'm1' },
-                { '_id' => nil, 'name' => 'm2' }
-              ]
+        account.atomic_updates.should eq(
+          {
+            '$push' => {
+              'memberships' => {
+                '$each' => [
+                  { '_id' => nil, 'name' => 'm1' },
+                  { '_id' => nil, 'name' => 'm2' }
+                ]
+              }
             }
           }
-        }
+        )
       end
     end
   end

--- a/spec/mongoid/attributes_spec.rb
+++ b/spec/mongoid/attributes_spec.rb
@@ -443,11 +443,11 @@ describe Mongoid::Attributes do
       end
 
       it 'writes the value into attributes' do
-        bar.attributes.should == { '_id' => bar.id, 'missing_field' => 42 }
+        bar.attributes.should eq({ '_id' => bar.id, 'missing_field' => 42 })
       end
 
       it 'makes the attribute accessible via []' do
-        bar['missing_field'].should == 42
+        bar['missing_field'].should eq 42
       end
 
       context 'when writing fields on a document with projection' do
@@ -488,7 +488,7 @@ describe Mongoid::Attributes do
 
           it 'writes the value' do
             from_db[:undefined_field] = 'x'
-            from_db[:undefined_field].should == 'x'
+            from_db[:undefined_field].should eq 'x'
           end
         end
       end
@@ -1545,7 +1545,7 @@ describe Mongoid::Attributes do
 
         it 'writes the value' do
           from_db.write_attribute(:undefined_field, 'x')
-          from_db.read_attribute(:undefined_field).should == 'x'
+          from_db.read_attribute(:undefined_field).should eq 'x'
         end
       end
     end
@@ -2561,7 +2561,7 @@ describe Mongoid::Attributes do
     end
 
     it 'persists the updated hash' do
-      church.location.should == { 'x' => 1, 'y' => 2 }
+      church.location.should eq({ 'x' => 1, 'y' => 2 })
     end
   end
 
@@ -2592,7 +2592,7 @@ describe Mongoid::Attributes do
 
     it 'persists the updated hash' do
       pending 'MONGOID-2951'
-      catalog.set_field.should == Set.new([ 1, 2 ])
+      catalog.set_field.should eq Set.new([ 1, 2 ])
     end
   end
 

--- a/spec/mongoid/changeable_spec.rb
+++ b/spec/mongoid/changeable_spec.rb
@@ -1101,8 +1101,8 @@ describe Mongoid::Changeable do
       end
 
       it 'does not add to the changes or changed_attributes hash' do
-        person.changes.should == {}
-        person.changed_attributes.should == {}
+        person.changes.should eq({})
+        person.changed_attributes.should eq({})
       end
     end
 
@@ -1120,8 +1120,8 @@ describe Mongoid::Changeable do
       end
 
       it 'adds to the changes or changed_attributes hash' do
-        person.changes.should == { "user_account_ids" => [ nil, [ user_account._id ] ] }
-        person.changed_attributes.should == { 'user_account_ids' => nil }
+        person.changes.should eq({ 'user_account_ids' => [ nil, [ user_account._id ] ] })
+        person.changed_attributes.should eq({ 'user_account_ids' => nil })
       end
     end
 
@@ -1139,8 +1139,8 @@ describe Mongoid::Changeable do
       end
 
       it 'does not add to the changes or changed_attributes hash' do
-        person.changes.should == {}
-        person.changed_attributes.should == {}
+        person.changes.should eq({})
+        person.changed_attributes.should eq({})
       end
     end
 
@@ -1158,8 +1158,8 @@ describe Mongoid::Changeable do
       end
 
       it 'does not add to the changes or changed_attributes hash' do
-        person.changes.should == { "user_account_ids" => [ [ user_account._id ], [] ] }
-        person.changed_attributes.should == { 'user_account_ids' => [ user_account._id ] }
+        person.changes.should eq({ 'user_account_ids' => [ [ user_account._id ], [] ] })
+        person.changed_attributes.should eq({ 'user_account_ids' => [ user_account._id ] })
       end
     end
 

--- a/spec/mongoid/changeable_spec.rb
+++ b/spec/mongoid/changeable_spec.rb
@@ -1101,7 +1101,7 @@ describe Mongoid::Changeable do
       end
 
       it 'does not add to the changes or changed_attributes hash' do
-        person.changes.should
+        person.changes.should == {}
         person.changed_attributes.should == {}
       end
     end
@@ -1120,8 +1120,7 @@ describe Mongoid::Changeable do
       end
 
       it 'adds to the changes or changed_attributes hash' do
-        person.changes.should
-        { 'user_account_ids' => [ nil, [ user_account._id ] ] }
+        person.changes.should == { "user_account_ids" => [ nil, [ user_account._id ] ] }
         person.changed_attributes.should == { 'user_account_ids' => nil }
       end
     end
@@ -1140,7 +1139,7 @@ describe Mongoid::Changeable do
       end
 
       it 'does not add to the changes or changed_attributes hash' do
-        person.changes.should
+        person.changes.should == {}
         person.changed_attributes.should == {}
       end
     end
@@ -1159,8 +1158,7 @@ describe Mongoid::Changeable do
       end
 
       it 'does not add to the changes or changed_attributes hash' do
-        person.changes.should
-        { 'user_account_ids' => [ [ user_account._id ], [] ] }
+        person.changes.should == { "user_account_ids" => [ [ user_account._id ], [] ] }
         person.changed_attributes.should == { 'user_account_ids' => [ user_account._id ] }
       end
     end

--- a/spec/mongoid/clients/factory_spec.rb
+++ b/spec/mongoid/clients/factory_spec.rb
@@ -100,7 +100,7 @@ describe Mongoid::Clients::Factory do
           end
 
           it 'sets Mongoid as a wrapping library' do
-            client.options[:wrapping_libraries].should == [ BSON::Document.new(
+            client.options[:wrapping_libraries].should eq [ BSON::Document.new(
               Mongoid::Clients::Factory::MONGOID_WRAPPING_LIBRARY
             ) ]
           end
@@ -122,7 +122,7 @@ describe Mongoid::Clients::Factory do
             end
 
             it 'adds Mongoid as another wrapping library' do
-              client.options[:wrapping_libraries].should == [
+              client.options[:wrapping_libraries].should eq [
                 BSON::Document.new(Mongoid::Clients::Factory::MONGOID_WRAPPING_LIBRARY),
                 { 'name' => 'Foo' }
               ]

--- a/spec/mongoid/contextual/aggregable/memory_spec.rb
+++ b/spec/mongoid/contextual/aggregable/memory_spec.rb
@@ -387,7 +387,7 @@ describe Mongoid::Contextual::Aggregable::Memory do
 
       shared_examples 'sums and returns an integer' do
         it 'sums' do
-          sum.should == 1500
+          sum.should eq 1500
         end
 
         it 'returns integer' do
@@ -412,7 +412,7 @@ describe Mongoid::Contextual::Aggregable::Memory do
 
         shared_examples 'sums and returns an integer' do
           it 'sums' do
-            sum.should == -500
+            sum.should eq(-500)
           end
 
           it 'returns integer' do
@@ -442,7 +442,7 @@ describe Mongoid::Contextual::Aggregable::Memory do
       end
 
       it 'sums' do
-        sum.should == 1500
+        sum.should eq 1500
       end
 
       it 'returns integer' do

--- a/spec/mongoid/contextual/memory_spec.rb
+++ b/spec/mongoid/contextual/memory_spec.rb
@@ -494,7 +494,7 @@ describe Mongoid::Contextual::Memory do
           I18n.locale = :en
           Dictionary.create!(description: 'english-text')
           I18n.locale = :he
-          distinct.should == 'english-text'
+          distinct.should eq 'english-text'
         end
       end
 
@@ -1593,7 +1593,7 @@ describe Mongoid::Contextual::Memory do
           I18n.locale = :en
           Dictionary.create!(description: 'english-text')
           I18n.locale = :he
-          plucked.should == 'english-text'
+          plucked.should eq 'english-text'
         end
       end
 

--- a/spec/mongoid/contextual/mongo_spec.rb
+++ b/spec/mongoid/contextual/mongo_spec.rb
@@ -601,7 +601,7 @@ describe Mongoid::Contextual::Mongo do
           I18n.locale = :en
           Dictionary.create!(description: 'english-text')
           I18n.locale = :he
-          distinct.should == 'english-text'
+          distinct.should eq 'english-text'
         end
       end
 

--- a/spec/mongoid/criteria/queryable/expandable_spec.rb
+++ b/spec/mongoid/criteria/queryable/expandable_spec.rb
@@ -26,8 +26,7 @@ describe Mongoid::Criteria::Queryable::Expandable do
       it 'does not modify input' do
         criterion_copy = criterion.dup.freeze
 
-        query.send(:expand_condition_to_array_values, criterion).should
-        expected
+        query.send(:expand_condition_to_array_values, criterion).should == expected
 
         expect(criterion).to eq(criterion_copy)
       end

--- a/spec/mongoid/criteria/queryable/expandable_spec.rb
+++ b/spec/mongoid/criteria/queryable/expandable_spec.rb
@@ -10,7 +10,7 @@ describe Mongoid::Criteria::Queryable::Expandable do
   describe '#expand_condition_to_array_values' do
     shared_examples_for 'expands' do
       it 'expands' do
-        query.send(:expand_condition_to_array_values, criterion).should == expected
+        query.send(:expand_condition_to_array_values, criterion).should eq expected
       end
 
       context 'when input is frozen' do
@@ -19,14 +19,14 @@ describe Mongoid::Criteria::Queryable::Expandable do
         end
 
         it 'expands' do
-          query.send(:expand_condition_to_array_values, criterion).should == expected
+          query.send(:expand_condition_to_array_values, criterion).should eq expected
         end
       end
 
       it 'does not modify input' do
         criterion_copy = criterion.dup.freeze
 
-        query.send(:expand_condition_to_array_values, criterion).should == expected
+        query.send(:expand_condition_to_array_values, criterion).should eq expected
 
         expect(criterion).to eq(criterion_copy)
       end

--- a/spec/mongoid/criteria/queryable/mergeable_spec.rb
+++ b/spec/mongoid/criteria/queryable/mergeable_spec.rb
@@ -52,17 +52,17 @@ describe Mongoid::Criteria::Queryable::Mergeable do
     end
 
     it 'expands simple keys' do
-      query.send(:_mongoid_expand_keys, { a: 1 }).should == { 'a' => 1 }
+      query.send(:_mongoid_expand_keys, { a: 1 }).should eq({ 'a' => 1 })
     end
 
     it 'expands Key instances' do
-      query.send(:_mongoid_expand_keys, { gt => 42 }).should == { 'age' => { '$gt' => 42 } }
+      query.send(:_mongoid_expand_keys, { gt => 42 }).should eq({ 'age' => { '$gt' => 42 } })
     end
 
     it 'expands multiple Key instances on the same field' do
-      query.send(:_mongoid_expand_keys, { gt => 42, lt => 50 }).should == {
-        'age' => { '$gt' => 42, '$lt' => 50 }
-      }
+      query.send(:_mongoid_expand_keys, { gt => 42, lt => 50 }).should eq(
+        { 'age' => { '$gt' => 42, '$lt' => 50 } }
+      )
     end
 
     context 'given implicit equality and Key instance on the same field' do
@@ -70,17 +70,17 @@ describe Mongoid::Criteria::Queryable::Mergeable do
         context "for non-regular expression value #{value}" do
           context 'implicit equality then Key instance' do
             it 'expands implicit equality with $eq and combines with Key operator' do
-              query.send(:_mongoid_expand_keys, { 'age' => value, lt => 50 }).should == {
-                'age' => { '$eq' => value, '$lt' => 50 }
-              }
+              query.send(:_mongoid_expand_keys, { 'age' => value, lt => 50 }).should eq(
+                { 'age' => { '$eq' => value, '$lt' => 50 } }
+              )
             end
           end
 
           context 'symbol operator then implicit equality' do
             it 'expands implicit equality with $eq and combines with Key operator' do
-              query.send(:_mongoid_expand_keys, { gt => 42, 'age' => value }).should == {
-                'age' => { '$gt' => 42, '$eq' => value }
-              }
+              query.send(:_mongoid_expand_keys, { gt => 42, 'age' => value }).should eq(
+                { 'age' => { '$gt' => 42, '$eq' => value } }
+              )
             end
           end
         end
@@ -92,17 +92,17 @@ describe Mongoid::Criteria::Queryable::Mergeable do
         context "for regular expression value #{value}" do
           context 'implicit equality then Key instance' do
             it 'expands implicit equality with $eq and combines with Key operator' do
-              query.send(:_mongoid_expand_keys, { 'age' => value, lt => 50 }).should == {
-                'age' => { '$regex' => value, '$lt' => 50 }
-              }
+              query.send(:_mongoid_expand_keys, { 'age' => value, lt => 50 }).should eq(
+                { 'age' => { '$regex' => value, '$lt' => 50 } }
+              )
             end
           end
 
           context 'Key instance then implicit equality' do
             it 'expands implicit equality with $eq and combines with Key operator' do
-              query.send(:_mongoid_expand_keys, { gt => 50, 'age' => value }).should == {
-                'age' => { '$gt' => 50, '$regex' => value }
-              }
+              query.send(:_mongoid_expand_keys, { gt => 50, 'age' => value }).should eq(
+                { 'age' => { '$gt' => 50, '$regex' => value } }
+              )
             end
           end
         end
@@ -110,13 +110,13 @@ describe Mongoid::Criteria::Queryable::Mergeable do
     end
 
     it 'Ruby does not allow same symbol operator with different values' do
-      { gt => 42, gtp => 50 }.should == { gtp => 50 }
+      { gt => 42, gtp => 50 }.should eq({ gtp => 50 })
     end
 
     context 'field name => value' do
       shared_examples_for 'expands' do
         it 'expands' do
-          expanded.should == { 'foo' => 'bar' }
+          expanded.should eq({ 'foo' => 'bar' })
         end
       end
 
@@ -147,14 +147,14 @@ describe Mongoid::Criteria::Queryable::Mergeable do
       end
 
       it 'expands' do
-        expanded.should == { 'foo' => { '$gt' => 'bar' } }
+        expanded.should eq({ 'foo' => { '$gt' => 'bar' } })
       end
     end
 
     context 'operator => operator value expression' do
       shared_examples_for 'expands' do
         it 'expands' do
-          expanded.should == { 'foo' => { '$in' => [ 'bar' ] } }
+          expanded.should eq({ 'foo' => { '$in' => [ 'bar' ] } })
         end
       end
 

--- a/spec/mongoid/criteria/queryable/selectable_logical_spec.rb
+++ b/spec/mongoid/criteria/queryable/selectable_logical_spec.rb
@@ -76,9 +76,7 @@ describe Mongoid::Criteria::Queryable::Selectable do
     context 'when provided a single criterion that is handled via Key' do
       shared_examples_for 'adds the conditions to top level' do
         it 'adds the conditions to top level' do
-          expect(selection.selector).to eq({
-                                             'field' => { '$gt' => 3 }
-                                           })
+          expect(selection.selector).to eq({ 'field' => { '$gt' => 3 } })
         end
 
         it_behaves_like 'returns a cloned query'
@@ -112,9 +110,7 @@ describe Mongoid::Criteria::Queryable::Selectable do
         end
 
         it 'adds the conditions' do
-          expect(selection.selector).to eq({
-                                             'field' => { '$gte' => Time.new(2020, 1, 1) }
-                                           })
+          expect(selection.selector).to eq({ 'field' => { '$gte' => Time.new(2020, 1, 1) } })
         end
 
         it 'keeps argument type' do
@@ -128,9 +124,7 @@ describe Mongoid::Criteria::Queryable::Selectable do
         end
 
         it 'adds the conditions' do
-          expect(selection.selector).to eq({
-                                             'field' => { '$gte' => Time.utc(2020, 1, 1) }
-                                           })
+          expect(selection.selector).to eq({ 'field' => { '$gte' => Time.utc(2020, 1, 1) } })
         end
 
         it 'converts argument to a time' do
@@ -144,9 +138,7 @@ describe Mongoid::Criteria::Queryable::Selectable do
         end
 
         it 'adds the conditions' do
-          expect(selection.selector).to eq({
-                                             'field' => { '$gte' => Time.utc(2020, 1, 1) }
-                                           })
+          expect(selection.selector).to eq({ 'field' => { '$gte' => Time.utc(2020, 1, 1) } })
         end
 
         it 'converts argument to a time' do
@@ -161,9 +153,7 @@ describe Mongoid::Criteria::Queryable::Selectable do
       end
 
       it 'builds the correct selector' do
-        expect(selection.selector).to eq({
-                                           'test' => { '$elemMatch' => { 'field' => { '$in' => [ 1, 2 ] } } }
-                                         })
+        expect(selection.selector).to eq({ 'test' => { '$elemMatch' => { 'field' => { '$in' => [ 1, 2 ] } } } })
       end
 
       it_behaves_like 'returns a cloned query'
@@ -176,10 +166,7 @@ describe Mongoid::Criteria::Queryable::Selectable do
         end
 
         it 'adds the conditions to top level' do
-          expect(selection.selector).to eq({
-                                             'first' => [ 1, 2 ],
-                                             'second' => [ 3, 4 ]
-                                           })
+          expect(selection.selector).to eq({ 'first' => [ 1, 2 ], 'second' => [ 3, 4 ] })
         end
 
         it_behaves_like 'returns a cloned query'
@@ -191,12 +178,7 @@ describe Mongoid::Criteria::Queryable::Selectable do
         end
 
         it 'combines via $and operator' do
-          expect(selection.selector).to eq({
-                                             'first' => [ 1, 2 ],
-                                             '$and' => [
-                                               { 'first' => [ 3, 4 ] }
-                                             ]
-                                           })
+          expect(selection.selector).to eq({ 'first' => [ 1, 2 ], '$and' => [ { 'first' => [ 3, 4 ] } ] })
         end
 
         it_behaves_like 'returns a cloned query'
@@ -735,10 +717,7 @@ describe Mongoid::Criteria::Queryable::Selectable do
         end
 
         it 'adds new conditions to top level' do
-          selection.selector.should == {
-            'foo' => 'bar',
-            'hello' => 'world'
-          }
+          selection.selector.should eq({ 'foo' => 'bar', 'hello' => 'world' })
         end
       end
 
@@ -748,10 +727,7 @@ describe Mongoid::Criteria::Queryable::Selectable do
         end
 
         it 'adds new conditions to top level' do
-          selection.selector.should == {
-            'foo' => 'bar',
-            'hello' => 'world'
-          }
+          selection.selector.should eq({ 'foo' => 'bar', 'hello' => 'world' })
         end
       end
 
@@ -761,13 +737,13 @@ describe Mongoid::Criteria::Queryable::Selectable do
         end
 
         it 'adds new conditions to top level' do
-          selection.selector.should == {
-            'foo' => 'bar',
-            '$or' => [
-              { 'one' => 'one' },
-              { 'two' => 'two' }
-            ]
-          }
+          selection.selector.should eq(
+            { 'foo' => 'bar',
+              '$or' => [
+                { 'one' => 'one' },
+                { 'two' => 'two' }
+              ] }
+          )
         end
       end
     end
@@ -1090,11 +1066,11 @@ describe Mongoid::Criteria::Queryable::Selectable do
         end
 
         it 'combines conditions with $eq' do
-          selection.selector.should == {
-            expected_operator => [
+          selection.selector.should eq(
+            { expected_operator => [
               { 'field' => { '$eq' => 1, '$gt' => 0 } }
-            ]
-          }
+            ] }
+          )
         end
       end
 
@@ -1104,11 +1080,11 @@ describe Mongoid::Criteria::Queryable::Selectable do
         end
 
         it 'combines conditions with $regex' do
-          selection.selector.should == {
-            expected_operator => [
+          selection.selector.should eq(
+            { expected_operator => [
               { 'field' => { '$regex' => /t/, '$gt' => 0 } }
-            ]
-          }
+            ] }
+          )
         end
       end
     end
@@ -1580,13 +1556,15 @@ describe Mongoid::Criteria::Queryable::Selectable do
         end
 
         it 'generates the expected query' do
-          query.selector.should == { '$or' => [
-            { 'a' => 1 },
-            # Date instance is converted to a Time instance in local time,
-            # because we are querying on a Time field and dates are interpreted
-            # in local time when assigning to Time fields
-            { 'published' => { '$gt' => Time.zone.local(2020, 2, 3) } }
-          ] }
+          query.selector.should eq(
+            { '$or' => [
+              { 'a' => 1 },
+              # Date instance is converted to a Time instance in local time,
+              # because we are querying on a Time field and dates are interpreted
+              # in local time when assigning to Time fields
+              { 'published' => { '$gt' => Time.zone.local(2020, 2, 3) } }
+            ] }
+          )
         end
       end
 
@@ -1596,13 +1574,15 @@ describe Mongoid::Criteria::Queryable::Selectable do
         end
 
         it 'generates the expected query' do
-          query.selector.should == { '$or' => [
-            { 'a' => 1 },
-            # Date instance is converted to a Time instance in UTC,
-            # because we are querying on a Date field and dates are interpreted
-            # in UTC when persisted as dates by Mongoid
-            { 'submitted_on' => { '$gt' => Time.utc(2020, 2, 3) } }
-          ] }
+          query.selector.should eq(
+            { '$or' => [
+              { 'a' => 1 },
+              # Date instance is converted to a Time instance in UTC,
+              # because we are querying on a Date field and dates are interpreted
+              # in UTC when persisted as dates by Mongoid
+              { 'submitted_on' => { '$gt' => Time.utc(2020, 2, 3) } }
+            ] }
+          )
         end
       end
     end
@@ -1975,11 +1955,11 @@ describe Mongoid::Criteria::Queryable::Selectable do
         end
 
         it 'combines conditions with $eq' do
-          selection.selector.should == {
+          selection.selector.should eq(
             '$and' => [ { '$nor' => [
               { 'field' => { '$eq' => 1, '$gt' => 0 } }
             ] } ]
-          }
+          )
         end
       end
 
@@ -1989,11 +1969,11 @@ describe Mongoid::Criteria::Queryable::Selectable do
         end
 
         it 'combines conditions with $regex' do
-          selection.selector.should == {
+          selection.selector.should eq(
             '$and' => [ { '$nor' => [
               { 'field' => { '$regex' => /t/, '$gt' => 0 } }
             ] } ]
-          }
+          )
         end
       end
     end
@@ -2421,13 +2401,15 @@ describe Mongoid::Criteria::Queryable::Selectable do
         end
 
         it 'generates the expected query' do
-          query.selector.should == { '$nor' => [
-            { 'a' => 1 },
-            # Date instance is converted to a Time instance in local time,
-            # because we are querying on a Time field and dates are interpreted
-            # in local time when assigning to Time fields
-            { 'published' => { '$gt' => Time.zone.local(2020, 2, 3) } }
-          ] }
+          query.selector.should eq(
+            { '$nor' => [
+              { 'a' => 1 },
+              # Date instance is converted to a Time instance in local time,
+              # because we are querying on a Time field and dates are interpreted
+              # in local time when assigning to Time fields
+              { 'published' => { '$gt' => Time.zone.local(2020, 2, 3) } }
+            ] }
+          )
         end
       end
 
@@ -2437,13 +2419,15 @@ describe Mongoid::Criteria::Queryable::Selectable do
         end
 
         it 'generates the expected query' do
-          query.selector.should == { '$nor' => [
-            { 'a' => 1 },
-            # Date instance is converted to a Time instance in UTC,
-            # because we are querying on a Date field and dates are interpreted
-            # in UTC when persisted as dates by Mongoid
-            { 'submitted_on' => { '$gt' => Time.utc(2020, 2, 3) } }
-          ] }
+          query.selector.should eq(
+            { '$nor' => [
+              { 'a' => 1 },
+              # Date instance is converted to a Time instance in UTC,
+              # because we are querying on a Date field and dates are interpreted
+              # in UTC when persisted as dates by Mongoid
+              { 'submitted_on' => { '$gt' => Time.utc(2020, 2, 3) } }
+            ] }
+          )
         end
       end
     end

--- a/spec/mongoid/criteria/queryable/selectable_where_spec.rb
+++ b/spec/mongoid/criteria/queryable/selectable_where_spec.rb
@@ -505,19 +505,23 @@ describe Mongoid::Criteria::Queryable::Selectable do
 
       shared_examples_for 'adds conditions to existing query' do
         it 'adds conditions to existing query' do
-          selection.selector.should == {
-            'test' => 1,
-            mql_operator => [ { 'hello' => 'world' } ]
-          }
+          selection.selector.should eq(
+            {
+              'test' => 1,
+              mql_operator => [ { 'hello' => 'world' } ]
+            }
+          )
         end
       end
 
       shared_examples_for 'adds conditions to existing query with an extra $and' do
         it 'adds conditions to existing query' do
-          selection.selector.should == {
-            'test' => 1,
-            mql_operator => [ { 'hello' => 'world' } ]
-          }
+          selection.selector.should eq(
+            {
+              'test' => 1,
+              mql_operator => [ { 'hello' => 'world' } ]
+            }
+          )
         end
       end
 

--- a/spec/mongoid/criteria/queryable/storable_spec.rb
+++ b/spec/mongoid/criteria/queryable/storable_spec.rb
@@ -15,7 +15,7 @@ describe Mongoid::Criteria::Queryable::Storable do
         end
 
         it 'adds to top level' do
-          modified.selector.should == { '$and' => [ { 'foo' => 'bar' } ] }
+          modified.selector.should eq({ '$and' => [ { 'foo' => 'bar' } ] })
         end
       end
 
@@ -29,8 +29,7 @@ describe Mongoid::Criteria::Queryable::Storable do
         end
 
         it 'adds to top level' do
-          modified.selector.should == { 'zoom' => 'zoom',
-                                        '$and' => [ { 'foo' => 'bar' } ] }
+          modified.selector.should eq({ 'zoom' => 'zoom', '$and' => [ { 'foo' => 'bar' } ] })
         end
       end
 
@@ -44,9 +43,7 @@ describe Mongoid::Criteria::Queryable::Storable do
         end
 
         it 'adds to existing $and' do
-          modified.selector.should == {
-            '$and' => [ { 'zoom' => 'zoom' }, { 'foo' => 'bar' } ]
-          }
+          modified.selector.should eq({ '$and' => [ { 'zoom' => 'zoom' }, { 'foo' => 'bar' } ] })
         end
       end
 
@@ -60,9 +57,7 @@ describe Mongoid::Criteria::Queryable::Storable do
         end
 
         it 'adds to existing $and' do
-          modified.selector.should == {
-            '$and' => [ { 'foo' => 'zoom' }, { 'foo' => 'bar' } ]
-          }
+          modified.selector.should eq({ '$and' => [ { 'foo' => 'zoom' }, { 'foo' => 'bar' } ] })
         end
       end
 
@@ -76,9 +71,7 @@ describe Mongoid::Criteria::Queryable::Storable do
         end
 
         it 'adds to existing $and' do
-          modified.selector.should == {
-            '$and' => [ { 'zoom' => 'zoom' }, { 'foo' => 'bar' } ], 'foo' => 'baz'
-          }
+          modified.selector.should eq({ '$and' => [ { 'zoom' => 'zoom' }, { 'foo' => 'bar' } ], 'foo' => 'baz' })
         end
       end
     end
@@ -90,7 +83,7 @@ describe Mongoid::Criteria::Queryable::Storable do
         end
 
         it 'adds to top level' do
-          modified.selector.should == { '$or' => [ { 'foo' => 'bar' } ] }
+          modified.selector.should eq({ '$or' => [ { 'foo' => 'bar' } ] })
         end
       end
 
@@ -104,10 +97,7 @@ describe Mongoid::Criteria::Queryable::Storable do
         end
 
         it 'adds the new conditions' do
-          modified.selector.should == {
-            'zoom' => 'zoom',
-            '$or' => [ { 'foo' => 'bar' } ]
-          }
+          modified.selector.should eq({ 'zoom' => 'zoom', '$or' => [ { 'foo' => 'bar' } ] })
         end
       end
 
@@ -121,9 +111,7 @@ describe Mongoid::Criteria::Queryable::Storable do
         end
 
         it 'adds to existing $or' do
-          modified.selector.should == {
-            '$or' => [ { 'zoom' => 'zoom' }, { 'foo' => 'bar' } ]
-          }
+          modified.selector.should eq({ '$or' => [ { 'zoom' => 'zoom' }, { 'foo' => 'bar' } ] })
         end
       end
     end
@@ -136,9 +124,7 @@ describe Mongoid::Criteria::Queryable::Storable do
       end
 
       it 'adds the condition' do
-        modified.selector.should == {
-          'foo' => 'bar'
-        }
+        modified.selector.should eq({ 'foo' => 'bar' })
       end
     end
 
@@ -164,10 +150,7 @@ describe Mongoid::Criteria::Queryable::Storable do
       end
 
       it 'adds the condition' do
-        modified.selector.should == {
-          'foo' => 'bar',
-          'zoom' => 'zoom'
-        }
+        modified.selector.should eq({ 'foo' => 'bar', 'zoom' => 'zoom' })
       end
     end
 
@@ -181,10 +164,7 @@ describe Mongoid::Criteria::Queryable::Storable do
       end
 
       it 'adds the new condition using $and' do
-        modified.selector.should == {
-          'foo' => 'bar',
-          '$and' => [ { 'foo' => 'zoom' } ]
-        }
+        modified.selector.should eq({ 'foo' => 'bar', '$and' => [ { 'foo' => 'zoom' } ] })
       end
     end
 
@@ -198,12 +178,7 @@ describe Mongoid::Criteria::Queryable::Storable do
       end
 
       it 'combines the conditions using $and' do
-        modified.selector.should == {
-          'foo' => {
-            '$in' => [ 'bar' ],
-            '$nin' => [ 'zoom' ]
-          }
-        }
+        modified.selector.should eq({ 'foo' => { '$in' => [ 'bar' ], '$nin' => [ 'zoom' ] } })
       end
     end
 
@@ -217,12 +192,7 @@ describe Mongoid::Criteria::Queryable::Storable do
       end
 
       it 'combines the conditions using $and' do
-        modified.selector.should == {
-          'foo' => {
-            :$in => [ 'bar' ],
-            :$nin => [ 'zoom' ]
-          }
-        }
+        modified.selector.should eq({ 'foo' => { :$in => [ 'bar' ], :$nin => [ 'zoom' ] } })
       end
     end
 
@@ -236,10 +206,12 @@ describe Mongoid::Criteria::Queryable::Storable do
       end
 
       it 'adds the new condition using $and' do
-        modified.selector.should == {
-          'foo' => { '$in' => [ 'bar' ] },
-          '$and' => [ { 'foo' => { '$in' => [ 'zoom' ] } } ]
-        }
+        modified.selector.should eq(
+          {
+            'foo' => { '$in' => [ 'bar' ] },
+            '$and' => [ { 'foo' => { '$in' => [ 'zoom' ] } } ]
+          }
+        )
       end
     end
 
@@ -253,10 +225,12 @@ describe Mongoid::Criteria::Queryable::Storable do
       end
 
       it 'adds the new condition using $and' do
-        modified.selector.should == {
-          'foo' => { :$in => [ 'bar' ] },
-          '$and' => [ { 'foo' => { :$in => [ 'zoom' ] } } ]
-        }
+        modified.selector.should eq(
+          {
+            'foo' => { :$in => [ 'bar' ] },
+            '$and' => [ { 'foo' => { :$in => [ 'zoom' ] } } ]
+          }
+        )
       end
     end
   end

--- a/spec/mongoid/criteria_projection_spec.rb
+++ b/spec/mongoid/criteria_projection_spec.rb
@@ -227,7 +227,7 @@ describe Mongoid::Criteria do
       context 'when id is aliased to _id' do
         shared_examples 'requests _id field' do
           it 'requests _id field' do
-            criteria.options[:fields].should == { '_id' => 1 }
+            criteria.options[:fields].should eq({ '_id' => 1 })
           end
         end
 
@@ -247,7 +247,7 @@ describe Mongoid::Criteria do
           end
 
           it 'requests content field and _id field' do
-            criteria.options[:fields].should == { '_id' => 1, 'name' => 1 }
+            criteria.options[:fields].should eq({ '_id' => 1, 'name' => 1 })
           end
         end
       end
@@ -255,13 +255,13 @@ describe Mongoid::Criteria do
       context 'when id is not aliased to _id' do
         shared_examples 'requests _id field' do
           it 'requests _id field' do
-            criteria.options[:fields].should == { '_id' => 1 }
+            criteria.options[:fields].should eq({ '_id' => 1 })
           end
         end
 
         shared_examples 'requests id field and _id field' do
           it 'requests id field and _id field' do
-            criteria.options[:fields].should == { '_id' => 1, 'id' => 1 }
+            criteria.options[:fields].should eq({ '_id' => 1, 'id' => 1 })
           end
         end
 
@@ -326,13 +326,13 @@ describe Mongoid::Criteria do
 
       shared_examples 'unprojects id' do
         it 'does not unproject _id' do
-          criteria.options[:fields].should == { 'id' => 0 }
+          criteria.options[:fields].should eq({ 'id' => 0 })
         end
 
         let(:instance) { criteria.first }
 
         it 'returns _id' do
-          instance._id.should == 'foo'
+          instance._id.should eq 'foo'
         end
 
         it 'does not return id' do

--- a/spec/mongoid/criteria_spec.rb
+++ b/spec/mongoid/criteria_spec.rb
@@ -1816,7 +1816,7 @@ describe Mongoid::Criteria do
           I18n.locale = :en
           Dictionary.create!(description: 'english-text')
           I18n.locale = :he
-          plucked.should == 'english-text'
+          plucked.should eq 'english-text'
         end
       end
 
@@ -2401,13 +2401,13 @@ describe Mongoid::Criteria do
     context 'when provided no arguments' do
       context 'on a model class' do
         it 'returns an empty criteria' do
-          Band.where.selector.should == {}
+          Band.where.selector.should eq({})
         end
       end
 
       context 'on an association' do
         it 'returns an empty criteria' do
-          match.records.where.selector.should == {}
+          match.records.where.selector.should eq({})
         end
       end
     end

--- a/spec/mongoid/document_fields_spec.rb
+++ b/spec/mongoid/document_fields_spec.rb
@@ -23,7 +23,7 @@ describe Mongoid::Document do
         registry.save!
 
         _registry = Registry.find(registry.id)
-        _registry.data.should == data
+        _registry.data.should eq data
       end
     end
 
@@ -46,7 +46,7 @@ describe Mongoid::Document do
         registry.save!
 
         _registry = Registry.find(registry.id)
-        _registry.data.should == BSON::Binary.new(data)
+        _registry.data.should eq BSON::Binary.new(data)
       end
     end
 
@@ -113,7 +113,7 @@ describe Mongoid::Document do
         registry.save!
 
         _registry = Registry.find(registry.id)
-        _registry.obj_id.should == obj_id
+        _registry.obj_id.should eq obj_id
       end
     end
 
@@ -134,7 +134,7 @@ describe Mongoid::Document do
         registry.save!
 
         _registry = Registry.find(registry.id)
-        _registry.obj_id.should == BSON::ObjectId.from_string(obj_id)
+        _registry.obj_id.should eq BSON::ObjectId.from_string(obj_id)
       end
     end
 
@@ -169,14 +169,14 @@ describe Mongoid::Document do
       end
 
       it 'assigns nil' do
-        registry.obj_id.should == 'hello'
+        registry.obj_id.should eq 'hello'
       end
 
       it 'persists' do
         registry.save!
 
         _registry = Registry.find(registry.id)
-        _registry.obj_id.should == 'hello'
+        _registry.obj_id.should eq 'hello'
       end
     end
 
@@ -190,14 +190,14 @@ describe Mongoid::Document do
       end
 
       it 'assigns nil' do
-        registry.obj_id.should == :sym
+        registry.obj_id.should eq :sym
       end
 
       it 'persists' do
         registry.save!
 
         _registry = Registry.find(registry.id)
-        _registry.obj_id.should == :sym
+        _registry.obj_id.should eq :sym
       end
     end
   end
@@ -213,11 +213,11 @@ describe Mongoid::Document do
       end
 
       it 'round-trips the value' do
-        found_church.location[:state].should == :ny
+        found_church.location[:state].should eq :ny
       end
 
       it 'stringifies the key' do
-        found_church.location.keys.should == %w[state]
+        found_church.location.keys.should eq %w[state]
       end
 
       it 'retrieves value as symbol via driver' do
@@ -226,7 +226,7 @@ describe Mongoid::Document do
         church
 
         v = Church.collection.find.first
-        v['location'].should == { 'state' => :ny }
+        v['location'].should eq({ 'state' => :ny })
       end
     end
   end

--- a/spec/mongoid/document_persistence_context_spec.rb
+++ b/spec/mongoid/document_persistence_context_spec.rb
@@ -13,19 +13,19 @@ describe Mongoid::Document do
 
   describe '.client_name' do
     it 'returns client name' do
-      Person.client_name.should == :default
+      Person.client_name.should eq :default
     end
   end
 
   describe '.database_name' do
     it 'returns database name' do
-      Person.database_name.should == 'mongoid_test'
+      Person.database_name.should eq 'mongoid_test'
     end
   end
 
   describe '.collection_name' do
     it 'returns collection name' do
-      Person.collection_name.should == :people
+      Person.collection_name.should eq :people
     end
   end
 

--- a/spec/mongoid/factory_spec.rb
+++ b/spec/mongoid/factory_spec.rb
@@ -190,7 +190,7 @@ describe Mongoid::Factory do
           end
 
           it 'sets the attributes to generated _id only' do
-            document.attributes.should == { '_id' => document.id }
+            document.attributes.should eq({ '_id' => document.id })
           end
         end
       end
@@ -210,7 +210,7 @@ describe Mongoid::Factory do
         it 'sets the attributes to _type only' do
           skip 'https://jira.mongodb.org/browse/MONGOID-5179'
           # Note that Address provides the _id override.
-          document.attributes.should == { '_type' => 'Address' }
+          document.attributes.should eq({ '_type' => 'Address' })
         end
       end
 
@@ -223,7 +223,7 @@ describe Mongoid::Factory do
 
         it 'sets the attributes to empty' do
           # Note that Address provides the _id override.
-          document.attributes.should == { '_type' => 'ShipmentAddress' }
+          document.attributes.should eq({ '_type' => 'ShipmentAddress' })
         end
       end
     end

--- a/spec/mongoid/fields_spec.rb
+++ b/spec/mongoid/fields_spec.rb
@@ -1576,7 +1576,7 @@ describe Mongoid::Fields do
       let(:shape) { Shape.new }
 
       it 'is correctly set' do
-        shape.attributes['_type'].should == 'Shape'
+        shape.attributes['_type'].should eq 'Shape'
       end
     end
 
@@ -1584,7 +1584,7 @@ describe Mongoid::Fields do
       let(:circle) { Circle.new }
 
       it 'is correctly set' do
-        circle.attributes['_type'].should == 'Circle'
+        circle.attributes['_type'].should eq 'Circle'
       end
     end
   end

--- a/spec/mongoid/inspectable_spec.rb
+++ b/spec/mongoid/inspectable_spec.rb
@@ -74,7 +74,7 @@ describe Mongoid::Inspectable do
       let(:shirt) { Shirt.new(id: 1, _id: 2) }
 
       it 'shows the correct _id and id values' do
-        shirt.inspect.should == '#<Shirt _id: 2, color: nil, id: "1">'
+        shirt.inspect.should eq '#<Shirt _id: 2, color: nil, id: "1">'
       end
     end
   end
@@ -150,7 +150,7 @@ describe Mongoid::Inspectable do
       let(:shirt) { Shirt.new(id: 1, _id: 2) }
 
       it 'shows the correct _id and id values' do
-        shirt.pretty_inspect.should == "#<Shirt _id: 2, color: nil, id: \"1\">\n"
+        shirt.pretty_inspect.should eq "#<Shirt _id: 2, color: nil, id: \"1\">\n"
       end
     end
   end

--- a/spec/mongoid/matcher/extract_attribute_spec.rb
+++ b/spec/mongoid/matcher/extract_attribute_spec.rb
@@ -24,7 +24,7 @@ describe 'Matcher.extract_attribute' do
           let(:expected) { spec.fetch('result') }
 
           it 'has the expected result' do
-            actual.should == expected
+            actual.should eq expected
           end
         end
       end

--- a/spec/mongoid/persistable/deletable_spec.rb
+++ b/spec/mongoid/persistable/deletable_spec.rb
@@ -318,9 +318,9 @@ describe Mongoid::Persistable::Deletable do
           end
 
           it 'does not destroy dependent documents' do
-            Bolt.count.should == 1
+            Bolt.count.should eq 1
             parent.delete
-            Bolt.count.should == 1
+            Bolt.count.should eq 1
           end
         end
 
@@ -330,9 +330,9 @@ describe Mongoid::Persistable::Deletable do
           end
 
           it 'does not destroy dependent documents' do
-            Threadlocker.count.should == 1
+            Threadlocker.count.should eq 1
             parent.delete
-            Threadlocker.count.should == 1
+            Threadlocker.count.should eq 1
           end
         end
 
@@ -342,9 +342,9 @@ describe Mongoid::Persistable::Deletable do
           end
 
           it 'does not destroy dependent documents' do
-            Sealer.count.should == 1
+            Sealer.count.should eq 1
             parent.delete
-            Sealer.count.should == 1
+            Sealer.count.should eq 1
           end
         end
       end
@@ -356,9 +356,9 @@ describe Mongoid::Persistable::Deletable do
           end
 
           it 'does not destroy dependent documents' do
-            Nut.count.should == 1
+            Nut.count.should eq 1
             parent.delete
-            Nut.count.should == 1
+            Nut.count.should eq 1
           end
         end
 
@@ -368,9 +368,9 @@ describe Mongoid::Persistable::Deletable do
           end
 
           it 'does not destroy dependent documents' do
-            Washer.count.should == 1
+            Washer.count.should eq 1
             parent.delete
-            Washer.count.should == 1
+            Washer.count.should eq 1
           end
         end
 
@@ -380,9 +380,9 @@ describe Mongoid::Persistable::Deletable do
           end
 
           it 'does not destroy dependent documents' do
-            Spacer.count.should == 1
+            Spacer.count.should eq 1
             parent.delete
-            Spacer.count.should == 1
+            Spacer.count.should eq 1
           end
         end
       end
@@ -468,9 +468,9 @@ describe Mongoid::Persistable::Deletable do
           end
 
           it 'does not destroy dependent documents' do
-            Bolt.count.should == 1
+            Bolt.count.should eq 1
             Hole.delete_all
-            Bolt.count.should == 1
+            Bolt.count.should eq 1
           end
         end
 
@@ -480,9 +480,9 @@ describe Mongoid::Persistable::Deletable do
           end
 
           it 'does not destroy dependent documents' do
-            Threadlocker.count.should == 1
+            Threadlocker.count.should eq 1
             Hole.delete_all
-            Threadlocker.count.should == 1
+            Threadlocker.count.should eq 1
           end
         end
 
@@ -492,9 +492,9 @@ describe Mongoid::Persistable::Deletable do
           end
 
           it 'does not destroy dependent documents' do
-            Sealer.count.should == 1
+            Sealer.count.should eq 1
             Hole.delete_all
-            Sealer.count.should == 1
+            Sealer.count.should eq 1
           end
         end
       end
@@ -506,9 +506,9 @@ describe Mongoid::Persistable::Deletable do
           end
 
           it 'does not destroy dependent documents' do
-            Nut.count.should == 1
+            Nut.count.should eq 1
             Hole.delete_all
-            Nut.count.should == 1
+            Nut.count.should eq 1
           end
         end
 
@@ -518,9 +518,9 @@ describe Mongoid::Persistable::Deletable do
           end
 
           it 'does not destroy dependent documents' do
-            Washer.count.should == 1
+            Washer.count.should eq 1
             Hole.delete_all
-            Washer.count.should == 1
+            Washer.count.should eq 1
           end
         end
 
@@ -530,9 +530,9 @@ describe Mongoid::Persistable::Deletable do
           end
 
           it 'does not destroy dependent documents' do
-            Spacer.count.should == 1
+            Spacer.count.should eq 1
             Hole.delete_all
-            Spacer.count.should == 1
+            Spacer.count.should eq 1
           end
         end
       end

--- a/spec/mongoid/persistable/deletable_spec.rb
+++ b/spec/mongoid/persistable/deletable_spec.rb
@@ -318,7 +318,7 @@ describe Mongoid::Persistable::Deletable do
           end
 
           it 'does not destroy dependent documents' do
-            Bolt.count.should
+            Bolt.count.should == 1
             parent.delete
             Bolt.count.should == 1
           end
@@ -330,7 +330,7 @@ describe Mongoid::Persistable::Deletable do
           end
 
           it 'does not destroy dependent documents' do
-            Threadlocker.count.should
+            Threadlocker.count.should == 1
             parent.delete
             Threadlocker.count.should == 1
           end
@@ -342,7 +342,7 @@ describe Mongoid::Persistable::Deletable do
           end
 
           it 'does not destroy dependent documents' do
-            Sealer.count.should
+            Sealer.count.should == 1
             parent.delete
             Sealer.count.should == 1
           end
@@ -356,7 +356,7 @@ describe Mongoid::Persistable::Deletable do
           end
 
           it 'does not destroy dependent documents' do
-            Nut.count.should
+            Nut.count.should == 1
             parent.delete
             Nut.count.should == 1
           end
@@ -368,7 +368,7 @@ describe Mongoid::Persistable::Deletable do
           end
 
           it 'does not destroy dependent documents' do
-            Washer.count.should
+            Washer.count.should == 1
             parent.delete
             Washer.count.should == 1
           end
@@ -380,7 +380,7 @@ describe Mongoid::Persistable::Deletable do
           end
 
           it 'does not destroy dependent documents' do
-            Spacer.count.should
+            Spacer.count.should == 1
             parent.delete
             Spacer.count.should == 1
           end
@@ -468,7 +468,7 @@ describe Mongoid::Persistable::Deletable do
           end
 
           it 'does not destroy dependent documents' do
-            Bolt.count.should
+            Bolt.count.should == 1
             Hole.delete_all
             Bolt.count.should == 1
           end
@@ -480,7 +480,7 @@ describe Mongoid::Persistable::Deletable do
           end
 
           it 'does not destroy dependent documents' do
-            Threadlocker.count.should
+            Threadlocker.count.should == 1
             Hole.delete_all
             Threadlocker.count.should == 1
           end
@@ -492,7 +492,7 @@ describe Mongoid::Persistable::Deletable do
           end
 
           it 'does not destroy dependent documents' do
-            Sealer.count.should
+            Sealer.count.should == 1
             Hole.delete_all
             Sealer.count.should == 1
           end
@@ -506,7 +506,7 @@ describe Mongoid::Persistable::Deletable do
           end
 
           it 'does not destroy dependent documents' do
-            Nut.count.should
+            Nut.count.should == 1
             Hole.delete_all
             Nut.count.should == 1
           end
@@ -518,7 +518,7 @@ describe Mongoid::Persistable::Deletable do
           end
 
           it 'does not destroy dependent documents' do
-            Washer.count.should
+            Washer.count.should == 1
             Hole.delete_all
             Washer.count.should == 1
           end
@@ -530,7 +530,7 @@ describe Mongoid::Persistable::Deletable do
           end
 
           it 'does not destroy dependent documents' do
-            Spacer.count.should
+            Spacer.count.should == 1
             Hole.delete_all
             Spacer.count.should == 1
           end

--- a/spec/mongoid/persistable/destroyable_spec.rb
+++ b/spec/mongoid/persistable/destroyable_spec.rb
@@ -221,9 +221,9 @@ describe Mongoid::Persistable::Destroyable do
           end
 
           it 'destroys dependent documents' do
-            Bolt.count.should == 1
+            Bolt.count.should eq 1
             parent.destroy
-            Bolt.count.should == 0
+            Bolt.count.should eq 0
           end
         end
 
@@ -233,9 +233,9 @@ describe Mongoid::Persistable::Destroyable do
           end
 
           it 'deletes dependent documents' do
-            Threadlocker.count.should == 1
+            Threadlocker.count.should eq 1
             parent.destroy
-            Threadlocker.count.should == 0
+            Threadlocker.count.should eq 0
           end
         end
 
@@ -245,9 +245,9 @@ describe Mongoid::Persistable::Destroyable do
           end
 
           it 'raises an exception' do
-            Sealer.count.should == 1
+            Sealer.count.should eq 1
             expect { parent.destroy }.to raise_error(Mongoid::Errors::DeleteRestriction)
-            Sealer.count.should == 1
+            Sealer.count.should eq 1
           end
         end
       end
@@ -259,9 +259,9 @@ describe Mongoid::Persistable::Destroyable do
           end
 
           it 'destroys dependent documents' do
-            Nut.count.should == 1
+            Nut.count.should eq 1
             parent.destroy
-            Nut.count.should == 0
+            Nut.count.should eq 0
           end
         end
 
@@ -271,9 +271,9 @@ describe Mongoid::Persistable::Destroyable do
           end
 
           it 'deletes dependent documents' do
-            Washer.count.should == 1
+            Washer.count.should eq 1
             parent.destroy
-            Washer.count.should == 0
+            Washer.count.should eq 0
           end
         end
 
@@ -283,9 +283,9 @@ describe Mongoid::Persistable::Destroyable do
           end
 
           it 'raises an exception' do
-            Spacer.count.should == 1
+            Spacer.count.should eq 1
             expect { parent.destroy }.to raise_error(Mongoid::Errors::DeleteRestriction)
-            Spacer.count.should == 1
+            Spacer.count.should eq 1
           end
         end
       end
@@ -547,9 +547,9 @@ describe Mongoid::Persistable::Destroyable do
           end
 
           it 'destroys dependent documents' do
-            Bolt.count.should == 1
+            Bolt.count.should eq 1
             Hole.destroy_all
-            Bolt.count.should == 0
+            Bolt.count.should eq 0
           end
         end
 
@@ -561,9 +561,9 @@ describe Mongoid::Persistable::Destroyable do
           end
 
           it 'deletes dependent documents' do
-            Threadlocker.count.should == 1
+            Threadlocker.count.should eq 1
             Hole.destroy_all
-            Threadlocker.count.should == 0
+            Threadlocker.count.should eq 0
           end
         end
 
@@ -575,9 +575,9 @@ describe Mongoid::Persistable::Destroyable do
           end
 
           it 'raises an exception' do
-            Sealer.count.should == 1
+            Sealer.count.should eq 1
             expect { Hole.destroy_all }.to raise_error(Mongoid::Errors::DeleteRestriction)
-            Sealer.count.should == 1
+            Sealer.count.should eq 1
           end
         end
       end
@@ -589,9 +589,9 @@ describe Mongoid::Persistable::Destroyable do
           end
 
           it 'destroys dependent documents' do
-            Nut.count.should == 1
+            Nut.count.should eq 1
             Hole.destroy_all
-            Nut.count.should == 0
+            Nut.count.should eq 0
           end
         end
 
@@ -601,9 +601,9 @@ describe Mongoid::Persistable::Destroyable do
           end
 
           it 'deletes dependent documents' do
-            Washer.count.should == 1
+            Washer.count.should eq 1
             Hole.destroy_all
-            Washer.count.should == 0
+            Washer.count.should eq 0
           end
         end
 
@@ -613,9 +613,9 @@ describe Mongoid::Persistable::Destroyable do
           end
 
           it 'raises an exception' do
-            Spacer.count.should == 1
+            Spacer.count.should eq 1
             expect { Hole.destroy_all }.to raise_error(Mongoid::Errors::DeleteRestriction)
-            Spacer.count.should == 1
+            Spacer.count.should eq 1
           end
         end
       end

--- a/spec/mongoid/persistable/destroyable_spec.rb
+++ b/spec/mongoid/persistable/destroyable_spec.rb
@@ -221,7 +221,7 @@ describe Mongoid::Persistable::Destroyable do
           end
 
           it 'destroys dependent documents' do
-            Bolt.count.should
+            Bolt.count.should == 1
             parent.destroy
             Bolt.count.should == 0
           end
@@ -233,7 +233,7 @@ describe Mongoid::Persistable::Destroyable do
           end
 
           it 'deletes dependent documents' do
-            Threadlocker.count.should
+            Threadlocker.count.should == 1
             parent.destroy
             Threadlocker.count.should == 0
           end
@@ -245,7 +245,7 @@ describe Mongoid::Persistable::Destroyable do
           end
 
           it 'raises an exception' do
-            Sealer.count.should
+            Sealer.count.should == 1
             expect { parent.destroy }.to raise_error(Mongoid::Errors::DeleteRestriction)
             Sealer.count.should == 1
           end
@@ -259,7 +259,7 @@ describe Mongoid::Persistable::Destroyable do
           end
 
           it 'destroys dependent documents' do
-            Nut.count.should
+            Nut.count.should == 1
             parent.destroy
             Nut.count.should == 0
           end
@@ -271,7 +271,7 @@ describe Mongoid::Persistable::Destroyable do
           end
 
           it 'deletes dependent documents' do
-            Washer.count.should
+            Washer.count.should == 1
             parent.destroy
             Washer.count.should == 0
           end
@@ -283,7 +283,7 @@ describe Mongoid::Persistable::Destroyable do
           end
 
           it 'raises an exception' do
-            Spacer.count.should
+            Spacer.count.should == 1
             expect { parent.destroy }.to raise_error(Mongoid::Errors::DeleteRestriction)
             Spacer.count.should == 1
           end
@@ -547,7 +547,7 @@ describe Mongoid::Persistable::Destroyable do
           end
 
           it 'destroys dependent documents' do
-            Bolt.count.should
+            Bolt.count.should == 1
             Hole.destroy_all
             Bolt.count.should == 0
           end
@@ -561,7 +561,7 @@ describe Mongoid::Persistable::Destroyable do
           end
 
           it 'deletes dependent documents' do
-            Threadlocker.count.should
+            Threadlocker.count.should == 1
             Hole.destroy_all
             Threadlocker.count.should == 0
           end
@@ -575,7 +575,7 @@ describe Mongoid::Persistable::Destroyable do
           end
 
           it 'raises an exception' do
-            Sealer.count.should
+            Sealer.count.should == 1
             expect { Hole.destroy_all }.to raise_error(Mongoid::Errors::DeleteRestriction)
             Sealer.count.should == 1
           end
@@ -589,7 +589,7 @@ describe Mongoid::Persistable::Destroyable do
           end
 
           it 'destroys dependent documents' do
-            Nut.count.should
+            Nut.count.should == 1
             Hole.destroy_all
             Nut.count.should == 0
           end
@@ -601,7 +601,7 @@ describe Mongoid::Persistable::Destroyable do
           end
 
           it 'deletes dependent documents' do
-            Washer.count.should
+            Washer.count.should == 1
             Hole.destroy_all
             Washer.count.should == 0
           end
@@ -613,7 +613,7 @@ describe Mongoid::Persistable::Destroyable do
           end
 
           it 'raises an exception' do
-            Spacer.count.should
+            Spacer.count.should == 1
             expect { Hole.destroy_all }.to raise_error(Mongoid::Errors::DeleteRestriction)
             Spacer.count.should == 1
           end

--- a/spec/mongoid/persistable/savable_spec.rb
+++ b/spec/mongoid/persistable/savable_spec.rb
@@ -302,9 +302,9 @@ describe Mongoid::Persistable::Savable do
           truck.save!
 
           _truck = Truck.find(truck.id)
-          _truck.crates.length.should == 2
-          _truck.crates.first.volume.should == 2
-          _truck.crates.last.volume.should == 1
+          _truck.crates.length.should eq 2
+          _truck.crates.first.volume.should eq 2
+          _truck.crates.last.volume.should eq 1
         end
       end
 
@@ -319,9 +319,9 @@ describe Mongoid::Persistable::Savable do
           truck.save!
 
           _truck = Truck.find(truck.id)
-          _truck.seats.length.should == 1
-          _truck.seats.first.armrests.length.should == 1
-          _truck.seats.first.armrests.first.side.should == 'left'
+          _truck.seats.length.should eq 1
+          _truck.seats.first.armrests.length.should eq 1
+          _truck.seats.first.armrests.first.side.should eq 'left'
         end
       end
 
@@ -336,10 +336,10 @@ describe Mongoid::Persistable::Savable do
           truck.save!
 
           _truck = Truck.find(truck.id)
-          _truck.crates.length.should == 2
-          _truck.crates.first.toys.length.should == 1
-          _truck.crates.first.toys.first.name.should == 'Bear'
-          _truck.crates.last.toys.length.should == 0
+          _truck.crates.length.should eq 2
+          _truck.crates.first.toys.length.should eq 1
+          _truck.crates.first.toys.first.name.should eq 'Bear'
+          _truck.crates.last.toys.length.should eq 0
         end
 
         context 'when also updating first embedded top level association' do
@@ -351,10 +351,10 @@ describe Mongoid::Persistable::Savable do
             truck.save!
 
             _truck = Truck.find(truck.id)
-            _truck.crates.length.should == 2
-            _truck.crates.first.toys.length.should == 1
-            _truck.crates.first.toys.first.name.should == 'Bear'
-            _truck.crates.last.toys.length.should == 0
+            _truck.crates.length.should eq 2
+            _truck.crates.first.toys.length.should eq 1
+            _truck.crates.first.toys.first.name.should eq 'Bear'
+            _truck.crates.last.toys.length.should eq 0
           end
         end
       end

--- a/spec/mongoid/persistable/savable_spec.rb
+++ b/spec/mongoid/persistable/savable_spec.rb
@@ -302,8 +302,8 @@ describe Mongoid::Persistable::Savable do
           truck.save!
 
           _truck = Truck.find(truck.id)
-          _truck.crates.length.should
-          _truck.crates.first.volume.should
+          _truck.crates.length.should == 2
+          _truck.crates.first.volume.should == 2
           _truck.crates.last.volume.should == 1
         end
       end
@@ -319,8 +319,8 @@ describe Mongoid::Persistable::Savable do
           truck.save!
 
           _truck = Truck.find(truck.id)
-          _truck.seats.length.should
-          _truck.seats.first.armrests.length.should
+          _truck.seats.length.should == 1
+          _truck.seats.first.armrests.length.should == 1
           _truck.seats.first.armrests.first.side.should == 'left'
         end
       end
@@ -336,9 +336,9 @@ describe Mongoid::Persistable::Savable do
           truck.save!
 
           _truck = Truck.find(truck.id)
-          _truck.crates.length.should
-          _truck.crates.first.toys.length.should
-          _truck.crates.first.toys.first.name.should
+          _truck.crates.length.should == 2
+          _truck.crates.first.toys.length.should == 1
+          _truck.crates.first.toys.first.name.should == 'Bear'
           _truck.crates.last.toys.length.should == 0
         end
 
@@ -351,9 +351,9 @@ describe Mongoid::Persistable::Savable do
             truck.save!
 
             _truck = Truck.find(truck.id)
-            _truck.crates.length.should
-            _truck.crates.first.toys.length.should
-            _truck.crates.first.toys.first.name.should
+            _truck.crates.length.should == 2
+            _truck.crates.first.toys.length.should == 1
+            _truck.crates.first.toys.first.name.should == 'Bear'
             _truck.crates.last.toys.length.should == 0
           end
         end

--- a/spec/mongoid/persistable/upsertable_spec.rb
+++ b/spec/mongoid/persistable/upsertable_spec.rb
@@ -52,7 +52,7 @@ describe Mongoid::Persistable::Upsertable do
 
         shared_examples 'replaces the existing fields' do
           it 'replaces the existing fields' do
-            Band.count.should
+            Band.count.should == 1
 
             existing.reload
             existing.views.should be_nil
@@ -62,7 +62,7 @@ describe Mongoid::Persistable::Upsertable do
 
         shared_examples 'retains the existing fields' do
           it 'retains the existing fields' do
-            Band.count.should
+            Band.count.should == 1
 
             existing.reload
             existing.views.should eq(42)

--- a/spec/mongoid/persistable/upsertable_spec.rb
+++ b/spec/mongoid/persistable/upsertable_spec.rb
@@ -52,21 +52,21 @@ describe Mongoid::Persistable::Upsertable do
 
         shared_examples 'replaces the existing fields' do
           it 'replaces the existing fields' do
-            Band.count.should == 1
+            Band.count.should eq 1
 
             existing.reload
             existing.views.should be_nil
-            existing.name.should == 'Tool'
+            existing.name.should eq 'Tool'
           end
         end
 
         shared_examples 'retains the existing fields' do
           it 'retains the existing fields' do
-            Band.count.should == 1
+            Band.count.should eq 1
 
             existing.reload
             existing.views.should eq(42)
-            existing.name.should == 'Tool'
+            existing.name.should eq 'Tool'
           end
         end
 

--- a/spec/mongoid/reloadable_spec.rb
+++ b/spec/mongoid/reloadable_spec.rb
@@ -684,7 +684,7 @@ describe Mongoid::Reloadable do
         end
 
         it 'reloads the document' do
-          band.name.should
+          band.name.should == 'test'
 
           band.reload
 
@@ -701,7 +701,7 @@ describe Mongoid::Reloadable do
 
         it 'creates a new document with default values' do
           original_id = band.id
-          band.name.should
+          band.name.should == 'test'
 
           band.reload
 
@@ -737,7 +737,7 @@ describe Mongoid::Reloadable do
       end
 
       it 'resets the associations' do
-        church.acolytes.first.name.should
+        church.acolytes.first.name.should == 'test'
 
         church.reload
 

--- a/spec/mongoid/reloadable_spec.rb
+++ b/spec/mongoid/reloadable_spec.rb
@@ -239,7 +239,7 @@ describe Mongoid::Reloadable do
             agent.reload
           end.should_not raise_error
 
-          agent.title.should == '007'
+          agent.title.should eq '007'
         end
 
         it 'sets new_record to false' do
@@ -684,11 +684,11 @@ describe Mongoid::Reloadable do
         end
 
         it 'reloads the document' do
-          band.name.should == 'test'
+          band.name.should eq 'test'
 
           band.reload
 
-          band.name.should == 'Sun Project'
+          band.name.should eq 'Sun Project'
         end
       end
 
@@ -701,7 +701,7 @@ describe Mongoid::Reloadable do
 
         it 'creates a new document with default values' do
           original_id = band.id
-          band.name.should == 'test'
+          band.name.should eq 'test'
 
           band.reload
 
@@ -737,13 +737,13 @@ describe Mongoid::Reloadable do
       end
 
       it 'resets the associations' do
-        church.acolytes.first.name.should == 'test'
+        church.acolytes.first.name.should eq 'test'
 
         church.reload
 
         church.acolytes._loaded?.should be false
 
-        church.acolytes.first.name.should == 'Borg'
+        church.acolytes.first.name.should eq 'Borg'
       end
     end
 

--- a/spec/mongoid/scopable_spec.rb
+++ b/spec/mongoid/scopable_spec.rb
@@ -537,7 +537,7 @@ describe Mongoid::Scopable do
           end
 
           it 'sets the conditions from keyword arguments' do
-            scope.selector.should == { 'name' => 'Emily', 'deleted' => true }
+            scope.selector.should eq({ 'name' => 'Emily', 'deleted' => true })
           end
         end
 
@@ -1119,15 +1119,15 @@ describe Mongoid::Scopable do
       it 'restores previous scope' do
         Band.with_scope(c1) do |_crit|
           Band.with_scope(c2) do |_crit2|
-            Mongoid::Threaded.current_scope(Band).selector.should == {
-              'active' => true,
-              '$and' => [ { 'active' => false } ]
-            }
+            Mongoid::Threaded.current_scope(Band).selector.should eq(
+              {
+                'active' => true,
+                '$and' => [ { 'active' => false } ]
+              }
+            )
           end
 
-          Mongoid::Threaded.current_scope(Band).selector.should == {
-            'active' => true
-          }
+          Mongoid::Threaded.current_scope(Band).selector.should eq({ 'active' => true })
         end
       end
     end
@@ -1141,9 +1141,7 @@ describe Mongoid::Scopable do
             Mongoid::Threaded.current_scope(Band).should be_nil
           end
 
-          Mongoid::Threaded.current_scope(Band).selector.should == {
-            'active' => true
-          }
+          Mongoid::Threaded.current_scope(Band).selector.should eq({ 'active' => true })
         end
       end
     end

--- a/spec/mongoid/touchable_spec.rb
+++ b/spec/mongoid/touchable_spec.rb
@@ -618,8 +618,7 @@ describe Mongoid::Touchable do
         end
 
         it "updates the child's timestamp" do
-          floor.updated_at.should
-          update_time
+          floor.updated_at.should == update_time
           floor.reload.updated_at.should == update_time
         end
       end

--- a/spec/mongoid/touchable_spec.rb
+++ b/spec/mongoid/touchable_spec.rb
@@ -618,8 +618,8 @@ describe Mongoid::Touchable do
         end
 
         it "updates the child's timestamp" do
-          floor.updated_at.should == update_time
-          floor.reload.updated_at.should == update_time
+          floor.updated_at.should eq update_time
+          floor.reload.updated_at.should eq update_time
         end
       end
 


### PR DESCRIPTION
We applied `rubocop -a`, which is supposed to be safe, but it silently broke multiple files by changing `.should == x` constructs into simply `.should` (presumably because it detected a void comparison and assumed it was superfluous). This PR repairs those artifacts.