### PR TITLE
MONGOID-5929 Add AGENTS.md

### DIFF
--- a/.github/code-review.md
+++ b/.github/code-review.md
@@ -1,0 +1,37 @@
+# Code Reviews
+
+When reviewing code, focus on:
+
+## Security Critical Issues
+- Check for hardcoded secrets, API keys, or credentials
+- Check for instances of potential method call injection, dynamic code execution, symbol injection or other code injection vulnerabilities.
+
+## Performance Red Flags
+- Spot inefficient loops and algorithmic issues.
+- Check for memory leaks and resource cleanup.
+
+## Code Quality Essentials
+- Methods should be focused and appropriately sized. If a method is doing too much, suggest refactorings to split it up.
+- Use clear, descriptive naming conventions.
+- Avoid encapsulation violations and ensure proper separation of concerns.
+- All public classes, modules, and methods should have clear documentation in YARD format.
+- If `method_missing` is implemented, ensure that `respond_to_missing?` is also implemented.
+- Rubocop is used by this project to enforce code style. Always refer to the project's .rubocop.yml file for guidance on the project's style preferences.
+
+## Mongoid-specific Concerns
+- Mongoid::Document classes may be declared to exist in different database clusters. Look for code that should be multi-cluster-aware.
+- Query state is stored on the current thread or fiber (depending on the current value of Mongoid::Config.isolation_level). Look for code that might fail in a multi-threaded or multi-fiber setup, including resources that ought to be protected by a synchronization mechanism.
+
+## Review Style
+- Be specific and actionable in feedback
+- Explain the "why" behind recommendations
+- Acknowledge good patterns when you see them
+- Ask clarifying questions when code intent is unclear
+- When possible, suggest that the pull request be labelled as a `bug`, a `feature`, or a `bcbreak` (a "backwards-compatibility break").
+- PR's with no user-visible effect do not need to be labeled.
+
+Always prioritize security vulnerabilities and performance issues that could impact users.
+
+Always suggest changes to improve readability and testability.
+
+When reviewing code, be encouraging.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,17 @@
+# Project Description
+
+Mongoid is a Ruby Object-Document Mapper (ODM) framework for MongoDB. Mongoid allows developers to define their data models using Ruby classes, and it handles the mapping between these classes and the underlying MongoDB collections. It is built on top of the MongoDB Ruby driver, and is intended to be a (mostly) drop-in replacement for ActiveRecord in Ruby on Rails applications.
+
+# Project Structure
+
+- `examples` - example scripts showing how to use Mongoid
+- `gemfiles` - Gemfiles for testing different usage scenarios. `standard.gemfile` is the default, and is used for development, testing, and production.
+- `lib` - the main source code for Mongoid
+- `perf` - performance and benchmark scripts
+- `spec` - RSpec tests for Mongoid
+
+# Code Review Guidelines
+
 When reviewing code, focus on:
 
 ## Security Critical Issues
@@ -26,25 +40,10 @@ When reviewing code, focus on:
 - Acknowledge good patterns when you see them
 - Ask clarifying questions when code intent is unclear
 - When possible, suggest that the pull request be labelled as a `bug`, a `feature`, or a `bcbreak` (a "backwards-compatibility break").
-- PRs that change only tests or infrastructure configuration do not need to be labelled.
+- PR's with no user-visible effect do not need to be labeled.
 
 Always prioritize security vulnerabilities and performance issues that could impact users.
 
-Always suggest changes to improve readability and testability. For example, this suggestion seeks to make the code more readable, reusable, and testable:
+Always suggest changes to improve readability and testability.
 
-```ruby
-  # Instead of:
-  if (user.email && user.email.include?('@') && user.email.length > 5)
-    submitButton.enabled = true
-  else
-    submitButton.enabled = false
-  end
-  
-  # Consider:
-  def valid_email?(email)
-    email && email.include?('@') && email.length > 5
-  end
-  
-  submitButton.enabled = valid_email?(user.email);
-```
-
+Be encouraging.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,49 +1,57 @@
 # Project Description
 
-Mongoid is a Ruby Object-Document Mapper (ODM) framework for MongoDB. Mongoid allows developers to define their data models using Ruby classes, and it handles the mapping between these classes and the underlying MongoDB collections. It is built on top of the MongoDB Ruby driver, and is intended to be a (mostly) drop-in replacement for ActiveRecord in Ruby on Rails applications.
+Mongoid is a Ruby Object-Document Mapper (ODM) framework for MongoDB. Mongoid allows developers to define their data models using Ruby classes, and it handles the mapping between these classes and the underlying MongoDB collections. It is built on top of the MongoDB Ruby driver, and is intended to be a (mostly) drop-in replacement for ActiveRecord in Ruby on Rails applications. The project targets Ruby 2.7+. Do not use syntax or stdlib features unavailable in Ruby 2.7.
 
 # Project Structure
 
