### PR TITLE
MONGOID-5932 Add Ruby 4.0 support to 9.0-stable

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -406,6 +406,10 @@ axes:
         display_name: "MongoDB Latest"
         variables:
            MONGODB_VERSION: "latest"
+      - id: "8.2"
+        display_name: "MongoDB 8.2"
+        variables:
+           MONGODB_VERSION: "8.2"
       - id: "8.0"
         display_name: "MongoDB 8.0"
         variables:
@@ -506,10 +510,18 @@ axes:
         display_name: ruby-3.3
         variables:
           RVM_RUBY: "ruby-3.3"
-      - id: "ruby-head"
-        display_name: ruby-head
+      - id: "ruby-3.4"
+        display_name: ruby-3.4
         variables:
-           RVM_RUBY: "ruby-head"
+          RVM_RUBY: "ruby-3.4"
+      - id: "ruby-4.0"
+        display_name: ruby-4.0
+        variables:
+          RVM_RUBY: "ruby-4.0"
+      - id: "ruby-dev"
+        display_name: ruby-dev
+        variables:
+           RVM_RUBY: "ruby-dev"
 
   - id: "jruby"
     display_name: JRuby Version
@@ -518,10 +530,17 @@ axes:
         display_name: jruby-9.4
         variables:
            RVM_RUBY: "jruby-9.4"
+      - id: "jruby-10.0"
+        display_name: jruby-10.0
+        variables:
+           RVM_RUBY: "jruby-10.0"
 
   - id: "os"
     display_name: OS
     values:
+      - id: ubuntu-24.04
+        display_name: "Ubuntu 24.04"
+        run_on: ubuntu2404-small
       - id: ubuntu-22.04
         display_name: "Ubuntu 22.04"
         run_on: ubuntu2204-small
@@ -643,7 +662,7 @@ axes:
 buildvariants:
 - matrix_name: "mongodb-latest"
   matrix_spec:
-    ruby: ["ruby-3.3"]
+    ruby: [ "ruby-3.3" ]
     driver: ["current"]
     topology: ['replica_set']
     mongodb-version: ['latest']
@@ -652,23 +671,23 @@ buildvariants:
   tasks:
     - name: "test"
 
-- matrix_name: "ruby-3.2 + db-7.0"
+- matrix_name: recent_mdbs
   matrix_spec:
-    ruby: ["ruby-3.2"]
+    ruby: ["ruby-4.0", "ruby-3.4", "ruby-3.3"]
     driver: ["current"]
-    topology: ['server', 'replica_set', 'sharded_cluster']
-    mongodb-version: ['7.0']
+    topology: '*'
+    mongodb-version: ["8.2", "8.0", "7.0"]
     os: ubuntu-22.04
   display_name: "${ruby}, ${driver}, ${mongodb-version}, ${topology}"
   tasks:
     - name: "test"
 
-- matrix_name: "ruby-3.2 + db-6.0"
+- matrix_name: "ruby-3.2"
   matrix_spec:
     ruby: ["ruby-3.2"]
     driver: ["current"]
     topology: ['server', 'replica_set', 'sharded_cluster']
-    mongodb-version: ['6.0']
+    mongodb-version: ['7.0']
     os: ubuntu-22.04
   display_name: "${ruby}, ${driver}, ${mongodb-version}, ${topology}"
   tasks:
@@ -698,11 +717,11 @@ buildvariants:
 
 - matrix_name: "jruby"
   matrix_spec:
-    jruby: ["jruby-9.4"]
+    jruby: ["jruby-10.0", "jruby-9.4"]
     driver: ["current"]
     topology: ['replica_set', 'sharded_cluster']
-    mongodb-version: '7.0'
-    os: ubuntu-22.04
+    mongodb-version: '8.0'
+    os: ubuntu-24.04
   display_name: "${jruby}, ${driver}, ${mongodb-version}, ${topology}"
   tasks:
     - name: "test"
@@ -718,13 +737,24 @@ buildvariants:
   tasks:
     - name: "test"
 
