### PR TITLE
MONGOID-5930 Add Mongoid::Config.allow_reparenting_via_nested_attributes

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -68,6 +68,37 @@ RSpec::Core::RakeTask.new('spec:progress') do |spec|
   spec.pattern = "spec/**/*_spec.rb"
 end
 
+RUBOCOPABLE = %w[ examples gemfiles perf lib spec mongoid.gemspec Gemfile Rakefile upload-api-docs ].freeze
+
+desc 'Run rubocop'
+task rubocop: %w[ rubocop:run ]
+
+namespace :rubocop do
+  desc 'Run rubocop on the codebase'
+  task :run do
+    Bundler.with_unbundled_env do
+      sh 'bundle', 'exec', 'rubocop', *RUBOCOPABLE, verbose: false
+    end
+  end
+
+  desc 'Add a git pre-commit hook that runs rubocop'
+  task :install_hook do
+    hook_path = File.join('.git', 'hooks', 'pre-commit')
+    hook_script = <<~HOOK
+      #!/usr/bin/env bash
+      set -e
+
+      echo "Running rubocop..."
+      rake rubocop
+    HOOK
+
+    File.write(hook_path, hook_script)
+    FileUtils.chmod('+x', hook_path)
+
+    puts "Git pre-commit hook installed at #{hook_path}."
+  end
+end
+
 desc 'Build and validate the evergreen config'
 task eg: %w[ eg:build eg:validate ]
 

--- a/lib/mongoid/association/nested/many.rb
+++ b/lib/mongoid/association/nested/many.rb
@@ -184,11 +184,17 @@ module Mongoid
             else
               update_document(doc, attrs)
             end
-          else
+          elsif association.embedded?
+            raise Errors::DocumentNotFound.new(association.klass, id)
+          elsif association.is_a?(Association::Referenced::HasAndBelongsToMany) || Mongoid.allow_reparenting_via_nested_attributes?
+            Mongoid::Warnings.warn_reparenting_via_nested_attributes if Mongoid.allow_reparenting_via_nested_attributes?
+
             # push existing document to association
             doc = association.klass.unscoped.find(converted)
             update_document(doc, attrs)
             existing.push(doc) unless destroyable?(attrs)
+          else
+            raise Errors::DocumentNotFound.new(association.klass, { _id: id, association.foreign_key => parent.id })
           end
 
           parent.children_may_have_changed!

--- a/lib/mongoid/config.rb
+++ b/lib/mongoid/config.rb
@@ -110,6 +110,21 @@ module Mongoid
     # to `:global_thread_pool`.
     option :global_executor_concurrency, default: nil
 
+    # When this flag is true, it will be possible to change the parent of a
+    # record in a "has_many" association by passing the child record's id in the
+    # nested attributes for another parent record.
+    #
+    # When this flag is false, attempting to change the parent of a record in a
+    # "has-many" association via nested attributes will raise an error.
+    #
+    # The default is `true`. Note that allowing reparenting via nested attributes
+    # is a potential security risk, since it could allow a malicious user to move
+    # records that they do not own to a parent record that they do own.
+    #
+    # This option will default to `false` in Mongoid 9.1, and will be removed
+    # in Mongoid 10.
+    option :allow_reparenting_via_nested_attributes, default: true
+
     # When this flag is false, a document will become read-only only once the
     # #readonly! method is called, and an error will be raised on attempting
     # to save or update such documents, instead of just on delete. When this

--- a/lib/mongoid/config/defaults.rb
+++ b/lib/mongoid/config/defaults.rb
@@ -34,7 +34,6 @@ module Mongoid
 
         when '9.0'
           # All flag defaults currently reflect 9.0 behavior.
-          load_defaults '9.0'
 
         else
           raise ArgumentError, "Unknown version: #{version}"

--- a/lib/mongoid/config/defaults.rb
+++ b/lib/mongoid/config/defaults.rb
@@ -18,19 +18,24 @@ module Mongoid
         case version.to_s
         when /^[0-7]\./
           raise ArgumentError, "Version no longer supported: #{version}"
-        when "8.0"
+
+        when '8.0'
           self.legacy_readonly = true
 
-          load_defaults "8.1"
-        when "8.1"
+          load_defaults '8.1'
+
+        when '8.1'
           self.immutable_ids = false
           self.legacy_persistence_context_behavior = true
           self.around_callbacks_for_embeds = true
           self.prevent_multiple_calls_of_embedded_callbacks = false
 
-          load_defaults "9.0"
-        when "9.0"
+          load_defaults '9.0'
+
+        when '9.0'
           # All flag defaults currently reflect 9.0 behavior.
+          load_defaults '9.0'
+
         else
           raise ArgumentError, "Unknown version: #{version}"
         end

--- a/lib/mongoid/warnings.rb
+++ b/lib/mongoid/warnings.rb
@@ -33,5 +33,6 @@ module Mongoid
     warning :symbol_type_deprecated, 'The BSON Symbol type is deprecated by MongoDB. Please use String or StringifiedSymbol field types instead of the Symbol field type.'
     warning :legacy_readonly, 'The readonly! method will only mark the document readonly when the legacy_readonly feature flag is switched off.'
     warning :mutable_ids, 'Ignoring updates to immutable attribute `_id`. Please set Mongoid::Config.immutable_ids to true and update your code so that `_id` is never updated.'
