### PR TITLE
New :fallback option to handle nil for singular associations

### DIFF
--- a/lib/mongoid/association/accessors.rb
+++ b/lib/mongoid/association/accessors.rb
@@ -344,7 +344,10 @@ module Mongoid
         association.inverse_class.tap do |klass|
           klass.re_define_method("#{name}=") do |object|
             without_autobuild do
-              object = nil if association.fallback? && !object.is_a?(association.relation_class)
+              if association.fallback?
+                klass = association.polymorphic? ? Mongoid::Document : association.relation_class
+                object = nil unless object.is_a?(klass)
+              end
 
               if value = get_relation(name, association, object)
                 value = __build__(name, value, association) unless value.respond_to?(:substitute)

--- a/lib/mongoid/association/accessors.rb
+++ b/lib/mongoid/association/accessors.rb
@@ -301,7 +301,10 @@ module Mongoid
         association.inverse_class.tap do |klass|
           klass.re_define_method(name) do |reload = false|
             value = get_relation(name, association, nil, reload)
-            value = send("build_#{name}") if value.nil? && association.autobuilding? && !without_autobuild?
+            next value unless value.nil? && !without_autobuild?
+            next association.fallback if association.fallback?
+            next send("build_#{name}") if association.autobuilding?
+
             value
           end
         end
@@ -341,6 +344,8 @@ module Mongoid
         association.inverse_class.tap do |klass|
           klass.re_define_method("#{name}=") do |object|
             without_autobuild do
+              object = nil if association.fallback? && !object.is_a?(association.relation_class)
+
               if value = get_relation(name, association, object)
                 value = __build__(name, value, association) unless value.respond_to?(:substitute)
 

--- a/lib/mongoid/association/depending.rb
+++ b/lib/mongoid/association/depending.rb
@@ -96,17 +96,17 @@ module Mongoid
       private
 
       def _dependent_delete_all!(association)
-        return unless relation = send(association.name)
+        return unless relation = without_autobuild { send(association.name) }
 
         if relation.respond_to?(:dependents) && relation.dependents.blank?
           relation.clear
         else
-          ::Array.wrap(send(association.name)).each { |rel| rel.delete }
+          ::Array.wrap(relation).each { |rel| rel.delete }
         end
       end
 
       def _dependent_destroy!(association)
-        return unless relation = send(association.name)
+        return unless relation = without_autobuild { send(association.name) }
 
         if relation.is_a?(Enumerable)
           relation.entries
@@ -117,19 +117,19 @@ module Mongoid
       end
 
       def _dependent_nullify!(association)
-        return unless relation = send(association.name)
+        return unless relation = without_autobuild { send(association.name) }
 
         relation.nullify
       end
 
       def _dependent_restrict_with_exception!(association)
-        if (relation = send(association.name)) && !relation.blank?
+        if (relation = without_autobuild { send(association.name) }) && !relation.blank?
           raise Errors::DeleteRestriction.new(relation, association.name)
         end
       end
 
       def _dependent_restrict_with_error!(association)
-        return unless (relation = send(association.name)) && !relation.blank?
+        return unless (relation = without_autobuild { send(association.name) }) && !relation.blank?
 
         errors.add(association.name, :destroy_restrict_with_error_dependencies_exist)
         throw(:abort, false)

--- a/lib/mongoid/association/embedded/embeds_one.rb
+++ b/lib/mongoid/association/embedded/embeds_one.rb
@@ -21,6 +21,7 @@ module Mongoid
           as
           cascade_callbacks
           cyclic
+          fallback
           store_as
         ]
 

--- a/lib/mongoid/association/nested/one.rb
+++ b/lib/mongoid/association/nested/one.rb
@@ -26,7 +26,12 @@ module Mongoid
         def build(parent)
           return if reject?(parent, attributes)
 
