### PR TITLE
MONGOID-5751 avoid unnecessary autosaves of unchanged subtrees

### DIFF
--- a/lib/mongoid/association/referenced/auto_save.rb
+++ b/lib/mongoid/association/referenced/auto_save.rb
@@ -30,13 +30,24 @@ module Mongoid
           Threaded.exit_autosave(self)
         end
 
-        # Check if there is changes for auto-saving
+        # Check if there are changes for auto-saving. Returns true if the
+        # document is new, changed, or marked for destruction, or if any
+        # in-memory referenced child with autosave: true recursively
+        # satisfies the same condition.
         #
-        # @example Return true if there is changes on self or in
-        #           autosaved associations.
-        #   document.changed_for_autosave?
-        def changed_for_autosave?(doc)
-          doc.new_record? || doc.changed? || doc.marked_for_destruction?
+        # The seen set prevents infinite recursion when autosave associations
+        # form a cycle (e.g. a belongs_to with autosave: true whose target
+        # has a has_many with autosave: true pointing back).
+        #
+        # @param [ Document ] doc The document to check.
+        # @param [ Set ] seen Documents already visited (cycle guard).
+        #
+        # @return [ true | false ] Whether the document needs autosaving.
+        def changed_for_autosave?(doc, seen = Set.new)
+          return false unless seen.add?(doc)
+
+          doc.new_record? || doc.changed? || doc.marked_for_destruction? ||
+            autosave_children_changed?(doc, seen)
         end
 
         # Define the autosave method on an association's owning class for
@@ -58,6 +69,8 @@ module Mongoid
                 __autosaving__ do
                   if assoc_value = ivar(association.name)
                     Array(assoc_value).each do |doc|
+                      next unless changed_for_autosave?(doc)
+
                       pc = doc.persistence_context? ? doc.persistence_context : persistence_context.for_child(doc)
                       doc.with(pc) do |d|
                         d.save
@@ -68,6 +81,22 @@ module Mongoid
               end
             end
             klass.after_persist_parent save_method, unless: :autosaved?
+          end
+        end
+
+        private
+
+        # Returns true if any in-memory referenced child with autosave: true
+        # needs saving.
+        #
+        # @param [ Document ] doc The document whose children to check.
+        # @param [ Set ] seen Cycle guard passed through from changed_for_autosave?.
+        #
+        # @return [ true | false ]
+        def autosave_children_changed?(doc, seen)
+          doc.class.relations.values.select { |a| a.autosave? && !a.embedded? }.any? do |assoc|
+            (assoc_value = doc.ivar(assoc.name)) &&
+              Array(assoc_value).any? { |child| changed_for_autosave?(child, seen) }
           end
         end
       end

--- a/lib/mongoid/association/referenced/auto_save.rb
+++ b/lib/mongoid/association/referenced/auto_save.rb
@@ -96,8 +96,16 @@ module Mongoid
         def autosave_children_changed?(doc, seen)
           doc.class.relations.values.select { |a| a.autosave? && !a.embedded? }.any? do |assoc|
             (assoc_value = doc.ivar(assoc.name)) &&
-              assoc_value.in_memory.any? { |child| changed_for_autosave?(child, seen) }
+              in_memory_docs(assoc_value).any? { |child| changed_for_autosave?(child, seen) }
           end
+        end
+
+        # Returns the in-memory documents for an association value without
+        # triggering a database load of any unloaded documents. Association
+        # proxies expose in_memory for this purpose; a plain document (which
+        # belongs_to can store directly in the ivar) is itself in-memory.
+        def in_memory_docs(assoc_value)
+          assoc_value.respond_to?(:in_memory) ? assoc_value.in_memory : [ assoc_value ]
         end
       end
     end

--- a/lib/mongoid/association/referenced/auto_save.rb
+++ b/lib/mongoid/association/referenced/auto_save.rb
@@ -96,7 +96,7 @@ module Mongoid
         def autosave_children_changed?(doc, seen)
           doc.class.relations.values.select { |a| a.autosave? && !a.embedded? }.any? do |assoc|
             (assoc_value = doc.ivar(assoc.name)) &&
-              Array(assoc_value).any? { |child| changed_for_autosave?(child, seen) }
+              assoc_value.in_memory.any? { |child| changed_for_autosave?(child, seen) }
           end
         end
       end

