### PR TITLE
MONGOID-5684 Ensure hash-typed fields return Hash

### DIFF
--- a/lib/mongoid/attributes.rb
+++ b/lib/mongoid/attributes.rb
@@ -101,6 +101,11 @@ module Mongoid
     # @api private
     def process_raw_attribute(name, raw, field)
       value = field ? field.demongoize(raw) : raw
+      # When demongoize converts a BSON::Document to a plain Hash (i.e.
+      # legacy_hash_fields is false), store the plain Hash back into
+      # attributes so that in-place mutations on the returned value are
+      # visible to dirty tracking.
+      attributes[name] = value if raw.is_a?(BSON::Document) && !value.is_a?(BSON::Document)
       is_relation = relations.key?(name)
       attribute_will_change!(name) if value.resizable? && !is_relation
       value

--- a/lib/mongoid/config.rb
+++ b/lib/mongoid/config.rb
@@ -78,6 +78,11 @@ module Mongoid
     # Store BigDecimals as Decimal128s instead of strings in the db.
     option :map_big_decimal_to_decimal128, default: true
 
+    # When true (the default), preserve legacy behavior where Hash-typed fields
+    # return BSON::Document after loading from the database. Set to false to
+    # have Hash-typed fields return plain Hash, matching the declared field type.
+    option :legacy_hash_fields, default: true
+
     # Allow BSON::Decimal128 to be parsed and returned directly in
     # field values. When BSON 5 is present and this option is set to false
     # (the default), BSON::Decimal128 values in the database will be returned

--- a/lib/mongoid/extensions/hash.rb
+++ b/lib/mongoid/extensions/hash.rb
@@ -105,6 +105,27 @@ module Mongoid
       Mongoid.deprecate(self, :to_criteria)
 
       module ClassMethods
+        # Turn the object from a Mongo-friendly type back to the Ruby type.
+        # When +legacy_hash_fields+ is false, converts BSON::Document to a
+        # plain Hash recursively so that Hash-typed fields always return Hash.
+        #
+        # @param [ Object ] object The object to demongoize.
+        #
+        # @return [ Hash | Object | nil ] The demongoized object.
+        def demongoize(object)
+          return if object.nil?
+          return object if Mongoid.config.legacy_hash_fields
+
+          case object
+          when BSON::Document
+            object.each_with_object({}) { |(k, v), h| h[k] = ::Hash.demongoize(v) }
+          when ::Hash
+            object.transform_values { |v| ::Hash.demongoize(v) }
+          else
+            object
+          end
+        end
+
         # Turn the object from the ruby type we deal with to a Mongo friendly
         # type.
         #

--- a/lib/mongoid/extensions/hash.rb
+++ b/lib/mongoid/extensions/hash.rb
@@ -108,22 +108,18 @@ module Mongoid
         # Turn the object from a Mongo-friendly type back to the Ruby type.
         # When +legacy_hash_fields+ is false, converts BSON::Document to a
         # plain Hash recursively so that Hash-typed fields always return Hash.
+        # Plain Hash inputs are returned as-is; conversion is only needed once
+        # (when the raw BSON::Document is first read from the database).
         #
         # @param [ Object ] object The object to demongoize.
         #
         # @return [ Hash | Object | nil ] The demongoized object.
         def demongoize(object)
           return if object.nil?
-          return object if Mongoid.config.legacy_hash_fields
+          return object unless object.is_a?(BSON::Document) &&
+                               !Mongoid.config.legacy_hash_fields
 
-          case object
-          when BSON::Document
-            object.each_with_object({}) { |(k, v), h| h[k] = ::Hash.demongoize(v) }
-          when ::Hash
-            object.transform_values { |v| ::Hash.demongoize(v) }
-          else
-            object
-          end
+          object.each_with_object({}) { |(k, v), h| h[k] = ::Hash.demongoize(v) }
         end
 
         # Turn the object from the ruby type we deal with to a Mongo friendly