-          @existing = parent.send(association.name)
+          @existing =
+            if association.fallback?
+              parent.send(:without_autobuild) { parent.send(association.name) }
+            else
+              parent.send(association.name)
+            end
           if update?
             delete_id(attributes)
             existing.assign_attributes(attributes)

--- a/lib/mongoid/association/options.rb
+++ b/lib/mongoid/association/options.rb
@@ -39,6 +39,23 @@ module Mongoid
         !!@options[:autobuild]
       end
 
+      # Invokes the :fallback Proc and returns the null object that stands in
+      # for the association when its actual value is nil. The Proc is invoked
+      # on every access; identity is the user's responsibility (return a fresh
+      # instance, a shared constant, or whatever the Proc chooses).
+      #
+      # @return [ Object | nil ] The Proc's return value, or nil if not set.
+      def fallback
+        @options[:fallback]&.call
+      end
+
+      # Whether the association has a :fallback (null object) option set.
+      #
+      # @return [ true | false ]
+      def fallback?
+        !@options[:fallback].nil?
+      end
+
       # Is the association cyclic.
       #
       # @return [ true | false ] Whether the association is cyclic.

--- a/lib/mongoid/association/referenced/belongs_to.rb
+++ b/lib/mongoid/association/referenced/belongs_to.rb
@@ -22,6 +22,7 @@ module Mongoid
           autosave
           counter_cache
           dependent
+          fallback
           foreign_key
           index
           polymorphic

--- a/lib/mongoid/association/referenced/counter_cache.rb
+++ b/lib/mongoid/association/referenced/counter_cache.rb
@@ -110,7 +110,7 @@ module Mongoid
                   end
                 end
 
-                if (record = __send__(name)) && !current.nil?
+                if (record = without_autobuild { __send__(name) }) && !current.nil?
                   record[cache_column] = (record[cache_column] || 0) + 1
                   record.class.with(record.persistence_context) do |_class|
                     _class.increment_counter(cache_column, current) if record.persisted?
@@ -120,7 +120,7 @@ module Mongoid
             end
 
             klass.after_create do
-              if record = __send__(name)
+              if record = without_autobuild { __send__(name) }
                 record[cache_column] = (record[cache_column] || 0) + 1
 
                 if record.persisted?
@@ -133,7 +133,7 @@ module Mongoid
             end
 
             klass.before_destroy do
-              if record = __send__(name)
+              if record = without_autobuild { __send__(name) }
                 record[cache_column] = (record[cache_column] || 0) - 1 unless record.frozen?
 
                 if record.persisted?

--- a/lib/mongoid/association/referenced/has_one.rb
+++ b/lib/mongoid/association/referenced/has_one.rb
@@ -22,6 +22,7 @@ module Mongoid
           autobuild
           autosave
           dependent
+          fallback
           foreign_key
           primary_key
           scope

--- a/lib/mongoid/association/relatable.rb
+++ b/lib/mongoid/association/relatable.rb
@@ -421,7 +421,9 @@ module Mongoid
           end
 
           if @options.key?(:autobuild)
-            raise Errors::InvalidRelationOption.new(@owner_class, name, :fallback, self.class::VALID_OPTIONS)
+            raise ArgumentError,
+                  "The :fallback option for association '#{name}' on " \
+                  "#{@owner_class} cannot be combined with :autobuild."
           end
         end
 

--- a/lib/mongoid/association/relatable.rb
+++ b/lib/mongoid/association/relatable.rb
@@ -413,6 +413,18 @@ module Mongoid
           end
         end
 
+        if @options.key?(:fallback)
+          unless @options[:fallback].respond_to?(:call)
+            raise ArgumentError,
+                  "The :fallback option for association '#{name}' on " \
+                  "#{@owner_class} must be a Proc or lambda."
+          end
+
+          if @options.key?(:autobuild)
+            raise Errors::InvalidRelationOption.new(@owner_class, name, :fallback, self.class::VALID_OPTIONS)
+          end
+        end
+
         [ name, :"#{name}?", :"#{name}=" ].each do |n|
           raise Errors::InvalidRelation.new(@owner_class, n) if Mongoid.destructive_fields.include?(n)
         end

