### PR TITLE
MONGOID-5923 Support auto emdedding vector search indexes and searches

### DIFF
--- a/lib/mongoid/fields.rb
+++ b/lib/mongoid/fields.rb
@@ -504,26 +504,20 @@ module Mongoid
         end
       end
 
-      # Registers an Atlas Vector Search index for the named text field using
-      # the auto-embedding (autoEmbed) type. Atlas generates the embeddings
-      # automatically at index and query time; no pre-computed vectors are
-      # required.
-      #
-      # The named field must already be declared on the model (or be an
-      # existing document attribute). This method only registers the search
-      # index; it does not create or modify the Ruby field definition.
+      # Declares a text field and registers a corresponding Atlas Vector Search
+      # index for it using the auto-embedding (autoEmbed) type. Atlas generates
+      # the embeddings automatically at index and query time; no pre-computed
+      # vectors are required.
       #
       # @example Minimal declaration.
       #   class Article
       #     include Mongoid::Document
-      #     field :description, type: String
-      #     auto_embed_field :description, model: 'voyage-4'
+      #     auto_embed_field :description
       #   end
       #
       # @example With all options.
       #   class Article
       #     include Mongoid::Document
-      #     field :description, type: String
       #     auto_embed_field :description,
       #                      model: 'voyage-4',
       #                      num_dimensions: 512,
@@ -532,7 +526,8 @@ module Mongoid
       #                      index: :article_embed
       #   end
       #
-      # @param [ Symbol | String ] name The text field to auto-embed.
+      # @param [ Symbol | String ] name The name of the text field to declare
+      #   and auto-embed.
       # @param [ String ] model The embedding model name. Defaults to 'voyage-4'
       #   (recommended). Supported values at Public Preview: voyage-4-large,
       #   voyage-4, voyage-4-lite, voyage-code-3.
@@ -545,6 +540,8 @@ module Mongoid
       # @param [ Symbol | String | nil ] index The index name. If omitted the
       #   index is unnamed and Atlas calls it 'default'.
       def auto_embed_field(name, model: 'voyage-4', num_dimensions: nil, quantization: nil, similarity: nil, index: nil)
+        field(name, type: String)
+
         field_spec = {
           type: 'autoEmbed',
           modality: 'text',

--- a/lib/mongoid/fields.rb
+++ b/lib/mongoid/fields.rb
@@ -504,6 +504,64 @@ module Mongoid
         end
       end
 
+      # Registers an Atlas Vector Search index for the named text field using
+      # the auto-embedding (autoEmbed) type. Atlas generates the embeddings
+      # automatically at index and query time; no pre-computed vectors are
+      # required.
+      #
+      # The named field must already be declared on the model (or be an
+      # existing document attribute). This method only registers the search
+      # index; it does not create or modify the Ruby field definition.
+      #
+      # @example Minimal declaration.
+      #   class Article
+      #     include Mongoid::Document
+      #     field :description, type: String
+      #     auto_embed_field :description, model: 'voyage-4'
+      #   end
+      #
+      # @example With all options.
+      #   class Article
+      #     include Mongoid::Document
+      #     field :description, type: String
+      #     auto_embed_field :description,
+      #                      model: 'voyage-4',
+      #                      num_dimensions: 512,
+      #                      quantization: 'binary',
+      #                      similarity: 'cosine',
+      #                      index: :article_embed
+      #   end
+      #
+      # @param [ Symbol | String ] name The text field to auto-embed.
+      # @param [ String ] model The embedding model name. Defaults to 'voyage-4'
+      #   (recommended). Supported values at Public Preview: voyage-4-large,
+      #   voyage-4, voyage-4-lite, voyage-code-3.
+      # @param [ Integer | nil ] num_dimensions Number of vector dimensions.
+      #   Supported values: 256, 512, 1024, 2048. Default: 1024.
+      # @param [ String | nil ] quantization Quantization type: float, scalar,
+      #   binary, or binaryNoRescore. Default: scalar.
+      # @param [ String | nil ] similarity Similarity function: dotProduct,
+      #   cosine, or euclidean.
+      # @param [ Symbol | String | nil ] index The index name. If omitted the
+      #   index is unnamed and Atlas calls it 'default'.
+      def auto_embed_field(name, model: 'voyage-4', num_dimensions: nil, quantization: nil, similarity: nil, index: nil)
+        field_spec = {
+          type: 'autoEmbed',
+          modality: 'text',
+          path: name.to_s,
+          model: model
+        }
+        field_spec[:numDimensions] = num_dimensions if num_dimensions
+        field_spec[:quantization]  = quantization  if quantization
+        field_spec[:similarity]    = similarity    if similarity
+
+        if index
+          vector_search_index(index, fields: [ field_spec ])
+        else
+          vector_search_index(fields: [ field_spec ])
+        end
+      end
+
       # Defines all the fields that are accessible on the Document
       # For each field that is defined, a getter and setter will be
       # added as an instance method to the Document.

--- a/lib/mongoid/search_indexable.rb
+++ b/lib/mongoid/search_indexable.rb
@@ -99,6 +99,52 @@ module Mongoid
       )
     end
 
