### PR TITLE
MONGOID-5898 Add vector search support

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -940,5 +940,6 @@ buildvariants:
     auth: auth
     ssl: yes
   display_name: "Atlas (Full)"
+  tags: ["pr"]
   tasks:
     - name: testatlas_task_group

--- a/.evergreen/config/variants.yml.erb
+++ b/.evergreen/config/variants.yml.erb
@@ -291,5 +291,6 @@ buildvariants:
     auth: auth
     ssl: yes
   display_name: "Atlas (Full)"
+  tags: ["pr"]
   tasks:
     - name: testatlas_task_group

--- a/lib/mongoid/fields.rb
+++ b/lib/mongoid/fields.rb
@@ -460,6 +460,50 @@ module Mongoid
         Fields.database_field_name(name, relations, aliased_fields, aliased_associations)
       end
 
+      # Declares a vector embedding field and registers a corresponding Atlas
+      # Vector Search index for it in one step.
+      #
+      # The field is stored as an Array. For advanced index options
+      # (quantization, indexing method, HNSW tuning) use the explicit
+      # +field+ + +vector_search_index+ combination instead.
+      #
+      # @example Minimal declaration.
+      #   class Article
+      #     include Mongoid::Document
+      #     vector_field :embedding, dimensions: 1536
+      #   end
+      #
+      # @example With all options.
+      #   class Article
+      #     include Mongoid::Document
+      #     vector_field :embedding, dimensions: 1536,
+      #                              similarity: 'dotProduct',
+      #                              index: :article_vectors
+      #   end
+      #
+      # @param [ Symbol | String ] name The name of the embedding field.
+      # @param [ Integer ] dimensions The number of vector dimensions. Required.
+      # @param [ String ] similarity The similarity metric to use: 'cosine'
+      #   (default), 'euclidean', or 'dotProduct'.
+      # @param [ Symbol | String | nil ] index The name for the vector search
+      #   index. If omitted the index is unnamed and Atlas calls it 'default'.
+      def vector_field(name, dimensions:, similarity: 'cosine', index: nil)
+        field(name, type: Array)
+
+        field_spec = {
+          type: 'vector',
+          path: name.to_s,
+          numDimensions: dimensions,
+          similarity: similarity
+        }
+
+        if index
+          vector_search_index(index, fields: [ field_spec ])
+        else
+          vector_search_index(fields: [ field_spec ])
+        end
+      end
+
       # Defines all the fields that are accessible on the Document
       # For each field that is defined, a getter and setter will be
       # added as an instance method to the Document.

--- a/lib/mongoid/search_indexable.rb
+++ b/lib/mongoid/search_indexable.rb
@@ -55,6 +55,50 @@ module Mongoid
       self.search_index_specs = []
     end
 
+    # Performs a vector search for documents similar to this one, using
+    # this document's stored embedding as the query vector. The document
+    # itself is excluded from the results.
+    #
+    # @example Find articles similar to this one.
+    #   article.vector_search(limit: 5, filter: { status: 'published' })
+    #
+    # @param [ String | Symbol | nil ] index The name of the vector search
+    #   index to use (optional if only one is declared on the model).
+    # @param [ String | Symbol | nil ] path The field containing the stored
+    #   vector (optional if unambiguous from the index definition).
+    # @param [ Integer ] limit The maximum number of results (default: 10).
+    # @param [ Integer | nil ] num_candidates The number of candidates to
+    #   consider during the ANN search; defaults to limit * 10.
+    # @param [ Hash | nil ] filter An optional MongoDB filter to pre-filter
+    #   candidates before scoring.
+    # @param [ Array ] pipeline Additional aggregation stages to append after
+    #   the vector search and score projection.
+    #
+    # @return [ Array<Mongoid::Document> ] matching documents, each with
+    #   a populated +vector_search_score+ attribute.
+    def vector_search(index: nil, path: nil, limit: 10, num_candidates: nil, filter: nil, pipeline: [])
+      _index, resolved_path = self.class.send(:resolve_vector_index, index, path)
+      query_vector = public_send(resolved_path)
+
+      if query_vector.nil?
+        raise ArgumentError,
+              "#{resolved_path} is nil on this document; cannot perform vector search"
+      end
+
+      self_filter = { '_id' => { '$ne' => _id } }
+      combined_filter = filter ? { '$and' => [ self_filter, filter ] } : self_filter
+
+      self.class.vector_search(
+        query_vector,
+        index: index,
+        path: path,
+        limit: limit,
+        num_candidates: num_candidates,
+        filter: combined_filter,
+        pipeline: pipeline
+      )
+    end
+
     # Implementations for the feature's class-level methods.
     module ClassMethods
       # Request the creation of all registered search indices. Note