--- a/lib/mongoid/serializable.rb
+++ b/lib/mongoid/serializable.rb
@@ -127,10 +127,18 @@ module Mongoid
       inclusions = options[:include]
       relation_names(inclusions).each do |name|
         association = relations[name.to_s]
-        if association && relation = send(association.name)
-          attributes[association.name.to_s] =
-            relation.serializable_hash(relation_options(inclusions, options, name))
-        end
+        next unless association
+
+        relation =
+          if association.fallback?
+            without_autobuild { send(association.name) }
+          else
+            send(association.name)
+          end
+        next unless relation
+
+        attributes[association.name.to_s] =
+          relation.serializable_hash(relation_options(inclusions, options, name))
       end
     end
 

--- a/spec/mongoid/association/fallback_spec.rb
+++ b/spec/mongoid/association/fallback_spec.rb
@@ -321,6 +321,37 @@ describe 'associations with the :fallback option' do
     end
   end
 
+  context 'with nested attributes' do
+    before(:all) do
+      class Composer
+        include Mongoid::Document
+
+        field :name
+
+        embedded_in :symphony
+      end
+
+      class Symphony
+        include Mongoid::Document
+
+        embeds_one :composer, fallback: -> { Anonymous.new }
+        accepts_nested_attributes_for :composer
+      end
+    end
+
+    after(:all) do
+      Object.send(:remove_const, :Symphony)
+      Object.send(:remove_const, :Composer)
+    end
+
+    it 'builds the nested document instead of operating on the fallback' do
+      symphony = Symphony.new
+
+      expect { symphony.composer_attributes = { name: 'Mahler' } }.not_to raise_error
+      expect(symphony.composer.name).to eq('Mahler')
+    end
+  end
+
   context 'validation of the :fallback option' do
     it 'rejects a declaration that combines :fallback with :autobuild' do
       expect do

--- a/spec/mongoid/association/fallback_spec.rb
+++ b/spec/mongoid/association/fallback_spec.rb
@@ -177,6 +177,118 @@ describe 'associations with the :fallback option' do
     end
   end
 
+  context 'with a dependent strategy and no real associated document' do
+    before(:all) do
+      class Composer
+        include Mongoid::Document
+      end
+    end
+
+    after(:all) do
+      Object.send(:remove_const, :Composer)
+    end
+
+    context 'when the strategy is :destroy' do
+      before(:all) do
+        class Symphony
+          include Mongoid::Document
+
+          has_one :composer, dependent: :destroy, fallback: -> { Anonymous.new }
+        end
+      end
+
+      after(:all) do
+        Object.send(:remove_const, :Symphony)
+      end
+
+      it 'does not apply the strategy to the fallback when destroying the owner' do
+        symphony = Symphony.create!
+
+        expect { symphony.destroy }.not_to raise_error
+      end
+    end
+
+    context 'when the strategy is :nullify' do
+      before(:all) do
+        class Symphony
+          include Mongoid::Document
+
+          has_one :composer, dependent: :nullify, fallback: -> { Anonymous.new }
+        end
+      end
+
+      after(:all) do
+        Object.send(:remove_const, :Symphony)
+      end
+
+      it 'does not apply the strategy to the fallback when destroying the owner' do
+        symphony = Symphony.create!
+
+        expect { symphony.destroy }.not_to raise_error
+      end
+    end
+
+    context 'when the strategy is :delete_all' do
+      before(:all) do
+        class Symphony
+          include Mongoid::Document
+
+          has_one :composer, dependent: :delete_all, fallback: -> { Anonymous.new }
+        end
+      end
+
+      after(:all) do
+        Object.send(:remove_const, :Symphony)
+      end
+
+      it 'does not apply the strategy to the fallback when destroying the owner' do
+        symphony = Symphony.create!
+
+        expect { symphony.destroy }.not_to raise_error
+      end
+    end
+
+    context 'when the strategy is :restrict_with_exception' do
+      before(:all) do
+        class Symphony
+          include Mongoid::Document
+
+          has_one :composer, dependent: :restrict_with_exception, fallback: -> { Anonymous.new }
+        end
+      end
+
+      after(:all) do
+        Object.send(:remove_const, :Symphony)
+      end
+
+      it 'does not apply the strategy to the fallback when destroying the owner' do
+        symphony = Symphony.create!
+
+        expect { symphony.destroy }.not_to raise_error
+      end
+    end
+
+    context 'when the strategy is :restrict_with_error' do
+      before(:all) do
+        class Symphony
+          include Mongoid::Document
+
+          has_one :composer, dependent: :restrict_with_error, fallback: -> { Anonymous.new }
+        end
+      end
+
+      after(:all) do
+        Object.send(:remove_const, :Symphony)
+      end
+
+      it 'does not block destroying the owner because of the fallback' do
+        symphony = Symphony.create!
+
+        expect(symphony.destroy).to be_truthy
+      end
+    end
+  end
+
   context 'validation of the :fallback option' do
     it 'rejects a declaration that combines :fallback with :autobuild' do
       expect do

