### PR TITLE
MONGOID-5881 Persist empty array set via raw attribute write in before_save

### DIFF
--- a/lib/mongoid/association/embedded/embeds_many/proxy.rb
+++ b/lib/mongoid/association/embedded/embeds_many/proxy.rb
@@ -601,7 +601,12 @@ module Mongoid
           # @api private
           def update_attributes_hash
             if _target.empty?
-              _base.attributes.delete(_association.store_as)
+              # Only remove the key if it is absent or nil. If it is already
+              # an empty array, the caller explicitly set it to [] (e.g. via
+              # a raw write_attribute call), and that intent must be preserved
+              # so the empty array is persisted to the database.
+              stored = _association.store_as
+              _base.attributes.delete(stored) unless _base.attributes[stored] == []
             else
               _base.attributes.merge!(_association.store_as => _target.map(&:attributes))
             end

--- a/spec/mongoid/association/embedded/embeds_many/proxy_spec.rb
+++ b/spec/mongoid/association/embedded/embeds_many/proxy_spec.rb
@@ -4524,6 +4524,39 @@ describe Mongoid::Association::Embedded::EmbedsMany::Proxy do
         expect(reloaded_band).not_to have_key(:labels)
       end
     end
+
+    context 'when set via raw attribute write in a before_save callback' do
+      after { Band.reset_callbacks(:save) }
+
+      let(:reloaded_band) { Band.collection.find(_id: band._id).first }
+
+      context 'on a new record' do
+        before { Band.before_save { self[:labels] ||= [] } }
+
+        let(:band) { Band.create! }
+
+        it 'persists the empty list' do
+          expect(reloaded_band).to have_key(:labels)
+          expect(reloaded_band[:labels]).to eq []
+        end
+      end
+
+      context 'on an existing record' do
+        # Reload the band from MongoDB so the labels proxy has not been
+        # initialized, which is the scenario that triggers the bug.
+        let(:band) { Band.find(Band.create!._id) }
+
+        before do
+          Band.before_save { self[:labels] ||= [] }
+          band.save!
+        end
+
+        it 'persists the empty list' do
+          expect(reloaded_band).to have_key(:labels)
+          expect(reloaded_band[:labels]).to eq []
+        end
+      end
+    end
   end
 
   context 'when using assign_attributes with an already populated array' do


### PR DESCRIPTION
## Description

Fixes MONGOID-5881: setting an `embeds_many` association to an empty array via a raw attribute write (e.g. `self[:labels] ||= []`) in a `before_save` callback was not being persisted to the database.

### Root cause

The regression was introduced by the MONGOID-4397 fix (commit `e08fff0e5`, Mongoid 8.0+). That commit added `update_attributes_hash` to `EmbedsMany::Proxy`, which deletes the association key from the parent's attributes hash whenever the proxy target is empty:

```ruby
def update_attributes_hash
  if _target.empty?
    _base.attributes.delete(_association.store_as)  # ← the problem
  else
    _base.attributes.merge!(...)
  end
end
```

On **insert**, `as_attributes` iterates over all embedded relations and calls `send(:labels)` to lazily initialize each proxy. When the proxy initializes with an empty target (from the `[]` the callback just wrote), `update_attributes_hash` deletes the key. `add_attributes_for_relation` then sees neither the key nor a non-blank relation, returns early, and the insert document is assembled without `labels: []`.

On **update**, the bug does not trigger because `generate_atomic_updates` (which reads `changes`) runs before `_descendants.each` (which lazily initializes the proxy), so the dirty state is captured while the key is still present.

### Fix

In `update_attributes_hash`, only delete the key when it is absent or `nil`. If the key is already `[]`, a caller explicitly set it to an empty array and that intent must be preserved:

```ruby
_base.attributes.delete(stored) unless _base.attributes[stored] == []
```

### Tests

Two new examples under `when trying to persist the empty list` → `when set via raw attribute write in a before_save callback`:

- **on a new record** — the previously failing INSERT case
- **on an existing record** — the UPDATE case with a freshly-loaded document (proxy uninitialized at save time)

The existing `does not persist the empty list` example (covering the never-set case) continues to pass, confirming the fix does not cause spurious empty arrays to appear in documents that never had the association set.