@@ -152,6 +196,82 @@ module Mongoid
         search_index_specs.push(spec)
       end
 
+      # Adds a vector search index definition. Also defines a read-only
+      # +vector_search_score+ field on the model the first time it is called,
+      # which is populated on documents returned by +vector_search+.
+      #
+      # @example Create a vector search index.
+      #   class Person
+      #     include Mongoid::Document
+      #     vector_search_index({ fields: [...] })
+      #     vector_search_index :my_vector_index, { fields: [...] }
+      #   end
+      #
+      # @param [ Symbol | String | Hash ] name_or_defn Either the name of the index to
+      #    define, or the index definition.
+      # @param [ Hash ] defn The vector search index definition.
+      def vector_search_index(name_or_defn, defn = nil)
+        name = name_or_defn
+        name, defn = nil, name if name.is_a?(Hash)
+
+        spec = { type: 'vectorSearch', definition: defn }.tap { |s| s[:name] = name.to_s if name }
+        search_index_specs.push(spec)
+
+        return if fields.key?('vector_search_score')
+
+        field :vector_search_score, type: Float
+        attr_readonly :vector_search_score
+      end
+
+      # Performs an Atlas Vector Search query and returns matching documents.
+      # Each returned document has a +vector_search_score+ attribute populated
+      # with its relevance score.
+      #
+      # The vector field (given by +path:+) is excluded from the returned
+      # documents by default, as vectors are large and rarely useful after
+      # retrieval.
+      #
+      # @example Search by an explicit query vector.
+      #   Article.vector_search(embedding, limit: 5, filter: { status: 'published' })
+      #
+      # @param [ Array<Numeric> ] vector The query vector.
+      # @param [ String | Symbol | nil ] index The name of the vector search
+      #   index to use (optional if only one is declared on the model).
+      # @param [ String | Symbol | nil ] path The field containing the stored
+      #   vector (optional if unambiguous from the index definition).
+      # @param [ Integer ] limit The maximum number of results (default: 10).
+      # @param [ Integer | nil ] num_candidates The number of candidates to
+      #   consider during the ANN search; defaults to limit * 10.
+      # @param [ Hash | nil ] filter An optional MongoDB filter to pre-filter
+      #   candidates before scoring.
+      # @param [ Array ] pipeline Additional aggregation stages to append after
+      #   the vector search and score projection.
+      #
+      # @return [ Array<Mongoid::Document> ] matching documents, each with
+      #   a populated +vector_search_score+ attribute.
+      def vector_search(vector, index: nil, path: nil, limit: 10, num_candidates: nil, filter: nil, pipeline: []) # rubocop:disable Metrics/ParameterLists
+        resolved_index, resolved_path = resolve_vector_index(index, path)
+        num_candidates ||= limit * 10
+
+        vs_options = {
+          'index' => resolved_index,
+          'path' => resolved_path,
+          'queryVector' => vector,
+          'numCandidates' => num_candidates,
+          'limit' => limit
+        }
+        vs_options['filter'] = filter if filter
+
+        agg_pipeline = [
+          { '$vectorSearch' => vs_options },
+          { '$addFields'    => { 'vector_search_score' => { '$meta' => 'vectorSearchScore' } } },
+          { '$project'      => { resolved_path => 0 } }
+        ]
+        agg_pipeline.concat(Array(pipeline))
+
+        collection.aggregate(agg_pipeline).map { |doc| instantiate(doc) }
+      end
+
       private
 
       # Retrieves the index records for the indexes with the given names.
@@ -161,6 +281,54 @@ module Mongoid
       # @return [ Array<Hash> ] the raw index documents
       def get_indexes(names)
         collection.search_indexes.select { |i| names.include?(i['name']) }