+    # Performs an Atlas Vector Search query for documents with text similar
+    # to this document's stored text field, using auto-embedding. The current
+    # document is excluded from the results.
+    #
+    # @example Find articles with similar descriptions.
+    #   article.auto_embed_search(limit: 5, filter: { status: 'published' })
+    #
+    # @param [ String | Symbol | nil ] index The name of the auto-embed index
+    #   to use (optional when only one is declared on the model).
+    # @param [ String | Symbol | nil ] path The indexed text field path
+    #   (optional if unambiguous from the index definition).
+    # @param [ Integer ] limit Maximum number of results (default: 10).
+    # @param [ Integer | nil ] num_candidates Candidates for ANN search;
+    #   defaults to limit * 10. Ignored when exact: true.
+    # @param [ Hash | nil ] filter Optional MongoDB filter for pre-filtering.
+    # @param [ true | false ] exact Use exact nearest-neighbor search (default: false).
+    # @param [ String | nil ] model Query-time embedding model override.
+    # @param [ Array ] pipeline Additional aggregation stages to append.
+    #
+    # @return [ Array<Mongoid::Document> ] matching documents, each with
+    #   a populated +vector_search_score+ attribute.
+    def auto_embed_search(index: nil, path: nil, limit: 10, num_candidates: nil, filter: nil, exact: false, model: nil, pipeline: []) # rubocop:disable Metrics/ParameterLists
+      _index, resolved_path = self.class.send(:resolve_auto_embed_index, index, path)
+      text = public_send(resolved_path)
+
+      if text.nil?
+        raise ArgumentError,
+              "#{resolved_path} is nil on this document; cannot perform auto-embed search"
+      end
+
+      self_filter = { '_id' => { '$ne' => _id } }
+      combined_filter = filter ? { '$and' => [ self_filter, filter ] } : self_filter
+
+      self.class.auto_embed_search(
+        text,
+        index: index,
+        path: path,
+        limit: limit,
+        num_candidates: num_candidates,
+        filter: combined_filter,
+        exact: exact,
+        model: model,
+        pipeline: pipeline
+      )
+    end
+
     # Implementations for the feature's class-level methods.
     module ClassMethods
       # Request the creation of all registered search indices. Note

--- a/lib/mongoid/search_indexable.rb
+++ b/lib/mongoid/search_indexable.rb
@@ -272,6 +272,59 @@ module Mongoid
         collection.aggregate(agg_pipeline).map { |doc| instantiate(doc) }
       end
 