--- a/perf/benchmark_hash_demongoize.rb
+++ b/perf/benchmark_hash_demongoize.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+# Benchmarks Hash.demongoize performance for the three scenarios relevant to
+# MONGOID-5684:
+#
+#   legacy     - legacy_hash_fields: true (BSON::Document returned as-is, O(1))
+#   first read - legacy_hash_fields: false, BSON::Document input (conversion, O(N))
+#   subsequent - legacy_hash_fields: false, plain Hash input (returns self, O(1))
+#
+# Each scenario uses a separate Benchmark.ips block with the config flag set
+# before measurement begins, so the flag is stable during the entire run.
+#
+# Run with:
+#   bundle exec ruby perf/benchmark_hash_demongoize.rb
+
+require 'benchmark/ips'
+require 'mongoid'
+
+# ---------------------------------------------------------------------------
+# Test documents
+# ---------------------------------------------------------------------------
+
+EMPTY = BSON::Document.new.freeze
+
+FLAT = BSON::Document.new(
+  'name' => 'Alice',
+  'age' => 30,
+  'active' => true,
+  'score' => 9.5,
+  'tag' => 'vip'
+).freeze
+
+# Three levels deep, 10 keys at each level. Leaf values are integers.
+NESTED = BSON::Document.new(
+  10.times.to_h do |i|
+    [
+      "l1_#{i}",
+      BSON::Document.new(
+        10.times.to_h do |j|
+          [
+            "l2_#{j}",
+            BSON::Document.new(
+              10.times.to_h { |k| [ "l3_#{k}", k ] }
+            )
+          ]
+        end
+      )
+    ]
+  end
+).freeze
+
+# Pre-converted plain Hash equivalents for the "subsequent read" scenario.
+Mongoid.config.legacy_hash_fields = false
+EMPTY_PLAIN  = Hash.demongoize(EMPTY)
+FLAT_PLAIN   = Hash.demongoize(FLAT)
+NESTED_PLAIN = Hash.demongoize(NESTED)
+Mongoid.config.legacy_hash_fields = true
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+CASES = [
+  [ 'empty (0 keys)',              EMPTY,  EMPTY_PLAIN ],
+  [ 'flat (5 keys)',               FLAT,   FLAT_PLAIN ],
+  [ 'nested (3 levels, 10 keys)',  NESTED, NESTED_PLAIN ]
+].freeze
+
+def section(title)
+  puts "\n#{'=' * 60}"
+  puts title
+  puts '=' * 60
+end
+
+# ---------------------------------------------------------------------------
+# Scenario 1: legacy behavior (flag = true)
+# Config is set once before the block; all three cases share the same flag.
+# ---------------------------------------------------------------------------
+
+section 'Scenario 1: legacy_hash_fields: true (BSON::Document returned as-is)'
+
+Mongoid.config.legacy_hash_fields = true
+Benchmark.ips do |x|
+  x.config(warmup: 2, time: 5)
+  CASES.each do |label, bson, _|
+    x.report(label) { Hash.demongoize(bson) }
+  end
+  x.compare!
+end
+
+# ---------------------------------------------------------------------------
+# Scenario 2: first read (flag = false, BSON::Document input)
+# This is the O(N) path: allocates and populates a new plain Hash.
+# ---------------------------------------------------------------------------
+
+section 'Scenario 2: legacy_hash_fields: false, BSON::Document input (first read)'
+
+Mongoid.config.legacy_hash_fields = false
+Benchmark.ips do |x|
+  x.config(warmup: 2, time: 5)
+  CASES.each do |label, bson, _|
+    x.report(label) { Hash.demongoize(bson) }
+  end
+  x.compare!
+end
+
+# ---------------------------------------------------------------------------
+# Scenario 3: subsequent reads (flag = false, plain Hash input)
+# After the write-back in process_raw_attribute, attributes holds a plain Hash.
+# This should be O(1): two type checks, one return.
+# ---------------------------------------------------------------------------
+
+section 'Scenario 3: legacy_hash_fields: false, plain Hash input (subsequent reads)'
+
+Mongoid.config.legacy_hash_fields = false
+Benchmark.ips do |x|
+  x.config(warmup: 2, time: 5)
+  CASES.each do |label, _, plain|
+    x.report(label) { Hash.demongoize(plain) }
+  end
+  x.compare!
+end
+
+Mongoid.config.legacy_hash_fields = true

--- a/spec/mongoid/changeable_spec.rb
+++ b/spec/mongoid/changeable_spec.rb
@@ -251,6 +251,63 @@ describe Mongoid::Changeable do
           end
         end
       end
