### PR TITLE
MONGOID-5867 Merge touch updates into embedded document insert

### DIFF
--- a/lib/mongoid/persistable/creatable.rb
+++ b/lib/mongoid/persistable/creatable.rb
@@ -41,6 +41,12 @@ module Mongoid
 
       # Insert the embedded document.
       #
+      # When the parent association is touchable (which is the default for
+      # +embedded_in+), the touch timestamp updates are merged into the
+      # same +update_one+ call that performs the insert. This avoids a
+      # second round-trip that the +after_save+ touch callback would
+      # otherwise issue.
+      #
       # @api private
       #
       # @example Insert the document as embedded.
@@ -54,8 +60,18 @@ module Mongoid
           _parent.insert
         else
           selector = _parent.atomic_selector
+          operations = atomic_inserts
+
+          if _touchable_parent?
+            touches = _parent._gather_touch_updates(Time.current)
+            if touches.present?
+              operations['$set'] = touches
+              Threaded.begin_touch_merged(self)
+            end
+          end
+
           _root.collection.find(selector).update_one(
-            positionally(selector, atomic_inserts),
+            positionally(selector, operations),
             session: _session
           )
         end

--- a/lib/mongoid/threaded.rb
+++ b/lib/mongoid/threaded.rb
@@ -22,6 +22,8 @@ module Mongoid
 
     VALIDATIONS_KEY = 'validations'
 
+    TOUCH_MERGED_KEY = 'touch-merged'
+
     STACK_KEYS = Hash.new do |hash, key|
       hash[key] = "#{key}-stack"
     end
@@ -202,6 +204,17 @@ module Mongoid
       validations_for(document.class).push(document._id)
     end
 
+    # Mark that a document's touch updates have been merged into
+    # an atomic insert on the current thread.
+    #
+    # @example Begin touch merged.
+    #   Threaded.begin_touch_merged(doc)
+    #
+    # @param [ Document ] document The embedded document being inserted.
+    def begin_touch_merged(document)
+      touch_merged_for(document.class).push(document._id)
+    end
+
     # Exit autosaving a document on the current thread.
     #
     # @example Exit autosave.
@@ -220,6 +233,16 @@ module Mongoid
     # @param [ Document ] document The document to validate.
     def exit_validate(document)
       validations_for(document.class).delete_one(document._id)
+    end
+
+    # Clear the touch-merged flag for a document on the current thread.
+    #
+    # @example Exit touch merged.
+    #   Threaded.exit_touch_merged(doc)
+    #
+    # @param [ Document ] document The document to clear.
+    def exit_touch_merged(document)
+      touch_merged_for(document.class).delete_one(document._id)
     end
 
     # Begin suppressing default scopes for given model on the current thread.
@@ -353,6 +376,19 @@ module Mongoid
       validations_for(document.class).include?(document._id)
     end
 
+    # Is the document flagged as having had its touch updates
+    # merged into an atomic insert?
+    #
+    # @example Is the document touch-merged?
+    #   Threaded.touch_merged?(doc)
+    #
+    # @param [ Document ] document The document to check.
+    #
+    # @return [ true | false ] If the document's touch was merged.
+    def touch_merged?(document)
+      touch_merged_for(document.class).include?(document._id)
+    end
+
     # Get all autosaves on the current thread.
     #
     # @example Get all autosaves.
@@ -395,6 +431,28 @@ module Mongoid
     # @return [ Array ] The current validations.
     def validations_for(klass)
       validations[klass] ||= []
+    end
+
+    # Get all touch-merged tracking on the current thread.
+    #
+    # @example Get all touch-merged.
+    #   Threaded.touch_merged
+    #
+    # @return [ Hash ] The current touch-merged tracking hash.
+    def touch_merged
+      get(TOUCH_MERGED_KEY) { {} }
+    end
+
+    # Get all touch-merged document IDs on the current thread for the class.
+    #
+    # @example Get all touch-merged.
+    #   Threaded.touch_merged_for(Sofa)
+    #
+    # @param [ Class ] klass The class to check.
+    #
+    # @return [ Array ] The current touch-merged document IDs.
+    def touch_merged_for(klass)
+      touch_merged[klass] ||= []
     end
 
     # Cache a session for this thread for a client.

--- a/lib/mongoid/touchable.rb
+++ b/lib/mongoid/touchable.rb
@@ -211,6 +211,19 @@ module Mongoid
       association.inverse_class.class_eval do
         define_method(method_name) do
           without_autobuild do
+            # If the touch updates were already merged into an atomic
+            # insert (see Persistable::Creatable#insert_as_embedded),
+            # skip the redundant persistence but still run :touch
+            # callbacks and clean up dirty tracking.
+            if Threaded.touch_merged?(self)
+              Threaded.exit_touch_merged(self)
+              if relation = __send__(name)
+                relation._run_touch_callbacks_from_root
+                relation._clear_touch_updates(association.touch_field)
+              end
+              next
+            end
+
             if !touch_callbacks_suppressed? && relation = __send__(name)
               # This looks up touch_field at runtime, rather than at method definition time.
               # If touch_field is nil, it will only touch the default field (updated_at).

--- a/spec/mongoid/touchable_spec.rb
+++ b/spec/mongoid/touchable_spec.rb
@@ -1399,4 +1399,117 @@ describe Mongoid::Touchable do
       end
     end
   end