--- a/spec/mongoid/association/fallback_spec.rb
+++ b/spec/mongoid/association/fallback_spec.rb
@@ -352,6 +352,32 @@ describe 'associations with the :fallback option' do
     end
   end
 
+  context 'when serialized with an included association' do
+    before(:all) do
+      class Composer
+        include Mongoid::Document
+      end
+
+      class Symphony
+        include Mongoid::Document
+
+        belongs_to :composer, fallback: -> { Anonymous.new }
+      end
+    end
+
+    after(:all) do
+      Object.send(:remove_const, :Symphony)
+      Object.send(:remove_const, :Composer)
+    end
+
+    it 'omits the fallback when the real association is nil' do
+      symphony = Symphony.new
+
+      expect { symphony.serializable_hash(include: :composer) }.not_to raise_error
+      expect(symphony.serializable_hash(include: :composer)).not_to have_key('composer')
+    end
+  end
+
   context 'validation of the :fallback option' do
     it 'rejects a declaration that combines :fallback with :autobuild' do
       expect do

--- a/spec/mongoid/association/fallback_spec.rb
+++ b/spec/mongoid/association/fallback_spec.rb
@@ -1,0 +1,201 @@
+require 'spec_helper'
+
+describe 'associations with the :fallback option' do
+  before(:all) do
+    class Anonymous
+      def attribution
+        'Composer unknown'
+      end
+    end
+  end
+
+  after(:all) do
+    Object.send(:remove_const, :Anonymous)
+  end
+
+  context 'belongs_to' do
+    before(:all) do
+      class Composer
+        include Mongoid::Document
+
+        field :name
+
+        def attribution
+          "Composed by #{name}"
+        end
+      end
+
+      class Symphony
+        include Mongoid::Document
+
+        belongs_to :composer, fallback: -> { Anonymous.new }
+      end
+    end
+
+    after(:all) do
+      Object.send(:remove_const, :Symphony)
+      Object.send(:remove_const, :Composer)
+    end
+
+    it 'returns a fresh null object instance on every access when the association is nil' do
+      symphony = Symphony.create!
+
+      expect(symphony.composer.attribution).to eq('Composer unknown')
+      expect(symphony.composer).not_to equal(symphony.composer)
+    end
+
+    it 'returns the real associated document when the FK is set' do
+      symphony = Symphony.create!(composer: Composer.create!(name: 'Mahler'))
+
+      expect(Symphony.find(symphony.id).composer.attribution).to eq('Composed by Mahler')
+    end
+
+    it 'treats a direct null object assignment as nil' do
+      symphony = Symphony.create!
+
+      symphony.composer = Anonymous.new
+      symphony.save!
+
+      expect(Symphony.find(symphony.id).composer_id).to be_nil
+    end
+
+    it 'treats a null object passed via the constructor as nil' do
+      symphony = Symphony.create!(composer: Anonymous.new)
+
+      expect(Symphony.find(symphony.id).composer_id).to be_nil
+    end
+  end
+
+  context 'has_one' do
+    before(:all) do
+      class Composer
+        include Mongoid::Document
+
+        field :name
+
+        belongs_to :symphony
+
+        def attribution
+          "Composed by #{name}"
+        end
+      end
+
+      class Symphony
+        include Mongoid::Document
+
+        has_one :composer, fallback: -> { Anonymous.new }
+      end
+    end
+
+    after(:all) do
+      Object.send(:remove_const, :Symphony)
+      Object.send(:remove_const, :Composer)
+    end
+
+    it 'returns a fresh null object instance on every access when the association is nil' do
+      symphony = Symphony.create!
+
+      expect(symphony.composer.attribution).to eq('Composer unknown')
+      expect(symphony.composer).not_to equal(symphony.composer)
+    end
+
+    it 'returns the real associated document when one exists' do
+      symphony = Symphony.create!
+      Composer.create!(symphony: symphony, name: 'Mahler')
+
+      expect(Symphony.find(symphony.id).composer.attribution).to eq('Composed by Mahler')
+    end
+
+    it 'treats a direct null object assignment as nil' do
+      symphony = Symphony.create!
+
+      symphony.composer = Anonymous.new
+      symphony.save!
+
+      expect(Composer.where(symphony_id: symphony.id).first).to be_nil
+    end
+
+    it 'treats a null object passed via the constructor as nil' do
+      symphony = Symphony.create!(composer: Anonymous.new)
+
+      expect(Composer.where(symphony_id: symphony.id).first).to be_nil
+    end
+  end
+
+  context 'embeds_one' do
+    before(:all) do
+      class Composer
+        include Mongoid::Document
+
+        field :name
+
+        embedded_in :symphony
+
+        def attribution
+          "Composed by #{name}"
+        end
+      end
+
+      class Symphony
+        include Mongoid::Document
+
+        embeds_one :composer, fallback: -> { Anonymous.new }
+      end
+    end
+
+    after(:all) do
+      Object.send(:remove_const, :Symphony)
+      Object.send(:remove_const, :Composer)
+    end
+
+    it 'returns a fresh null object instance on every access when the association is nil' do
+      symphony = Symphony.create!
+
+      expect(symphony.composer.attribution).to eq('Composer unknown')
+      expect(symphony.composer).not_to equal(symphony.composer)
+    end
+
+    it 'returns the real embedded document when one exists' do
+      symphony = Symphony.create!(composer: Composer.new(name: 'Mahler'))
+
+      expect(Symphony.find(symphony.id).composer.attribution).to eq('Composed by Mahler')
+    end
+
+    it 'treats a direct null object assignment as nil' do
+      symphony = Symphony.create!
+
+      symphony.composer = Anonymous.new
+      symphony.save!
+
+      expect(Symphony.collection.find(_id: symphony.id).first['composer']).to be_nil
+    end
+
+    it 'treats a null object passed via the constructor as nil' do
+      symphony = Symphony.create!(composer: Anonymous.new)
+
+      expect(Symphony.collection.find(_id: symphony.id).first['composer']).to be_nil
+    end
+  end
+
+  context 'validation of the :fallback option' do
+    it 'rejects a declaration that combines :fallback with :autobuild' do
+      expect do
+        Class.new do
+          include Mongoid::Document
+
+          belongs_to :composer, fallback: -> { Object.new }, autobuild: true
+        end
+      end.to raise_error(Mongoid::Errors::InvalidRelationOption)
+    end
+
+    it 'rejects a non-callable :fallback value' do
+      expect do
+        Class.new do
+          include Mongoid::Document
+
+          belongs_to :composer, fallback: Object.new
+        end
+      end.to raise_error(ArgumentError, /must be a Proc or lambda/)
+    end
+  end
+end

