### PR TITLE
MONGOID-5915 avoid async state corruption by forcing child fibers to copy parent state

### DIFF
--- a/lib/mongoid/threaded.rb
+++ b/lib/mongoid/threaded.rb
@@ -10,6 +10,10 @@ module Mongoid
     # symbol because keys for fiber-local storage must be symbols.
     STORAGE_KEY = :'[mongoid]'
 
+    # Tracks which fiber owns the storage hash, to detect when a fiber has
+    # inherited (rather than created) its storage from a parent fiber.
+    STORAGE_OWNER_KEY = :'[mongoid]:owner'
+
     DATABASE_OVERRIDE_KEY = 'db-override'
 
     # The key to override the client.
@@ -51,7 +55,8 @@ module Mongoid
       when :thread
         Thread.current.thread_variable_set(STORAGE_KEY, nil)
       when :fiber
-        Fiber[STORAGE_KEY] = nil
+        Fiber[STORAGE_KEY] = {}
+        Fiber[STORAGE_OWNER_KEY] = Fiber.current.object_id
       else
         raise "Unknown isolation level: #{Config.real_isolation_level.inspect}"
       end
@@ -587,7 +592,17 @@ module Mongoid
         storage_hash
 
       when :fiber
-        Fiber[STORAGE_KEY] ||= {}
+        # Fiber[] storage is inherited by child fibers, so multiple sibling
+        # fibers would otherwise share a single mutable hash. We detect
+        # inheritance by comparing the stored owner ID to the current fiber;
+        # on first access by a new fiber we copy the inherited state so each
+        # fiber starts with a snapshot of its parent's state rather than a
+        # shared reference.
+        if Fiber[STORAGE_OWNER_KEY] != Fiber.current.object_id
+          Fiber[STORAGE_KEY] = (Fiber[STORAGE_KEY] || {}).dup
+          Fiber[STORAGE_OWNER_KEY] = Fiber.current.object_id
+        end
+        Fiber[STORAGE_KEY]
 
       else
         raise "Unknown isolation level: #{Config.real_isolation_level.inspect}"

--- a/spec/integration/isolation_state_spec.rb
+++ b/spec/integration/isolation_state_spec.rb
@@ -172,6 +172,48 @@ describe 'Mongoid::Config.isolation_level' do
         end
       end
 
+      context 'when sibling fibers interleave execution' do
+        around do |example|
+          Mongoid::Threaded.reset!
+          example.run
+          Mongoid::Threaded.reset!
+        end
+
+        it 'does not allow one sibling fiber to corrupt another sibling fiber state' do
+          Mongoid::Threaded.set('x', 'parent')
+
+          value_seen_by_a = nil
+
+          fiber_a = Fiber.new do
+            Mongoid::Threaded.set('x', 'from_a')
+            Fiber.yield
+            value_seen_by_a = Mongoid::Threaded.get('x')
+          end
+
+          fiber_b = Fiber.new do
+            Mongoid::Threaded.set('x', 'from_b')
+          end
+
+          fiber_a.resume
+          fiber_b.resume
+          fiber_a.resume
+
+          expect(value_seen_by_a).to eq('from_a')
+        end
+
+        it 'preserves the parent fiber state after sibling fibers run' do
+          Mongoid::Threaded.set('x', 'parent')
+
+          fiber_a = Fiber.new { Mongoid::Threaded.set('x', 'from_a') }
+          fiber_b = Fiber.new { Mongoid::Threaded.set('x', 'from_b') }
+
+          fiber_a.resume
+          fiber_b.resume
+
+          expect(Mongoid::Threaded.get('x')).to eq('parent')
+        end
+      end
+
       describe '#reset!' do
         context 'when operating in nested fibers' do
           let(:result) do


### PR DESCRIPTION
MONGOID-5882 added the ability to specify isolation state, so that Mongoid could run under either threads or fibers. However, the fiber isolation mode was insufficient and allowed sibling fibers to clobber shared state. This change still allows fibers to inherit state from their parent, but keeps the shared state more isolated.