+
+      context 'when the attribute is a hash field and legacy_hash_fields is true (default)' do
+        let(:person) do
+          Person.create!(map: { 'location' => 'Home' })
+        end
+
+        let(:reloaded) do
+          Person.find(person.id)
+        end
+
+        it 'returns a BSON::Document after loading from the database' do
+          expect(reloaded.map).to be_a(BSON::Document)
+        end
+      end
+
+      context 'when the attribute is a hash field and legacy_hash_fields is false' do
+        around do |example|
+          Mongoid.config.legacy_hash_fields = false
+          example.run
+        ensure
+          Mongoid.config.legacy_hash_fields = true
+        end
+
+        let(:person) do
+          Person.create!(map: { 'location' => 'Home' })
+        end
+
+        let(:reloaded) do
+          Person.find(person.id)
+        end
+
+        it 'returns a plain Hash after loading from the database' do
+          expect(reloaded.map).to be_a(Hash)
+          expect(reloaded.map).not_to be_a(BSON::Document)
+        end
+
+        it 'returns the correct value' do
+          expect(reloaded.map).to eq({ 'location' => 'Home' })
+        end
+
+        context 'when the field is modified after loading' do
+          before do
+            reloaded.map['location'] = 'Work'
+          end
+
+          it 'field_was returns a plain Hash' do
+            old_value, = reloaded.map_change
+            expect(old_value).to be_a(Hash)
+            expect(old_value).not_to be_a(BSON::Document)
+          end
+
+          it 'field_was holds the original value' do
+            old_value, = reloaded.map_change
+            expect(old_value).to eq({ 'location' => 'Home' })
+          end
+        end
+      end
     end
 
     context 'when the attribute has not changed from the persisted value' do

--- a/spec/mongoid/extensions/hash_spec.rb
+++ b/spec/mongoid/extensions/hash_spec.rb
@@ -179,6 +179,72 @@ describe Mongoid::Extensions::Hash do
         expect(demongoized).to eq(1)
       end
     end
+
+    context 'when the object is a BSON::Document and legacy_hash_fields is true' do
+      let(:doc) { BSON::Document.new('x' => 1, 'y' => 2) }
+
+      it 'returns the BSON::Document unchanged (legacy behavior)' do
+        expect(Hash.demongoize(doc)).to be_a(BSON::Document)
+        expect(Hash.demongoize(doc)).to equal(doc)
+      end
+    end
+
+    context 'when the object is a BSON::Document and legacy_hash_fields is false' do
+      around do |example|
+        Mongoid.config.legacy_hash_fields = false
+        example.run
+      ensure
+        Mongoid.config.legacy_hash_fields = true
+      end
+
+      let(:doc) { BSON::Document.new('x' => 1, 'y' => 2) }
+
+      it 'returns a plain Hash' do
+        result = Hash.demongoize(doc)
+        expect(result).to be_a(Hash)
+        expect(result).not_to be_a(BSON::Document)
+      end
+
+      it 'preserves the key/value data' do
+        result = Hash.demongoize(doc)
+        expect(result).to eq({ 'x' => 1, 'y' => 2 })
+      end
+
+      context 'when the object is a plain Hash with plain values' do
+        let(:plain) { { 'x' => 1, 'y' => 'hello' } }
+
+        it 'returns an equivalent plain Hash' do
+          result = Hash.demongoize(plain)
+          expect(result).to be_a(Hash)
+          expect(result).not_to be_a(BSON::Document)
+          expect(result).to eq({ 'x' => 1, 'y' => 'hello' })
+        end
+      end
+
+      context 'when the object is a plain Hash containing a nested BSON::Document' do
+        let(:hash_with_nested) do
+          { 'a' => BSON::Document.new('b' => 1) }
+        end
+
+        it 'recursively converts nested BSON::Documents inside plain Hash' do
+          result = Hash.demongoize(hash_with_nested)
+          expect(result['a']).to be_a(Hash)
+          expect(result['a']).not_to be_a(BSON::Document)
+          expect(result['a']['b']).to eq(1)
+        end
+      end
+
+      context 'when the BSON::Document has nested BSON::Documents' do
+        let(:nested) { BSON::Document.new('a' => BSON::Document.new('b' => 3)) }
+
+        it 'recursively converts nested BSON::Documents to plain Hash' do
+          result = Hash.demongoize(nested)
+          expect(result['a']).to be_a(Hash)
+          expect(result['a']).not_to be_a(BSON::Document)
+          expect(result['a']['b']).to eq(3)
+        end
+      end
+    end
   end
 
   describe '.mongoize' do

--- a/spec/mongoid/extensions/hash_spec.rb
+++ b/spec/mongoid/extensions/hash_spec.rb
@@ -210,27 +210,11 @@ describe Mongoid::Extensions::Hash do
         expect(result).to eq({ 'x' => 1, 'y' => 2 })
       end
 
-      context 'when the object is a plain Hash with plain values' do
+      context 'when the object is a plain Hash' do
         let(:plain) { { 'x' => 1, 'y' => 'hello' } }
 