+      end
+
+      # Resolves the index name and vector path from the declared specs,
+      # applying inference when either is omitted.
+      #
+      # @param [ String | Symbol | nil ] index The requested index name.
+      # @param [ String | Symbol | nil ] path The requested field path.
+      #
+      # @return [ Array<String> ] the resolved [ index_name, field_path ] pair.
+      def resolve_vector_index(index, path)
+        vector_specs = search_index_specs.select { |s| s[:type] == 'vectorSearch' }
+
+        raise ArgumentError, "No vector search indexes declared on #{name}" if vector_specs.empty?
+
+        spec = if index
+                 found = vector_specs.find { |s| s[:name] == index.to_s }
+                 raise ArgumentError, "No vector search index '#{index}' declared on #{name}" unless found
+
+                 found
+               elsif vector_specs.size == 1
+                 vector_specs.first
+               else
+                 raise ArgumentError,
+                       "#{name} has multiple vector search indexes; specify index: to select one"
+               end
+
+        resolved_index = spec[:name] || 'default'
+        resolved_path  = path ? path.to_s : infer_vector_path(spec)
+
+        [ resolved_index, resolved_path ]
+      end
+
+      # Infers the vector field path from the index definition by locating
+      # the first field declared with type 'vector'.
+      #
+      # @param [ Hash ] spec The vector search index spec.
+      #
+      # @return [ String ] the field path.
+      def infer_vector_path(spec)
+        field_list = spec.dig(:definition, :fields) || spec.dig(:definition, 'fields') || []
+        vector_field = field_list.find { |f| (f[:type] || f['type']) == 'vector' }
+
+        unless vector_field
+          raise ArgumentError,
+                "Cannot infer vector path on #{name}: no 'vector' type field in index definition; specify path:"
+        end
+
+        (vector_field[:path] || vector_field['path']).to_s
       end
     end
   end

--- a/spec/mongoid/fields_spec.rb
+++ b/spec/mongoid/fields_spec.rb
@@ -2045,4 +2045,82 @@ describe Mongoid::Fields do
       end
     end
   end
+
+  describe '.vector_field' do
+    let(:model) do
+      Class.new do
+        include Mongoid::Document
+
+        store_in collection: BSON::ObjectId.new.to_s
+        vector_field :embedding, dimensions: 1536
+      end
+    end
+
+    it 'defines an Array field with the given name' do
+      expect(model.fields['embedding'].type).to eq(Array)
+    end
+
+    it 'adds a vector search index spec' do
+      expect(model.search_index_specs).to eq [
+        {
+          type: 'vectorSearch',
+          definition: {
+            fields: [ {
+              type: 'vector',
+              path: 'embedding',
+              numDimensions: 1536,
+              similarity: 'cosine'
+            } ]
+          }
+        }
+      ]
+    end
+
+    it 'adds a vector_search_score field' do
+      expect(model.fields).to have_key('vector_search_score')
+    end
+
+    context 'with a custom similarity' do
+      let(:model) do
+        Class.new do
+          include Mongoid::Document
+
+          store_in collection: BSON::ObjectId.new.to_s
+          vector_field :embedding, dimensions: 768, similarity: 'dotProduct'
+        end
+      end
+
+      it 'uses the given similarity in the index spec' do
+        field_spec = model.search_index_specs.first.dig(:definition, :fields).first
+        expect(field_spec[:similarity]).to eq('dotProduct')
+      end
+    end
+
+    context 'with an explicit index name' do
+      let(:model) do
+        Class.new do
+          include Mongoid::Document
+
+          store_in collection: BSON::ObjectId.new.to_s
+          vector_field :embedding, dimensions: 1536, index: :article_vectors
+        end
+      end
+
+      it 'names the index spec accordingly' do
+        expect(model.search_index_specs.first[:name]).to eq('article_vectors')
+      end
+    end
+
+    context 'when dimensions is omitted' do
+      it 'raises ArgumentError' do
+        expect do
+          Class.new do
+            include Mongoid::Document
+
+            vector_field :embedding
+          end
+        end.to raise_error(ArgumentError, /dimensions/)
+      end
+    end
+  end
 end

--- a/spec/mongoid/search_indexable_spec.rb
+++ b/spec/mongoid/search_indexable_spec.rb
@@ -62,24 +62,29 @@ class SearchIndexHelper
 end
 
 describe Mongoid::SearchIndexable do
