### PR TITLE
MONGOID-5930 Add Mongoid::Config.allow_reparenting_via_nested_attributes

### DIFF
--- a/lib/mongoid/association/nested/many.rb
+++ b/lib/mongoid/association/nested/many.rb
@@ -189,11 +189,17 @@ module Mongoid
             else
               update_document(doc, attrs)
             end
-          else
+          elsif Mongoid.allow_reparenting_via_nested_attributes?
+            Mongoid::Warnings.warn_reparenting_via_nested_attributes
+
             # push existing document to association
             doc = association.klass.unscoped.find(converted)
             update_document(doc, attrs)
             existing.push(doc) unless destroyable?(attrs)
+          elsif association.embedded?
+            raise Errors::DocumentNotFound.new(association.klass, id)
+          else
+            raise Errors::DocumentNotFound.new(association.klass, { _id: id, association.foreign_key => parent.id })
           end
 
           parent.children_may_have_changed!

--- a/lib/mongoid/association/nested/many.rb
+++ b/lib/mongoid/association/nested/many.rb
@@ -191,8 +191,8 @@ module Mongoid
             end
           elsif association.embedded?
             raise Errors::DocumentNotFound.new(association.klass, id)
-          elsif Mongoid.allow_reparenting_via_nested_attributes?
-            Mongoid::Warnings.warn_reparenting_via_nested_attributes
+          elsif association.is_a?(Association::Referenced::HasAndBelongsToMany) || Mongoid.allow_reparenting_via_nested_attributes?
+            Mongoid::Warnings.warn_reparenting_via_nested_attributes if Mongoid.allow_reparenting_via_nested_attributes?
 
             # push existing document to association
             doc = association.klass.unscoped.find(converted)

--- a/lib/mongoid/association/nested/many.rb
+++ b/lib/mongoid/association/nested/many.rb
@@ -189,6 +189,8 @@ module Mongoid
             else
               update_document(doc, attrs)
             end
+          elsif association.embedded?
+            raise Errors::DocumentNotFound.new(association.klass, id)
           elsif Mongoid.allow_reparenting_via_nested_attributes?
             Mongoid::Warnings.warn_reparenting_via_nested_attributes
 
@@ -196,8 +198,6 @@ module Mongoid
             doc = association.klass.unscoped.find(converted)
             update_document(doc, attrs)
             existing.push(doc) unless destroyable?(attrs)
-          elsif association.embedded?
-            raise Errors::DocumentNotFound.new(association.klass, id)
           else
             raise Errors::DocumentNotFound.new(association.klass, { _id: id, association.foreign_key => parent.id })
           end

--- a/lib/mongoid/config.rb
+++ b/lib/mongoid/config.rb
@@ -130,6 +130,21 @@ module Mongoid
       validate_isolation_level!(level)
     }
 
+    # When this flag is true, it will be possible to change the parent of a
+    # record in a has_many association by passing the child record's id in the
+    # nested attributes for another parent record.
+    #
+    # When this flag is false, attempting to change the parent of a record in a
+    # has_many association via nested attributes will raise an error.
+    #
+    # The default is `false`. Note that allowing reparenting via nested attributes
+    # is a potential security risk, since it could allow a malicious user to move
+    # records that they do not own to a parent record that they do own.
+    #
+    # This option will be removed in Mongoid 10, and the only behavior will be
+    # as if this option were set to false.
+    option :allow_reparenting_via_nested_attributes, default: false
+
     # Returns the (potentially-dereferenced) isolation level that Mongoid
     # will use to store its internal state. If `isolation_level` is set to
     # `:rails`, this will return the isolation level that Rails is current

--- a/lib/mongoid/config.rb
+++ b/lib/mongoid/config.rb
@@ -131,12 +131,11 @@ module Mongoid
     }
 
     # When this flag is true, it will be possible to change the parent of a