+      # Performs an Atlas Vector Search query using auto-embedding. Atlas
+      # generates the query vector from the supplied text at query time; no
+      # pre-computed embedding is required.
+      #
+      # Each returned document has a +vector_search_score+ attribute populated
+      # with its relevance score.
+      #
+      # @example Search by text.
+      #   Article.auto_embed_search('machine learning', limit: 5)
+      #
+      # @example Exact nearest-neighbor search (no numCandidates).
+      #   Article.auto_embed_search('deep learning', exact: true, limit: 5)
+      #
+      # @param [ String ] text The query text.
+      # @param [ String | Symbol | nil ] index The name of the auto-embed index
+      #   to use (optional when only one is declared on the model).
+      # @param [ String | Symbol | nil ] path The indexed text field path
+      #   (optional if unambiguous from the index definition).
+      # @param [ Integer ] limit Maximum number of results (default: 10).
+      # @param [ Integer | nil ] num_candidates Candidates for ANN search;
+      #   defaults to limit * 10. Ignored when exact: true.
+      # @param [ Hash | nil ] filter Optional MongoDB filter for pre-filtering.
+      # @param [ true | false ] exact Use exact nearest-neighbor (ENN) search
+      #   instead of ANN (default: false). When true, numCandidates is omitted.
+      # @param [ String | nil ] model Query-time embedding model override.
+      # @param [ Array ] pipeline Additional aggregation stages appended after
+      #   the vector search and score projection.
+      #
+      # @return [ Array<Mongoid::Document> ] matching documents, each with
+      #   a populated +vector_search_score+ attribute.
+      def auto_embed_search(text, index: nil, path: nil, limit: 10, num_candidates: nil, filter: nil, exact: false, model: nil, pipeline: []) # rubocop:disable Metrics/ParameterLists
+        resolved_index, resolved_path = resolve_auto_embed_index(index, path)
+
+        vs_options = {
+          'index' => resolved_index,
+          'path' => resolved_path,
+          'query' => { 'text' => text },
+          'limit' => limit
+        }
+        vs_options['numCandidates'] = num_candidates || (limit * 10) unless exact
+        vs_options['exact'] = true if exact
+        vs_options['filter'] = filter if filter
+        vs_options['model'] = model if model
+
+        agg_pipeline = [
+          { '$vectorSearch' => vs_options },
+          { '$addFields'    => { 'vector_search_score' => { '$meta' => 'vectorSearchScore' } } }
+        ]
+        agg_pipeline.concat(Array(pipeline))
+
+        collection.aggregate(agg_pipeline).map { |doc| instantiate(doc) }
+      end
+
       private
 
       # Retrieves the index records for the indexes with the given names.
@@ -329,6 +382,68 @@ module Mongoid
         end
 
         (vector_field[:path] || vector_field['path']).to_s
+      end
+
+      # Resolves the index name and text field path for an auto-embedding
+      # query, applying inference when either is omitted.
+      #
+      # @param [ String | Symbol | nil ] index The requested index name.
+      # @param [ String | Symbol | nil ] path The requested field path.
+      #
+      # @return [ Array<String> ] the resolved [ index_name, field_path ] pair.
+      def resolve_auto_embed_index(index, path)
+        auto_embed_specs = search_index_specs.select do |s|
+          s[:type] == 'vectorSearch' &&
+            (s.dig(:definition, :fields) || s.dig(:definition, 'fields') || [])
+              .any? { |f| (f[:type] || f['type']) == 'autoEmbed' }
+        end
+
+        raise ArgumentError, "No auto-embed indexes declared on #{name}" if auto_embed_specs.empty?
+
+        # Extracted to keep cyclomatic complexity within RuboCop's threshold.
+        spec = select_auto_embed_spec(auto_embed_specs, index)
+        resolved_index = spec[:name] || 'default'
+        resolved_path  = path ? path.to_s : infer_auto_embed_path(spec)
+
+        [ resolved_index, resolved_path ]
+      end
+
+      # Picks one spec from the list of auto-embed specs, guided by +index+.
+      #
+      # @param [ Array<Hash> ] specs The candidate auto-embed specs.
+      # @param [ String | Symbol | nil ] index The requested index name.
+      #
+      # @return [ Hash ] the selected spec.
+      def select_auto_embed_spec(specs, index)
+        if index
+          found = specs.find { |s| s[:name] == index.to_s }
+          raise ArgumentError, "No auto-embed index '#{index}' declared on #{name}" unless found
+
+          found
+        elsif specs.size == 1
+          specs.first
+        else
+          raise ArgumentError,
+                "#{name} has multiple auto-embed indexes; specify index: to select one"
+        end
+      end
+
+      # Infers the text field path from an index definition by locating
+      # the first field declared with type 'autoEmbed'.
+      #
+      # @param [ Hash ] spec The vector search index spec.
+      #
+      # @return [ String ] the field path.
+      def infer_auto_embed_path(spec)
+        field_list = spec.dig(:definition, :fields) || spec.dig(:definition, 'fields') || []
+        ae_field   = field_list.find { |f| (f[:type] || f['type']) == 'autoEmbed' }
+
+        unless ae_field
+          raise ArgumentError,
+                "Cannot infer path on #{name}: no 'autoEmbed' field in index definition; specify path:"
+        end
+
+        (ae_field[:path] || ae_field['path']).to_s
       end
     end
   end