-  before do
-    skip "#{described_class} requires at Atlas environment (set ATLAS_URI)" if ENV['ATLAS_URI'].nil?
-  end
-
-  let(:model) do
-    Class.new do
-      include Mongoid::Document
-
-      store_in collection: BSON::ObjectId.new.to_s
-
-      search_index mappings: { dynamic: false }
-      search_index :with_dynamic_mappings, mappings: { dynamic: true }
-    end
-  end
-
-  let(:helper) { SearchIndexHelper.new(model) }
+  # Unit tests — no Atlas connection required.
 
   describe '.search_index_specs' do
+    let(:model) do
+      Class.new do
+        include Mongoid::Document
+
+        store_in collection: BSON::ObjectId.new.to_s
+        search_index mappings: { dynamic: false }
+        search_index :with_dynamic_mappings, mappings: { dynamic: true }
+      end
+    end
+
+    let(:vector_model) do
+      Class.new do
+        include Mongoid::Document
+
+        store_in collection: BSON::ObjectId.new.to_s
+        vector_search_index fields: [ { type: 'vector', path: 'embedding', numDimensions: 1536, similarity: 'cosine' } ]
+        vector_search_index :named_vector_index, fields: [ { type: 'vector', path: 'other', numDimensions: 768, similarity: 'euclidean' } ]
+      end
+    end
+
     context 'when no search indexes have been defined' do
       it 'has no search index specs' do
         expect(Person.search_index_specs).to be_empty
@@ -94,52 +99,247 @@ describe Mongoid::SearchIndexable do
         ]
       end
     end
+
+    context 'when vector search indexes have been defined' do
+      it 'has search index specs with vectorSearch type' do
+        expect(vector_model.search_index_specs).to eq [
+          { type: 'vectorSearch', definition: { fields: [ { type: 'vector', path: 'embedding', numDimensions: 1536, similarity: 'cosine' } ] } },
+          { type: 'vectorSearch', name: 'named_vector_index', definition: { fields: [ { type: 'vector', path: 'other', numDimensions: 768, similarity: 'euclidean' } ] } }
+        ]
+      end
+    end
   end
 
-  context 'when needing to first create search indexes' do
-    let(:requested_definitions) { model.search_index_specs.map { |spec| spec[:definition].with_indifferent_access } }
-    let(:index_names) { model.create_search_indexes }
-    let(:actual_indexes) { helper.wait_for(*index_names) }
-    let(:actual_definitions) { actual_indexes.map { |i| i['latestDefinition'] } }
+  describe '.vector_search_index' do
+    let(:vector_model) do
+      Class.new do
+        include Mongoid::Document
 
-    describe '.create_search_indexes' do
-      it 'creates the indexes' do
-        expect(actual_definitions).to eq requested_definitions
+        store_in collection: BSON::ObjectId.new.to_s
+        field :embedding, type: Array
+        vector_search_index fields: [ { type: 'vector', path: 'embedding', numDimensions: 3, similarity: 'cosine' } ]
       end
     end
 
-    describe '.search_indexes' do
-      before { actual_indexes } # wait for the indices to be created
+    it 'adds a vector_search_score field to the model' do
+      expect(vector_model.fields).to have_key('vector_search_score')
+    end
 
-      let(:queried_definitions) { model.search_indexes.map { |i| i['latestDefinition'] } }
+    it 'marks vector_search_score as readonly' do
+      expect(vector_model.readonly_attributes).to include('vector_search_score')
+    end
 
-      it 'queries the available search indexes' do
-        expect(queried_definitions).to eq requested_definitions
+    it 'defines vector_search_score only once across multiple declarations' do
+      model = Class.new do
+        include Mongoid::Document
+
+        store_in collection: BSON::ObjectId.new.to_s
+        vector_search_index :idx1, fields: [ { type: 'vector', path: 'a', numDimensions: 3, similarity: 'cosine' } ]
+        vector_search_index :idx2, fields: [ { type: 'vector', path: 'b', numDimensions: 3, similarity: 'cosine' } ]
+      end
+      expect(model.fields.count { |k, _| k == 'vector_search_score' }).to eq 1
+    end
+
+    context 'when only a regular search_index is declared' do
+      it 'does not add vector_search_score' do
+        model = Class.new do
+          include Mongoid::Document
+
+          store_in collection: BSON::ObjectId.new.to_s
+          search_index mappings: { dynamic: true }
+        end
+        expect(model.fields).not_to have_key('vector_search_score')
+      end
+    end
+  end
+
+  describe '.vector_search argument validation' do
+    let(:no_index_model) do
+      Class.new do
+        include Mongoid::Document
+
+        store_in collection: BSON::ObjectId.new.to_s
       end
     end
 