--- a/spec/mongoid/association/fallback_spec.rb
+++ b/spec/mongoid/association/fallback_spec.rb
@@ -360,7 +360,7 @@ describe 'associations with the :fallback option' do
 
           belongs_to :composer, fallback: -> { Object.new }, autobuild: true
         end
-      end.to raise_error(Mongoid::Errors::InvalidRelationOption)
+      end.to raise_error(ArgumentError, /cannot be combined with :autobuild/)
     end
 
     it 'rejects a non-callable :fallback value' do

--- a/spec/mongoid/association/fallback_spec.rb
+++ b/spec/mongoid/association/fallback_spec.rb
@@ -378,6 +378,29 @@ describe 'associations with the :fallback option' do
     end
   end
 
+  context 'with a counter cache' do
+    before(:all) do
+      class Composer
+        include Mongoid::Document
+      end
+
+      class Symphony
+        include Mongoid::Document
+
+        belongs_to :composer, counter_cache: true, fallback: -> { Anonymous.new }
+      end
+    end
+
+    after(:all) do
+      Object.send(:remove_const, :Symphony)
+      Object.send(:remove_const, :Composer)
+    end
+
+    it 'does not update the counter on the fallback' do
+      expect { Symphony.create! }.not_to raise_error
+    end
+  end
+
   context 'validation of the :fallback option' do
     it 'rejects a declaration that combines :fallback with :autobuild' do
       expect do