--- a/lib/mongoid/search_indexable.rb
+++ b/lib/mongoid/search_indexable.rb
@@ -323,7 +323,8 @@ module Mongoid
       # pre-computed embedding is required.
       #
       # Each returned document has a +vector_search_score+ attribute populated
-      # with its relevance score.
+      # with its relevance score. Unlike +vector_search+, the indexed text field
+      # is retained in returned documents.
       #
       # @example Search by text.
       #   Article.auto_embed_search('machine learning', limit: 5)

--- a/spec/mongoid/fields_spec.rb
+++ b/spec/mongoid/fields_spec.rb
@@ -2123,4 +2123,115 @@ describe Mongoid::Fields do
       end
     end
   end
+
+  describe '.auto_embed_field' do
+    let(:model) do
+      Class.new do
+        include Mongoid::Document
+
+        store_in collection: BSON::ObjectId.new.to_s
+        auto_embed_field :description, model: 'voyage-4'
+      end
+    end
+
+    it 'registers a vectorSearch index spec with autoEmbed type' do
+      expect(model.search_index_specs).to eq [
+        {
+          type: 'vectorSearch',
+          definition: {
+            fields: [
+              { type: 'autoEmbed', modality: 'text', path: 'description', model: 'voyage-4' }
+            ]
+          }
+        }
+      ]
+    end
+
+    it 'adds a vector_search_score field' do
+      expect(model.fields).to have_key('vector_search_score')
+    end
+
+    it 'does not define a Ruby field for the named attribute' do
+      expect(model.fields).not_to have_key('description')
+    end
+
+    context 'with optional numDimensions' do
+      let(:model) do
+        Class.new do
+          include Mongoid::Document
+
+          store_in collection: BSON::ObjectId.new.to_s
+          auto_embed_field :description, model: 'voyage-4', num_dimensions: 512
+        end
+      end
+
+      it 'includes numDimensions in the field spec' do
+        field_spec = model.search_index_specs.first.dig(:definition, :fields).first
+        expect(field_spec[:numDimensions]).to eq 512
+      end
+    end
+
+    context 'with optional quantization' do
+      let(:model) do
+        Class.new do
+          include Mongoid::Document
+
+          store_in collection: BSON::ObjectId.new.to_s
+          auto_embed_field :description, model: 'voyage-4', quantization: 'binary'
+        end
+      end
+
+      it 'includes quantization in the field spec' do
+        field_spec = model.search_index_specs.first.dig(:definition, :fields).first
+        expect(field_spec[:quantization]).to eq 'binary'
+      end
+    end
+
+    context 'with optional similarity' do
+      let(:model) do
+        Class.new do
+          include Mongoid::Document
+
+          store_in collection: BSON::ObjectId.new.to_s
+          auto_embed_field :description, model: 'voyage-4', similarity: 'cosine'
+        end
+      end
+
+      it 'includes similarity in the field spec' do
+        field_spec = model.search_index_specs.first.dig(:definition, :fields).first
+        expect(field_spec[:similarity]).to eq 'cosine'
+      end
+    end
+
+    context 'with a named index' do
+      let(:model) do
+        Class.new do
+          include Mongoid::Document
+
+          store_in collection: BSON::ObjectId.new.to_s
+          auto_embed_field :description, model: 'voyage-4', index: :article_embed
+        end
+      end
+
+      it 'registers the index under the given name' do
+        expect(model.search_index_specs.first[:name]).to eq 'article_embed'
+      end
+    end
+
+    context 'when model: is omitted' do
+      let(:model) do
+        Class.new do
+          include Mongoid::Document
+
+          store_in collection: BSON::ObjectId.new.to_s
+          auto_embed_field :description
+        end
+      end
+
+      it 'defaults model to voyage-4' do
+        field_spec = model.search_index_specs.first.dig(:definition, :fields).first
+        expect(field_spec[:model]).to eq 'voyage-4'
+      end
+    end
+  end
 end

