### PR TITLE
MONGOID-5931 Remove dead and unreachable code

### DIFF
--- a/lib/mongoid/clients/factory.rb
+++ b/lib/mongoid/clients/factory.rb
@@ -111,10 +111,6 @@ module Mongoid
         version: VERSION
       }.freeze
 
-      def driver_version
-        Mongo::VERSION.split('.')[0...2].map(&:to_i)
-      end
-
       # Prepare options for Mongo::Client based on Mongoid client configuration.
       #
       # @param [ Hash ] opts Parameters from options section of Mongoid client configuration.
@@ -125,16 +121,14 @@ module Mongoid
         options = opts.dup
         options[:platform] = PLATFORM_DETAILS
         options[:app_name] = Mongoid::Config.app_name if Mongoid::Config.app_name
-        if (driver_version <=> [ 2, 13 ]) >= 0
-          wrap_lib = if options[:wrapping_libraries]
-                       [ MONGOID_WRAPPING_LIBRARY ] + options[:wrapping_libraries]
-                     else
-                       [ MONGOID_WRAPPING_LIBRARY ]
-                     end.tap do |wrap|
-            wrap << { name: 'Rails', version: ::Rails.version } if defined?(::Rails) && ::Rails.respond_to?(:version)
-          end
-          options[:wrapping_libraries] = wrap_lib
+        wrap_lib = if options[:wrapping_libraries]
+                     [ MONGOID_WRAPPING_LIBRARY ] + options[:wrapping_libraries]
+                   else
+                     [ MONGOID_WRAPPING_LIBRARY ]
+                   end.tap do |wrap|
+          wrap << { name: 'Rails', version: ::Rails.version } if defined?(::Rails) && ::Rails.respond_to?(:version)
         end
+        options[:wrapping_libraries] = wrap_lib
         options.reject { |k, _v| k == :hosts }.to_hash.symbolize_keys!
       end
     end

--- a/lib/mongoid/config.rb
+++ b/lib/mongoid/config.rb
@@ -548,6 +548,10 @@ module Mongoid
       end
     end
 
+    # Wraps configuration options that have been deprecated so that assigning
+    # them emits a deprecation warning. OPTIONS is intentionally empty when no
+    # options are currently deprecated; it is populated as options are retired,
+    # at which point this module rewrites their setters to warn.
     module DeprecatedOptions
       OPTIONS = %i[]
 


### PR DESCRIPTION
## Description

MONGOID-5931: audit the codebase for dead and unreachable code and remove/refactor/document each site.

I ran three detection passes:

- **RuboCop lint cops** (`Lint/UnreachableCode`, `UselessAssignment`, `UnusedMethodArgument`, `UselessMethodDefinition`, etc.) — zero offenses across all files.
- **debride** — 312 flagged methods, which a grep/AST caller cross-reference (against both `lib/` and `spec/`) narrowed to 5 non-public zero-caller candidates. All 5 were false positives: the `_dependent_*!` methods in `association/depending.rb` are dispatched via `send("_dependent_#{dependent}!", ...)`.
- **Version/capability guard sweep** — checked `RUBY_VERSION`, `BSON::VERSION`, and driver-version guards against the gemspec minimums.

The main outcome is that the codebase is largely free of dead code. The one genuine site was an obsolete driver-version guard.

### Changes

- **`clients/factory.rb`**: removed the `if (driver_version <=> [2, 13]) >= 0` guard. The gemspec requires `mongo >= 2.18.0`, so this is always true; the body now runs unconditionally. The `driver_version` helper (its only caller) is removed.
- **`config.rb`**: documented that `DeprecatedOptions::OPTIONS` is intentionally empty when no options are deprecated, so the inert-looking module reads as deliberate scaffolding.

### Reviewed and intentionally left in place

- `config.rb` `RUBY_VERSION < '3.2'` and `< '3.0'` guards — reachable under supported Ruby (gemspec requires >= 2.7).
- `config.rb` `BSON::VERSION >= '5.0.0'` guard — both bson 4 and 5 are supported at runtime.

### Testing

`spec/mongoid/clients/factory_spec.rb` and `spec/mongoid/config_spec.rb` pass against a local replica set (313 examples, 0 failures; 4 pending are libmongocrypt-gated and unrelated). RuboCop is clean.