+- matrix_name: "ruby-dev"
+  matrix_spec:
+    ruby: ["ruby-dev"]
+    driver: ["current"]
+    topology: [ 'replica_set' ]
+    mongodb-version: "8.2"
+    os: ubuntu-24.04
+  display_name: "${ruby}, ${driver}, ${mongodb-version}, ${topology}"
+  tasks:
+    - name: "test"
+
 - matrix_name: "driver-upcoming"
   matrix_spec:
     driver: [master, stable]
-    ruby: ["ruby-3.3"]
-    mongodb-version: "6.0"
+    ruby: ["ruby-4.0"]
+    mongodb-version: "8.2"
     topology: ['replica_set', 'sharded_cluster']
-    os: ubuntu-22.04
+    os: ubuntu-24.04
   display_name: "${ruby}, ${driver}, ${mongodb-version}, ${topology}"
   tasks:
      - name: "test"
@@ -765,10 +795,10 @@ buildvariants:
 - matrix_name: "bson-master"
   matrix_spec:
     driver: [bson-master]
-    ruby: ["ruby-3.3"]
-    mongodb-version: "7.0"
+    ruby: ["ruby-4.0"]
+    mongodb-version: "8.2"
     topology: "server"
-    os: ubuntu-22.04
+    os: ubuntu-24.04
   display_name: "${ruby}, ${driver}, ${mongodb-version}, ${topology}"
   tasks:
     - name: "test"
@@ -776,12 +806,12 @@ buildvariants:
 
 - matrix_name: "rails-master"
   matrix_spec:
-    ruby: ["ruby-3.2"]
+    ruby: ["ruby-4.0"]
     driver: ["current"]
-    mongodb-version: "7.0"
+    mongodb-version: "8.2"
     topology: "server"
     rails: ['master']
-    os: ubuntu-22.04
+    os: ubuntu-24.04
     fle: helper
   display_name: "${rails}, ${driver}, ${mongodb-version} (FLE ${fle})"
   tasks:
@@ -789,9 +819,9 @@ buildvariants:
 
 - matrix_name: "rails-8"
   matrix_spec:
-    ruby: ["ruby-3.3"]
+    ruby: ["ruby-3.4"]
     driver: ["current"]
-    mongodb-version: "7.0"
+    mongodb-version: "8.0"
     topology: "server"
     rails: ['8.0', '8.1']
     os: ubuntu-22.04
@@ -839,9 +869,9 @@ buildvariants:
 
 - matrix_name: app-tests-rails-8
   matrix_spec:
-    ruby: ["ruby-3.2", "ruby-3.3"]
+    ruby: ["ruby-4.0", "ruby-3.4"]
     driver: ["current"]
-    mongodb-version: '7.0'
+    mongodb-version: "8.2"
     topology: server
     app-tests: yes
     rails: ['8.0']
@@ -852,9 +882,9 @@ buildvariants:
 
 - matrix_name: app-tests-rails-7
   matrix_spec:
-    ruby: ["ruby-3.2", "ruby-3.3"]
+    ruby: ["ruby-3.4", "ruby-3.3"]
     driver: ["current"]
-    mongodb-version: '7.0'
+    mongodb-version: '8.0'
     topology: server
     app-tests: yes
     rails: ['7.0', '7.1', '7.2']
@@ -862,19 +892,6 @@ buildvariants:
   display_name: "app tests ${driver}, ${ruby}, ${rails}"
   tasks:
     - name: "test"
-
-- matrix_name: app-tests-rails-6
-  matrix_spec:
-    ruby: ["ruby-2.7"]
-    driver: ["current"]
-    mongodb-version: '5.0'
-    topology: server
-    app-tests: yes
-    rails: ['6.0', '6.1']
-    os: ubuntu-20.04
-  display_name: "app tests ${driver}, ${ruby}, ${rails}"
-  tasks:
-     - name: "test"
 
 # https://github.com/rails/rails/issues/49737
 #- matrix_name: app-tests-jruby-9-4
