### PR TITLE
MONGOID-6001 Handle empty has_and_belongs_to_many foreign key arrays

### DIFF
--- a/lib/mongoid/association/referenced/has_and_belongs_to_many/buildable.rb
+++ b/lib/mongoid/association/referenced/has_and_belongs_to_many/buildable.rb
@@ -20,14 +20,20 @@ module Mongoid
           # @return [ Array<Document> ] The documents.
           def build(_base, object, _type = nil, selected_fields = nil)
             if query?(object)
+              if object.is_a?(Array) && object.empty?
+                # An empty stored key array is not $lookup output. Build a none
+                # criteria so reset, empty?, and size do not query the database.
+                return query_criteria(nil)
+              end
+
               # Handle array of hashes from $lookup aggregation
-              if object.is_a?(Array) && object.any? && object.all? { |o| o.is_a?(Hash) }
+              if object.is_a?(Array) && object.all? { |o| o.is_a?(Hash) }
                 return object.map do |attrs|
                   Factory.execute_from_db(klass, attrs, nil, selected_fields, execute_callbacks: false)
                 end
               end
 
-              query_criteria((object.is_a?(Array) && object.empty?) ? nil : object)
+              query_criteria(object)
             else
               object.try(:dup)
             end

--- a/lib/mongoid/association/referenced/has_and_belongs_to_many/buildable.rb
+++ b/lib/mongoid/association/referenced/has_and_belongs_to_many/buildable.rb
@@ -21,13 +21,13 @@ module Mongoid
           def build(_base, object, _type = nil, selected_fields = nil)
             if query?(object)
               # Handle array of hashes from $lookup aggregation
-              if object.is_a?(Array) && object.all? { |o| o.is_a?(Hash) }
+              if object.is_a?(Array) && object.any? && object.all? { |o| o.is_a?(Hash) }
                 return object.map do |attrs|
                   Factory.execute_from_db(klass, attrs, nil, selected_fields, execute_callbacks: false)
                 end
               end
 
-              query_criteria(object)
+              query_criteria((object.is_a?(Array) && object.empty?) ? nil : object)
             else
               object.try(:dup)
             end

--- a/spec/integration/associations/has_and_belongs_to_many_spec.rb
+++ b/spec/integration/associations/has_and_belongs_to_many_spec.rb
@@ -60,6 +60,23 @@ module HabtmSpec
 end
 
 describe 'has_and_belongs_to_many associations' do
+  context 'when the stored foreign-key array is empty' do
+    it 'can reset and enumerate the association proxy' do
+      item = HabtmSpec::Item.create!
+      HabtmSpec::Item.collection.update_one(
+        { _id: item.id },
+        { '$set' => { color_ids: [] } }
+      )
+      item = HabtmSpec::Item.find(item.id)
+      colours = item.colors
+
+      expect_query(0) do
+        colours.reset
+        expect(colours.to_a).to eq []
+      end
+    end
+  end
+
   context 'when an anonymous class defines a has_and_belongs_to_many association' do
     let(:klass) do
       Class.new do

--- a/spec/integration/associations/has_and_belongs_to_many_spec.rb
+++ b/spec/integration/associations/has_and_belongs_to_many_spec.rb
@@ -62,17 +62,14 @@ end
 describe 'has_and_belongs_to_many associations' do
   context 'when the stored foreign-key array is empty' do
     it 'can reset and enumerate the association proxy' do
-      item = HabtmSpec::Item.create!
-      HabtmSpec::Item.collection.update_one(
-        { _id: item.id },
-        { '$set' => { color_ids: [] } }
-      )
-      item = HabtmSpec::Item.find(item.id)
-      colours = item.colors
+      item = HabtmSpec::Item.create!(color_ids: [])
+      colors = item.reload.colors
 
       expect_query(0) do
