### PR TITLE
Add `rake rubocop` and `rake rubocop:install_hook` tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -65,6 +65,37 @@ RSpec::Core::RakeTask.new('spec:progress') do |spec|
   spec.pattern = 'spec/**/*_spec.rb'
 end
 
+RUBOCOPABLE = %w[ examples gemfiles perf lib spec mongoid.gemspec Gemfile Rakefile upload-api-docs ].freeze
+
+desc 'Run rubocop'
+task rubocop: %w[ rubocop:run ]
+
+namespace :rubocop do
+  desc 'Run rubocop on the codebase'
+  task :run do
+    Bundler.with_unbundled_env do
+      sh 'bundle', 'exec', 'rubocop', *RUBOCOPABLE, verbose: false
+    end
+  end
+
+  desc 'Add a git pre-commit hook that runs rubocop'
+  task :install_hook do
+    hook_path = File.join('.git', 'hooks', 'pre-commit')
+    hook_script = <<~HOOK
+      #!/usr/bin/env bash
+      set -e
+
+      echo "Running rubocop..."
+      rake rubocop
+    HOOK
+
+    File.write(hook_path, hook_script)
+    FileUtils.chmod('+x', hook_path)
+
+    puts "Git pre-commit hook installed at #{hook_path}."
+  end
+end
+
 desc 'Build and validate the evergreen config'
 task eg: %w[ eg:build eg:validate ]
 


### PR DESCRIPTION
Adds two new rake tasks (for convenience):

- `rake rubocop` -- runs rubocop on an explicit list of directories and files, so that local exploratory scripts don't confuse the linter
- `rake rubocop:install_hook` -- sets the git pre-commit hook to run `rake rubocop`.