--- a/spec/mongoid/fields_spec.rb
+++ b/spec/mongoid/fields_spec.rb
@@ -2151,8 +2151,8 @@ describe Mongoid::Fields do
       expect(model.fields).to have_key('vector_search_score')
     end
 
-    it 'does not define a Ruby field for the named attribute' do
-      expect(model.fields).not_to have_key('description')
+    it 'defines a String field for the named attribute' do
+      expect(model.fields['description'].type).to eq String
     end
 
     context 'with optional numDimensions' do

--- a/spec/mongoid/search_indexable_spec.rb
+++ b/spec/mongoid/search_indexable_spec.rb
@@ -215,6 +215,48 @@ describe Mongoid::SearchIndexable do
     end
   end
 
+  describe '#auto_embed_search argument validation' do
+    let(:model) do
+      Class.new do
+        include Mongoid::Document
+
+        store_in collection: BSON::ObjectId.new.to_s
+        field :description, type: String
+        auto_embed_field :description, model: 'voyage-4'
+      end
+    end
+
+    it 'raises ArgumentError when the text field is nil' do
+      doc = model.new(description: nil)
+      expect { doc.auto_embed_search }.to raise_error(ArgumentError, /description is nil/)
+    end
+
+    it 'raises ArgumentError when no auto-embed indexes are declared on the model' do
+      bare_model = Class.new do
+        include Mongoid::Document
+
+        store_in collection: BSON::ObjectId.new.to_s
+        field :description, type: String
+      end
+      doc = bare_model.new(description: 'hello')
+      expect { doc.auto_embed_search }.to raise_error(ArgumentError, /No auto-embed indexes declared/)
+    end
+
+    it 'raises ArgumentError when multiple indexes exist and none is specified' do
+      multi_model = Class.new do
+        include Mongoid::Document
+
+        store_in collection: BSON::ObjectId.new.to_s
+        field :description, type: String
+        field :summary,     type: String
+        auto_embed_field :description, model: 'voyage-4', index: :idx1
+        auto_embed_field :summary,     model: 'voyage-4', index: :idx2
+      end
+      doc = multi_model.new(description: 'hello')
+      expect { doc.auto_embed_search }.to raise_error(ArgumentError, /multiple auto-embed indexes/)
+    end
+  end
+
   describe '.auto_embed_search argument validation' do
     let(:no_index_model) do
       Class.new do

--- a/spec/mongoid/search_indexable_spec.rb
+++ b/spec/mongoid/search_indexable_spec.rb
@@ -439,5 +439,115 @@ describe Mongoid::SearchIndexable do
         end
       end
     end
