### PR TITLE
Fix installed i18n version for Ruby < 3.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ end
 
 if RUBY_VERSION < '3.2'
   # 1.15.0 uses Fiber[:foo] syntax, which breaks on Ruby 3.1
-  i18n_version << '< 1.15.0'
+  i18n_versions << '< 1.15.0'
 end
 
 gem 'i18n', *i18n_versions

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,11 @@ if RUBY_PLATFORM =~ /java/
   i18n_versions << '< 1.8.8'
 end
 
+if RUBY_VERSION < '3.2'
+  # 1.15.0 uses Fiber[:foo] syntax, which breaks on Ruby 3.1
+  i18n_version << '< 1.15.0'
+end
+
 gem 'i18n', *i18n_versions
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem


### PR DESCRIPTION
i18n 1.15.0 was released on 17 Jun 2026 and specified the incorrect minimum Ruby version (3.1). It should have been 3.2, because it began using `Fiber[:foo]` to reference fiber-local variables, but that syntax is unavailable in Ruby 3.1.