-        colours.reset
-        expect(colours.to_a).to eq []
+        colors.reset
+        expect(colors.empty?).to be true
+        expect(colors.size).to be 0
+        expect(colors.to_a).to eq []
       end
     end
   end

--- a/spec/mongoid/association/referenced/has_and_belongs_to_many/buildable_spec.rb
+++ b/spec/mongoid/association/referenced/has_and_belongs_to_many/buildable_spec.rb
@@ -107,6 +107,21 @@ describe Mongoid::Association::Referenced::HasAndBelongsToMany::Buildable do
       end
     end
 
+    context 'when provided an empty array' do
+      let!(:object) do
+        []
+      end
+
+      let!(:criteria) do
+        Preference.none
+      end
+
+      it 'returns the criteria' do
+        expect(documents).to be_a(Mongoid::Criteria)
+        expect(documents).to eq(criteria)
+      end
+    end
+
     context 'when provided a object' do
       context 'when the object is not nil' do
         let(:object) do

--- a/spec/mongoid/association/referenced/has_and_belongs_to_many/buildable_spec.rb
+++ b/spec/mongoid/association/referenced/has_and_belongs_to_many/buildable_spec.rb
@@ -108,17 +108,13 @@ describe Mongoid::Association::Referenced::HasAndBelongsToMany::Buildable do
     end
 
     context 'when provided an empty array' do
-      let!(:object) do
+      let(:object) do
         []
       end
 
-      let!(:criteria) do
-        Preference.none
-      end
-
-      it 'returns the criteria' do
+      it 'returns an empty criteria' do
         expect(documents).to be_a(Mongoid::Criteria)
-        expect(documents).to eq(criteria)
+        expect(documents.empty_and_chainable?).to be true
       end
     end
 


### PR DESCRIPTION
## Description

Mongoid 9.1.0 raises `NoMethodError` when a `has_and_belongs_to_many` association stores an empty foreign-key array and the association is reset before it is enumerated. Mongoid 9.0.9 does not reproduce the issue.

Mongoid itself can create this data. For example, `Team.create!(user_ids: [])` stores an explicit empty array.

### Root cause

The array-of-hashes `$lookup` branch in `HasAndBelongsToMany::Buildable#build` was added by MONGOID-5731 in [pull request 6081](https://github.com/mongodb/mongoid/pull/6081). Because `[].all? { |o| o.is_a?(Hash) }` returns `true`, an empty persisted foreign-key array is treated as `$lookup` output and returned as a plain Array. After the association proxy is reset, `HasMany::Enumerable` has no unloaded criteria and can call methods on a missing criteria object.

### Fix

The `$lookup` branch now accepts only non-empty arrays of hashes. For an empty foreign-key array, the code passes `nil` to `query_criteria`, which returns `crit.none`. This keeps the association safe to reset and lets its target `empty?`, `size`, and enumeration methods return an empty result without querying the database, even when the general empty-`$in` short-circuit option is disabled. Proxy `count` and `exists?` are outside this guarantee because they build criteria from the stored IDs.

### Scope

Some Array-backed targets from `$lookup` can still fail after `reset`, including non-empty `has_and_belongs_to_many` results and empty `has_many` results. That issue predates this regression and is outside this change. A follow-up should harden `HasMany::Enumerable` for Array targets.

### Tests

The tests cover:

* Building a `has_and_belongs_to_many` association from an empty foreign-key array returns an empty `Mongoid::Criteria`.
* `Team.create!(user_ids: [])` persists the empty array, and the same association proxy can be reset and used with `empty?`, `size`, and enumeration without a query.
* Existing `includes`/preload tests cover empty eager-loaded results without an extra query.
* Existing tests continue to cover non-empty ID arrays and arrays of `$lookup` documents.

### Verification

* The focused association and integration specs pass: 1499 examples, 0 failures.
* RuboCop is clean.

### Related Mongoid tickets

MONGOID-5030 covers short-circuiting queries whose `$in` value is an empty array. It provides related context, but it is not the same regression.