-    describe '.remove_search_index' do
-      let(:target_index) { actual_indexes.first }
+    let(:multi_index_model) do
+      Class.new do
+        include Mongoid::Document
+
+        store_in collection: BSON::ObjectId.new.to_s
+        vector_search_index :idx1, fields: [ { type: 'vector', path: 'a', numDimensions: 3, similarity: 'cosine' } ]
+        vector_search_index :idx2, fields: [ { type: 'vector', path: 'b', numDimensions: 3, similarity: 'cosine' } ]
+      end
+    end
+
+    let(:single_index_model) do
+      Class.new do
+        include Mongoid::Document
+
+        store_in collection: BSON::ObjectId.new.to_s
+        field :embedding, type: Array
+        vector_search_index fields: [ { type: 'vector', path: 'embedding', numDimensions: 3, similarity: 'cosine' } ]
+      end
+    end
+
+    it 'raises ArgumentError when no vector search indexes are declared' do
+      expect { no_index_model.vector_search([ 0.1, 0.2, 0.3 ]) }
+        .to raise_error(ArgumentError, /No vector search indexes declared/)
+    end
+
+    it 'raises ArgumentError when multiple indexes exist and none is specified' do
+      expect { multi_index_model.vector_search([ 0.1, 0.2, 0.3 ]) }
+        .to raise_error(ArgumentError, /multiple vector search indexes/)
+    end
+
+    it 'raises ArgumentError when the specified index name does not exist' do
+      expect { single_index_model.vector_search([ 0.1, 0.2, 0.3 ], index: 'nonexistent') }
+        .to raise_error(ArgumentError, /No vector search index 'nonexistent'/)
+    end
+  end
+
+  describe '#vector_search argument validation' do
+    let(:model) do
+      Class.new do
+        include Mongoid::Document
+
+        store_in collection: BSON::ObjectId.new.to_s
+        field :embedding, type: Array
+        vector_search_index fields: [ { type: 'vector', path: 'embedding', numDimensions: 3, similarity: 'cosine' } ]
+      end
+    end
+
+    it 'raises ArgumentError when the vector field is nil' do
+      doc = model.new(embedding: nil)
+      expect { doc.vector_search }.to raise_error(ArgumentError, /embedding is nil/)
+    end
+  end
+
+  # Atlas integration tests — skipped when ATLAS_URI is not set.
+
+  context 'Atlas integration' do
+    before do
+      skip "#{described_class} requires an Atlas environment (set ATLAS_URI)" if ENV['ATLAS_URI'].nil?
+    end
+
+    let(:model) do
+      Class.new do
+        include Mongoid::Document
+
+        store_in collection: BSON::ObjectId.new.to_s
+        search_index mappings: { dynamic: false }
+        search_index :with_dynamic_mappings, mappings: { dynamic: true }
+      end
+    end
+
+    let(:helper) { SearchIndexHelper.new(model) }
+
+    context 'when needing to first create search indexes' do
+      let(:requested_definitions) { model.search_index_specs.map { |spec| spec[:definition].with_indifferent_access } }
+      let(:index_names) { model.create_search_indexes }
+      let(:actual_indexes) { helper.wait_for(*index_names) }
+      let(:actual_definitions) { actual_indexes.map { |i| i['latestDefinition'] } }
+
+      describe '.create_search_indexes' do
+        it 'creates the indexes' do
+          expect(actual_definitions).to eq requested_definitions
+        end
+      end
+
+      describe '.search_indexes' do
+        before { actual_indexes } # wait for the indices to be created
+
+        let(:queried_definitions) { model.search_indexes.map { |i| i['latestDefinition'] } }
+
+        it 'queries the available search indexes' do
+          expect(queried_definitions).to eq requested_definitions
+        end
+      end
+
+      describe '.remove_search_index' do
+        let(:target_index) { actual_indexes.first }
+
+        before do
+          model.remove_search_index id: target_index['id']
+          helper.wait_for_absence_of target_index['name']
+        end
+
+        it 'removes the requested index' do
+          expect(model.search_indexes(id: target_index['id'])).to be_empty
+        end
+      end
+
+      describe '.remove_search_indexes' do
+        before do
+          actual_indexes # wait for the indexes to be created
+          model.remove_search_indexes
+          helper.wait_for_absence_of(actual_indexes.map { |i| i['name'] })
+        end
+
+        it 'removes the indexes' do
+          expect(model.search_indexes).to be_empty
+        end
+      end
+    end
+
+    context 'with a vector search index' do
+      let(:vector_model) do
+        Class.new do
+          include Mongoid::Document
+
+          store_in collection: BSON::ObjectId.new.to_s
+          field :embedding, type: Array
+          vector_search_index fields: [ { type: 'vector', path: 'embedding', numDimensions: 3, similarity: 'cosine' } ]
+        end
+      end
+
+      let(:vector_helper) { SearchIndexHelper.new(vector_model) }
+
+      # Three orthogonal unit vectors as a minimal, predictable dataset.
+      let!(:doc_a) { vector_model.create!(embedding: [ 1.0, 0.0, 0.0 ]) }
+      let!(:doc_b) { vector_model.create!(embedding: [ 0.0, 1.0, 0.0 ]) }
+      let!(:doc_c) { vector_model.create!(embedding: [ 0.0, 0.0, 1.0 ]) }
 
       before do