+    warning :reparenting_via_nested_attributes, 'Reparenting documents via nested attributes is insecure and is deprecated. Set Mongoid.allow_reparenting_via_nested_attributes to false and update your code to avoid reparenting documents via nested attributes.'
   end
 end

--- a/spec/mongoid/attributes/nested_spec.rb
+++ b/spec/mongoid/attributes/nested_spec.rb
@@ -164,24 +164,47 @@ describe Mongoid::Attributes::Nested do
       end
     end
 
-    context "when the relation is a references many" do
-
+    context 'when the relation is a has-many' do
       before do
         Person.send(:undef_method, :posts_attributes=)
         Person.accepts_nested_attributes_for :posts
       end
 
-      let(:person) do
-        Person.new(posts_attributes: { "1" => { title: "First" }})
+      context 'when adding a new document to a relation' do
+        let(:person) do
+          Person.new(posts_attributes: { '1' => { title: 'First' } })
+        end
+
+        it 'sets the nested attributes' do
+          expect(person.posts.first.title).to eq('First')
+        end
       end
 
-      it "sets the nested attributes" do
-        expect(person.posts.first.title).to eq("First")
+      context 'when adding an existing document to a relation' do
+        let(:person1) { Person.create! }
+        let(:post) { person1.posts.create!(title: 'Sample Post') }
+
+        let(:person2) { Person.create!(posts_attributes: { '0' => { id: post.id, title: 'Reparented!' } }) }
+
+        context 'when allow_reparenting_via_nested_attributes is false' do
+          config_override :allow_reparenting_via_nested_attributes, false
+
+          it 'raises a document not found error' do
+            expect { person2 }.to raise_error(Mongoid::Errors::DocumentNotFound)
+          end
+        end
+
+        context 'when allow_reparenting_via_nested_attributes is true' do
+          config_override :allow_reparenting_via_nested_attributes, true
+
+          it 'sets the nested attributes' do
+            expect(person2.posts.map(&:title)).to eq([ 'Reparented!' ])
+          end
+        end
       end
     end
 
-    context "when the relation is a references and referenced in many" do
-
+    context 'when the relation is a has-and-belongs-to-many' do
       before do
         Person.send(:undef_method, :preferences_attributes=)
         Person.accepts_nested_attributes_for :preferences
@@ -1355,10 +1378,11 @@ describe Mongoid::Attributes::Nested do
             context "when the ids do not match" do
 
               it "raises an error" do
-                expect {
+                expect do
                   person.addresses_attributes =
-                    { "foo" => { "id" => "test", "street" => "Test" } }
-                }.to raise_error(Mongoid::Errors::DocumentNotFound, /Document\(s\) not found for class Address with id\(s\)/)
+                    { 'foo' => { 'id' => 'test', 'street' => 'Test' } }
+                end.to raise_error(Mongoid::Errors::DocumentNotFound,
+                                   /Document\(s\) not found for class Address/)
               end
             end
           end
@@ -3012,12 +3036,12 @@ describe Mongoid::Attributes::Nested do
                 end
 
                 it "raises a document not found error" do
-                  expect {
+                  expect do
                     person.posts_attributes =
-                      { "0" =>
-                        { "id" => BSON::ObjectId.new.to_s, "title" => "Rogue" }
-                      }
-                  }.to raise_error(Mongoid::Errors::DocumentNotFound, /Document\(s\) not found for class Post with id\(s\)/)
+                      { '0' =>
+                        { 'id' => BSON::ObjectId.new.to_s, 'title' => 'Rogue' } }
+                  end.to raise_error(Mongoid::Errors::DocumentNotFound,
+                                     /Document\(s\) not found for class Post/)
                 end
               end
             end
@@ -3048,10 +3072,11 @@ describe Mongoid::Attributes::Nested do
             context "when the ids do not match" do
 
               it "raises an error" do
-                expect {
+                expect do
                   person.posts_attributes =
-                    { "foo" => { "id" => "test", "title" => "Test" } }
-                }.to raise_error(Mongoid::Errors::DocumentNotFound, /Document\(s\) not found for class Post with id\(s\)/)
+                    { 'foo' => { 'id' => 'test', 'title' => 'Test' } }
+                end.to raise_error(Mongoid::Errors::DocumentNotFound,
+                                   /Document\(s\) not found for class Post/)
               end
             end
           end
@@ -3765,10 +3790,11 @@ describe Mongoid::Attributes::Nested do
             context "when the ids do not match" do
 
               it "raises an error" do
-                expect {
+                expect do
                   person.preferences_attributes =
-                    { "foo" => { "id" => "test", "name" => "Test" } }
-                }.to raise_error(Mongoid::Errors::DocumentNotFound, /Document\(s\) not found for class Preference with id\(s\)/)
+                    { 'foo' => { 'id' => 'test', 'name' => 'Test' } }
+                end.to raise_error(Mongoid::Errors::DocumentNotFound,
+                                   /Document\(s\) not found for class Preference/)
               end
             end
           end


### PR DESCRIPTION
_(Backport of #6127 to 9.0-stable)_

## Summary

Add `Mongoid::Config.allow_reparenting_via_nested_attributes`, defaulting to `true`. When false, this prevents dependent has_many records from being reparented via use of nested attributes. When true, records may be reparented via nested attributes.

This setting will default to `false` in Mongoid 9.1, and will be removed in Mongoid 10.