--- a/spec/mongoid/association/fallback_spec.rb
+++ b/spec/mongoid/association/fallback_spec.rb
@@ -289,6 +289,38 @@ describe 'associations with the :fallback option' do
     end
   end
 
+  context 'on a polymorphic belongs_to' do
+    before(:all) do
+      class Composer
+        include Mongoid::Document
+      end
+
+      class Symphony
+        include Mongoid::Document
+
+        belongs_to :author, polymorphic: true, fallback: -> { Anonymous.new }
+      end
+    end
+
+    after(:all) do
+      Object.send(:remove_const, :Symphony)
+      Object.send(:remove_const, :Composer)
+    end
+
+    it 'does not raise when assigning a real document' do
+      symphony = Symphony.new
+
+      expect { symphony.author = Composer.new }.not_to raise_error
+    end
+
+    it 'treats a null object assignment as nil' do
+      symphony = Symphony.new
+
+      expect { symphony.author = Anonymous.new }.not_to raise_error
+      expect(symphony.author_id).to be_nil
+    end
+  end
+
   context 'validation of the :fallback option' do
     it 'rejects a declaration that combines :fallback with :autobuild' do
       expect do


### PR DESCRIPTION
## Summary

A `:fallback` option has been added to `belongs_to`, `has_one`, and `embeds_one`. 

This option accepts a `Proc`, and whenever the association would be `nil`, Mongoid returns whatever the proc gives back (i.e. it follows the "null object" pattern).

```ruby
class Anonymous
  def attribution
    "Composer unknown"
  end
end

class Composer
  include Mongoid::Document
  field :name

  def attribution
    "Composed by #{name}"
  end
end

class Symphony
  include Mongoid::Document
  belongs_to :composer, fallback: -> { Anonymous.new }
end

Symphony.create!.composer.attribution
# => "Composer unknown"

Symphony.create!(composer: Composer.create!(name: "Mahler")).composer.attribution
# => "Composed by Mahler"
```

It behaves similarly with `has_one` and `embeds_one`.

Things to note:

- The proc runs **on every access** — fresh instance each time. If you want identity, memoize in the Proc.
- Null object **never persists**. Anything you assign that isn't an instance of the association's class (or a subclass) becomes `nil` — whether via setter or constructor.
- A real document always wins — if the FK is set, the Proc never runs.
- Can't combine with `:autobuild` (they want opposite things). Raises `InvalidRelationOption`.

Credit to @cperezabo for this feature.