@@ -892,11 +909,11 @@ buildvariants:
 
 - matrix_name: "auto-encryption"
   matrix_spec:
-    ruby: ruby-3.1
+    ruby: ruby-3.4
     driver: current
     topology: replica_set
-    mongodb-version: ['6.0']
-    os: ubuntu-22.04
+    mongodb-version: "8.2"
+    os: ubuntu-24.04
     rails: ['7.0']
     fle: helper
   display_name: "FLE: ${rails}, ${driver}, ${mongodb-version}"
@@ -905,7 +922,7 @@ buildvariants:
 
 - matrix_name: atlas-full
   matrix_spec:
-    ruby: ruby-3.2
+    ruby: ruby-3.4
     os: ubuntu-22.04
     auth: auth
     ssl: yes

--- a/.evergreen/config/axes.yml.erb
+++ b/.evergreen/config/axes.yml.erb
@@ -6,6 +6,10 @@ axes:
         display_name: "MongoDB Latest"
         variables:
            MONGODB_VERSION: "latest"
+      - id: "8.2"
+        display_name: "MongoDB 8.2"
+        variables:
+           MONGODB_VERSION: "8.2"
       - id: "8.0"
         display_name: "MongoDB 8.0"
         variables:
@@ -106,10 +110,18 @@ axes:
         display_name: ruby-3.3
         variables:
           RVM_RUBY: "ruby-3.3"
-      - id: "ruby-head"
-        display_name: ruby-head
+      - id: "ruby-3.4"
+        display_name: ruby-3.4
         variables:
-           RVM_RUBY: "ruby-head"
+          RVM_RUBY: "ruby-3.4"
+      - id: "ruby-4.0"
+        display_name: ruby-4.0
+        variables:
+          RVM_RUBY: "ruby-4.0"
+      - id: "ruby-dev"
+        display_name: ruby-dev
+        variables:
+           RVM_RUBY: "ruby-dev"
 
   - id: "jruby"
     display_name: JRuby Version
@@ -118,10 +130,17 @@ axes:
         display_name: jruby-9.4
         variables:
            RVM_RUBY: "jruby-9.4"
+      - id: "jruby-10.0"
+        display_name: jruby-10.0
+        variables:
+           RVM_RUBY: "jruby-10.0"
 
   - id: "os"
     display_name: OS
     values:
+      - id: ubuntu-24.04
+        display_name: "Ubuntu 24.04"
+        run_on: ubuntu2404-small
       - id: ubuntu-22.04
         display_name: "Ubuntu 22.04"
         run_on: ubuntu2204-small

--- a/.evergreen/config/variants.yml.erb
+++ b/.evergreen/config/variants.yml.erb
@@ -1,7 +1,19 @@
+<%
+  latest_ruby = "ruby-4.0".inspect
+  recent_rubies = %w( ruby-4.0 ruby-3.4 ruby-3.3 )
+  recent_mri_rubies = %w( ruby-4.0 ruby-3.4 ruby-3.3 )
+  jrubies = %w( jruby-10.0 jruby-9.4 )
+  supported_mri_rubies_3 = %w( ruby-4.0 ruby-3.4 ruby-3.3 ruby-3.2 ruby-3.1 ruby-3.0 )
+  supported_mri_ruby_2 = "ruby-2.7".inspect
+  supported_rubies = (supported_mri_rubies_3 + [supported_mri_ruby_2] + jrubies)
+
+  latest_stable_mdb = "8.2".inspect
+  recent_mdbs = %w( 8.2 8.0 7.0 )
+%>
 buildvariants:
 - matrix_name: "mongodb-latest"
   matrix_spec:
-    ruby: ["ruby-3.3"]
+    ruby: [ "ruby-3.3" ]
     driver: ["current"]
     topology: ['replica_set']
     mongodb-version: ['latest']
@@ -10,23 +22,23 @@ buildvariants:
   tasks:
     - name: "test"
 
-- matrix_name: "ruby-3.2 + db-7.0"
+- matrix_name: recent_mdbs
   matrix_spec:
