### PR TITLE
MONGOID-5972 Avoid merging conflicting touch paths into embedded inserts

### DIFF
--- a/lib/mongoid/persistable/creatable.rb
+++ b/lib/mongoid/persistable/creatable.rb
@@ -39,13 +39,45 @@ module Mongoid
         { atomic_insert_modifier => { atomic_position => as_attributes } }
       end
 
+      # Determine whether merging the touch updates into the insert
+      # operations would produce an update whose operators target both a
+      # path and one of its ancestors or descendants. MongoDB rejects such
+      # an update with error 40. This can happen for embeds_many inserts,
+      # where the operations target the array (via $push) but the touches
+      # include a path inside that array (e.g. items.0.updated_at) when a
+      # sibling has a pending touch.
+      #
+      # @api private
+      #
+      # @param [ Hash ] operations The atomic insert operations.
+      # @param [ Hash ] touches The touch updates to merge.
+      #
+      # @return [ true | false ] Whether any touch path conflicts with a
+      #   path the insert operations target.
+      def conflicting_touch_paths?(operations, touches)
+        targeted = operations.each_value.flat_map do |doc|
+          doc.respond_to?(:keys) ? doc.keys.map(&:to_s) : []
+        end
+
+        touches.each_key.any? do |touch_path|
+          path = touch_path.to_s
+          targeted.any? do |target|
+            path == target || path.start_with?("#{target}.") ||
+              target.start_with?("#{path}.")
+          end
+        end
+      end
+
       # Insert the embedded document.
       #
       # When the parent association is touchable (which is the default for
       # +embedded_in+), the touch timestamp updates are merged into the
       # same +update_one+ call that performs the insert. This avoids a
       # second round-trip that the +after_save+ touch callback would
-      # otherwise issue.
+      # otherwise issue. The merge is skipped when a touch path would
+      # conflict with a path the insert targets (see
+      # +conflicting_touch_paths?+); such touches are deferred to the
+      # callback's separate round-trip.
       #
       # @api private
       #
@@ -64,7 +96,7 @@ module Mongoid
 
           if _touchable_parent?
             touches = _parent._gather_touch_updates(Time.current)
-            if touches.present?
+            if touches.present? && !conflicting_touch_paths?(operations, touches)
               operations['$set'] = (operations['$set'] || {}).merge(touches)
               Threaded.begin_touch_merged(self)
             end

--- a/spec/mongoid/touchable_spec.rb
+++ b/spec/mongoid/touchable_spec.rb
@@ -1536,5 +1536,33 @@ describe Mongoid::Touchable do
         expect(building.updated_at).to be > original_updated_at
       end
     end
+
+    context 'when an existing child of the same array has a pending touch' do
+      let(:building) do
+        TouchableSpec::Embedded::Building.create!(title: 'Tower')
+      end
+
+      before do
+        floor = building.floors.create!(level: 1)
+        # Leave a pending touch on the existing sibling so merging it into
+        # the insert would target a path inside the pushed array.
+        floor.updated_at = Time.now + 60
+      end
+
+      it 'does not raise a conflict error when creating a sibling' do
+        expect { building.floors.create!(level: 2) }.not_to raise_error
+      end
+
+      it 'persists the new sibling' do
+        building.floors.create!(level: 2)
+        expect(building.reload.floors.length).to eq(2)
+      end
+
+      it 'touches the parent' do
+        building.floors.create!(level: 2)
+        building.reload
+        expect(building.updated_at).to be_within(5).of(Time.now)
+      end
+    end
   end
 end


### PR DESCRIPTION
MONGOID-5972: Inserting an `embeds_many` child while another child of the same array has a pending touch update raises `Mongo::Error::OperationFailure [40]`.

## Description

Fixes a regression introduced by MONGOID-5867 (Merge touch updates into embedded document insert). `insert_as_embedded` merged the parent's pending touch updates into the same `update_one` that performed the embedded insert. For `embeds_many`, the insert produces `$push` on the array while a dirty sibling can make the touches include a path inside that array (e.g. `items.0.updated_at`). MongoDB rejects a single update whose operators target both a path and one of its ancestors or descendants, so the write failed with error 40. Before 9.1.0 the touch was persisted in its own `update_one` and the two never shared an update document.

The merge is now skipped when any touch path conflicts (equal, ancestor, or descendant) with a path the insert already targets. Such touches are deferred to the `after_save` callback's separate round-trip, matching pre-9.1 behavior. The single-round-trip optimization in MONGOID-5867 is preserved for the common case.

## Verification

- Added a regression context under `describe 'touch merged with embedded insert'` in `spec/mongoid/touchable_spec.rb` (the embedded push/create touch-merge coverage). It fails on master with error 40 and passes with the fix.
- Touchable suite: 245 examples, 0 failures.
- Persistable suite: 881 examples, 0 failures.
- Creatable + touchable suites: 315 examples, 0 failures.
- Timestamps, atomic, and embedded-association suites: 1584 examples, 0 failures.
