### PR TITLE
Release candidate for Mongoid 9.0.11

### DIFF
--- a/lib/mongoid/version.rb
+++ b/lib/mongoid/version.rb
@@ -5,5 +5,5 @@ module Mongoid
   #
   # Note that this file is automatically updated via `rake candidate:create`.
   # Manual changes to this file will be overwritten by that rake task.
-  VERSION = '9.0.10'
+  VERSION = '9.0.11'
 end

--- a/product.yml
+++ b/product.yml
@@ -4,5 +4,5 @@ description: a Ruby ODM for MongoDB
 package: mongoid
 jira: https://jira.mongodb.org/projects/MONGOID
 version:
-  number: 9.0.10
+  number: 9.0.11
   file: lib/mongoid/version.rb


### PR DESCRIPTION
The MongoDB Ruby team is pleased to announce version 9.0.11 of the `mongoid` gem - a Ruby ODM for MongoDB. This is a new patch release in the 9.0.x series of Mongoid.

Install this release using [RubyGems](https://rubygems.org/) via the command line as follows: 

~~~
gem install -v 9.0.11 mongoid
~~~

Or simply add it to your `Gemfile`:

~~~
gem 'mongoid', '9.0.11'
~~~

Have any feedback? Click on through to MongoDB's JIRA and [open a new ticket](https://jira.mongodb.org/projects/MONGOID) to let us know what's on your mind 🧠.

# New Features

### [MONGOID-5930](https://jira.mongodb.org/browse/MONGOID-5930) Add Mongoid::Config.allow_reparenting_via_nested_attributes ([PR](https://github.com/mongodb/mongoid/pull/6131))

Add `Mongoid::Config.allow_reparenting_via_nested_attributes`, defaulting to `true`. When false, this prevents dependent has_many records from being reparented via use of nested attributes. When true, records may be reparented via nested attributes.

This setting will default to `false` in Mongoid 9.1, and will be removed in Mongoid 10.

### [MONGOID-5751](https://jira.mongodb.org/browse/MONGOID-5751) avoid unnecessary autosaves of unchanged subtrees ([PR](https://github.com/mongodb/mongoid/pull/6134))

The legacy behavior of associations with `autosave: true` resulted in all `#save` being invoked on all children of those associations, whether those children actually needed it or not. All corresponding `after_save` hooks were invoked as well, recursively, clear to the bottom of the autosave tree.

This PR adds an option to change this behavior, ensuring that subtrees are only autosaved if there are any changed documents in the subtree. 

```ruby
Mongoid.autosave_saves_unchanged_documents = true
```

The default is `true`, allowing the legacy behavior to prevail. If your program depends on this legacy behavior, you are encouraged to rewrite the affected code and set the value to `false`. The default value of this option will be `false` in Mongoid 9.1, and will go away in Mongoid 10. At that point the legacy autosave behavior will be removed.