+
+    context 'with an auto-embed search index' do
+      let(:embed_model) do
+        Class.new do
+          include Mongoid::Document
+
+          store_in collection: BSON::ObjectId.new.to_s
+          field :description, type: String
+          auto_embed_field :description, model: 'voyage-4'
+        end
+      end
+
+      let(:embed_helper) { SearchIndexHelper.new(embed_model) }
+
+      context 'when creating an auto-embed index' do
+        before { embed_helper } # ensure collection is set up before indexes are created
+
+        let(:index_names) { embed_model.create_search_indexes }
+        let(:actual_indexes) { embed_helper.wait_for(*index_names) }
+
+        describe '.create_search_indexes' do
+          it 'creates the auto-embed index' do
+            expect(actual_indexes).not_to be_empty
+          end
+
+          it 'creates an index with the autoEmbed field type' do
+            field_types = actual_indexes
+                          .flat_map { |i| i.dig('latestDefinition', 'fields') }
+                          .map { |f| f['type'] }
+            expect(field_types).to include('autoEmbed')
+          end
+        end
+
+        describe '.auto_embed_search' do
+          before do
+            actual_indexes # wait for index to be ready
+            embed_model.create(description: 'machine learning and neural networks')
+            embed_model.create(description: 'recipe for chocolate cake')
+            embed_model.create(description: 'deep learning for natural language processing')
+            # Atlas may need a moment to index new documents
+            sleep 5
+          end
+
+          it 'returns documents ranked by text similarity' do
+            results = embed_model.auto_embed_search('AI and machine learning', limit: 2)
+            expect(results).not_to be_empty
+            expect(results.first).to be_a(embed_model)
+            expect(results.first.vector_search_score).to be_a(Float)
+          end
+
+          it 'does not return more documents than the limit' do
+            results = embed_model.auto_embed_search('AI', limit: 1)
+            expect(results.size).to be <= 1
+          end
+
+          it 'supports exact nearest-neighbor search' do
+            results = embed_model.auto_embed_search('neural networks', exact: true, limit: 2)
+            expect(results).not_to be_empty
+          end
+        end
+
+        describe '#auto_embed_search' do
+          before do
+            actual_indexes # wait for index to be ready
+            embed_model.create(description: 'machine learning and neural networks')
+            embed_model.create(description: 'recipe for chocolate cake')
+            sleep 5
+          end
+
+          it 'returns similar documents excluding self' do
+            doc = embed_model.create(description: 'deep learning research')
+            sleep 5 # wait for the new document to be indexed
+            results = doc.auto_embed_search(limit: 5)
+            expect(results).not_to be_empty
+            expect(results.map(&:id)).not_to include(doc.id)
+          end
+        end
+      end
+
+      context 'with numDimensions and quantization options' do
+        let(:embed_model_with_opts) do
+          Class.new do
+            include Mongoid::Document
+
+            store_in collection: BSON::ObjectId.new.to_s
+            field :description, type: String
+            auto_embed_field :description,
+                             model: 'voyage-4',
+                             num_dimensions: 512,
+                             quantization: 'scalar'
+          end
+        end
+
+        let(:opts_helper) { SearchIndexHelper.new(embed_model_with_opts) }
+
+        before { opts_helper } # initialize (drop/create collection) before index creation
+
+        it 'creates the index with the specified numDimensions and quantization' do
+          index_names = embed_model_with_opts.create_search_indexes
+          actual_indexes = opts_helper.wait_for(*index_names)
+
+          field_spec = actual_indexes
+                       .flat_map { |i| i.dig('latestDefinition', 'fields') }
+                       .find { |f| f['type'] == 'autoEmbed' }
+
+          expect(field_spec['numDimensions']).to eq 512
+          expect(field_spec['quantization']).to eq 'scalar'
+        end
+      end
+    end
   end
 end

--- a/spec/mongoid/search_indexable_spec.rb
+++ b/spec/mongoid/search_indexable_spec.rb
@@ -438,6 +438,10 @@ describe Mongoid::SearchIndexable do
     end
 
     context 'with an auto-embed search index' do
+      before do
+        skip 'per DRIVERS-3315: "Integration tests can be deferred to follow up work to complete once a CI-compatible server is available with this feature (autoembedding indexes)"'
+      end
+
       let(:embed_model) do
         Class.new do
           include Mongoid::Document

--- a/spec/mongoid/search_indexable_spec.rb
+++ b/spec/mongoid/search_indexable_spec.rb
@@ -215,6 +215,61 @@ describe Mongoid::SearchIndexable do
     end
   end
 