-    # record in a non-embedded "many" association (such as `has_many` or
-    # `has_and_belongs_to_many`) by passing the child record's id in the nested
-    # attributes for another parent record.
+    # record in a "has_many" association by passing the child record's id in the
+    # nested attributes for another parent record.
     #
     # When this flag is false, attempting to change the parent of a record in a
-    # non-embedded "many" association via nested attributes will raise an error.
+    # "has-many" association via nested attributes will raise an error.
     #
     # The default is `false`. Note that allowing reparenting via nested attributes
     # is a potential security risk, since it could allow a malicious user to move

--- a/lib/mongoid/config.rb
+++ b/lib/mongoid/config.rb
@@ -131,11 +131,12 @@ module Mongoid
     }
 
     # When this flag is true, it will be possible to change the parent of a
-    # record in a has_many association by passing the child record's id in the
-    # nested attributes for another parent record.
+    # record in a non-embedded "many" association (such as `has_many` or
+    # `has_and_belongs_to_many`) by passing the child record's id in the nested
+    # attributes for another parent record.
     #
     # When this flag is false, attempting to change the parent of a record in a
-    # has_many association via nested attributes will raise an error.
+    # non-embedded "many" association via nested attributes will raise an error.
     #
     # The default is `false`. Note that allowing reparenting via nested attributes
     # is a potential security risk, since it could allow a malicious user to move

--- a/lib/mongoid/config/defaults.rb
+++ b/lib/mongoid/config/defaults.rb
@@ -15,10 +15,12 @@ module Mongoid
         case version.to_s
         when /^[0-7]\./
           raise ArgumentError, "Version no longer supported: #{version}"
+
         when '8.0'
           self.legacy_readonly = true
 
           load_defaults '8.1'
+
         when '8.1'
           self.immutable_ids = false
           self.legacy_persistence_context_behavior = true
@@ -26,8 +28,15 @@ module Mongoid
           self.prevent_multiple_calls_of_embedded_callbacks = false
 
           load_defaults '9.0'
+
         when '9.0'
-          # All flag defaults currently reflect 9.0 behavior.
+          self.allow_reparenting_via_nested_attributes = true
+
+          load_defaults '9.1'
+
+        when '9.1'
+          # All flag defaults currently reflect 9.1 behavior.
+
         else
           raise ArgumentError, "Unknown version: #{version}"
         end

--- a/lib/mongoid/warnings.rb
+++ b/lib/mongoid/warnings.rb
@@ -32,5 +32,6 @@ module Mongoid
             'The readonly! method will only mark the document readonly when the legacy_readonly feature flag is switched off.'
     warning :mutable_ids,
             'Ignoring updates to immutable attribute `_id`. Please set Mongoid::Config.immutable_ids to true and update your code so that `_id` is never updated.'
+    warning :reparenting_via_nested_attributes, 'Reparenting documents via nested attributes is insecure and is deprecated. Set Mongoid.allow_reparenting_via_nested_attributes to false and update your code to avoid reparenting documents via nested attributes.'
   end
 end

--- a/spec/mongoid/attributes/nested_spec.rb
+++ b/spec/mongoid/attributes/nested_spec.rb
@@ -189,16 +189,41 @@ describe Mongoid::Attributes::Nested do
           )
         end
 
-        it 'sets the nested attributes' do
-          expect(person.preferences.map(&:name)).to eq([ preference.name ])
+        context 'when allow_reparenting_via_nested_attributes is false' do
+          config_override :allow_reparenting_via_nested_attributes, false
+
+          it 'sets raises an exception' do
+            expect { person }.to raise_error(Mongoid::Errors::DocumentNotFound)
+          end
         end
 