-    ruby: ["ruby-3.2"]
+    ruby: <%= recent_rubies %>
     driver: ["current"]
-    topology: ['server', 'replica_set', 'sharded_cluster']
-    mongodb-version: ['7.0']
+    topology: '*'
+    mongodb-version: <%= recent_mdbs %>
     os: ubuntu-22.04
   display_name: "${ruby}, ${driver}, ${mongodb-version}, ${topology}"
   tasks:
     - name: "test"
 
-- matrix_name: "ruby-3.2 + db-6.0"
+- matrix_name: "ruby-3.2"
   matrix_spec:
     ruby: ["ruby-3.2"]
     driver: ["current"]
     topology: ['server', 'replica_set', 'sharded_cluster']
-    mongodb-version: ['6.0']
+    mongodb-version: ['7.0']
     os: ubuntu-22.04
   display_name: "${ruby}, ${driver}, ${mongodb-version}, ${topology}"
   tasks:
@@ -56,11 +68,11 @@ buildvariants:
 
 - matrix_name: "jruby"
   matrix_spec:
-    jruby: ["jruby-9.4"]
+    jruby: <%= jrubies %>
     driver: ["current"]
     topology: ['replica_set', 'sharded_cluster']
-    mongodb-version: '7.0'
-    os: ubuntu-22.04
+    mongodb-version: '8.0'
+    os: ubuntu-24.04
   display_name: "${jruby}, ${driver}, ${mongodb-version}, ${topology}"
   tasks:
     - name: "test"
@@ -76,13 +88,24 @@ buildvariants:
   tasks:
     - name: "test"
 
+- matrix_name: "ruby-dev"
+  matrix_spec:
+    ruby: ["ruby-dev"]
+    driver: ["current"]
+    topology: [ 'replica_set' ]
+    mongodb-version: <%= latest_stable_mdb %>
+    os: ubuntu-24.04
+  display_name: "${ruby}, ${driver}, ${mongodb-version}, ${topology}"
+  tasks:
+    - name: "test"
+
 - matrix_name: "driver-upcoming"
   matrix_spec:
     driver: [master, stable]
-    ruby: ["ruby-3.3"]
-    mongodb-version: "6.0"
+    ruby: ["ruby-4.0"]
+    mongodb-version: <%= latest_stable_mdb %>
     topology: ['replica_set', 'sharded_cluster']
-    os: ubuntu-22.04
+    os: ubuntu-24.04
   display_name: "${ruby}, ${driver}, ${mongodb-version}, ${topology}"
   tasks:
      - name: "test"
@@ -123,10 +146,10 @@ buildvariants:
 - matrix_name: "bson-master"
   matrix_spec:
     driver: [bson-master]
-    ruby: ["ruby-3.3"]
-    mongodb-version: "7.0"
+    ruby: ["ruby-4.0"]
+    mongodb-version: <%= latest_stable_mdb %>
     topology: "server"
-    os: ubuntu-22.04
+    os: ubuntu-24.04
   display_name: "${ruby}, ${driver}, ${mongodb-version}, ${topology}"
   tasks:
     - name: "test"
@@ -134,12 +157,12 @@ buildvariants:
 
 - matrix_name: "rails-master"
   matrix_spec:
-    ruby: ["ruby-3.2"]
+    ruby: ["ruby-4.0"]
     driver: ["current"]
-    mongodb-version: "7.0"
+    mongodb-version: <%= latest_stable_mdb %>
     topology: "server"
     rails: ['master']
-    os: ubuntu-22.04
+    os: ubuntu-24.04
     fle: helper
   display_name: "${rails}, ${driver}, ${mongodb-version} (FLE ${fle})"
   tasks:
@@ -147,9 +170,9 @@ buildvariants:
 
 - matrix_name: "rails-8"
   matrix_spec:
-    ruby: ["ruby-3.3"]
+    ruby: ["ruby-3.4"]
     driver: ["current"]
-    mongodb-version: "7.0"
+    mongodb-version: "8.0"
     topology: "server"
     rails: ['8.0', '8.1']
     os: ubuntu-22.04
