### PR TITLE
MONGOID-5934 Fix NoMethodError in nested attributes when raise_not_found_error is false

### DIFF
--- a/lib/mongoid/association/nested/many.rb
+++ b/lib/mongoid/association/nested/many.rb
@@ -197,6 +197,12 @@ module Mongoid
 
               # push existing document to association
               doc = association.klass.unscoped.find(converted)
+              # find returns nil instead of raising when
+              # Mongoid.raise_not_found_error is false; a missing document
+              # must still be an error here, consistent with the other
+              # not-found branches.
+              raise Errors::DocumentNotFound.new(association.klass, id) if doc.nil?
+
               update_document(doc, attrs)
               existing.push(doc)
             end

--- a/spec/mongoid/attributes/nested_spec.rb
+++ b/spec/mongoid/attributes/nested_spec.rb
@@ -188,6 +188,30 @@ describe Mongoid::Attributes::Nested do
           it 'sets the nested attributes' do
             expect(person2.posts.map(&:title)).to eq([ 'Reparented!' ])
           end
+
+          context 'when the id does not correspond to an existing document' do
+            let(:person2) do
+              Person.create!(posts_attributes: { '0' => { id: BSON::ObjectId.new, title: 'Ghost' } })
+            end
+
+            context 'when raise_not_found_error is true' do
+              config_override :raise_not_found_error, true
+
+              it 'raises a document not found error' do
+                expect { person2 }.to raise_error(Mongoid::Errors::DocumentNotFound,
+                                                  /Document\(s\) not found for class Post/)
+              end
+            end
+
+            context 'when raise_not_found_error is false' do
+              config_override :raise_not_found_error, false
+
+              it 'raises a document not found error' do
+                expect { person2 }.to raise_error(Mongoid::Errors::DocumentNotFound,
+                                                  /Document\(s\) not found for class Post/)
+              end
+            end
+          end
         end
 
         context 'when _destroy is true for a document not in the relation' do
@@ -247,6 +271,32 @@ describe Mongoid::Attributes::Nested do
             preferences_attributes: { 0 => { id: preference.id, name: preference_name } }
           )
           expect(person.preferences.map(&:name)).to eq([ preference_name ])
+        end
+
+        context 'when the id does not correspond to an existing document' do
+          let(:person) do
+            Person.new(
+              preferences_attributes: { 0 => { id: BSON::ObjectId.new, name: 'Ghost' } }
+            )
+          end
+
+          context 'when raise_not_found_error is true' do
+            config_override :raise_not_found_error, true
+
+            it 'raises a document not found error' do
+              expect { person }.to raise_error(Mongoid::Errors::DocumentNotFound,
+                                               /Document\(s\) not found for class Preference/)
+            end
+          end
+
+          context 'when raise_not_found_error is false' do
+            config_override :raise_not_found_error, false
+
+            it 'raises a document not found error' do
+              expect { person }.to raise_error(Mongoid::Errors::DocumentNotFound,
+                                               /Document\(s\) not found for class Preference/)
+            end
+          end
         end
 
         context 'when _destroy is true for a document not in the relation' do


### PR DESCRIPTION
With `Mongoid.raise_not_found_error = false`, a nested-attributes hash referencing a non-existent `_id` on a `has_and_belongs_to_many` association (or any association when `allow_reparenting_via_nested_attributes` is enabled) crashed with `NoMethodError: undefined method 'update_attributes' for nil`.

`Nested::Many#update_nested_relation` looks the document up with `association.klass.unscoped.find(converted)`. `find` honors `raise_not_found_error` and returns `nil` when the flag is off, and the `nil` flowed straight into `update_document`. The other two not-found branches in the same method raise `Errors::DocumentNotFound` unconditionally, and ActiveRecord likewise raises `RecordNotFound` for unmatched nested ids regardless of configuration, so this branch now does the same: a `nil` from `find` raises `Errors::DocumentNotFound`.

Behavior with `raise_not_found_error = true` is unchanged: `find` raises before the new guard is reached, with the same exception class and message.

Changes:

- `lib/mongoid/association/nested/many.rb`: nil guard after the `find` in the HABTM/reparenting branch, raising `Errors::DocumentNotFound`.
- `spec/mongoid/attributes/nested_spec.rb`: new contexts for `has_many` (with reparenting enabled) and `has_and_belongs_to_many` with a non-existent id, each covering `raise_not_found_error` true (regression guard) and false (failed with `NoMethodError` before the fix).

Test plan (all against a local 3-node replica set):

- [x] `spec/mongoid/attributes/nested_spec.rb` — 713 examples, 0 failures (new examples fail with `NoMethodError` before the fix)
- [x] Regression sweep: `spec/mongoid/attributes`, `spec/mongoid/attributes_spec.rb`, `spec/mongoid/association/nested`, `spec/mongoid/association/referenced/has_and_belongs_to_many`, `spec/mongoid/association/referenced/has_many`, `spec/mongoid/association/embedded`, `spec/mongoid/persistable` — 6028 examples, 0 failures, 13 pending (pre-existing)
- [x] `bundle exec rubocop` on changed files — no offenses

[MONGOID-5934](https://jira.mongodb.org/browse/MONGOID-5934)