-        it 'returns an equivalent plain Hash' do
-          result = Hash.demongoize(plain)
-          expect(result).to be_a(Hash)
-          expect(result).not_to be_a(BSON::Document)
-          expect(result).to eq({ 'x' => 1, 'y' => 'hello' })
-        end
-      end
-
-      context 'when the object is a plain Hash containing a nested BSON::Document' do
-        let(:hash_with_nested) do
-          { 'a' => BSON::Document.new('b' => 1) }
-        end
-
-        it 'recursively converts nested BSON::Documents inside plain Hash' do
-          result = Hash.demongoize(hash_with_nested)
-          expect(result['a']).to be_a(Hash)
-          expect(result['a']).not_to be_a(BSON::Document)
-          expect(result['a']['b']).to eq(1)
+        it 'returns the same object unchanged' do
+          expect(Hash.demongoize(plain)).to equal(plain)
         end
       end
 


### PR DESCRIPTION
Fixes [MONGOID-5684](https://jira.mongodb.org/browse/MONGOID-5684).

### Problem

When a document with a `field :name, type: Hash` is saved and reloaded, the field value is a `BSON::Document` rather than a plain `Hash`:

```ruby
class Foo
  include Mongoid::Document
  field :feature, type: Hash
end

foo = Foo.create!(feature: { 'x' => 1 })
foo = Foo.find(foo.id)
foo.feature.class  #=> BSON::Document  (should be Hash)
```

This happens because `BSON::Document` is a subclass of `Hash`, so Mongoid's type check passes — but `Hash::ClassMethods` had no `demongoize` method, so the call fell through to `Object.demongoize`, which returns its argument unchanged.

A secondary symptom: after modifying the field, `field_was` returned a plain `Hash` whose string keys weren't accessible via symbol — inconsistent with the `BSON::Document` returned by the getter.

### Fix

**`lib/mongoid/extensions/hash.rb`** — Add `Hash::ClassMethods#demongoize`. When `legacy_hash_fields` is `false`, it converts `BSON::Document` → `Hash` recursively. Plain `Hash` inputs are returned as the same object (no allocation), so subsequent attribute reads are O(1).

**`lib/mongoid/attributes.rb`** — After demongoizing a `BSON::Document` to a plain `Hash`, write the plain `Hash` back into `attributes`. This ensures in-place mutations on the returned value are visible to dirty tracking. The write-back is scoped precisely to the `BSON::Document` → `Hash` conversion and does not affect other field types (Date, Time, BigDecimal, Set, etc.).

**`lib/mongoid/config.rb`** — Add the `legacy_hash_fields` option (default: `true`).

### Feature flag

The fix is opt-in to avoid breaking applications that depend on the current behavior:

```ruby
Mongoid.configure do |config|
  config.legacy_hash_fields = false  # opt in to correct behavior
end
```

The default (`true`) preserves the existing behavior unchanged.

### Performance

`Hash.demongoize` is called on every attribute read. The key question is whether the conversion adds unacceptable overhead.

**Scenario 1 — `legacy_hash_fields: true` (current behavior, BSON::Document returned as-is)**

| Input | Throughput |
|---|---|
| Empty | 7.67M i/s |
| Flat, 5 keys | 7.60M i/s |
| Nested, 3 levels × 10 keys | 7.57M i/s |

O(1), no allocation — just a config check and an early return.

**Scenario 2 — `legacy_hash_fields: false`, first read (BSON::Document input, conversion)**

| Input | Throughput | vs. legacy |
|---|---|---|
| Empty | 5.10M i/s | 1.5× slower |
| Flat, 5 keys | 1.22M i/s | 4.2× slower |
| Nested, 3 levels × 10 keys | 6.87k i/s | **742× slower** |

This is the one-time cost paid when a document is first loaded from the database. For the nested case, 111 `Hash` objects are allocated and 1,110 nodes are visited per call (145 µs on the benchmark machine). This cost is proportional to the size and depth of the stored value.

**Scenario 3 — `legacy_hash_fields: false`, subsequent reads (plain Hash input)**

After the first read, `attributes` holds the converted plain `Hash`. Subsequent reads return it as-is:

| Input | Throughput | vs. legacy |
|---|---|---|
| Empty | 27.2M i/s | 3.5× faster |
| Flat, 5 keys | 27.1M i/s | 3.6× faster |
| Nested, 3 levels × 10 keys | 27.2M i/s | 3.6× faster |

O(1), size-independent — two type checks and an early return.

**Summary:** with `legacy_hash_fields: false`, each Hash-typed attribute read pays a one-time conversion cost proportional to the hash's size. All subsequent reads of that field are faster than the current legacy path. Applications with large, deeply-nested Hash fields loaded frequently from the database should measure the first-read cost against their own document shapes before enabling the flag.