-        it 'updates attributes of existing document which is added to relation' do
-          preference_name = 'updated preference'
-          person = Person.new(
-            preferences_attributes: { 0 => { id: preference.id, name: preference_name } }
-          )
-          expect(person.preferences.map(&:name)).to eq([ preference_name ])
+        context 'when allow_reparenting_via_nested_attributes is true' do
+          config_override :allow_reparenting_via_nested_attributes, true
+
+          it 'sets the nested attributes' do
+            expect(person.preferences.map(&:name)).to eq([ preference.name ])
+          end
+
+          it 'updates attributes of existing document which is added to relation' do
+            preference_name = 'updated preference'
+            person = Person.new(
+              preferences_attributes: { 0 => { id: preference.id, name: preference_name } }
+            )
+            expect(person.preferences.map(&:name)).to eq([ preference_name ])
+          end
+        end
+      end
+
+      context 'when referencing an existing document in a relation' do
+        let(:preference) { Preference.create!(name: 'sample preference') }
+        let(:person) do
+          Person.create(preferences: [ preference ]).tap do |person|
+            person.preferences_attributes = { 0 => { id: preference.id, name: 'updated name' } }
+          end
+        end
+
+        it 'updates attributes of existing document' do
+          expect(person.preferences.map(&:name)).to eq([ 'updated name' ])
         end
       end
     end
@@ -1221,7 +1246,7 @@ describe Mongoid::Attributes::Nested do
                   person.addresses_attributes =
                     { 'foo' => { 'id' => 'test', 'street' => 'Test' } }
                 end.to raise_error(Mongoid::Errors::DocumentNotFound,
-                                   /Document\(s\) not found for class Address with id\(s\)/)
+                                   /Document\(s\) not found for class Address/)
               end
             end
           end
@@ -2719,7 +2744,7 @@ describe Mongoid::Attributes::Nested do
                       { '0' =>
                         { 'id' => BSON::ObjectId.new.to_s, 'title' => 'Rogue' } }
                   end.to raise_error(Mongoid::Errors::DocumentNotFound,
-                                     /Document\(s\) not found for class Post with id\(s\)/)
+                                     /Document not found for class Post/)
                 end
               end
             end
@@ -2751,7 +2776,7 @@ describe Mongoid::Attributes::Nested do
                   person.posts_attributes =
                     { 'foo' => { 'id' => 'test', 'title' => 'Test' } }
                 end.to raise_error(Mongoid::Errors::DocumentNotFound,
-                                   /Document\(s\) not found for class Post with id\(s\)/)
+                                   /Document not found for class Post/)
               end
             end
           end
@@ -3406,7 +3431,7 @@ describe Mongoid::Attributes::Nested do
                   person.preferences_attributes =
                     { 'foo' => { 'id' => 'test', 'name' => 'Test' } }
                 end.to raise_error(Mongoid::Errors::DocumentNotFound,
-                                   /Document\(s\) not found for class Preference with id\(s\)/)
+                                   /Document not found for class Preference/)
               end
             end
           end

--- a/spec/mongoid/attributes/nested_spec.rb
+++ b/spec/mongoid/attributes/nested_spec.rb
@@ -192,7 +192,7 @@ describe Mongoid::Attributes::Nested do
         context 'when allow_reparenting_via_nested_attributes is false' do
           config_override :allow_reparenting_via_nested_attributes, false
 
-          it 'sets raises an exception' do
+          it 'raises a document not found error' do
             expect { person }.to raise_error(Mongoid::Errors::DocumentNotFound)
           end
         end

--- a/spec/mongoid/attributes/nested_spec.rb
+++ b/spec/mongoid/attributes/nested_spec.rb
@@ -152,22 +152,47 @@ describe Mongoid::Attributes::Nested do
       end
     end
 
-    context 'when the relation is a references many' do
+    context 'when the relation is a has-many' do
       before do
         Person.send(:undef_method, :posts_attributes=)
         Person.accepts_nested_attributes_for :posts
       end
 
-      let(:person) do
-        Person.new(posts_attributes: { '1' => { title: 'First' } })
+      context 'when adding a new document to a relation' do
+        let(:person) do
+          Person.new(posts_attributes: { '1' => { title: 'First' } })
+        end
+
+        it 'sets the nested attributes' do
+          expect(person.posts.first.title).to eq('First')
+        end
       end
 
