### PR TITLE
MONGOID-5944 merge $set when inserting embeds_one with touch

### DIFF
--- a/lib/mongoid/persistable/creatable.rb
+++ b/lib/mongoid/persistable/creatable.rb
@@ -65,7 +65,7 @@ module Mongoid
           if _touchable_parent?
             touches = _parent._gather_touch_updates(Time.current)
             if touches.present?
-              operations['$set'] = touches
+              operations['$set'] = (operations['$set'] || {}).merge(touches)
               Threaded.begin_touch_merged(self)
             end
           end

--- a/lib/mongoid/traversable.rb
+++ b/lib/mongoid/traversable.rb
@@ -211,7 +211,7 @@ module Mongoid
       # @api private
       def self.add_discriminator_mapping(value, klass = self)
         self.discriminator_mapping ||= {}
-        self.discriminator_mapping[value] = klass
+        discriminator_mapping[value] = klass
         superclass.add_discriminator_mapping(value, klass) if hereditary?
       end
 
@@ -225,7 +225,7 @@ module Mongoid
       #
       # @api private
       def self.get_discriminator_mapping(value)
-        self.discriminator_mapping[value] if self.discriminator_mapping
+        discriminator_mapping[value] if discriminator_mapping
       end
     end
 

--- a/spec/mongoid/touchable_spec.rb
+++ b/spec/mongoid/touchable_spec.rb
@@ -1511,5 +1511,30 @@ describe Mongoid::Touchable do
         expect(building.updated_at).to eq(original_building_updated_at)
       end
     end
+
+    context 'when creating an embeds_one document with touch: true (regression for #6128)' do
+      let(:building) do
+        TouchableSpec::Embedded::Building.create!(title: 'Tower')
+      end
+
+      it 'persists the embedded document fields after create_<assoc>' do
+        building.create_lobby(name: 'Main Lobby')
+
+        reloaded = TouchableSpec::Embedded::Building.find(building.id)
+        expect(reloaded.lobby).not_to be_nil
+        expect(reloaded.lobby.name).to eq('Main Lobby')
+      end
+
+      it 'updates the parent updated_at after create_<assoc>' do
+        original_updated_at = building.updated_at
+
+        Timecop.travel(Time.now + 10) do
+          building.create_lobby(name: 'Main Lobby')
+        end
+
+        building.reload
+        expect(building.updated_at).to be > original_updated_at
+      end
+    end
   end
 end

--- a/spec/mongoid/touchable_spec_models.rb
+++ b/spec/mongoid/touchable_spec_models.rb
@@ -10,6 +10,16 @@ module TouchableSpec
 
       embeds_many :entrances, class_name: 'TouchableSpec::Embedded::Entrance'
       embeds_many :floors, class_name: 'TouchableSpec::Embedded::Floor'
+      embeds_one :lobby, class_name: 'TouchableSpec::Embedded::Lobby'
+    end
+
+    class Lobby
+      include Mongoid::Document
+      include Mongoid::Timestamps
+
+      field :name, type: String
+
+      embedded_in :building, touch: true, class_name: 'TouchableSpec::Embedded::Building'
     end
 
     class Entrance


### PR DESCRIPTION
## Overview

When inserting an `embeds_one` document whose `embedded_in` association has `touch: true`, `atomic_inserts` returns `{ "$set" => { field => doc } }`. The code introduced in #6128 assigned `operations['$set'] = touches`, which **silently overwrote** the embedded document data with only the touch timestamp, causing the child document to disappear after reload.

For `embeds_many`, the insert modifier is `$push`, so there is no `$set` collision — the bug only affects `embeds_one`.

**Root cause:** assignment instead of merge on line 68 of `lib/mongoid/persistable/creatable.rb`.

## Fix

```ruby
# Before (buggy)
operations['$set'] = touches

# After
operations['$set'] = (operations['$set'] || {}).merge(touches)
```

This is a no-op for `embeds_many` (no existing `$set` key). For `embeds_one`, it merges the touch timestamps into the same `$set` that carries the document fields.

## Reproduction

From the [bug report](https://github.com/mongodb/mongoid/pull/6128#issuecomment-4486180962):

```ruby
class Parent
  include Mongoid::Document
  include Mongoid::Timestamps
  embeds_one :child
end

class Child
  include Mongoid::Document
  include Mongoid::Timestamps
  embedded_in :parent
end

parent = Parent.create!(name: "test")
parent.create_child(value: "important_data")

reloaded = Parent.find(parent.id)
reloaded.child  # nil on 9.1.0 — data silently dropped
```

## Changes

- `lib/mongoid/persistable/creatable.rb` — one-line fix (merge instead of assign)
- `spec/mongoid/touchable_spec_models.rb` — adds `Lobby` (`embeds_one`) + `Building#embeds_one :lobby`
- `spec/mongoid/touchable_spec.rb` — two regression examples for the `embeds_one` + touch case

## Testing

The two new regression examples cover:
- `create_<assoc>` persists embedded document fields after reload
- parent `updated_at` is still bumped after `create_<assoc>`