+
+  describe 'touch merged with embedded insert' do
+    context 'when pushing an embedded document with touch: true' do
+      let(:building) do
+        TouchableSpec::Embedded::Building.create!(title: 'Tower')
+      end
+
+      let(:floor) do
+        building.floors.create!(level: 1)
+      end
+
+      before do
+        # Ensure building and floor are persisted and timestamps are set.
+        building
+        floor
+      end
+
+      it 'issues a single update_one when pushing a child into a touchable parent' do
+        sofa = TouchableSpec::Embedded::Sofa.new
+
+        expect_query(1) do
+          floor.sofas.push(sofa)
+        end
+      end
+
+      it 'updates updated_at on the parent after push' do
+        original_floor_updated_at = floor.updated_at
+        original_building_updated_at = building.updated_at
+
+        Timecop.travel(Time.now + 10) do
+          floor.sofas.push(TouchableSpec::Embedded::Sofa.new)
+        end
+
+        building.reload
+        expect(building.updated_at).to be > original_building_updated_at
+        expect(building.floors.first.updated_at).to be > original_floor_updated_at
+      end
+
+      it 'persists the embedded document' do
+        sofa = TouchableSpec::Embedded::Sofa.new
+        floor.sofas.push(sofa)
+
+        building.reload
+        expect(building.floors.first.sofas.length).to eq(1)
+      end
+
+      it 'runs touch callbacks on the parent chain' do
+        sofa = TouchableSpec::Embedded::Sofa.new
+        floor.sofas.push(sofa)
+
+        # Verify callbacks ran by checking the in-memory timestamps
+        # were updated (touch sets updated_at in-memory via write_attribute).
+        expect(floor.updated_at).to be_within(5).of(Time.now)
+        expect(building.updated_at).to be_within(5).of(Time.now)
+      end
+    end
+
+    context 'when pushing an embedded document with touch: false' do
+      let(:building) do
+        TouchableSpec::Embedded::Building.create!(title: 'Tower')
+      end
+
+      let(:floor) do
+        building.floors.create!(level: 1)
+      end
+
+      before do
+        building
+        floor
+      end
+
+      it 'does not merge touch updates (touch: false on Chair)' do
+        original_floor_updated_at = floor.updated_at
+
+        Timecop.travel(Time.now + 10) do
+          floor.chairs.push(TouchableSpec::Embedded::Chair.new)
+        end
+
+        # Floor should not be touched because Chair has touch: false.
+        expect(floor.updated_at).to eq(original_floor_updated_at)
+      end
+    end
+
+    context 'when pushing into a non-touchable parent' do
+      let(:building) do
+        TouchableSpec::Embedded::Building.create!(title: 'Tower')
+      end
+
+      let(:entrance) do
+        building.entrances.create!(level: 0)
+      end
+
+      before do
+        building
+        entrance
+      end
+
+      it 'does not touch the building (Entrance has touch: false)' do
+        # Reload to get the MongoDB-persisted timestamp (with truncated
+        # sub-millisecond precision) so the comparison is stable.
+        building.reload
+        original_building_updated_at = building.updated_at
+
+        Timecop.travel(Time.now + 10) do
+          entrance.cameras.push(TouchableSpec::Embedded::Camera.new)
+        end
+
+        building.reload
+        # Camera touches Entrance, but Entrance does NOT touch Building.
+        expect(building.updated_at).to eq(original_building_updated_at)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

When inserting an embedded document with a touchable parent (the default for `embedded_in`), Mongoid issues two separate `update_one` calls:

1. `$push` — inserts the embedded document (`insert_as_embedded`)
2. `$set` — updates `updated_at` on the parent chain (`after_save` touch callback)

This commit merges both into a single `update_one`, eliminating the redundant round-trip.

- `insert_as_embedded` gathers touch updates via `_gather_touch_updates` and merges the `$set` into the same operation as the `$push`
- The `after_save` touch callback checks a `Threaded` flag and skips the now-redundant persistence, while still running `:touch` callbacks and cleaning up dirty tracking
- The `Threaded` flag follows the existing `begin_autosave`/`exit_autosave`/`autosaved?` pattern

## Relationship to positionally()

[Jamis noted in MONGOID-5867](https://jira.mongodb.org/browse/MONGOID-5867?focusedId=8027497#comment-8027497) that consolidating the parent touch with the insert is tricky because of the `positionally` utility method, which replaces explicit array indexes with the `$` positional update operator.

This implementation avoids that concern: the merged `$set` touch paths are included in the same `operations` hash that `positionally` already processes for the `$push`. Both operators get consistent index-to-`$` replacement in the same call. For example, with `Building > floors[0] > sofas`:

```ruby
# Before positionally:
{ "$push" => { "floors.0.sofas" => doc },
  "$set"  => { "floors.0.updated_at" => time, "updated_at" => time } }

# After positionally (selector includes floors._id):
{ "$push" => { "floors.$.sofas" => doc },
  "$set"  => { "floors.$.updated_at" => time, "updated_at" => time } }
```

No new race conditions are introduced — the stale-index concern is mitigated by the existing `positionally` mechanism identically for both operators.

## Test plan

- [x] Single `update_one` when pushing into a touchable parent (`expect_query(1)`)
- [x] `updated_at` propagated to all ancestors after reload
- [x] Embedded document is persisted correctly
- [x] Touch callbacks still fire on the parent chain
- [x] No behavior change with `touch: false`
- [x] Full `touchable_spec.rb` suite passes (240 examples, 0 failures)
- [x] Rubocop clean