-      it 'sets the nested attributes' do
-        expect(person.posts.first.title).to eq('First')
+      context 'when adding an existing document to a relation' do
+        let(:person1) { Person.create! }
+        let(:post) { person1.posts.create!(title: 'Sample Post') }
+
+        let(:person2) { Person.create!(posts_attributes: { '0' => { id: post.id, title: 'Reparented!' } }) }
+
+        context 'when allow_reparenting_via_nested_attributes is false' do
+          config_override :allow_reparenting_via_nested_attributes, false
+
+          it 'raises a document not found error' do
+            expect { person2 }.to raise_error(Mongoid::Errors::DocumentNotFound)
+          end
+        end
+
+        context 'when allow_reparenting_via_nested_attributes is true' do
+          config_override :allow_reparenting_via_nested_attributes, true
+
+          it 'sets the nested attributes' do
+            expect(person2.posts.map(&:title)).to eq([ 'Reparented!' ])
+          end
+        end
       end
     end
 
-    context 'when the relation is a references and referenced in many' do
+    context 'when the relation is a has-and-belongs-to-many' do
       before do
         Person.send(:undef_method, :preferences_attributes=)
         Person.accepts_nested_attributes_for :preferences
@@ -189,41 +214,16 @@ describe Mongoid::Attributes::Nested do
           )
         end
 
-        context 'when allow_reparenting_via_nested_attributes is false' do
-          config_override :allow_reparenting_via_nested_attributes, false
-
-          it 'raises a document not found error' do
-            expect { person }.to raise_error(Mongoid::Errors::DocumentNotFound)
-          end
+        it 'sets the nested attributes' do
+          expect(person.preferences.map(&:name)).to eq([ preference.name ])
         end
 
-        context 'when allow_reparenting_via_nested_attributes is true' do
-          config_override :allow_reparenting_via_nested_attributes, true
-
-          it 'sets the nested attributes' do
-            expect(person.preferences.map(&:name)).to eq([ preference.name ])
-          end
-
-          it 'updates attributes of existing document which is added to relation' do
-            preference_name = 'updated preference'
-            person = Person.new(
-              preferences_attributes: { 0 => { id: preference.id, name: preference_name } }
-            )
-            expect(person.preferences.map(&:name)).to eq([ preference_name ])
-          end
-        end
-      end
-
-      context 'when referencing an existing document in a relation' do
-        let(:preference) { Preference.create!(name: 'sample preference') }
-        let(:person) do
-          Person.create(preferences: [ preference ]).tap do |person|
-            person.preferences_attributes = { 0 => { id: preference.id, name: 'updated name' } }
-          end
-        end
-
-        it 'updates attributes of existing document' do
-          expect(person.preferences.map(&:name)).to eq([ 'updated name' ])
+        it 'updates attributes of existing document which is added to relation' do
+          preference_name = 'updated preference'
+          person = Person.new(
+            preferences_attributes: { 0 => { id: preference.id, name: preference_name } }
+          )
+          expect(person.preferences.map(&:name)).to eq([ preference_name ])
         end
       end
     end
@@ -3431,7 +3431,7 @@ describe Mongoid::Attributes::Nested do
                   person.preferences_attributes =
                     { 'foo' => { 'id' => 'test', 'name' => 'Test' } }
                 end.to raise_error(Mongoid::Errors::DocumentNotFound,
-                                   /Document not found for class Preference/)
+                                   /Document\(s\) not found for class Preference/)
               end
             end
           end


### PR DESCRIPTION
## Summary

Add `Mongoid::Config.allow_reparenting_via_nested_attributes`, defaulting to `false`. When false, this prevents dependent has_many records from being reparented via use of nested attributes. When true, records may be reparented via nested attributes.

This setting will be removed in Mongoid 10, and reparenting  via nested attributes will not be allowed.