### PR TITLE
Clean up a few one-off linter complaints

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -26,11 +26,6 @@ Lint/AmbiguousRange:
 Lint/AssignmentInCondition:
   Enabled: false
 
-# Offense count: 1
-Lint/BinaryOperatorWithIdenticalOperands:
-  Exclude:
-    - 'spec/mongoid/equality_spec.rb'
-
 # Offense count: 225
 # Configuration parameters: AllowedMethods.
 # AllowedMethods: enums
@@ -84,11 +79,6 @@ Lint/EmptyClass:
     - 'spec/support/models/bed.rb'
     - 'spec/support/models/other_owner_object.rb'
 
-# Offense count: 1
-Lint/FloatComparison:
-  Exclude:
-    - 'lib/mongoid/matcher/bits.rb'
-
 # Offense count: 2
 Lint/HashCompareByIdentity:
   Exclude:
@@ -101,23 +91,12 @@ Lint/IneffectiveAccessModifier:
     - 'lib/mongoid/association/builders.rb'
     - 'lib/mongoid/copyable.rb'
 
-# Offense count: 1
-# This cop supports unsafe autocorrection (--autocorrect-all).
-Lint/InterpolationCheck:
-  Exclude:
-    - 'spec/mongoid/attributes/dynamic_spec.rb'
-
 # Offense count: 2
 # Configuration parameters: AllowedParentClasses.
 Lint/MissingSuper:
   Exclude:
     - 'lib/mongoid/criteria/queryable/pipeline.rb'
     - 'lib/mongoid/criteria/queryable/smash.rb'
-
-# Offense count: 1
-Lint/NonLocalExitFromIterator:
-  Exclude:
-    - 'spec/integration/app_spec.rb'
 
 # Offense count: 3
 # This cop supports safe autocorrection (--autocorrect).
@@ -172,11 +151,6 @@ Lint/SuppressedException:
 # Configuration parameters: AllowKeywordBlockArguments.
 Lint/UnderscorePrefixedVariableName:
   Enabled: false
-
-# Offense count: 1
-Lint/UnmodifiedReduceAccumulator:
-  Exclude:
-    - 'lib/mongoid/criteria/queryable/selectable.rb'
 
 # Offense count: 6
 Lint/UnreachableCode:

--- a/Rakefile
+++ b/Rakefile
@@ -65,6 +65,37 @@ RSpec::Core::RakeTask.new('spec:progress') do |spec|
   spec.pattern = 'spec/**/*_spec.rb'
 end
 
+RUBOCOPABLE = %w[ examples gemfiles perf lib spec mongoid.gemspec Gemfile Rakefile upload-api-docs ].freeze
+
+desc 'Run rubocop'
+task rubocop: %w[ rubocop:run ]
+
+namespace :rubocop do
+  desc 'Run rubocop on the codebase'
+  task :run do
+    Bundler.with_unbundled_env do
+      sh 'bundle', 'exec', 'rubocop', *RUBOCOPABLE, verbose: false
+    end
+  end
+
+  desc 'Add a git pre-commit hook that runs rubocop'
+  task :install_hook do
+    hook_path = File.join('.git', 'hooks', 'pre-commit')
+    hook_script = <<~HOOK
+      #!/usr/bin/env bash
+      set -e
+
+      echo "Running rubocop..."
+      rake rubocop
+    HOOK
+
+    File.write(hook_path, hook_script)
+    FileUtils.chmod('+x', hook_path)
+
+    puts "Git pre-commit hook installed at #{hook_path}."
+  end
+end
+
 desc 'Build and validate the evergreen config'
 task eg: %w[ eg:build eg:validate ]
 

--- a/lib/mongoid/criteria/queryable/selectable.rb
+++ b/lib/mongoid/criteria/queryable/selectable.rb
@@ -755,7 +755,9 @@ module Mongoid
         #
         # @return [ Selectable ] The cloned selectable.
         def where(*criteria)
-          criteria.inject(clone) do |_query, criterion|
+          return clone.reset_strategies! if criteria.empty?
+
+          criteria.inject(self) do |query, criterion|
             raise Errors::CriteriaArgumentRequired, :where if criterion.nil?
 
             # We need to save the criterion in an instance variable so
@@ -766,14 +768,12 @@ module Mongoid
             # only ever specify one criterion to #where.
             @criterion = criterion
             if criterion.is_a?(String)
-              js_query(criterion)
+              query.js_query(criterion)
             else
