### PR TITLE
MONGOID-5750 Allow build_foo on embeds_one/has_one/etc. to specify the associated document's type

### DIFF
--- a/lib/mongoid/association/builders.rb
+++ b/lib/mongoid/association/builders.rb
@@ -20,17 +20,20 @@ module Mongoid
 
       private
 
-      # Parse out the attributes and the options from the args passed to a
-      # build_ or create_ methods.
+      # Parses the arguments passed to the build and create methods. The first
+      # argument is always the attributes (defaulting to {} if not given). The
+      # last argument is always the options hash, if the last argument is a
+      # hash. The first of any remaining arguments is the type.
       #
-      # @example Parse the args.
-      #   doc.parse_args(:name => "Joe")
+      # @param [ Array ] args The arguments passed to the method.
       #
-      # @param [ Hash... ] *args The arguments.
-      #
-      # @return [ Array<Hash> ] The attributes and options.
-      def parse_args(*args)
-        [ args.first || {}, (args.size > 1) ? args[1] : {} ]
+      # @return [ Array ] An array containing the attributes, type, and options.
+      def parse_args(args)
+        attributes = args.shift || {}
+        opts = args.last.is_a?(Hash) ? args.pop : {}
+        type = args.shift
+
+        [ attributes, type, opts ]
       end
 
       # Defines a builder method. This is defined as #build_name.
@@ -44,8 +47,9 @@ module Mongoid
       def self.define_builder!(association)
         association.inverse_class.tap do |klass|
           klass.re_define_method("build_#{association.name}") do |*args|
-            attributes, _options = parse_args(*args)
-            document = Factory.execute_build(association.relation_class, attributes, execute_callbacks: false)
+            attributes, type, _opts = parse_args(args)
+
+            document = Factory.execute_build(type || association.relation_class, attributes, execute_callbacks: false)
             _building do
               child = send("#{association.name}=", document)
               child.run_pending_callbacks
@@ -68,8 +72,9 @@ module Mongoid
       def self.define_creator!(association)
         association.inverse_class.tap do |klass|
           klass.re_define_method("create_#{association.name}") do |*args|
-            attributes, _options = parse_args(*args)
-            document = Factory.execute_build(association.relation_class, attributes, execute_callbacks: false)
+            attributes, type, _opts = parse_args(args)
+
+            document = Factory.execute_build(type || association.relation_class, attributes, execute_callbacks: false)
             doc = _assigning do
               send("#{association.name}=", document)
             end

--- a/lib/mongoid/association/embedded/embeds_many.rb
+++ b/lib/mongoid/association/embedded/embeds_many.rb
@@ -157,6 +157,8 @@ module Mongoid
           define_getter!
           define_setter!
           define_existence_check!
+          define_builder!
+          define_creator!
           @owner_class.cyclic = true if cyclic?
           @owner_class.validates_associated(name) if validate?
         end

--- a/lib/mongoid/association/embedded/embeds_many.rb
+++ b/lib/mongoid/association/embedded/embeds_many.rb
@@ -157,8 +157,6 @@ module Mongoid
           define_getter!
           define_setter!
           define_existence_check!
-          define_builder!
-          define_creator!
           @owner_class.cyclic = true if cyclic?
           @owner_class.validates_associated(name) if validate?
         end

--- a/lib/mongoid/factory.rb
+++ b/lib/mongoid/factory.rb
@@ -175,12 +175,8 @@ module Mongoid
     def execute_build(klass, attributes = nil, options = {})
       attributes ||= {}
       dvalue = attributes[klass.discriminator_key] || attributes[klass.discriminator_key.to_sym]
-      type = klass.get_discriminator_mapping(dvalue)
-      if type
-        type.construct_document(attributes, options)
-      else
-        klass.construct_document(attributes, options)
-      end
+      type = klass.get_discriminator_mapping(dvalue) || klass
+      type.construct_document(attributes, options)
     end
 
     # Builds a new +Document+ from the supplied attributes loaded from the

--- a/spec/mongoid/association/builders_spec.rb
+++ b/spec/mongoid/association/builders_spec.rb
@@ -75,6 +75,49 @@ describe Mongoid::Association::Builders do
         end
       end
     end
+
+    context 'when providing a type argument' do
+      context 'when the relation is an embeds_one' do
+        let(:canvas) { Canvas.new }
+
+        context 'when the type is a subclass of the association class' do
+          let(:writer) { canvas.build_writer({}, PdfWriter) }
+
+          it 'builds an instance of the specified type' do
+            expect(writer).to be_a(PdfWriter)
+          end
+
+          it 'assigns the built document to the association' do
+            writer # build the association
+            expect(canvas.writer).to eq(writer)
+          end
+
+          it 'does not persist the document' do
+            expect(writer).not_to be_persisted
+          end
+        end
+
+        context 'when no type is given' do
+          let(:writer) { canvas.build_writer(speed: 3) }
+
+          it 'builds an instance of the default association class' do
+            expect(writer).to be_a(Writer)
+          end
+
+          it 'applies the given attributes' do
+            expect(writer.speed).to eq(3)
+          end
+        end
+
+        context 'when nil is passed as the type' do
+          let(:writer) { canvas.build_writer({}, nil) }
+
+          it 'builds an instance of the default association class' do
+            expect(writer).to be_a(Writer)
+          end
+        end
+      end
+    end
   end
 
   describe "#create_#\{name}" do
@@ -153,6 +196,33 @@ describe Mongoid::Association::Builders do
 
           it 'saves the child' do
             expect(game).to be_persisted
+          end
+        end
+      end
+    end
+
+    context 'when providing a type argument' do
+      context 'when the relation is an embeds_one' do
+        let(:canvas) { Canvas.new }
+
+        context 'when the type is a subclass of the association class' do
+          let(:writer) { canvas.create_writer({}, PdfWriter) }
+
+          it 'builds an instance of the specified type' do
+            expect(writer).to be_a(PdfWriter)
+          end
+
+          it 'assigns the built document to the association' do
+            writer # create the association
+            expect(canvas.writer).to eq(writer)
+          end
+        end
+
+        context 'when no type is given' do
+          let(:writer) { canvas.create_writer(speed: 3) }
+
+          it 'builds an instance of the default association class' do
+            expect(writer).to be_a(Writer)
           end
         end
       end


### PR DESCRIPTION
## Summary

When using `build_<association>` on an `embeds_one`/`has_one`/`belongs_to` (etc.) association, you can now specify the type of the associated document. For example:

```ruby
class Job
  include Mongoid::Document
  
  has_one :runner
end

class Runner
  include Mongoid::Document
  
  belongs_to :job
  field :name, type: String
end

class HeadlessRunner < Runner
end

job = Job.create
job.build_runner({ name: 'My Runner' }, HeadlessRunner)
```

The same syntax works with `create_<association>`.