-- `examples` - example scripts showing how to use Mongoid
-- `gemfiles` - Gemfiles for testing different usage scenarios. `standard.gemfile` is the default, and is used for development, testing, and production.
-- `lib` - the main source code for Mongoid
-- `perf` - performance and benchmark scripts
-- `spec` - RSpec tests for Mongoid
+- `lib/`: the main source code for Mongoid
+- `spec/`: RSpec tests for Mongoid
+- `examples/`: example scripts showing how to use Mongoid
+- `gemfiles/`: Gemfiles for testing different usage scenarios (`standard.gemfile` is the default, used for development, testing, and production)
+- `perf/`: performance and benchmark scripts
 
-# Code Review Guidelines
 
-When reviewing code, focus on:
+# Development Workflow
 
-## Security Critical Issues
-- Check for hardcoded secrets, API keys, or credentials
-- Check for instances of potential method call injection, dynamic code execution, symbol injection or other code injection vulnerabilities.
+## Running tests
 
-## Performance Red Flags
-- Spot inefficient loops and algorithmic issues.
-- Check for memory leaks and resource cleanup.
+Tests require a running MongoDB instance. Set the URI via the `MONGODB_URI` environment variable:
 
-## Code Quality Essentials
-- Methods should be focused and appropriately sized. If a method is doing too much, suggest refactorings to split it up.
-- Use clear, descriptive naming conventions.
-- Avoid encapsulation violations and ensure proper separation of concerns.
-- All public classes, modules, and methods should have clear documentation in YARD format.
-- If `method_missing` is implemented, ensure that `respond_to_missing?` is also implemented.
-- Rubocop is used by this project to enforce code style. Always refer to the project's .rubocop.yml file for guidance on the project's style preferences.
+```
+MONGODB_URI="mongodb://localhost:27017,localhost:27018,localhost:27019/" bundle exec rspec spec/path/to/spec.rb
+```
 
-## Mongoid-specific Concerns
-- Mongoid::Document classes may be declared to exist in different database clusters. Look for code that should be multi-cluster-aware.
-- Query state is stored on the current thread or fiber (depending on the current value of Mongoid::Config.isolation_level). Look for code that might fail in a multi-threaded or multi-fiber setup, including resources that ought to be protected by a synchronization mechanism.
+A replica set is typically available locally at `localhost:27017,27018,27019`.
 
-## Review Style
-- Be specific and actionable in feedback
-- Explain the "why" behind recommendations
-- Acknowledge good patterns when you see them
-- Ask clarifying questions when code intent is unclear
-- When possible, suggest that the pull request be labelled as a `bug`, a `feature`, or a `bcbreak` (a "backwards-compatibility break").
-- PR's with no user-visible effect do not need to be labeled.
+## Linting
 
-Always prioritize security vulnerabilities and performance issues that could impact users.
+Run RuboCop after making changes, and always before committing:
 
-Always suggest changes to improve readability and testability.
+```
+bundle exec rubocop lib/mongoid/changed_file.rb spec/mongoid/changed_file_spec.rb
+```
 
-Be encouraging.
+Pass the specific files you modified.
+
+RuboCop is configured with performance, rake, and rspec plugins (`.rubocop.yml`).
+
+## Commit convention
+
+Prefix commit messages with the JIRA ticket: `MONGOID-#### Short description`. The ticket number is typically in the branch name.
+
+## Prose style
+
+When writing prose — commit messages, code comments, documentation — be concise, write as a human would, avoid overly complicated sentences, and use no emojis.
+
+## Definition of done
+
+Always run the relevant spec file(s) against the local cluster before considering a task complete. Running tests is not optional. "Relevant" means: the spec file for each class you changed, plus any integration specs that exercise the affected feature. If MongoDB is not reachable, report this to the user rather than trying to work around it.
+
+## Thread, fiber, and multi-cluster safety
+
+Query state is stored on the current thread or fiber (depending on `Mongoid::Config.isolation_level`). Mongoid::Document classes may exist in different database clusters. When writing or modifying code that touches query scoping, persistence, or shared state, always consider multi-threaded, multi-fiber, and multi-cluster scenarios. Use existing synchronization primitives in the codebase rather than introducing new ones.
+
+
+# Code Reviews
+
+See [.github/code-review.md](.github/code-review.md) for code review guidelines.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
This adds a repository-level AGENTS.md file, replacing the copilot-specific `.github/copilot-instructions.md` file.