@@ -197,9 +220,9 @@ buildvariants:
 
 - matrix_name: app-tests-rails-8
   matrix_spec:
-    ruby: ["ruby-3.2", "ruby-3.3"]
+    ruby: ["ruby-4.0", "ruby-3.4"]
     driver: ["current"]
-    mongodb-version: '7.0'
+    mongodb-version: <%= latest_stable_mdb %>
     topology: server
     app-tests: yes
     rails: ['8.0']
@@ -210,9 +233,9 @@ buildvariants:
 
 - matrix_name: app-tests-rails-7
   matrix_spec:
-    ruby: ["ruby-3.2", "ruby-3.3"]
+    ruby: ["ruby-3.4", "ruby-3.3"]
     driver: ["current"]
-    mongodb-version: '7.0'
+    mongodb-version: '8.0'
     topology: server
     app-tests: yes
     rails: ['7.0', '7.1', '7.2']
@@ -220,19 +243,6 @@ buildvariants:
   display_name: "app tests ${driver}, ${ruby}, ${rails}"
   tasks:
     - name: "test"
-
-- matrix_name: app-tests-rails-6
-  matrix_spec:
-    ruby: ["ruby-2.7"]
-    driver: ["current"]
-    mongodb-version: '5.0'
-    topology: server
-    app-tests: yes
-    rails: ['6.0', '6.1']
-    os: ubuntu-20.04
-  display_name: "app tests ${driver}, ${ruby}, ${rails}"
-  tasks:
-     - name: "test"
 
 # https://github.com/rails/rails/issues/49737
 #- matrix_name: app-tests-jruby-9-4
@@ -250,11 +260,11 @@ buildvariants:
 
 - matrix_name: "auto-encryption"
   matrix_spec:
-    ruby: ruby-3.1
+    ruby: ruby-3.4
     driver: current
     topology: replica_set
-    mongodb-version: ['6.0']
-    os: ubuntu-22.04
+    mongodb-version: <%= latest_stable_mdb %>
+    os: ubuntu-24.04
     rails: ['7.0']
     fle: helper
   display_name: "FLE: ${rails}, ${driver}, ${mongodb-version}"
@@ -263,7 +273,7 @@ buildvariants:
 
 - matrix_name: atlas-full
   matrix_spec:
-    ruby: ruby-3.2
+    ruby: ruby-3.4
     os: ubuntu-22.04
     auth: auth
     ssl: yes

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "test-apps"]
-	path = test-apps
-	url = https://github.com/mongoid/mongoid-test-apps
 [submodule "spec/shared"]
 	path = spec/shared
 	url = https://github.com/mongodb-labs/mongo-ruby-spec-shared

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ Compatibility
 
 Mongoid supports and is tested against:
 
-- MRI 2.7 - 3.2
-- JRuby 9.4
-- MongoDB server 3.6 - 7.0
+- MRI 2.7 - 4.0
+- JRuby 9.4 and 10.0
+- MongoDB server 3.6 - 8.2
 
 Issues
 ------

--- a/mongoid.gemspec
+++ b/mongoid.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |s|
   s.add_dependency("activemodel", ['>=5.1', '< 8.2', '!= 7.0.0'])
   s.add_dependency("mongo", ['>=2.18.0', '<3.0.0'])
   s.add_dependency("concurrent-ruby", ['>= 1.0.5', '< 2.0'])
+  s.add_dependency("ostruct")
 
   s.add_development_dependency("bson", '>=4.14.0', '<6.0.0')
 

--- a/spec/integration/app_spec.rb
+++ b/spec/integration/app_spec.rb
@@ -37,37 +37,34 @@ describe 'Mongoid application tests' do
     FileUtils.mkdir_p(TMP_BASE)
   end
 
-  context 'demo application' do
+  context 'generated application' do
     context 'sinatra' do
       it 'runs' do