+  describe '.auto_embed_search argument validation' do
+    let(:no_index_model) do
+      Class.new do
+        include Mongoid::Document
+
+        store_in collection: BSON::ObjectId.new.to_s
+      end
+    end
+
+    let(:single_embed_model) do
+      Class.new do
+        include Mongoid::Document
+
+        store_in collection: BSON::ObjectId.new.to_s
+        auto_embed_field :description, model: 'voyage-4'
+      end
+    end
+
+    let(:multi_embed_model) do
+      Class.new do
+        include Mongoid::Document
+
+        store_in collection: BSON::ObjectId.new.to_s
+        auto_embed_field :description, model: 'voyage-4', index: :idx1
+        auto_embed_field :summary,     model: 'voyage-4', index: :idx2
+      end
+    end
+
+    it 'raises ArgumentError when no auto-embed indexes are declared' do
+      expect { no_index_model.auto_embed_search('hello') }
+        .to raise_error(ArgumentError, /No auto-embed indexes declared/)
+    end
+
+    it 'raises ArgumentError when multiple indexes exist and none is specified' do
+      expect { multi_embed_model.auto_embed_search('hello') }
+        .to raise_error(ArgumentError, /multiple auto-embed indexes/)
+    end
+
+    it 'raises ArgumentError when the specified index name does not exist' do
+      expect { single_embed_model.auto_embed_search('hello', index: 'nonexistent') }
+        .to raise_error(ArgumentError, /No auto-embed index 'nonexistent'/)
+    end
+
+    it 'raises ArgumentError when a model with only vector (non-autoEmbed) indexes is used' do
+      model = Class.new do
+        include Mongoid::Document
+
+        store_in collection: BSON::ObjectId.new.to_s
+        vector_search_index fields: [ { type: 'vector', path: 'emb', numDimensions: 3, similarity: 'cosine' } ]
+      end
+      expect { model.auto_embed_search('hello') }
+        .to raise_error(ArgumentError, /No auto-embed indexes declared/)
+    end
+  end
+
   # Atlas integration tests — skipped when ATLAS_URI is not set.
 
   context 'Atlas integration' do

--- a/spec/mongoid/search_indexable_spec.rb
+++ b/spec/mongoid/search_indexable_spec.rb
@@ -221,7 +221,6 @@ describe Mongoid::SearchIndexable do
         include Mongoid::Document
 
         store_in collection: BSON::ObjectId.new.to_s
-        field :description, type: String
         auto_embed_field :description, model: 'voyage-4'
       end
     end
@@ -247,8 +246,6 @@ describe Mongoid::SearchIndexable do
         include Mongoid::Document
 
         store_in collection: BSON::ObjectId.new.to_s
-        field :description, type: String
-        field :summary,     type: String
         auto_embed_field :description, model: 'voyage-4', index: :idx1
         auto_embed_field :summary,     model: 'voyage-4', index: :idx2
       end
@@ -446,7 +443,6 @@ describe Mongoid::SearchIndexable do
           include Mongoid::Document
 
           store_in collection: BSON::ObjectId.new.to_s
-          field :description, type: String
           auto_embed_field :description, model: 'voyage-4'
         end
       end
@@ -524,7 +520,6 @@ describe Mongoid::SearchIndexable do
             include Mongoid::Document
 
             store_in collection: BSON::ObjectId.new.to_s
-            field :description, type: String
             auto_embed_field :description,
                              model: 'voyage-4',
                              num_dimensions: 512,


### PR DESCRIPTION
## Summary

Mongoid can now define vector search indexes with [auto-embedding](https://www.mongodb.com/docs/atlas/atlas-vector-search/crud-embeddings/create-embeddings-automatic/?interface=driver), and provides a helper interface for querying documents by their semantic meaning using those indexed vector fields.

The simplest interface will define a `String` field using the `voyage-4` model.

```ruby
class Article
  include Mongoid::Document
  
  # Define `body` as a String field, indexed using the `voyage-4` auto-embedding model.
  auto_embed_field :body
end
```

You may declare the model and other parameters as well, if desired:

```ruby
class Article
  include Mongoid::Document

  auto_embed_field :body,
                       model: 'voyage-4-large'
                       num_dimensions: 512,
                       quantization: 'binary',
                       similarity: 'cosine',
                       index: :body_index
end
```

Then, create the new search indexes:

```bash
$ rake db:mongoid:create_search_indexes
```

Once the indexes are created, you can query them using the `auto_embed_search` method:

```ruby
articles = Article.auto_embed_search('machine learning', limit: 5)

# or, search for documents that are similar to an existing document
neighbors = article.auto_embed_search(limit: 5)
```