-              expr_query(criterion)
+              query.expr_query(criterion)
             end
-          end.reset_strategies!
+          end
         end
-
-        private
 
         # Adds the specified expression to the query.
         #
@@ -813,21 +813,6 @@ module Mongoid
           end
         end
 
-        # Force the values of the criterion to be evolved.
-        #
-        # @api private
-        #
-        # @example Force values to booleans.
-        #   selectable.force_typing(criterion) do |val|
-        #     Boolean.evolve(val)
-        #   end
-        #
-        # @param [ Hash ] criterion The criterion.
-        def typed_override(criterion, operator, &block)
-          criterion.transform_values!(&block) if criterion
-          __override__(criterion, operator)
-        end
-
         # Create a javascript selection.
         #
         # @api private
@@ -848,6 +833,23 @@ module Mongoid
             end
             query.reset_strategies!
           end
+        end
+
+        private
+
+        # Force the values of the criterion to be evolved.
+        #
+        # @api private
+        #
+        # @example Force values to booleans.
+        #   selectable.force_typing(criterion) do |val|
+        #     Boolean.evolve(val)
+        #   end
+        #
+        # @param [ Hash ] criterion The criterion.
+        def typed_override(criterion, operator, &block)
+          criterion.transform_values!(&block) if criterion
+          __override__(criterion, operator)
         end
 
         # Take the provided criterion and store it as a selection in the query

--- a/lib/mongoid/matcher/bits.rb
+++ b/lib/mongoid/matcher/bits.rb
@@ -33,7 +33,10 @@ module Mongoid
 
           int_matches?(value, condition)
         when Float
-          if (int_cond = condition.to_i).to_f == condition
+          # Allow floats that are whole numbers (e.g. 50.0), but reject those
+          # with a fractional part (e.g. 50.1) since bitwise ops require integers.
+          int_cond = condition.to_i
+          if int_cond == condition
             if int_cond < 0
               raise Errors::InvalidQuery,
                     "Invalid value for $#{operator_name} argument: negative numbers are not allowed: #{condition}"

--- a/spec/integration/app_spec.rb
+++ b/spec/integration/app_spec.rb
@@ -507,15 +507,12 @@ describe 'Mongoid application tests' do
     env
   end
 
-  def wait_for_port(port, timeout, process)
-    deadline = Mongoid::Utils.monotonic_time + timeout
-    loop do
-      Socket.tcp('localhost', port, nil, nil, connect_timeout: 0.5) do |_socket|
-        return
-      end
-    rescue IOError, SystemCallError
-      raise "Process #{process} died while waiting for port #{port}" unless process.alive?
-      raise if Mongoid::Utils.monotonic_time > deadline
-    end
+  def wait_for_port(port, timeout, process, deadline: Mongoid::Utils.monotonic_time + timeout)
+    Socket.tcp('localhost', port, nil, nil, connect_timeout: 0.5).close
+  rescue IOError, SystemCallError
+    raise "Process #{process} died while waiting for port #{port}" unless process.alive?
+    raise if Mongoid::Utils.monotonic_time > deadline
+
+    retry
   end
 end

--- a/spec/mongoid/attributes/dynamic_spec.rb
+++ b/spec/mongoid/attributes/dynamic_spec.rb
@@ -106,7 +106,7 @@ describe Mongoid::Attributes::Dynamic do
       end
     end
 
-    context 'when writing attributes via #{attribute}=' do
+    context 'when writing attributes via <attribute>=' do
       context 'when attribute is not already set' do
         let(:bar) { Bar.new }
 

--- a/spec/mongoid/equality_spec.rb
+++ b/spec/mongoid/equality_spec.rb
@@ -119,7 +119,7 @@ describe Mongoid::Equality do
 
       context 'when the instance is the same' do
         it 'returns true' do
-          expect(person === person).to be true
+          expect(person === person).to be true # rubocop:disable Lint/BinaryOperatorWithIdenticalOperands
         end
       end
     end


### PR DESCRIPTION
This PR addresses a few linter violations that each occur only once in the Mongoid code-base. Fixing some of them ended up requiring some small refactoring, and one of them (the `Queryable#where` method) actually revealed that the method has been misimplemented since 2019 (though it hasn't really mattered, since while the method claimed to support multiple arguments, `Criteria#where` always guarded that and required that no more than a single argument be given). Nevertheless, this PR fixes `Queryable#where` so the multi-argument version is correct now.