--- a/lib/mongoid/association/referenced/auto_save.rb
+++ b/lib/mongoid/association/referenced/auto_save.rb
@@ -94,6 +94,11 @@ module Mongoid
         #
         # @return [ true | false ]
         def autosave_children_changed?(doc, seen)
+          if Mongoid.autosave_saves_unchanged_documents?
+            Mongoid::Warnings.warn_autosave_saves_unchanged_documents
+            return true
+          end
+
           doc.class.relations.values.select { |a| a.autosave? && !a.embedded? }.any? do |assoc|
             (assoc_value = doc.ivar(assoc.name)) &&
               in_memory_docs(assoc_value).any? { |child| changed_for_autosave?(child, seen) }

--- a/lib/mongoid/config.rb
+++ b/lib/mongoid/config.rb
@@ -145,6 +145,15 @@ module Mongoid
     # as if this option were set to false.
     option :allow_reparenting_via_nested_attributes, default: false
 
+    # When this flag is true, any documents in associations with `autosave: true`
+    # will be saved even if they have not been changed. When this flag is false,
+    # only autosaved documents that have been changed will be saved. The default
+    # is false.
+    #
+    # This option will be removed in Mongoid 10, with the only behavior at that
+    # point being as if this option were set to false.
+    option :autosave_saves_unchanged_documents, default: false
+
     # Returns the (potentially-dereferenced) isolation level that Mongoid
     # will use to store its internal state. If `isolation_level` is set to
     # `:rails`, this will return the isolation level that Rails is current

--- a/lib/mongoid/config/defaults.rb
+++ b/lib/mongoid/config/defaults.rb
@@ -31,6 +31,7 @@ module Mongoid
 
         when '9.0'
           self.allow_reparenting_via_nested_attributes = true
+          self.autosave_saves_unchanged_documents = true
 
           load_defaults '9.1'
 

--- a/lib/mongoid/warnings.rb
+++ b/lib/mongoid/warnings.rb
@@ -33,5 +33,8 @@ module Mongoid
     warning :mutable_ids,
             'Ignoring updates to immutable attribute `_id`. Please set Mongoid::Config.immutable_ids to true and update your code so that `_id` is never updated.'
     warning :reparenting_via_nested_attributes, 'Reparenting documents via nested attributes is insecure and is deprecated. Set Mongoid.allow_reparenting_via_nested_attributes to false and update your code to avoid reparenting documents via nested attributes.'
+    warning :autosave_saves_unchanged_documents, "Autosave associations are currently configured to save documents even if they haven't changed. " \
+                                                 'This legacy behavior is deprecated. Set Mongoid.autosave_saves_unchanged_documents to false to ' \
+                                                 'skip saving unchanged documents in autosave associations.'
   end
 end

--- a/spec/mongoid/association/auto_save_spec.rb
+++ b/spec/mongoid/association/auto_save_spec.rb
@@ -446,12 +446,24 @@ describe Mongoid::Association::Referenced::AutoSave do
           expect(AutoSaveMONGOID5751::Table.after_save_count).to eq(1)
         end
 
-        it 'fires after_save only for the newly added row, not for pre-existing rows' do
-          expect(AutoSaveMONGOID5751::Row.after_save_count).to eq(1)
-        end
-
         it 'fires after_save only for the newly added cell' do
           expect(AutoSaveMONGOID5751::Cell.after_save_count).to eq(1)
+        end
+
+        context 'when autosave_saves_unchanged_documents is true' do
+          config_override :autosave_saves_unchanged_documents, true
+
+          it 'fires after_save for all new and pre-existing rows' do
+            expect(AutoSaveMONGOID5751::Row.after_save_count).to eq(4)
+          end
+        end
+
+        context 'when autosave_saves_unchanged_documents is false' do
+          config_override :autosave_saves_unchanged_documents, false
+
+          it 'fires after_save only for the newly added row, not for pre-existing rows' do
+            expect(AutoSaveMONGOID5751::Row.after_save_count).to eq(1)
+          end
         end
       end
     end

--- a/spec/mongoid/association/auto_save_spec.rb
+++ b/spec/mongoid/association/auto_save_spec.rb
@@ -4,6 +4,53 @@ require 'spec_helper'
 require_relative 'referenced/has_many_models'
 require_relative 'referenced/has_one_models'
 