-        skip 'https://jira.mongodb.org/browse/MONGOID-5826'
-
-        clone_application(
-          'https://github.com/mongoid/mongoid-demo',
-          subdir: 'sinatra-minimal',
-        ) do
-
+        create_sinatra_app('mongoid-sinatra-test') do
           # JRuby needs a long timeout
           start_app(%w(bundle exec ruby app.rb), 4567, 40) do |port|
             uri = URI.parse('http://localhost:4567/posts')
             resp = JSON.parse(uri.open.read)
 
             resp.should == []
-
           end
         end
       end
     end
 
     context 'rails-api' do
+      before(:all) do
+        # Rails 6.0/6.1 have Logger issues on Ruby 3.1+
+        # Rails < 7.1 have concurrent-ruby issues on Ruby 4.0+
+        if RUBY_VERSION >= '4.0' && SpecConfig.instance.rails_version < '7.1'
+          skip 'Rails < 7.1 is not compatible with Ruby 4.0+. Set RAILS=7.1 or higher.'
+        elsif RUBY_VERSION >= '3.1' && SpecConfig.instance.rails_version < '6.1'
+          skip 'Rails < 6.1 is not compatible with Ruby 3.1+. Set RAILS=6.1 or higher.'
+        end
+      end
+
       it 'runs' do
-        skip 'https://jira.mongodb.org/browse/MONGOID-5826'
-
-        clone_application(
-          'https://github.com/mongoid/mongoid-demo',
-          subdir: 'rails-api',
-        ) do
-
+        create_rails_api_app('mongoid-rails-api-test') do
           # JRuby needs a long timeout
           start_app(%w(bundle exec rails s), 3000, 50) do |port|
             uri = URI.parse('http://localhost:3000/posts')
@@ -114,7 +111,7 @@ describe 'Mongoid application tests' do
 
     Dir.chdir(TMP_BASE) do
       FileUtils.rm_rf(name)