-        model.remove_search_index id: target_index['id']
-        helper.wait_for_absence_of target_index['name']
+        names = vector_model.create_search_indexes
+        vector_helper.wait_for(*names)
       end
 
-      it 'removes the requested index' do
-        expect(model.search_indexes(id: target_index['id'])).to be_empty
-      end
-    end
+      describe '.vector_search' do
+        let(:results) { vector_model.vector_search([ 1.0, 0.0, 0.0 ], limit: 3) }
 
-    describe '.remove_search_indexes' do
-      before do
-        actual_indexes # wait for the indexes to be created
-        model.remove_search_indexes
-        helper.wait_for_absence_of(actual_indexes.map { |i| i['name'] })
+        it 'returns Mongoid document instances' do
+          expect(results).to all(be_a(vector_model))
+        end
+
+        it 'populates vector_search_score on each result' do
+          expect(results.map(&:vector_search_score)).to all(be_a(Float))
+        end
+
+        it 'excludes the vector field from results' do
+          expect(results.map(&:embedding)).to all(be_nil)
+        end
+
+        it 'orders results by descending score' do
+          scores = results.map(&:vector_search_score)
+          expect(scores).to eq(scores.sort.reverse)
+        end
       end
 
-      it 'removes the indexes' do
-        expect(model.search_indexes).to be_empty
+      describe '#vector_search' do
+        let(:results) { doc_a.vector_search(limit: 3) }
+
+        it 'returns Mongoid document instances' do
+          expect(results).to all(be_a(vector_model))
+        end
+
+        it 'populates vector_search_score on each result' do
+          expect(results.map(&:vector_search_score)).to all(be_a(Float))
+        end
+
+        it 'excludes the source document from results' do
+          expect(results.map(&:id)).not_to include(doc_a.id)
+        end
       end
     end
   end


### PR DESCRIPTION
## Summary

Mongoid can now define [vector search indexes](https://www.mongodb.com/docs/atlas/atlas-vector-search/vector-search-overview/?deployment-type=atlas&embedding=byo&interface=driver), and provides a helper interface for querying documents by their semantic meaning using those indexed vector fields.

The simplest interface will define an `Array` field, and a corresponding vector search index:

```ruby
class Article
  include Mongoid::Document
  
  # Define `embedding` as an Array field, and define a vector search index on it
  # with `dimensions` set to 1536.
  vector_field :embedding, dimensions: 1536
end
```

For more sophisticated configurations, you may also declare the field and the index separately:

```ruby
class Article
  include Mongoid::Document

  field :embedding, type: Array
  vector_search_index :embedding_index,
    fields: [
      { type: 'vector',
        path: 'embedding',
        dimensions: 1536,
        ...
      }
    ]
end
```

Then, create the new search indexes:

```bash
$ rake db:mongoid:create_search_indexes
```

Once the indexes are created, you can query them using the `vector_search` method:

```ruby
articles = Article.vector_search(vector, limit: 5)

# or, search for documents that are similar to an existing document
neighbors = article.vector_search(limit: 5)
```