+# Models for the MONGOID-5751 regression test: after_save callbacks must not
+# fire for pre-existing, unchanged documents when autosave: true cascades a
+# save from a parent to its children.
+module AutoSaveMONGOID5751
+  class Table
+    include Mongoid::Document
+
+    has_many :rows, autosave: true, class_name: 'AutoSaveMONGOID5751::Row',
+                    inverse_of: :table
+
+    class << self
+      attr_accessor :after_save_count
+    end
+    self.after_save_count = 0
+
+    after_save { self.class.after_save_count += 1 }
+  end
+
+  class Row
+    include Mongoid::Document
+
+    belongs_to :table, class_name: 'AutoSaveMONGOID5751::Table', inverse_of: :rows
+    has_many :cells, autosave: true, class_name: 'AutoSaveMONGOID5751::Cell',
+                     inverse_of: :row
+
+    class << self
+      attr_accessor :after_save_count
+    end
+    self.after_save_count = 0
+
+    after_save { self.class.after_save_count += 1 }
+  end
+
+  class Cell
+    include Mongoid::Document
+
+    belongs_to :row, class_name: 'AutoSaveMONGOID5751::Row', inverse_of: :cells
+
+    class << self
+      attr_accessor :after_save_count
+    end
+    self.after_save_count = 0
+
+    after_save { self.class.after_save_count += 1 }
+  end
+end
+
 describe Mongoid::Association::Referenced::AutoSave do
   describe '.auto_save' do
     before(:all) do
@@ -366,6 +413,45 @@ describe Mongoid::Association::Referenced::AutoSave do
 
         it 'cascades the save' do
           expect(harvest.reload.season).to eq('Fall')
+        end
+      end
+
+      # Regression test for MONGOID-5751: after_save must not fire for
+      # pre-existing, unchanged documents that are merely loaded into memory
+      # as a side-effect of the autosave traversal.
+      context 'when a parent with existing children has a new child added' do
+        before do
+          # Persist a table with 3 pre-existing rows, each with 3 cells.
+          table = AutoSaveMONGOID5751::Table.create!
+          3.times do
+            row = table.rows.create!
+            3.times { row.cells.create! }
+          end
+
+          # Reset counters so only the saves triggered by the call below are
+          # measured.
+          AutoSaveMONGOID5751::Table.after_save_count = 0
+          AutoSaveMONGOID5751::Row.after_save_count = 0
+          AutoSaveMONGOID5751::Cell.after_save_count = 0
+
+          # Reload the table fresh from the database, then append exactly one
+          # new row (with one new cell) and persist.
+          reloaded = AutoSaveMONGOID5751::Table.find(table.id)
+          new_row = reloaded.rows.build
+          new_row.cells.build
+          reloaded.save!
+        end
+
+        it 'fires after_save once for the parent table' do
+          expect(AutoSaveMONGOID5751::Table.after_save_count).to eq(1)
+        end
+
+        it 'fires after_save only for the newly added row, not for pre-existing rows' do
+          expect(AutoSaveMONGOID5751::Row.after_save_count).to eq(1)
+        end
+
+        it 'fires after_save only for the newly added cell' do
+          expect(AutoSaveMONGOID5751::Cell.after_save_count).to eq(1)
         end
       end
     end


### PR DESCRIPTION
This PR fixes a bug with `autosave: true` associations, that caused `after_save` callbacks to be invoked on children even if they hadn't changed. It recursively checks the entire subtree and skips saving it if nothing in it has changed.

## Summary

The legacy behavior of associations with `autosave: true` resulted in all `#save` being invoked on all children of those associations, whether those children actually needed it or not. All corresponding `after_save` hooks were invoked as well, recursively, clear to the bottom of the autosave tree.

This PR changes this behavior, ensuring that subtrees are only autosaved if there are any changed documents in the subtree. As there may be users that depend on the legacy behavior (expecting `after_save` hooks to be invoked even if the record has not changed, for instance), a feature flag has been added to allow the legacy behavior to be opted into.

```ruby
Mongoid.autosave_saves_unchanged_documents = true
```

When `true`, the legacy behavior prevails. If your program depends on this legacy behavior, you are encouraged to rewrite the affected code, because this flag will go away in Mongoid 10, and the legacy autosave behavior will be removed.