-      check_call(insert_rails_gem_version(%W(rails new #{name} --skip-spring --skip-active-record)), env: clean_env)
+      check_call(insert_rails_gem_version(%W(rails new #{name} --skip-spring --skip-active-record)), env: rails_env)
 
       Dir.chdir(name) do
         adjust_rails_defaults
@@ -126,10 +123,149 @@ describe 'Mongoid application tests' do
     end
   end
 
+  def create_sinatra_app(name)
+    Dir.chdir(TMP_BASE) do
+      FileUtils.rm_rf(name)
+      FileUtils.mkdir_p(name)
+
+      Dir.chdir(name) do
+        # Create minimal Sinatra app with Post model
+        File.open('app.rb', 'w') do |f|
+          f.write(<<~RUBY)
+            require 'sinatra'
+            require 'mongoid'
+            require 'json'
+
+            Mongoid.load!('config/mongoid.yml')
+
+            class Post
+              include Mongoid::Document
+              field :title, type: String
+            end
+
+            get '/posts' do
+              content_type :json
+              Post.all.to_json
+            end
+          RUBY
+        end
+
+        # Create Gemfile
+        File.open('Gemfile', 'w') do |f|
+          f.write(<<~RUBY)
+            source 'https://rubygems.org'
+            gem 'sinatra'
+            gem 'rackup'
+            gem 'mongoid', path: '#{File.expand_path(BASE)}'
+            gem 'puma'
+          RUBY
+        end
+
+        FileUtils.mkdir_p('config')
+        write_mongoid_yml
+        check_call(%w(bundle install), env: clean_env)
+
+        yield
+      end
+    end
+  end
+
+  def create_rails_api_app(name)
+    install_rails
+
+    Dir.chdir(TMP_BASE) do
+      FileUtils.rm_rf(name)
+      check_call(insert_rails_gem_version(%W(rails new #{name} --api --skip-spring --skip-active-record)), env: rails_env)
+
+      Dir.chdir(name) do
+        adjust_rails_defaults
+        adjust_app_gemfile
+
+        # Create Post model
+        File.open('app/models/post.rb', 'w') do |f|
+          f.write(<<~RUBY)
+            class Post
+              include Mongoid::Document
+              field :title, type: String
+            end
+          RUBY
+        end
+
+        # Create PostsController
+        File.open('app/controllers/posts_controller.rb', 'w') do |f|
+          f.write(<<~RUBY)
+            class PostsController < ApplicationController
+              def index
+                render json: Post.all
+              end
+            end
+          RUBY
+        end
+
+        # Add route
+        routes_content = File.read('config/routes.rb')
+        routes_content.sub!(/Rails\.application\.routes\.draw do\n/,
+                           "Rails.application.routes.draw do\n  resources :posts, only: [:index]\n")
+        File.open('config/routes.rb', 'w') { |f| f.write(routes_content) }
+
+        write_mongoid_yml
+        check_call(%w(bundle install), env: clean_env)
+
+        yield
+      end
+    end
+  end
+
+  def create_rails_rake_test_app(name)
+    install_rails
+
+    Dir.chdir(TMP_BASE) do
+      FileUtils.rm_rf(name)
+      check_call(insert_rails_gem_version(%W(rails new #{name} --api --skip-spring --skip-active-record)), env: rails_env)
+
+      Dir.chdir(name) do
+        adjust_rails_defaults
+        adjust_app_gemfile
+
+        # Create Post model with index
+        File.open('app/models/post.rb', 'w') do |f|
+          f.write(<<~RUBY)
+            class Post
+              include Mongoid::Document
+              include Mongoid::Timestamps
+              field :subject, type: String
+              field :message, type: String
+
+              index subject: 1
+            end
+          RUBY
+        end
+
+        # Create Comment model
+        File.open('app/models/comment.rb', 'w') do |f|
+          f.write(<<~RUBY)
+            class Comment
+              include Mongoid::Document
+              include Mongoid::Timestamps
+              belongs_to :post
+            end
+          RUBY
+        end
+
+        write_mongoid_yml
+        check_call(%w(bundle install), env: clean_env)
+      end
+    end
+  end
+
   context 'new application - rails' do
     before(:all) do
-      if SpecConfig.instance.rails_version < '7.1'
-        skip '`rails new` with rails < 7.1 fails because modern concurrent-ruby removed logger dependency'
+      # Rails 6.0/6.1 have Logger issues on Ruby 3.1+
+      # Rails < 7.1 have concurrent-ruby issues on Ruby 4.0+
+      if RUBY_VERSION >= '4.0' && SpecConfig.instance.rails_version < '7.1'
+        skip 'Rails < 7.1 is not compatible with Ruby 4.0+. Set RAILS=7.1 or higher.'
+      elsif RUBY_VERSION >= '3.1' && SpecConfig.instance.rails_version < '6.1'
+        skip 'Rails < 6.1 is not compatible with Ruby 3.1+. Set RAILS=6.1 or higher.'
       end
     end
 
@@ -186,16 +322,30 @@ describe 'Mongoid application tests' do
     if (rails_version = SpecConfig.instance.rails_version) == 'master'
     else
       check_call(%w(gem list))
+
+      # Rails 6.0 and 6.1 need logger gem on Ruby 2.7+ due to stdlib changes
+      if rails_version.to_f < 7.0 && RUBY_VERSION >= '2.7'
+        check_call(%w(gem install logger --no-document))
+      end
+
       check_call(%w(gem install rails --no-document --force -v) + ["~> #{rails_version}.0"])
     end
   end
 
-  context 'local test applications' do
+  context 'generated test applications' do
+    before(:all) do
+      # Rails 6.0/6.1 have Logger issues on Ruby 3.1+
+      # Rails < 7.1 have concurrent-ruby issues on Ruby 4.0+
+      if RUBY_VERSION >= '4.0' && SpecConfig.instance.rails_version < '7.1'
+        skip 'Rails < 7.1 is not compatible with Ruby 4.0+. Set RAILS=7.1 or higher.'
+      elsif RUBY_VERSION >= '3.1' && SpecConfig.instance.rails_version < '6.1'
+        skip 'Rails < 6.1 is not compatible with Ruby 3.1+. Set RAILS=6.1 or higher.'
+      end
+    end
+
     let(:client) { Mongoid.default_client }
 
     describe 'create_indexes rake task' do
-
-      APP_PATH = File.join(File.dirname(__FILE__), '../../test-apps/rails-api')
 
       %w(development production).each do |rails_env|
         context "in #{rails_env}" do
@@ -207,20 +357,11 @@ describe 'Mongoid application tests' do
                 clean_env.merge(RAILS_ENV: rails_env, AUTOLOADER: autoloader)
               end
 
+              let(:app_name) { "mongoid-rake-test-#{rails_env}-#{autoloader}" }
+              let(:app_path) { File.join(TMP_BASE, app_name) }
+
               before do
-                Dir.chdir(APP_PATH) do
-                  remove_bundler_req
-
-                  if BSON::Environment.jruby?
-                    # Remove existing Gemfile.lock - see
-                    # https://github.com/rubygems/rubygems/issues/3231
-                    require 'fileutils'
-                    FileUtils.rm_f('Gemfile.lock')
-                  end
-
-                  check_call(%w(bundle install), env: env)
-                  write_mongoid_yml
-                end
+                create_rails_rake_test_app(app_name)
 
                 client['posts'].drop
                 client['posts'].create
@@ -233,7 +374,7 @@ describe 'Mongoid application tests' do
                 index.should be nil
 
                 check_call(%w(bundle exec rake db:mongoid:create_indexes -t),
-                  cwd: APP_PATH, env: env)
+                  cwd: app_path, env: env)
 
                 index = client['posts'].indexes.detect do |index|
                   index['key'] == {'subject' => 1}
@@ -317,6 +458,12 @@ describe 'Mongoid application tests' do
       line =~ /mongoid/
     end
     gemfile_lines << "gem 'mongoid', path: '#{File.expand_path(BASE)}'\n"
+
+    # Rails 6.0 and 6.1 need logger gem on Ruby 2.7+ due to stdlib changes
+    if rails_version && rails_version.to_f < 7.0 && RUBY_VERSION >= '2.7'
+      gemfile_lines << "gem 'logger'\n"
+    end
+
     if rails_version
       gemfile_lines.delete_if do |line|
         line =~ /gem ['"]rails['"]/
@@ -374,6 +521,17 @@ describe 'Mongoid application tests' do
 
   def clean_env
     @clean_env ||= Hash[ENV.keys.grep(/BUNDLE|RUBYOPT/).map { |k| [k, nil ] }]
+  end
+
+  def rails_env
+    # For Rails 6.0/6.1 on Ruby 2.7+, we need to require logger
+    # to fix "uninitialized constant ActiveSupport::LoggerThreadSafeLevel::Logger"
+    env = clean_env.dup
+    rails_version = SpecConfig.instance.rails_version
+    if rails_version && rails_version.to_f < 7.0 && RUBY_VERSION >= '2.7'
+      env['RUBYOPT'] = '-rlogger'
+    end
+    env
   end
 
   def wait_for_port(port, timeout, process)

--- a/spec/mongoid/errors/document_not_found_spec.rb
+++ b/spec/mongoid/errors/document_not_found_spec.rb
@@ -64,9 +64,16 @@ describe Mongoid::Errors::DocumentNotFound do
       end
 
       it "contains the problem in the message" do
-        expect(error.message).to include(
-          "Document not found for class Person with attributes {:name=>\"syd\"}."
-        )
+        # Ruby 3.4+ changed Hash#inspect format from {:name=>"syd"} to {name: "syd"}
+        if RUBY_VERSION >= '3.4'
+          expect(error.message).to include(
+            "Document not found for class Person with attributes {name: \"syd\"}."
+          )
+        else
+          expect(error.message).to include(
+            "Document not found for class Person with attributes {:name=>\"syd\"}."
+          )
+        end
       end
 
       it "contains the summary in the message" do


### PR DESCRIPTION
Ruby 4.0 support was add previously for the master branch (#6082). This backports those changes to the 9.0-stable branch.